### PR TITLE
Add warning when accessibility is not explicitly set

### DIFF
--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -363,7 +363,7 @@ function createNativeWrapper(Component, config = {}) {
         });
         if (!accessibilitySetProperly) {
           console.warn(
-            'Content of BaseButton is not accesible. Consider adding accesible prop. If you dont wan’t to make it accesible, get rid of this warning by setting accesible prop explicitly to false.'
+            "Wrapped component does not support accessibility features. Consider adding accessible prop. If you don't want to make it accessible, get rid of this warning by setting accessible prop explicitly to false."
           );
         }
       }

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -347,11 +347,31 @@ const NATIVE_WRAPPER_PROPS_FILTER = {
   onGestureHandlerStateChange: PropTypes.func,
 };
 
-function createNativeWrapper(Component, config = {}) {
+function createNativeWrapper(
+  Component,
+  config = {},
+  checkAccessibility = false
+) {
   class ComponentWrapper extends React.Component {
     static propTypes = {
       ...Component.propTypes,
     };
+
+    componentDidMount() {
+      if (checkAccessibility) {
+        let accessibilitySetProperly = false;
+        React.Children.forEach(this.props.children, child => {
+          if (child.props.accessible !== undefined) {
+            accessibilitySetProperly = true;
+          }
+        });
+        if (!accessibilitySetProperly) {
+          console.warn(
+            'Content of BaseButton is not accesible. Consider adding accesible prop. If you dont wan’t to make it accesible, get rid of this warning by setting accesible prop explicitly to false.'
+          );
+        }
+      }
+    }
 
     static displayName = Component.displayName || 'ComponentWrapper';
 
@@ -425,10 +445,14 @@ State.print = state => {
   }
 };
 
-const RawButton = createNativeWrapper(GestureHandlerButton, {
-  shouldCancelWhenOutside: false,
-  shouldActivateOnStart: false,
-});
+const RawButton = createNativeWrapper(
+  GestureHandlerButton,
+  {
+    shouldCancelWhenOutside: false,
+    shouldActivateOnStart: false,
+  },
+  true
+);
 
 /* Buttons */
 
@@ -442,20 +466,6 @@ class BaseButton extends React.Component {
   constructor(props) {
     super(props);
     this._lastActive = false;
-  }
-
-  componentDidMount() {
-    let accessibilitySetProperly = false;
-    React.Children.forEach(this.props.children, child => {
-      if (child.props.accessible !== undefined) {
-        accessibilitySetProperly = true;
-      }
-    });
-    if (!accessibilitySetProperly) {
-      console.warn(
-        'Content of BaseButton is not accesible. Consider adding accesible prop. If you dont wan’t to make it accesible, get rid of this warning by setting accesible prop explicitly to false.'
-      );
-    }
   }
 
   _handleEvent = ({ nativeEvent }) => {

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -353,7 +353,7 @@ function createNativeWrapper(Component, config = {}) {
       ...Component.propTypes,
     };
 
-    static displayName = Component.displayName || "ComponentWrapper";
+    static displayName = Component.displayName || 'ComponentWrapper';
 
     _refHandler = node => {
       // bind native component's methods
@@ -442,6 +442,20 @@ class BaseButton extends React.Component {
   constructor(props) {
     super(props);
     this._lastActive = false;
+  }
+
+  componentDidMount() {
+    let accessibilitySetProperly = false;
+    React.Children.forEach(this.props.children, child => {
+      if (child.props.accessible !== undefined) {
+        accessibilitySetProperly = true;
+      }
+    });
+    if (!accessibilitySetProperly) {
+      console.warn(
+        'Content of BaseButton is not accesible. Consider adding accesible prop. If you dont wan’t to make it accesible, get rid of this warning by setting accesible prop explicitly to false.'
+      );
+    }
   }
 
   _handleEvent = ({ nativeEvent }) => {
@@ -588,7 +602,9 @@ const FlatListWithGHScroll = React.forwardRef((props, ref) => (
   <FlatList
     ref={ref}
     {...props}
-    renderScrollComponent={scrollProps => <WrappedScrollView {...scrollProps} />}
+    renderScrollComponent={scrollProps => (
+      <WrappedScrollView {...scrollProps} />
+    )}
   />
 ));
 

--- a/GestureHandler.js
+++ b/GestureHandler.js
@@ -347,18 +347,14 @@ const NATIVE_WRAPPER_PROPS_FILTER = {
   onGestureHandlerStateChange: PropTypes.func,
 };
 
-function createNativeWrapper(
-  Component,
-  config = {},
-  checkAccessibility = false
-) {
+function createNativeWrapper(Component, config = {}) {
   class ComponentWrapper extends React.Component {
     static propTypes = {
       ...Component.propTypes,
     };
 
     componentDidMount() {
-      if (checkAccessibility) {
+      if (config.checkAccessibility === true) {
         let accessibilitySetProperly = false;
         React.Children.forEach(this.props.children, child => {
           if (child.props.accessible !== undefined) {
@@ -445,14 +441,11 @@ State.print = state => {
   }
 };
 
-const RawButton = createNativeWrapper(
-  GestureHandlerButton,
-  {
-    shouldCancelWhenOutside: false,
-    shouldActivateOnStart: false,
-  },
-  true
-);
+const RawButton = createNativeWrapper(GestureHandlerButton, {
+  shouldCancelWhenOutside: false,
+  shouldActivateOnStart: false,
+  checkAccessibility: true,
+});
 
 /* Buttons */
 


### PR DESCRIPTION
# Motivation
In order to make Buttons from React Native Gesture handler accessible one is required to decorate the button's child with `accessible` prop. I wanted to make people aware that their buttons are not accessible to people with disabilities.

# Changes
I added `console.warn` that gets triggered when you don't explicitly pass accessible prop to children of a component wrapped by `NativeViewGestureHandler`. It may be `RawButton`, `BaseButton` or `RectButton`, but also a completely new component that does not exist yet. Checking for accessibility is opt-in. You have to pass `checkAccessibility: true` in config object for `createNativeWrapper` function.