### PR TITLE
[WEB] Fix x/y for PanGestureHandler onGestureEvent

### DIFF
--- a/web/DraggingGestureHandler.js
+++ b/web/DraggingGestureHandler.js
@@ -6,6 +6,7 @@ class DraggingGestureHandler extends GestureHandler {
   }
 
   transformNativeEvent({ deltaX, deltaY, velocityX, velocityY, center: { x, y } }) {
+    const rect = this.view.getBoundingClientRect(); 
     return {
       translationX: deltaX - (this.__initialX || 0),
       translationY: deltaY - (this.__initialY || 0),
@@ -13,8 +14,8 @@ class DraggingGestureHandler extends GestureHandler {
       absoluteY: y,
       velocityX,
       velocityY,
-      x,
-      y,
+      x: x - rect.left,
+      y: y - rect.top,
     };
   }
 }


### PR DESCRIPTION
https://kmagiera.github.io/react-native-gesture-handler/docs/handler-pan.html#x

> X/Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler. Expressed in point units.

Not sure what the performance implications are of calling `getBoundingClientRect()` in terms of layout thrashing. It appears we already call it once in the event handler anyway (https://github.com/kmagiera/react-native-gesture-handler/blob/5713701f4359dc11f4fb7ad3e4d78100b49730ce/web/GestureHandler.js#L102) so I would guess it doesn't add extra overhead