### PR TITLE
Replace Omit with Pick + Exclude

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -466,7 +466,9 @@ declare module 'react-native-gesture-handler' {
 declare module 'react-native-gesture-handler/Swipeable' {
   import { Animated, StyleProp, ViewStyle } from 'react-native';
   import { PanGestureHandlerProperties } from 'react-native-gesture-handler'
-  interface SwipeableProperties extends Omit<PanGestureHandlerProperties, 'onGestureEvent' | 'onHandlerStateChange'> {
+  type SwipeableExcludes = Exclude<keyof PanGestureHandlerProperties, 'onGestureEvent' | 'onHandlerStateChange'>
+
+  interface SwipeableProperties extends Pick<PanGestureHandlerProperties, SwipeableExcludes> {
     friction?: number;
     leftThreshold?: number;
     rightThreshold?: number;


### PR DESCRIPTION
Recently the type declarations include the use of the `Omit` library type. This type was added in TypeScript 3.5 (https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-5.html#the-omit-helper-type), and therefore the change prevents using this library with TypeScript projects that have not upgraded. (In my case, we use TypeScript 3.4.)

I replaced the use of `Omit` with the same implementation based on `Pick` and `Exclude`:
`type Omit<T, K extends keyof any> = Pick<T, Exclude<keyof T, K>>;`

I'm not sure what the minimum TypeScript this project supports, but this will at least prevent issues with some earlier 3.x versions.