### PR TITLE
fix(web): enable text selection in GestureHandler

### DIFF
--- a/web/GestureHandler.js
+++ b/web/GestureHandler.js
@@ -216,7 +216,11 @@ class GestureHandler {
     this.ref = ref;
 
     this.view = findNodeHandle(ref);
-    this.hammer = new Hammer.Manager(this.view);
+    this.hammer = new Hammer.Manager(this.view, {
+      cssProps: {
+        userSelect: 'auto',
+      },
+    });
 
     this.oldState = State.UNDETERMINED;
     this.previousState = State.UNDETERMINED;


### PR DESCRIPTION
Currently, you cannot select any text in the browser when it's wrapped with a `GestureHandler`. In the worst case you cannot select anything because the `GestureHandler` wraps the whole page (e.g. the Drawer navigation from `react-navigation`). This PR enables text selection within all `GestureHandlers`.