### PR TITLE
Fix incorrect links and whitespace in docs

### DIFF
--- a/docs/about-handlers.md
+++ b/docs/about-handlers.md
@@ -74,7 +74,7 @@ class Multitap extends Component {
 ---
 ### Using native components
 
-Gesture handler library exposes a set of components normally available in React Native that are wrapped in [`NativeViewGestureHandler`](handler-native.md).
+Gesture handler library exposes a set of components normally available in React Native that are wrapped in [`NativeViewGestureHandler`](handlers.md).
 Here is a list of exposed components:
  - `ScrollView`
  - `FlatList`

--- a/docs/about-handlers.md
+++ b/docs/about-handlers.md
@@ -42,7 +42,6 @@ An example of continuous handler is [`PanGestureHandler`](handler-pan.md) that o
 On the other hand, discrete gesture handlers once [activated](state.md#active) will not stay in the active state but will [end](state.md#ended) immediately.
 [`LongPressGestureHandler`](handler-longpress.md) is a discrete handler, as it only detects if the finger is placed for a sufficiently long period of time, it does not track finger movements (as that's the responsibility of [`PanGestureHandler`](handler-pan.md)).
 
-
 ---
 ### Nesting handlers
 
@@ -81,7 +80,7 @@ Here is a list of exposed components:
  - `Switch`
  - `TextInput`
  - `DrawerLayoutAndroid` (**Android only**)
- 
+
 If you want to use other handlers or [buttons](component-buttons.md) nested in a `ScrollView` or you want to use [`waitFor`](handler-common.md#waitfor) property to define interaction between a handler and `ScrollView`
 
 ---
@@ -127,4 +126,3 @@ class Draggable extends Component {
   }
 };
 ```
-

--- a/docs/component-buttons.md
+++ b/docs/component-buttons.md
@@ -6,7 +6,6 @@ sidebar_label: Buttons
 
 <img src="assets/samplebutton.gif" width="280" />
 
-
 Gesture handler library provides native components that can act as buttons. These can be treated as a replacement to `TouchableHighlight` or `TouchableOpacity` from RN core. Gesture handler's buttons recognize touches in native which makes the recognition process deterministic, allows for rendering ripples on Android in highly performant way (`TouchableNativeFeedback` requires that touch event does a roundtrip to JS before we can update ripple effect, which makes ripples lag a bit on older phones), and provides native and platform default interaction for buttons that are placed in a scrollable container (in which case the interaction is slightly delayed to prevent button from highlighting when you fling).
 
 Currently Gesture handler library exposes three components that render native touchable elements under the hood:
@@ -19,19 +18,22 @@ On top of that all the buttons are wrapped with `NativeViewGestureHandler` and t
 **IMPORTANT**: In order to make buttons accessible, you have to wrap your children in a `View` with `accessible` prop.
 Example:
 ```javascript
-  // Not accessible:
-  const NotAccessibleButton = () => (
-    <RectButton onPress={this._onPress}>
-      <Text>Foo</Text>
-    </RectButton>);
-  // Accessible:
-  const AccessibleButton = () => (
-    <RectButton onPress={this._onPress}>
-      <View accessible>
-        <Text>Bar</Text>
-      </View>
-    </RectButton>);
+// Not accessible:
+const NotAccessibleButton = () => (
+  <RectButton onPress={this._onPress}>
+    <Text>Foo</Text>
+  </RectButton>
+);
+// Accessible:
+const AccessibleButton = () => (
+  <RectButton onPress={this._onPress}>
+    <View accessible>
+      <Text>Bar</Text>
+    </View>
+  </RectButton>
+);
 ```
+
 It is applicable for both iOS and Android platform. On iOS, you won't be able to even select the button, on Android you won't be able to click it in accessibility mode.
 
 ## `BaseButton`
@@ -49,11 +51,11 @@ function that gets triggered when the button gets pressed (analogous to `onPress
 
 ---
 ### `rippleColor` (**Android only**)
-defines color of native [ripple](https://developer.android.com/reference/android/graphics/drawable/RippleDrawable) animation used since API level 21. 
+defines color of native [ripple](https://developer.android.com/reference/android/graphics/drawable/RippleDrawable) animation used since API level 21.
 
 ---
 ### `exclusive` (**iOS only**)
-defines if more than one button could be pressed simultaneously. By default set `true`. 
+defines if more than one button could be pressed simultaneously. By default set `true`.
 
 ---
 ## `RectButton`
@@ -87,6 +89,7 @@ opacity applied to the button when it is in an active state.
 ---
 
 ## Design patterns
+
 Components listed here were not designed to behave and look in the same way on both platforms but rather to be used for handling similar behaviour on iOS and Android taking into consideration their's design concepts.
 
 If you wish to get specific information about platforms design patterns, visit [official Apple docs](https://developer.apple.com/design/human-interface-guidelines/ios/controls) and [Material.io guideline](https://material.io/design/components/buttons.html#text-button), which widely describe how to implement coherent design.
@@ -101,16 +104,12 @@ Below we list some of the common usecases for button components to be used along
 
 If you have a list with clickable items or have an action button that need to display as a separate UI block (vs being inlined in a text) you should use `RectButton`. It changes opacity on click and additionally supports a ripple effect on Android.
 
-
 <img src="assets/androidsettings.gif" width="280" />
-
-
 <img src="assets/iossettings.gif" width="280" />
-
 
 To determine emphasis of button it's vital to use fill color or leave it transparent especially on Android.
 For medium emphasis you may consider outlined buttons which are used for lower impact than fill buttons.
- 
+
 <img src="assets/androidbutton.gif" width="280" />
 
 ### Icon or text only buttons
@@ -118,12 +117,8 @@ For medium emphasis you may consider outlined buttons which are used for lower i
 Use `BorderlessButton` for simple icon-only or text-only buttons. The interaction will be different depending on platform: on Android a borderless ripple will be rendered, whereas on iOS the button will be dimmed.
 It should be used if you wish to handle non-crucial actions and supportive behaviour.
 
-
 <img src="assets/androidmail.gif" width="280" />
-
-
 <img src="assets/iosmail.gif" width="280" />
-
 
 ### `PureNativeButton`
 

--- a/docs/component-drawer-layout.md
+++ b/docs/component-drawer-layout.md
@@ -8,7 +8,8 @@ This is a cross-platform replacement for React Native's [DrawerLayoutAndroid](ht
 
 ## Usage:
 
-`DrawerLayout` component isn't exported by default from the `react-native-gesture-handler` package. To use it, import it in the following way:
+`DrawerLayout` component isn't exported by default from the `react-native-gesture-handler` package.
+To use it, import it in the following way:
 ```js
 import DrawerLayout from 'react-native-gesture-handler/DrawerLayout';
 ```
@@ -55,7 +56,9 @@ function. This attribute is present in the standard implementation already and i
 component or function. Children is a component which is rendered by default and is wrapped by drawer. However, it could be also a render function which takes an Animated value as a parameter that indicates the progress of drawer opening/closing animation (progress value is 0 when closed and 1 when opened) is the same way like `renderNavigationView` prop.
 
 ## Example:
+
 See the [drawer example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/horizontalDrawer/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+
 ```js
 class Drawerable extends Component {
   renderDrawer = () => {
@@ -85,7 +88,4 @@ class Drawerable extends Component {
     );
   }
 }
-
 ```
-
-

--- a/docs/component-swipeable.md
+++ b/docs/component-swipeable.md
@@ -10,7 +10,8 @@ This component allows for implementing swipeable rows or similar interaction. It
 
 ### Usage:
 
-Similarly to the `DrawerLayout`, `Swipeable` component isn't exported by default from the `react-native-gesture-handler` package. To use it, import it in the following way:
+Similarly to the `DrawerLayout`, `Swipeable` component isn't exported by default from the `react-native-gesture-handler` package.
+To use it, import it in the following way:
 ```js
 import Swipeable from 'react-native-gesture-handler/Swipeable';
 ```
@@ -19,7 +20,7 @@ import Swipeable from 'react-native-gesture-handler/Swipeable';
 
 ---
 ### `friction`
- a number that specifies how much the visual interaction will be delayed compared to the gesture distance. e.g. value of 1 will indicate that the swipeable panel should exactly follow the gesture, 2 means it is going to be two times "slower".
+a number that specifies how much the visual interaction will be delayed compared to the gesture distance. e.g. value of 1 will indicate that the swipeable panel should exactly follow the gesture, 2 means it is going to be two times "slower".
 
 ---
 ### `leftThreshold`
@@ -78,7 +79,7 @@ method that is called when action panel starts animating on close.
 method that is expected to return an action panel that is going to be revealed from the left side when user swipes right.
 This map describes the values to use as inputRange for extra interpolation:
 AnimatedValue: [startValue, endValue]
-        
+
 progressAnimatedValue: [0, 1]
 dragAnimatedValue: [0, +]
 
@@ -89,7 +90,7 @@ To support `rtl` flexbox layouts use `flexDirection` styling.
 method that is expected to return an action panel that is going to be revealed from the right side when user swipes left.
 This map describes the values to use as inputRange for extra interpolation:
 AnimatedValue: [startValue, endValue]
-        
+
 progressAnimatedValue: [0, 1]
 dragAnimatedValue: [0, -]
 
@@ -104,6 +105,7 @@ style object for the container (Animated.View), for example to override `overflo
 style object for the children container (Animated.View), for example to apply `flex: 1`.
 
 ## Methods
+
 Using reference to `Swipeable` it's possible to trigger some actions on it
 
 ---
@@ -117,7 +119,6 @@ method that opens component on left side.
 ---
 ### `openRight`
 method that opens component on right side.
-
 
 ### Example:
 

--- a/docs/component-touchables.md
+++ b/docs/component-touchables.md
@@ -3,6 +3,7 @@ id: component-touchables
 title: Touchables
 sidebar_label: Touchables
 ---
+
 Gesture Handler library provides an implementation of RN's touchable components that are based on [native buttons](component-buttons.md) and does not rely on JS responder system utilized by RN. Our touchable implementation follows the same API and aims to be a drop-in replacement for touchables available in React Native.
 
 React Native's touchables API can be found here:
@@ -10,20 +11,19 @@ React Native's touchables API can be found here:
  - [Touchable Highlight](https://facebook.github.io/react-native/docs/touchablehighlight)
  - [Touchable Opacity](https://facebook.github.io/react-native/docs/touchableopacity)
  - [Touchable Without Feedback](https://facebook.github.io/react-native/docs/touchablewithoutfeedback)
- 
- All major touchable properties (except from `pressRetentionOffset`) have been adopted and should behave in a similar way as with RN's touchables. 
- 
- The motivation for using RNGH touchables as a replacement for these imported from React Native is to follow built-in native behavior more closely by utilizing platform native touch system instead of relying on the JS responder system.
- These touchables and their feedback behavior are deeply integrated with native
- gesture ecosystem and could be connected with other native components (e.g. `ScrollView`) and Gesture Handlers easily and in a more predictable way, which 
- follows native apps' behavior.
- 
- Our intention was to make switch for these touchables as simple as possible. In order to use RNGH's touchables the only thing you need to do is to change library from which you import touchable components.
- need only to change imports of touchables.
- 
- ### Example:
- 
- ```javascript
+
+All major touchable properties (except from `pressRetentionOffset`) have been adopted and should behave in a similar way as with RN's touchables.
+
+The motivation for using RNGH touchables as a replacement for these imported from React Native is to follow built-in native behavior more closely by utilizing platform native touch system instead of relying on the JS responder system.
+
+These touchables and their feedback behavior are deeply integrated with native gesture ecosystem and could be connected with other native components (e.g. `ScrollView`) and Gesture Handlers easily and in a more predictable way, which follows native apps' behavior.
+
+Our intention was to make switch for these touchables as simple as possible. In order to use RNGH's touchables the only thing you need to do is to change library from which you import touchable components.
+You need only to change imports of touchables.
+
+### Example:
+
+```javascript
 import {
   TouchableNativeFeedback,
   TouchableHighlight,
@@ -34,7 +34,7 @@ import {
 
 has to be replaced with:
 
- ```javascript
+```javascript
 import {
   TouchableNativeFeedback,
   TouchableHighlight,

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -12,4 +12,3 @@ The easiest way to get started with contributing code is by:
  - Updating the [documentation](https://github.com/software-mansion/react-native-gesture-handler/blob/master/docs) whenever you see some information is unclear, missing or out of date.
 
 Code is only one way how you can contribute. You may want to consider [replying on issues](https://github.com/software-mansion/react-native-gesture-handler/issues) if you know how to help.
-

--- a/docs/example.md
+++ b/docs/example.md
@@ -61,4 +61,3 @@ react-native run-ios
 ```
 
 You will need to have an Android or iOS device or emulator connected and `react-native-cli` package installed globally.
-

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -30,24 +30,22 @@ Since the library uses native support for handling gestures, it requires an exte
 
 #### Requirements
 
-| version | `react-native` version |
-| ------- | ---------------------- |
-| 1.4.0+  | 0.60.0+                |
-| 1.1.0+  | 0.57.2+                |
-| <1.1.0  | 0.50.0+                |
+| version    | `react-native` version |
+| -------    | ---------------------- |
+| 1.4.0+     | 0.60.0+                |
+| 1.1.0+     | 0.57.2+                |
+| &lt;1.1.0  | 0.50.0+                |
 
 Note that if you wish to use [`React.createRef()`](https://reactjs.org/docs/refs-and-the-dom.html) support for [interactions](interactions.md) you need to use v16.3 of [React](https://reactjs.org/)
 
 #### JS
 
 First, install the library using `yarn`:
-
 ```bash
 yarn add react-native-gesture-handler
 ```
 
 or with `npm` if you prefer:
-
 ```bash
 npm install --save react-native-gesture-handler
 ```
@@ -109,14 +107,13 @@ Make sure to [update the React Native CLI to the latest version](https://github.
 
 There is no additional configuration required on iOS except what follows in the next steps.
 
-If you're in a CocoaPods project (the default setup since React Native 0.60), make sure to install pods before you run your app:
-
+If you're in a CocoaPods project (the default setup since React Native 0.60),
+make sure to install pods before you run your app:
 ```sh
 cd ios && pod install
 ```
 
 For React Native 0.61 or greater, add the library as the first import in your index.js file:
-
 ```
 import 'react-native-gesture-handler';
 ```
@@ -161,7 +158,7 @@ Remember that you need to wrap each screen that you use in your app with `gestur
 On Android RNGH does not work by default because modals are not located under React Native Root view in native hierarchy.
 In order to make it workable, components need to be wrapped with `gestureHandlerRootHOC` (it's no-op on iOS and web).
 
-E.g. 
+E.g.
 ```js
 const ExampleWithHoc = gestureHandlerRootHOC(
   function GestureExample() {
@@ -180,7 +177,7 @@ export default function Example() {
     </Modal>
   );
 }
-``` 
+```
 
 ### For library authors
 
@@ -205,13 +202,11 @@ Note that `GestureHandlerRootView` acts like a normal `View`. So if you want it 
 ### Testing
 
 In order to load mocks provided by the library add following to your jest config in `package.json`:
-
 ```json
 "setupFiles": ["./node_modules/react-native-gesture-handler/jestSetup.js"]
 ```
 
 Example:
-
 ```json
 "jest": {
   "preset": "react-native",

--- a/docs/handler-common.md
+++ b/docs/handler-common.md
@@ -89,6 +89,3 @@ Current [state](state.md) of the handler. Expressed as one of the constants expo
 ### `numberOfPointers`
 
 Represents the number of pointers (fingers) currently placed on the screen.
-
-
-

--- a/docs/handler-force.md
+++ b/docs/handler-force.md
@@ -29,14 +29,12 @@ A maximal pressure that could be applied for handler. If the pressure is greater
 ### `feedbackOnActivation`
 Boolean value defining if haptic feedback has to be performed on activation.
 
-
 ## Event data
 See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to `ForceTouchGestureHandler`:
 
 ---
 ### `force`
 The pressure of a touch.
-
 
 ## Static method
 

--- a/docs/handler-pan.md
+++ b/docs/handler-pan.md
@@ -62,7 +62,7 @@ When the given number of fingers is placed on the screen and handler hasn't yet 
 Range along X axis (in points) where fingers travels without activation of handler. Moving outside of this range implies activation of handler. Range can be given as an array or a single number.
  If range is set as an array, first value must be lower or equal to 0, a the second one higher or equal to 0.
  If only one number `p` is given a range of `(-inf, p)` will be used if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
- 
+
 ---
 ### `activeOffsetY`
 
@@ -88,7 +88,7 @@ When the finger moves outside this range (in points) along X axis and handler ha
 ### `maxDeltaX`
 
 > This method is deprecated but supported for backward compatibility. Instead of using `maxDeltaX={N}` you can do `failOffsetX={[-N, N]}`.
-    
+
 When the finger travels the given distance expressed in points along X axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
 
 ---
@@ -202,5 +202,4 @@ class Circle extends Component {
     );
   }
 }
-
 ```

--- a/docs/handler-pinch.md
+++ b/docs/handler-pinch.md
@@ -5,21 +5,22 @@ sidebar_label: PinchGestureHandler
 ---
 
 A continuous gesture handler that recognizes pinch gesture. It allows for tracking the distance between two fingers and use that information to scale or zoom your content.
-The handler [activates](state.md#active) when fingers are placed on the screen and change their position. 
+The handler [activates](state.md#active) when fingers are placed on the screen and change their position.
 Gesture callback can be used for continuous tracking of the pinch gesture. It provides information about velocity, anchor (focal) point of gesture and scale.
- 
-The distance between the fingers is reported as a scale factor. At the beginning of the gesture, 
-the scale factor is 1.0. As the distance between the two fingers increases, the scale factor increases proportionally. 
-Similarly, the scale factor decreases as the distance between the fingers decreases. 
-Pinch gestures are used most commonly to change the size of objects or content onscreen. 
+
+The distance between the fingers is reported as a scale factor. At the beginning of the gesture, the scale factor is 1.0. As the distance between the two fingers increases, the scale factor increases proportionally.
+Similarly, the scale factor decreases as the distance between the fingers decreases.
+Pinch gestures are used most commonly to change the size of objects or content onscreen.
 For example, map views use pinch gestures to change the zoom level of the map.
 
 The handler is implemented using [UIPinchGestureRecognizer](https://developer.apple.com/documentation/uikit/uipinchgesturerecognizer) on iOS and from scratch on Android.
 
 ## Properties
-Properties provided to `PinchGestureHandler`  do not extend [common set of properties from base handler class](handler-common.md#properties).
+
+Properties provided to `PinchGestureHandler` do not extend [common set of properties from base handler class](handler-common.md#properties).
 
 ## Event data
+
 See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to `PinchGestureHandler`:
 
 ---
@@ -32,11 +33,11 @@ Velocity of the pan gesture the current moment. The value is expressed in point 
 
 ---
 ### `focalX`
-Position expressed in points along X axis of center anchor point of gesture 
+Position expressed in points along X axis of center anchor point of gesture
 
 ---
 ### `focalY`
-Position expressed in points along Y axis of center anchor point of gesture  
+Position expressed in points along Y axis of center anchor point of gesture
 
 ## Example
 

--- a/docs/handler-rotation.md
+++ b/docs/handler-rotation.md
@@ -6,16 +6,17 @@ sidebar_label: RotationGestureHandler
 
 A continuous gesture handler that recognizes rotation gesture and allows for tracking its movement.
 
-The handler [activates](state.md#active) when fingers are placed on the screen and change their position in a proper way. 
+The handler [activates](state.md#active) when fingers are placed on the screen and change their position in a proper way.
 Gesture callback can be used for continuous tracking of the rotation gesture. It provides information about the rotation, anchor (focal) point of gesture and progress of rotating.
-
 
 The handler is implemented using [UIRotationGestureRecognizer](https://developer.apple.com/documentation/uikit/uirotationgesturerecognizer) on iOS and from scratch on Android.
 
 ## Properties
-Properties provided to `RotationGestureHandler`  do not extend [common set of properties from base handler class](handler-common.md#properties).
+
+Properties provided to `RotationGestureHandler` do not extend [common set of properties from base handler class](handler-common.md#properties).
 
 ## Event data
+
 See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to `RotationGestureHandler`:
 
 ---
@@ -28,11 +29,11 @@ Velocity of the pan gesture the current moment. The value is expressed in point 
 
 ---
 ### `focalX`
-Position expressed in points along X axis of center anchor point of gesture 
+Position expressed in points along X axis of center anchor point of gesture
 
 ---
 ### `focalY`
-Position expressed in points along Y axis of center anchor point of gesture  
+Position expressed in points along Y axis of center anchor point of gesture
 
 ## Example
 
@@ -76,5 +77,4 @@ class RotableBox extends React.Component {
     );
   }
 }
-
 ```

--- a/docs/handler-tap.md
+++ b/docs/handler-tap.md
@@ -4,11 +4,10 @@ title: TapGestureHandler
 sidebar_label: TapGestureHandler
 ---
 
-A discrete gesture handler that recognizes tap (or many taps).  
+A discrete gesture handler that recognizes tap (or many taps).
 
-Tap gestures detect one or more fingers touching the screen briefly. 
-The fingers involved in these gestures must not move significantly from the initial touch points, 
-and you can configure the number of times the fingers must touch the screen and allowable distance. 
+Tap gestures detect one or more fingers touching the screen briefly.
+The fingers involved in these gestures must not move significantly from the initial touch points, and you can configure the number of times the fingers must touch the screen and allowable distance.
 For example, you might configure tap gesture recognizers to detect single taps, double taps, or triple taps.
 
 For the handler to be [activated](state.md#active) the specified number of fingers must tap the view a specified number of times in proper time and with short enough delay. When handler gets activated it will turn into [END](state.md#end) state immediately.
@@ -28,11 +27,11 @@ Time expressed in milliseconds which defines how fast finger has to be released 
 
 ---
 ### `maxDelayMs`
-Time expressed in milliseconds which could pass before next tap if many taps are required 
+Time expressed in milliseconds which could pass before next tap if many taps are required
 
 ---
 ### `numberOfTaps`
-A number of tap event required to  [activate](state.md#active) handler
+A number of tap event required to [activate](state.md#active) handler
 
 ---
 ### `maxDeltaX`
@@ -49,9 +48,8 @@ When the finger travels the given distance expressed in points along Y axis and 
 
 When the finger travels the given distance expressed in points and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
 
-
-
 ## Event data
+
 See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to `TapGestureHandler`:
 
 ---

--- a/docs/resources.md
+++ b/docs/resources.md
@@ -11,7 +11,7 @@ title: Learning Resources
 
 ## Talks and workshops
 
-[Declarative future of gestures and animations in React Native](https://www.youtube.com/watch?v=kdq4z2708VM) by by [Krzysztof Magiera](https://twitter.com/kzzzf) - talk that explains motivation behind creating gesture handler library. It also presents [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) and how and when it can be used with gesture handler.
+[Declarative future of gestures and animations in React Native](https://www.youtube.com/watch?v=kdq4z2708VM) by [Krzysztof Magiera](https://twitter.com/kzzzf) - talk that explains motivation behind creating gesture handler library. It also presents [react-native-reanimated](https://github.com/software-mansion/react-native-reanimated) and how and when it can be used with gesture handler.
 
 [React Native workshop with Expo team @ReactEurope 2018](https://youtu.be/JSIoE_ReeDk?t=41m49s) by [Brent Vetne](https://twitter.com/notbrent) – great workshop explaining gesture handler in details and presenting a few exercises that will help get you started.
 


### PR DESCRIPTION
I found a typo in the [doc](https://software-mansion.github.io/react-native-gesture-handler/docs/about-handlers.html#using-native-components), it caused the docs site generates an invalid link.

I fixed that and also take a look in docs, and modify some indents and newlines for keeping the doc looks consistently (๑ơ ω ơ)

#### docs/about-handlers.md
```diff
  ...
  Gesture handler library exposes a set of components normally available in React Native that 
- are wrapped in [`NativeViewGestureHandler`](handler-native.md).
+ are wrapped in [`NativeViewGestureHandler`](handlers.md).
```