### PR TITLE
Remove excessive logging

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.java
@@ -1,7 +1,6 @@
 package com.swmansion.gesturehandler.react;
 
 import android.os.SystemClock;
-import android.util.Log;
 import android.view.MotionEvent;
 import android.view.ViewGroup;
 import android.view.ViewParent;
@@ -50,10 +49,6 @@ public class RNGestureHandlerRootHelper {
 
     mReactRootView = findRootViewTag(wrappedView);
 
-    Log.i(
-            ReactConstants.TAG,
-            "[GESTURE HANDLER] Initialize gesture handler for root view " + mReactRootView);
-
     mContext = context;
     mOrchestrator = new GestureHandlerOrchestrator(
             wrappedView, registry, new RNViewConfigurationHelper());
@@ -68,9 +63,6 @@ public class RNGestureHandlerRootHelper {
   }
 
   public void tearDown() {
-    Log.i(
-            ReactConstants.TAG,
-            "[GESTURE HANDLER] Tearing down gesture handler registered for root view " + mReactRootView);
     RNGestureHandlerModule module = mContext.getNativeModule(RNGestureHandlerModule.class);
     module.getRegistry().dropHandler(mJSGestureHandler.getTag());
     module.unregisterRootHelper(this);

--- a/ios/RNGestureHandlerManager.m
+++ b/ios/RNGestureHandlerManager.m
@@ -161,9 +161,10 @@
 
 - (void)dealloc
 {
-    if ([_rootViews count] > 0) {
-        RCTLogError(@"Tearing down gesture handler registered for views %@", _rootViews);
-    }
+    // this actually happens when reloading.
+    // if ([_rootViews count] > 0) {
+    //     RCTLogError(@"Tearing down gesture handler registered for views %@", _rootViews);
+    // }
 }
 
 #pragma mark Events

--- a/ios/RNGestureHandlerManager.m
+++ b/ios/RNGestureHandlerManager.m
@@ -21,10 +21,6 @@
 #import "Handlers/RNRotationHandler.h"
 #import "Handlers/RNForceTouchHandler.h"
 
-// We use the method below instead of RCTLog because we log out messages after the bridge gets
-// turned down in some cases. Which normally with RCTLog would cause a crash in DEBUG mode
-#define RCTLifecycleLog(...) RCTDefaultLogFunction(RCTLogLevelInfo, RCTLogSourceNative, @(__FILE__), @(__LINE__), [NSString stringWithFormat:__VA_ARGS__])
-
 @interface RNGestureHandlerManager () <RNGestureHandlerEventEmitter, RNRootViewGestureRecognizerDelegate>
 
 @end
@@ -133,7 +129,6 @@
     RCTRootView *rootView = (RCTRootView *)parent;
     UIView *rootContentView = rootView.contentView;
     if (rootContentView != nil && ![_rootViews containsObject:rootContentView]) {
-        RCTLifecycleLog(@"[GESTURE HANDLER] Initialize gesture handler for root view %@", rootContentView);
         [_rootViews addObject:rootContentView];
         RNRootViewGestureRecognizer *recognizer = [RNRootViewGestureRecognizer new];
         recognizer.delegate = self;
@@ -167,7 +162,7 @@
 - (void)dealloc
 {
     if ([_rootViews count] > 0) {
-        RCTLifecycleLog(@"[GESTURE HANDLER] Tearing down gesture handler registered for views %@", _rootViews);
+        RCTLogError(@"Tearing down gesture handler registered for views %@", _rootViews);
     }
 }
 

--- a/ios/RNGestureHandlerManager.m
+++ b/ios/RNGestureHandlerManager.m
@@ -159,14 +159,6 @@
     }
 }
 
-- (void)dealloc
-{
-    // this actually happens when reloading.
-    // if ([_rootViews count] > 0) {
-    //     RCTLogError(@"Tearing down gesture handler registered for views %@", _rootViews);
-    // }
-}
-
 #pragma mark Events
 
 - (void)sendTouchEvent:(RNGestureHandlerEvent *)event


### PR DESCRIPTION
Hi,

as far as I can tell these log messages (initialise, tear down) are predictable and do not aid in debugging.

I'd like to remove these to not clutter the console.

I've removed the teardown warning also, as this happens frequently when using react-native's reload mechanism and as far as I know native modules are never dealloced in production builds.
