### PR TITLE
Update RotationHandler docs

### DIFF
--- a/docs/handler-rotation.md
+++ b/docs/handler-rotation.md
@@ -27,11 +27,11 @@ The rotation of the gesture in radians.
 Velocity of the pan gesture the current moment. The value is expressed in point units per second.
 
 ---
-### `focalX`
+### `anchorX`
 Position expressed in points along X axis of center anchor point of gesture 
 
 ---
-### `focalY`
+### `anchorY`
 Position expressed in points along Y axis of center anchor point of gesture  
 
 ## Example


### PR DESCRIPTION
Docs incorrectly had focalX and focalY as properties of a rotation handler. They are called anchorX and anchorY in the actual handler

fixes #706 