### PR TITLE
[web] Reset the gesture state when it begins to ensure tap gesture state is correct

### DIFF
--- a/web/GestureHandler.js
+++ b/web/GestureHandler.js
@@ -153,12 +153,6 @@ class GestureHandler {
 
     const event = this.transformEventData(nativeEvent);
 
-    // Reset the state for the next gesture
-    if (nativeEvent.isFinal) {
-      this.oldState = State.UNDETERMINED;
-      this.previousState = State.UNDETERMINED;
-    }
-
     invokeNullableMethod('onGestureEvent', onGestureEvent, event);
     invokeNullableMethod('onHandlerStateChange', onHandlerStateChange, event);
   };
@@ -265,6 +259,10 @@ class GestureHandler {
   }
 
   onStart({ deltaX, deltaY, rotation }) {
+    // Reset the state for the next gesture
+    this.oldState = State.UNDETERMINED;
+    this.previousState = State.UNDETERMINED;
+
     this.isGestureRunning = true;
     this.__initialX = deltaX;
     this.__initialY = deltaY;


### PR DESCRIPTION
When using web tap gesture, the old state would reset to `UNDETERMINED` causing tap gestures not to complete as expected.