### PR TITLE
doc(import): Swipeable import is now exported from reat-native-gestur…

### DIFF
--- a/docs/component-swipeable.md
+++ b/docs/component-swipeable.md
@@ -10,9 +10,10 @@ This component allows for implementing swipeable rows or similar interaction. It
 
 ### Usage:
 
-Similarly to the `DrawerLayout`, `Swipeable` component isn't exported by default from the `react-native-gesture-handler` package. To use it, import it in the following way:
+To use it, import it in the following way:
+
 ```js
-import Swipeable from 'react-native-gesture-handler/Swipeable';
+import { Swipeable } from 'react-native-gesture-handler';
 ```
 
 ## Properties


### PR DESCRIPTION
…e-handler

Working demo that prove https://snack.expo.io/@kopax/react-native-gesture-handler-issue-960

And the source code: https://github.com/software-mansion/react-native-gesture-handler/blob/master/index.js#L1

Types seems to be missing (Idea says)