### PR TITLE
Fix missing `Platform` import

### DIFF
--- a/touchables/TouchableNativeFeedback.android.js
+++ b/touchables/TouchableNativeFeedback.android.js
@@ -1,6 +1,7 @@
-import GenericTouchable from './GenericTouchable';
+import { Platform } from 'react-native';
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
+import GenericTouchable from './GenericTouchable';
 
 /**
  * TouchableNativeFeedback behaves slightly different than RN's TouchableNativeFeedback.


### PR DESCRIPTION
I'm a bit surprised that the linter didn't catch this, cause `Platform` isn't a global is it? 