### PR TITLE
[web] Multiply velocity to match velocity on native devices

### DIFF
--- a/web/DraggingGestureHandler.js
+++ b/web/DraggingGestureHandler.js
@@ -1,19 +1,27 @@
 import GestureHandler from './GestureHandler';
+import { PixelRatio } from 'react-native';
 
 class DraggingGestureHandler extends GestureHandler {
   get shouldEnableGestureOnSetup() {
     return true;
   }
 
-  transformNativeEvent({ deltaX, deltaY, velocityX, velocityY, center: { x, y } }) {
-    const rect = this.view.getBoundingClientRect(); 
+  transformNativeEvent({
+    deltaX,
+    deltaY,
+    velocityX,
+    velocityY,
+    center: { x, y },
+  }) {
+    const rect = this.view.getBoundingClientRect();
+    const ratio = PixelRatio.get();
     return {
       translationX: deltaX - (this.__initialX || 0),
       translationY: deltaY - (this.__initialY || 0),
       absoluteX: x,
       absoluteY: y,
-      velocityX,
-      velocityY,
+      velocityX: velocityX * ratio,
+      velocityY: velocityY * ratio,
       x: x - rect.left,
       y: y - rect.top,
     };


### PR DESCRIPTION
Velocity based gestures on web don't seem to match native gestures. This will make the interactions a little bit closer.