### PR TITLE
Fix passing props to gestureHandlerRootHOC.js

### DIFF
--- a/gestureHandlerRootHOC.js
+++ b/gestureHandlerRootHOC.js
@@ -7,10 +7,10 @@ export default function gestureHandlerRootHOC(
   Component,
   containerStyles = undefined
 ) {
-  function Wrapper() {
+  function Wrapper(props) {
     return (
       <GestureHandlerRootView style={[styles.container, containerStyles]}>
-        <Component {...this.props} />
+        <Component {...props} />
       </GestureHandlerRootView>
     );
   }


### PR DESCRIPTION
fixes: https://github.com/software-mansion/react-native-gesture-handler/issues/942

regression after: https://github.com/software-mansion/react-native-gesture-handler/commit/cc5e348cecb0a6403906a6f49df8f54b4b5c98ef