### PR TITLE
Fixes #930

### DIFF
--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -166,7 +166,9 @@
 
 @end
 
-@implementation RNTapGestureHandler
+@implementation RNTapGestureHandler {
+    RNGestureHandlerEventExtraData * _lastData;
+}
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
@@ -201,6 +203,15 @@
     CGFloat dist = [RCTConvert CGFloat:prop];
     recognizer.maxDistSq = dist * dist;
   }
+}
+
+- (RNGestureHandlerEventExtraData *)eventExtraData:(UIGestureRecognizer *)recognizer{
+    if (recognizer.state == UIGestureRecognizerStateEnded) {
+        return _lastData;
+    }
+    
+    _lastData = [super eventExtraData:recognizer];
+    return _lastData;
 }
 
 @end


### PR DESCRIPTION
This PR fixes issue #930. Having both single and double-tap would not report correct coordinates for single tap gestures.

Problem:
RNBetterTapGestureRecognizer doesn't return correct coordinates after the gesture has completed. i.e. `state == UIGestureRecognizerStateEnded`

Fix:
Simply keep the coordinates from the previous state of the gesture and pass those instead.

You can see the difference here.

Problematic: https://streamable.com/oqftv
Fixed: https://streamable.com/znhm3