### PR TITLE
Fix typo in exported root view type declaration

### DIFF
--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -454,7 +454,7 @@ declare module 'react-native-gesture-handler' {
     NativeViewGestureHandlerProperties & FlatListProperties<ItemT>
   > {}
 
-  export const GestureHandlerRootView: ReactComponentType<ViewProps>;
+  export const GestureHandlerRootView: React.ComponentType<ViewProps>;
 
   export function gestureHandlerRootHOC<P = {}>(
     Component: React.ComponentType<P>,


### PR DESCRIPTION
It looks like this should be `React.ComponentType` instead of `ReactComponentType` (`tsc` is erroring on the latter). I'm not too familiar with React typings though, so apologies in advance if I'm off base!