### PR TITLE
Export cancelsTouchesInView property on iOS

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -353,6 +353,7 @@ function createNativeWrapper(Component, config = {}) {
     static propTypes = {
       ...Component.propTypes,
     };
+
     static displayName = Component.displayName || 'ComponentWrapper';
 
     _refHandler = node => {
@@ -391,17 +392,13 @@ function createNativeWrapper(Component, config = {}) {
         { ...config } // watch out not to modify config
       );
       return (
-        <NativeViewGestureHandler
-          {...gestureHandlerProps}
-          ref={this.props.innerRef}>
+        <NativeViewGestureHandler {...gestureHandlerProps}>
           <Component {...this.props} ref={this._refHandler} />
         </NativeViewGestureHandler>
       );
     }
   }
-  return React.forwardRef((props, ref) => (
-    <ComponentWrapper innerRef={ref} {...props} />
-  ));
+  return ComponentWrapper;
 }
 
 const WrappedScrollView = createNativeWrapper(ScrollView, {
@@ -432,7 +429,6 @@ State.print = state => {
 const RawButton = createNativeWrapper(GestureHandlerButton, {
   shouldCancelWhenOutside: false,
   shouldActivateOnStart: false,
-  disallowInterruption: false,
 });
 
 /* Buttons */
@@ -486,12 +482,10 @@ class BaseButton extends React.Component {
   render() {
     const { style, rippleColor, ...rest } = this.props;
 
-    console.warn(rest.simultaneousHandlers);
     return (
       <RawButton
         style={[{ overflow: 'hidden' }, style]}
         rippleColor={processColor(rippleColor)}
-        ref={this.props.innerRef}
         {...rest}
         onGestureEvent={this._onGestureEvent}
         onHandlerStateChange={this._onHandlerStateChange}
@@ -499,10 +493,6 @@ class BaseButton extends React.Component {
     );
   }
 }
-
-const BaseButtonWithForwardedRef = React.forwardRef((props, ref) => (
-  <BaseButton innerRef={ref} {...props} />
-));
 
 const AnimatedBaseButton = Animated.createAnimatedComponent(BaseButton);
 
@@ -622,7 +612,7 @@ export {
   State,
   /* Buttons */
   RawButton,
-  BaseButtonWithForwardedRef as BaseButton,
+  BaseButton,
   RectButton,
   BorderlessButton,
   /* Other */

--- a/docs/handler-common.md
+++ b/docs/handler-common.md
@@ -34,6 +34,13 @@ Default value of this property is different depending on the handler type.
 Most of the handlers defaults to `true` but in case of the [`LongPressGestureHandler`](handler-longpress.md) and [`TapGestureHandler`](handler-tap.md)
 
 ---
+### `cancelsTouchesInView` (**iOS only**)
+Takes a boolean value and defaults to `true`.
+Determines if Gesture Handlers has to cancel touches for native components (native buttons). By default all Gesture Handler 
+cancel native buttons (it's also default on Android), but setting this flag to `false` disables this behavior. 
+For more details, visit [Apple docs](https://developer.apple.com/documentation/uikit/uigesturerecognizer/1624218-cancelstouchesinview)
+
+---
 ### `simultaneousHandlers`
 
 Accepts a react ref object or an array of refs to other handler components (refs should be created using [`React.createRef()`](https://reactjs.org/docs/refs-and-the-dom.html)). When set the handler will be allowed to [activate](state.md#active) even if one or more of the handlers provided by their refs are [active](state.md#active). It will also prevent the provided handlers from [cancelling](state.md#cancelled) current handler when they [activate](state.md#active). Read more in the [cross handler interaction](interactions.md#simultaneous-recognition) section.

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -93,6 +93,13 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
     } else {
         _shouldCancelWhenOutside = NO;
     }
+  
+    prop = config[@"cancelsTouchesInView"];
+    if (prop != nil) {
+      _recognizer.cancelsTouchesInView = [RCTConvert BOOL:prop];
+    } else {
+      _recognizer.cancelsTouchesInView = YES;
+    }
 
     prop = config[@"hitSlop"];
     if ([prop isKindOfClass:[NSNumber class]]) {

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -215,6 +215,7 @@ declare module 'react-native-gesture-handler' {
     enabled?: boolean;
     waitFor?: React.Ref<any> | React.Ref<any>[];
     simultaneousHandlers?: React.Ref<any> | React.Ref<any>[];
+    cancelsTouchesInView?: React.Ref<any> | React.Ref<any>[];
     shouldCancelWhenOutside?: boolean;
     hitSlop?:
       | number


### PR DESCRIPTION
## Motivation
I have observed in my library that using `Touchable` nested in `TapGestureHandler` leads to immediate cancellation of `Touchable` on iOS.

Issue related: https://github.com/osdnk/react-native-reanimated-bottom-sheet/issues/16 

By default, components have to cancel touches provided to native components. However, this behavior might be omitted by setting this flag to `false`. Then I could limit the impact of using `TapGestureHandler` on inner content

## Changes
* Exported property `cancelsTouchesInView` on iOS
* Added TS
* Added docs

/ @kmagiera @brentvatne @roshangm1 