### PR TITLE
Fix RectButton style prop forwarding

### DIFF
--- a/GestureButtons.js
+++ b/GestureButtons.js
@@ -112,7 +112,10 @@ export class RectButton extends React.Component {
     const resolvedStyle = StyleSheet.flatten(style ?? {});
 
     return (
-      <BaseButton {...rest} onActiveStateChange={this._onActiveStateChange}>
+      <BaseButton
+        {...rest}
+        style={resolvedStyle}
+        onActiveStateChange={this._onActiveStateChange}>
         <Animated.View
           style={[
             btnStyles.underlay,


### PR DESCRIPTION
Fixes #1014

Style wasn't getting passed anymore to BaseButton since 7048f6427a7d1a8fd3d5319e01535e99dfe11bc9