### PR TITLE
Add scrollTo* methods to type definition

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -434,7 +434,10 @@ declare module 'react-native-gesture-handler' {
 
   export class ScrollView extends React.Component<
     NativeViewGestureHandlerProperties & ScrollViewProperties
-  > {}
+  > {
+    scrollTo(y?: number | { x?: number; y?: number; animated?: boolean }, x?: number, animated?: boolean): void;
+    scrollToEnd(options?: { animated: boolean }): void;
+  }
 
   export class Switch extends React.Component<
     NativeViewGestureHandlerProperties & SwitchProperties
@@ -452,7 +455,12 @@ declare module 'react-native-gesture-handler' {
 
   export class FlatList<ItemT> extends React.Component<
     NativeViewGestureHandlerProperties & FlatListProperties<ItemT>
-  > {}
+  > {
+    scrollToEnd: (params?: { animated?: boolean }) => void;
+    scrollToIndex: (params: { animated?: boolean; index: number; viewOffset?: number; viewPosition?: number }) => void;
+    scrollToItem: (params: { animated?: boolean; item: ItemT; viewPosition?: number }) => void;
+    scrollToOffset: (params: { animated?: boolean; offset: number }) => void;
+  }
 
   export const GestureHandlerRootView: ReactComponentType<ViewProps>;
 


### PR DESCRIPTION
When replacing vanilla RN FlatList or ScrollList by the RNGH ones in a TypeScript project, we get some TS errors if component methods are used.

I copied the commonly used methods from https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/index.d.ts