### PR TITLE
Remove ToolbarAndroid (Lean Core)

### DIFF
--- a/GestureComponents.js
+++ b/GestureComponents.js
@@ -11,10 +11,7 @@ function memoizeWrap(Component, config) {
   }
   let memoized = MEMOIZED.get(Component);
   if (!memoized) {
-    memoized = createNativeWrapper(
-      Component,
-      config
-    );
+    memoized = createNativeWrapper(Component, config);
     MEMOIZED.set(Component, memoized);
   }
   return memoized;
@@ -36,9 +33,6 @@ module.exports = {
   },
   get TextInput() {
     return memoizeWrap(ReactNative.TextInput);
-  },
-  get ToolbarAndroid() {
-    return memoizeWrap(ReactNative.ToolbarAndroid);
   },
   get DrawerLayoutAndroid() {
     const DrawerLayoutAndroid = memoizeWrap(ReactNative.DrawerLayoutAndroid, {

--- a/GestureComponents.web.js
+++ b/GestureComponents.web.js
@@ -4,7 +4,6 @@ import {
   FlatList as RNFlatList,
   Switch as RNSwitch,
   TextInput as RNTextInput,
-  ToolbarAndroid as RNToolbarAndroid,
   ScrollView as RNScrollView,
 } from 'react-native';
 
@@ -20,7 +19,6 @@ export const Switch = createNativeWrapper(RNSwitch, {
   disallowInterruption: true,
 });
 export const TextInput = createNativeWrapper(RNTextInput);
-export const ToolbarAndroid = createNativeWrapper(RNToolbarAndroid);
 export const DrawerLayoutAndroid = createNativeWrapper(RNDrawerLayoutAndroid, {
   disallowInterruption: true,
 });

--- a/docs/about-handlers.md
+++ b/docs/about-handlers.md
@@ -80,7 +80,6 @@ Here is a list of exposed components:
  - `FlatList`
  - `Switch`
  - `TextInput`
- - `ToolbarAndroid` (**Android only**)
  - `DrawerLayoutAndroid` (**Android only**)
  
 If you want to use other handlers or [buttons](component-buttons.md) nested in a `ScrollView` or you want to use [`waitFor`](handler-common.md#waitfor) property to define interaction between a handler and `ScrollView`

--- a/docs/handlers.md
+++ b/docs/handlers.md
@@ -18,7 +18,6 @@ Whenever you use a native component that should handle touch events you can eith
  - `ScrollView`
  - `Switch`
  - `TextInput`
- - `ToolbarAndroid` (**Android only**)
  - `DrawerLayoutAndroid` (**Android only**)
 
 

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -9,7 +9,6 @@ declare module 'react-native-gesture-handler' {
     ScrollViewProperties,
     SwitchProperties,
     TextInputProperties,
-    ToolbarAndroidProperties,
     DrawerLayoutAndroidProperties,
     TouchableHighlightProperties,
     TouchableOpacityProperties,
@@ -436,10 +435,6 @@ declare module 'react-native-gesture-handler' {
 
   export class TextInput extends React.Component<
     NativeViewGestureHandlerProperties & TextInputProperties
-  > {}
-
-  export class ToolbarAndroid extends React.Component<
-    NativeViewGestureHandlerProperties & ToolbarAndroidProperties
   > {}
 
   export class DrawerLayoutAndroid extends React.Component<


### PR DESCRIPTION
You can see there isn't any reference to `ToolbarAndroid` on `react-native` anymore: https://github.com/facebook/react-native/search?q=ToolbarAndroid&type=Code

[It got removed on 0.61](https://github.com/facebook/react-native/issues/26591) I guess, with the [Lean Core](https://github.com/facebook/react-native/issues/23313) effort.

This is causing an error when using `react-native-web@0.12.0-rc.1` or newer:

```
Failed to compile
node_modules/react-native-gesture-handler/GestureComponents.web.js
Module not found: Can't resolve 'react-native-web/dist/exports/ToolbarAndroid' in 'node_modules/react-native-gesture-handler'
```