### PR TITLE
Make RNGH workable inside modals on Android

### DIFF
--- a/Example/draggable/index.js
+++ b/Example/draggable/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Animated, StyleSheet, View } from 'react-native';
+import { Animated, Modal, StyleSheet, View } from 'react-native';
 
 import {
   PanGestureHandler,
@@ -9,6 +9,7 @@ import {
 
 import { USE_NATIVE_DRIVER } from '../config';
 import { LoremIpsum } from '../common';
+import gestureHandlerRootHOC from '../../gestureHandlerRootHOC';
 
 export class DraggableBox extends Component {
   constructor(props) {
@@ -61,14 +62,26 @@ export class DraggableBox extends Component {
   }
 }
 
-export default class Example extends Component {
+const ExampleWithHoc = gestureHandlerRootHOC(
+  class Example extends Component {
+    render() {
+      return (
+        <View style={styles.scrollView}>
+          <LoremIpsum words={40} />
+          <DraggableBox />
+          <LoremIpsum />
+        </View>
+      );
+    }
+  }
+);
+
+export default class WrappedExample extends React.Component {
   render() {
     return (
-      <View style={styles.scrollView}>
-        <LoremIpsum words={40} />
-        <DraggableBox />
-        <LoremIpsum />
-      </View>
+      <Modal animationType="slide" transparent={false}>
+        <ExampleWithHoc />
+      </Modal>
     );
   }
 }

--- a/Example/draggable/index.js
+++ b/Example/draggable/index.js
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Animated, Modal, StyleSheet, View } from 'react-native';
+import { Animated, StyleSheet, View } from 'react-native';
 
 import {
   PanGestureHandler,
@@ -9,7 +9,6 @@ import {
 
 import { USE_NATIVE_DRIVER } from '../config';
 import { LoremIpsum } from '../common';
-import gestureHandlerRootHOC from '../../gestureHandlerRootHOC';
 
 export class DraggableBox extends Component {
   constructor(props) {
@@ -62,26 +61,14 @@ export class DraggableBox extends Component {
   }
 }
 
-const ExampleWithHoc = gestureHandlerRootHOC(
-  class Example extends Component {
-    render() {
-      return (
-        <View style={styles.scrollView}>
-          <LoremIpsum words={40} />
-          <DraggableBox />
-          <LoremIpsum />
-        </View>
-      );
-    }
-  }
-);
-
-export default class WrappedExample extends React.Component {
+export default class Example extends Component {
   render() {
     return (
-      <Modal animationType="slide" transparent={false}>
-        <ExampleWithHoc />
-      </Modal>
+      <View style={styles.scrollView}>
+        <LoremIpsum words={40} />
+        <DraggableBox />
+        <LoremIpsum />
+      </View>
     );
   }
 }

--- a/android/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
+++ b/android/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
@@ -1,0 +1,17 @@
+package com.facebook.react.views.modal;
+
+
+import android.view.MotionEvent;
+import android.view.ViewGroup;
+import android.view.ViewParent;
+
+public class RNGHModalUtils {
+    static public void dialogRootViewGroupOnChildStartedNativeGesture(ViewGroup modal, MotionEvent androidEvent) {
+        ((ReactModalHostView.DialogRootViewGroup) modal).onChildStartedNativeGesture(androidEvent);
+    }
+
+    static public boolean isDialogRootViewGroup(ViewParent modal) {
+        return modal instanceof ReactModalHostView.DialogRootViewGroup;
+    }
+
+}

--- a/android/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
+++ b/android/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
@@ -11,11 +11,11 @@ import android.view.ViewParent;
  */
 
 public class RNGHModalUtils {
-  static public void dialogRootViewGroupOnChildStartedNativeGesture(ViewGroup modal, MotionEvent androidEvent) {
+  public static void dialogRootViewGroupOnChildStartedNativeGesture(ViewGroup modal, MotionEvent androidEvent) {
     ((ReactModalHostView.DialogRootViewGroup) modal).onChildStartedNativeGesture(androidEvent);
   }
 
-  static public boolean isDialogRootViewGroup(ViewParent modal) {
+  public static boolean isDialogRootViewGroup(ViewParent modal) {
     return modal instanceof ReactModalHostView.DialogRootViewGroup;
   }
 }

--- a/android/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
+++ b/android/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
@@ -1,6 +1,5 @@
 package com.facebook.react.views.modal;
 
-
 import android.view.MotionEvent;
 import android.view.ViewGroup;
 import android.view.ViewParent;

--- a/android/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
+++ b/android/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
@@ -6,12 +6,11 @@ import android.view.ViewGroup;
 import android.view.ViewParent;
 
 public class RNGHModalUtils {
-    static public void dialogRootViewGroupOnChildStartedNativeGesture(ViewGroup modal, MotionEvent androidEvent) {
-        ((ReactModalHostView.DialogRootViewGroup) modal).onChildStartedNativeGesture(androidEvent);
-    }
+  static public void dialogRootViewGroupOnChildStartedNativeGesture(ViewGroup modal, MotionEvent androidEvent) {
+    ((ReactModalHostView.DialogRootViewGroup) modal).onChildStartedNativeGesture(androidEvent);
+  }
 
-    static public boolean isDialogRootViewGroup(ViewParent modal) {
-        return modal instanceof ReactModalHostView.DialogRootViewGroup;
-    }
-
+  static public boolean isDialogRootViewGroup(ViewParent modal) {
+    return modal instanceof ReactModalHostView.DialogRootViewGroup;
+  }
 }

--- a/android/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
+++ b/android/src/main/java/com/facebook/react/views/modal/RNGHModalUtils.java
@@ -4,6 +4,12 @@ import android.view.MotionEvent;
 import android.view.ViewGroup;
 import android.view.ViewParent;
 
+/**
+ * For handling gestures inside RNGH we need to have access to some methods of
+ * `ReactModalHostView.DialogRootViewGroup`. This class is not available outside
+ * package so this file exports important features.
+ */
+
 public class RNGHModalUtils {
   static public void dialogRootViewGroupOnChildStartedNativeGesture(ViewGroup modal, MotionEvent androidEvent) {
     ((ReactModalHostView.DialogRootViewGroup) modal).onChildStartedNativeGesture(androidEvent);

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -3,6 +3,7 @@ package com.swmansion.gesturehandler.react;
 import android.content.Context;
 import android.view.MotionEvent;
 import android.view.View;
+import android.view.ViewGroup;
 
 import com.facebook.react.ReactRootView;
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException;
@@ -555,7 +556,7 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
       while (!mRoots.isEmpty()) {
         int sizeBefore = mRoots.size();
         RNGestureHandlerRootHelper root = mRoots.get(0);
-        ReactRootView reactRootView = root.getRootView();
+        ViewGroup reactRootView = root.getRootView();
         if (reactRootView instanceof RNGestureHandlerEnabledRootView) {
           ((RNGestureHandlerEnabledRootView) reactRootView).tearDown();
         } else {
@@ -579,7 +580,8 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
     synchronized (mRoots) {
       for (int i = 0; i < mRoots.size(); i++) {
         RNGestureHandlerRootHelper root = mRoots.get(i);
-        if (root.getRootView().getRootViewTag() == rootViewTag) {
+        ViewGroup rootView = root.getRootView();
+        if (rootView instanceof ReactRootView && ((ReactRootView) rootView).getRootViewTag() == rootViewTag) {
           // we have found root helper registered for a given react root, we don't need to
           // initialize a new one then
           return;
@@ -638,7 +640,8 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
     synchronized (mRoots) {
       for (int i = 0; i < mRoots.size(); i++) {
         RNGestureHandlerRootHelper root = mRoots.get(i);
-        if (root.getRootView().getRootViewTag() == rootViewTag) {
+        ViewGroup rootView = root.getRootView();
+        if (rootView instanceof ReactRootView && ((ReactRootView) rootView).getRootViewTag() == rootViewTag) {
           return root;
         }
       }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -186,7 +186,7 @@ export default function Example() {
 
 If you're using gesture handler in your component library, you may want to wrap your library's code in the `GestureHandlerRootView` component. This will avoid extra configuration in `MainActivity.java` for the user.
 
-```jsx
+```js
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 export default MyComponent() {

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -157,11 +157,36 @@ You can check out [this example project](https://github.com/henrikra/nativeNavig
 
 Remember that you need to wrap each screen that you use in your app with `gestureHandlerRootHOC` as with native navigation libraries each screen maps to a separate root view. It will not be enough to wrap the main screen only.
 
+### Usage with modals on Android
+On Android RNGH does not work by default because modals are not located under React Native Root view in native hierarchy.
+In order to make it workable, components need to be wrapped with `gestureHandlerRootHOC` (it's no-op on iOS and web).
+
+E.g. 
+```js
+const ExampleWithHoc = gestureHandlerRootHOC(
+  function GestureExample() {
+    return (
+      <View>
+        <DraggableBox />
+      </View>
+    );
+  }
+);
+
+export default function Example() {
+  return (
+    <Modal animationType="slide" transparent={false}>
+      <ExampleWithHoc />
+    </Modal>
+  );
+}
+``` 
+
 ### For library authors
 
 If you're using gesture handler in your component library, you may want to wrap your library's code in the `GestureHandlerRootView` component. This will avoid extra configuration in `MainActivity.java` for the user.
 
-```js
+```jsx
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 export default MyComponent() {


### PR DESCRIPTION
## Motivation
Modals are currently not working with RNGH, because handlers need to be located under RootView in the native hierarchy. 

## Changes

It's fixed it by wrapping content of modals with `gestureHandlerHOC`. However, it called for a few native changes. 
In all places we were using RootView ref, I made it more generic to accept any `ViewGroup`. In places where methods of `RootView` were accessed I added checks and castings. 

Also, modal wrapper (`ReactModalHostView.DialogRootViewGroup`) is not accessible from another package so I added the file to the package (`com.facebook.react.views.modal`) exporting important functionalities.

Added docs.

## Test
I verified it iterating through example app and checking if every example (including these with RN's `PanResponer`) are working correctly.