### PR TITLE
Update types definition to avoid using non-existing type

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -454,7 +454,7 @@ declare module 'react-native-gesture-handler' {
     NativeViewGestureHandlerProperties & FlatListProperties<ItemT>
   > {}
 
-  export const GestureHandlerRootView: ReactComponentType<ViewProps>;
+  export const GestureHandlerRootView: React.ComponentType<ViewProps>;
 
   export function gestureHandlerRootHOC<P = {}>(
     Component: React.ComponentType<P>,


### PR DESCRIPTION
The types definition was using ReactComponentType instead of React.ComponentType