### PR TITLE
Replaced HammerJS with EGJS/HammerJS

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,21 @@
+{
+  "name": "react-native-gesture-handler",
+  "version": "1.5.2",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@egjs/hammerjs": {
+      "version": "2.0.17",
+      "resolved": "https://registry.npmjs.org/@egjs/hammerjs/-/hammerjs-2.0.17.tgz",
+      "integrity": "sha512-XQsZgjm2EcVUiZQf11UBJQfmZeEmOW8DpI1gsFeln6w0ae0ii4dMQEQ0kjl6DspdWX1aGY1/loyXnP0JS06e/A==",
+      "requires": {
+        "@types/hammerjs": "^2.0.36"
+      }
+    },
+    "@types/hammerjs": {
+      "version": "2.0.36",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.36.tgz",
+      "integrity": "sha512-7TUK/k2/QGpEAv/BCwSHlYu3NXZhQ9ZwBYpzr9tjlPIL2C5BeGhH3DmVavRx3ZNyELX5TLC91JTz/cen6AAtIQ=="
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "homepage": "https://github.com/software-mansion/react-native-gesture-handler#readme",
   "dependencies": {
-    "@egjs/hammerjs": "^2.0.8",
+    "hammerjs": "https://github.com/naver/hammer.js.git",
     "hoist-non-react-statics": "^2.3.1",
     "invariant": "^2.2.4",
     "prop-types": "^15.7.2"

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
   },
   "homepage": "https://github.com/software-mansion/react-native-gesture-handler#readme",
   "dependencies": {
+    "@egjs/hammerjs": "^2.0.17",
     "hammerjs": "https://github.com/naver/hammer.js.git",
     "hoist-non-react-statics": "^2.3.1",
     "invariant": "^2.2.4",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "homepage": "https://github.com/software-mansion/react-native-gesture-handler#readme",
   "dependencies": {
-    "hammerjs": "^2.0.8",
+    "@egjs/hammerjs": "^2.0.8",
     "hoist-non-react-statics": "^2.3.1",
     "invariant": "^2.2.4",
     "prop-types": "^15.7.2"

--- a/web/FlingGestureHandler.js
+++ b/web/FlingGestureHandler.js
@@ -1,4 +1,4 @@
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 
 import { Direction } from './constants';
 import { GesturePropError } from './Errors';

--- a/web/GestureHandler.js
+++ b/web/GestureHandler.js
@@ -1,4 +1,4 @@
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 import { findNodeHandle } from 'react-native';
 
 import State from '../State';

--- a/web/LongPressGestureHandler.js
+++ b/web/LongPressGestureHandler.js
@@ -1,4 +1,4 @@
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 
 import State from '../State';
 import PressGestureHandler from './PressGestureHandler';

--- a/web/PanGestureHandler.js
+++ b/web/PanGestureHandler.js
@@ -1,4 +1,4 @@
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 
 import {
   MULTI_FINGER_PAN_MAX_PINCH_THRESHOLD,

--- a/web/PinchGestureHandler.js
+++ b/web/PinchGestureHandler.js
@@ -1,4 +1,4 @@
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 
 import IndiscreteGestureHandler from './IndiscreteGestureHandler';
 

--- a/web/PressGestureHandler.js
+++ b/web/PressGestureHandler.js
@@ -1,4 +1,4 @@
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 
 import State from '../State';
 import {

--- a/web/RotationGestureHandler.js
+++ b/web/RotationGestureHandler.js
@@ -1,4 +1,4 @@
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 
 import { DEG_RAD } from './constants';
 import IndiscreteGestureHandler from './IndiscreteGestureHandler';

--- a/web/TapGestureHandler.js
+++ b/web/TapGestureHandler.js
@@ -1,4 +1,4 @@
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 
 import DiscreteGestureHandler from './DiscreteGestureHandler';
 import { isnan } from './utils';

--- a/web/constants.js
+++ b/web/constants.js
@@ -1,4 +1,4 @@
-import Hammer from 'hammerjs';
+import Hammer from '@egjs/hammerjs';
 
 import State from '../State';
 


### PR DESCRIPTION
I replaced all the imports for egjs and hammer.

I was running into an issue where my ssr wouldnt build properly for production.  The issue existed within hammerjs for the gesture handler, I had used the module swap for the testing process but next/build didnt work.

I figured it wasnt logical for it not to be in this repo and did the change myself.

Feel free to correct me if im wrong and we are choosing to not migrate.