### PR TITLE
Fix interactions with NativeViewGestureHandler 

### DIFF
--- a/createNativeWrapper.js
+++ b/createNativeWrapper.js
@@ -1,5 +1,4 @@
 import React, { useImperativeHandle, useRef } from 'react';
-import { findNodeHandle } from 'react-native';
 
 import NativeViewGestureHandler from './NativeViewGestureHandler';
 

--- a/createNativeWrapper.js
+++ b/createNativeWrapper.js
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useImperativeHandle, useRef } from 'react';
+import { findNodeHandle } from 'react-native';
 
 import NativeViewGestureHandler from './NativeViewGestureHandler';
 
@@ -42,9 +43,20 @@ export default function createNativeWrapper(Component, config = {}) {
       },
       { ...config } // watch out not to modify config
     );
+    const _ref = useRef();
+    const _gestureHandlerRef = useRef();
+    useImperativeHandle(ref, () => {
+      const node = _gestureHandlerRef.current;
+      // add handlerTag for relations config
+      if (_ref.current && node) {
+        _ref.current._handlerTag = node._handlerTag;
+        return _ref.current;
+      }
+      return null;
+    }, [_ref, _gestureHandlerRef]);
     return (
-      <NativeViewGestureHandler {...gestureHandlerProps}>
-        <Component {...props} ref={ref} />
+      <NativeViewGestureHandler {...gestureHandlerProps} ref={_gestureHandlerRef}>
+        <Component {...props} ref={_ref} />
       </NativeViewGestureHandler>
     );
   });


### PR DESCRIPTION
### Context
[`transformIntoHandlerTags`](https://github.com/software-mansion/react-native-gesture-handler/blob/master/createHandler.js#L91) creates an array of valid refs based on the value of the property `_handlerTag` of each ref passed to `waitFor` or `simultaneousHandlers` prop. The filtered array is then sent to native for configuration.
### `NativeViewGestureHandler` 
In the case of `NativeViewGestureHandler` the `_handlerTag` is set on the `NativeViewGestureHandler` ref properly.
**HOWEVER**, this value isn't passed to the ref of it's child. The child's ref is the one being passed back as the ref handler of the component. This makes sense.
**However**, in order to configure interactions on a different handler one would need to pass the `NativeViewGestureHandler` ref as part of `waitFor` or `simultaneousHandlers` prop. 
This is **IMPOSSIBLE** because the `NativeViewGestureHandler` ref isn't exposed.
The child's ref is passed instead and is filtered out by `transformIntoHandlerTags` due to the lack of `_handlerTag` property, making it completely useless.
### The End
This PR fixes the mentioned problem by setting the `_handlerTag` property on the `NativeViewGestureHandler` **child's ref** so when it is passed to `waitFor` or `simultaneousHandlers` it is treated as if it were a genuine gesture handler.