### PR TITLE
Fix GestureHandlerRootView type

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -454,7 +454,7 @@ declare module 'react-native-gesture-handler' {
     NativeViewGestureHandlerProperties & FlatListProperties<ItemT>
   > {}
 
-  export const GestureHandlerRootView: ReactComponentType<ViewProps>;
+  export const GestureHandlerRootView: React.ComponentType<ViewProps>;
 
   export function gestureHandlerRootHOC<P = {}>(
     Component: React.ComponentType<P>,


### PR DESCRIPTION
The exported `GestureHandlerRootView` component in type definitions, is throwing the following error. Occurs at line [457](https://github.com/software-mansion/react-native-gesture-handler/blob/d9c7553c8d7112dcff9bd498975a5f4b0a1fa9bc/react-native-gesture-handler.d.ts#L457).
```
Cannot find name 'ReactComponentType'. ts(2304)
```
TypeScript projects can break due to an incorrect type annotation. This PR fixes that small detail.
Bug was introduced in 1.5.4 version.