### PR TITLE
New prop 'waitForGroup'

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -13,6 +13,7 @@ import { createStackNavigator } from 'react-navigation-stack';
 import { RectButton, ScrollView } from 'react-native-gesture-handler';
 
 import SwipeableTable from './swipeable';
+import SwipeableWaitForGroup from './swipeableAndWaitForGroup';
 import Rows from './rows';
 import Multitap from './multitap';
 import Draggable from './draggable';
@@ -55,6 +56,10 @@ const SCREENS = {
   SwipeableTable: {
     screen: SwipeableTable,
     title: 'Gesture handler based SwipeableRow',
+  },
+  SwipeableWaitForGroup: {
+    screen: SwipeableWaitForGroup,
+    title: 'Only one active Swipeable at a time',
   },
   PanAndScroll: {
     screen: PanAndScroll,

--- a/Example/swipeable/AppleStyleSwipeableRow.js
+++ b/Example/swipeable/AppleStyleSwipeableRow.js
@@ -45,7 +45,11 @@ export default class AppleStyleSwipeableRow extends Component {
     );
   };
   renderRightActions = progress => (
-    <View style={{ width: 192, flexDirection: I18nManager.isRTL? 'row-reverse' : 'row' }}>
+    <View
+      style={{
+        width: 192,
+        flexDirection: I18nManager.isRTL ? 'row-reverse' : 'row',
+      }}>
       {this.renderRightAction('More', '#C8C7CD', 192, progress)}
       {this.renderRightAction('Flag', '#ffab00', 128, progress)}
       {this.renderRightAction('More', '#dd2c00', 64, progress)}
@@ -58,7 +62,7 @@ export default class AppleStyleSwipeableRow extends Component {
     this._swipeableRow.close();
   };
   render() {
-    const { children } = this.props;
+    const { children, waitForGroup } = this.props;
     return (
       <Swipeable
         ref={this.updateRef}
@@ -66,7 +70,8 @@ export default class AppleStyleSwipeableRow extends Component {
         leftThreshold={30}
         rightThreshold={40}
         renderLeftActions={this.renderLeftActions}
-        renderRightActions={this.renderRightActions}>
+        renderRightActions={this.renderRightActions}
+        waitForGroup={waitForGroup}>
         {children}
       </Swipeable>
     );

--- a/Example/swipeable/GmailStyleSwipeableRow.js
+++ b/Example/swipeable/GmailStyleSwipeableRow.js
@@ -50,7 +50,8 @@ export default class GmailStyleSwipeableRow extends Component {
     this._swipeableRow.close();
   };
   render() {
-    const { children } = this.props;
+    const { children, waitForGroup } = this.props;
+
     return (
       <Swipeable
         ref={this.updateRef}
@@ -58,7 +59,8 @@ export default class GmailStyleSwipeableRow extends Component {
         leftThreshold={80}
         rightThreshold={40}
         renderLeftActions={this.renderLeftActions}
-        renderRightActions={this.renderRightActions}>
+        renderRightActions={this.renderRightActions}
+        waitForGroup={waitForGroup}>
         {children}
       </Swipeable>
     );
@@ -71,18 +73,17 @@ const styles = StyleSheet.create({
     backgroundColor: '#388e3c',
     justifyContent: 'flex-end',
     alignItems: 'center',
-    flexDirection: I18nManager.isRTL ? 'row' : 'row-reverse'
+    flexDirection: I18nManager.isRTL ? 'row' : 'row-reverse',
   },
   actionIcon: {
     width: 30,
-    marginHorizontal: 10
+    marginHorizontal: 10,
   },
   rightAction: {
     alignItems: 'center',
     flexDirection: I18nManager.isRTL ? 'row-reverse' : 'row',
     backgroundColor: '#dd2c00',
     flex: 1,
-    justifyContent: 'flex-end'
-  }
+    justifyContent: 'flex-end',
+  },
 });
-

--- a/Example/swipeableAndWaitForGroup/index.js
+++ b/Example/swipeableAndWaitForGroup/index.js
@@ -1,0 +1,138 @@
+import React, { Component } from 'react';
+import { StyleSheet, Text, View, I18nManager } from 'react-native';
+
+import {
+  FlatList,
+  RectButton,
+  WaitForGroup,
+  useWaitForGroup,
+} from 'react-native-gesture-handler';
+
+//  To toggle LTR/RTL uncomment the next line
+// I18nManager.allowRTL(true);
+
+import AppleStyleSwipeableRow from '../swipeable/AppleStyleSwipeableRow';
+import GmailStyleSwipeableRow from '../swipeable/GmailStyleSwipeableRow';
+
+const Row = ({ item }) => (
+  <View style={styles.rectButton}>
+    <Text style={styles.fromText}>{item.from}</Text>
+    <Text numberOfLines={2} style={styles.messageText}>
+      {item.message}
+    </Text>
+    <Text style={styles.dateText}>
+      {item.when} {'❭'}
+    </Text>
+  </View>
+);
+
+const SwipeableRow = ({ item, index, waitForGroup }) => {
+  const StyledRow =
+    index % 2 === 0 ? AppleStyleSwipeableRow : GmailStyleSwipeableRow;
+
+  return (
+    <StyledRow waitForGroup={waitForGroup}>
+      <Row item={item} />
+    </StyledRow>
+  );
+};
+
+const Example = () => {
+  const waitForGroup = useWaitForGroup();
+
+  return (
+    <FlatList
+      data={DATA}
+      ItemSeparatorComponent={() => <View style={styles.separator} />}
+      renderItem={({ item, index }) => (
+        <SwipeableRow item={item} index={index} waitForGroup={waitForGroup} />
+      )}
+      keyExtractor={(item, index) => `message ${index}`}
+    />
+  );
+};
+
+export default Example;
+
+const styles = StyleSheet.create({
+  rectButton: {
+    flex: 1,
+    height: 80,
+    paddingVertical: 10,
+    paddingHorizontal: 20,
+    justifyContent: 'space-between',
+    flexDirection: 'column',
+    backgroundColor: 'white',
+  },
+  separator: {
+    backgroundColor: 'rgb(200, 199, 204)',
+    height: StyleSheet.hairlineWidth,
+  },
+  fromText: {
+    fontWeight: 'bold',
+    backgroundColor: 'transparent',
+  },
+  messageText: {
+    color: '#999',
+    backgroundColor: 'transparent',
+  },
+  dateText: {
+    backgroundColor: 'transparent',
+    position: 'absolute',
+    right: 20,
+    top: 10,
+    color: '#999',
+    fontWeight: 'bold',
+  },
+});
+
+const DATA = [
+  {
+    from: "D'Artagnan",
+    when: '3:11 PM',
+    message:
+      'Unus pro omnibus, omnes pro uno. Nunc scelerisque, massa non lacinia porta, quam odio dapibus enim, nec tincidunt dolor leo non neque',
+  },
+  {
+    from: 'Aramis',
+    when: '11:46 AM',
+    message:
+      'Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia Curae; Vivamus hendrerit ligula dignissim maximus aliquet. Integer tincidunt, tortor at finibus molestie, ex tellus laoreet libero, lobortis consectetur nisl diam viverra justo.',
+  },
+  {
+    from: 'Athos',
+    when: '6:06 AM',
+    message:
+      'Sed non arcu ullamcorper, eleifend velit eu, tristique metus. Duis id sapien eu orci varius malesuada et ac ipsum. Ut a magna vel urna tristique sagittis et dapibus augue. Vivamus non mauris a turpis auctor sagittis vitae vel ex. Curabitur accumsan quis mauris quis venenatis.',
+  },
+  {
+    from: 'Porthos',
+    when: 'Yesterday',
+    message:
+      'Vivamus id condimentum lorem. Duis semper euismod luctus. Morbi maximus urna ut mi tempus fermentum. Nam eget dui sed ligula rutrum venenatis.',
+  },
+  {
+    from: 'Domestos',
+    when: '2 days ago',
+    message:
+      'Aliquam imperdiet dolor eget aliquet feugiat. Fusce tincidunt mi diam. Pellentesque cursus semper sem. Aliquam ut ullamcorper massa, sed tincidunt eros.',
+  },
+  {
+    from: 'Cardinal Richelieu',
+    when: '2 days ago',
+    message:
+      'Pellentesque id quam ac tortor pellentesque tempor tristique ut nunc. Pellentesque posuere ut massa eget imperdiet. Ut at nisi magna. Ut volutpat tellus ut est viverra, eu egestas ex tincidunt. Cras tellus tellus, fringilla eget massa in, ultricies maximus eros.',
+  },
+  {
+    from: "D'Artagnan",
+    when: 'Week ago',
+    message:
+      'Aliquam non aliquet mi. Proin feugiat nisl maximus arcu imperdiet euismod nec at purus. Vestibulum sed dui eget mauris consequat dignissim.',
+  },
+  {
+    from: 'Cardinal Richelieu',
+    when: '2 weeks ago',
+    message:
+      'Vestibulum ac nisi non augue viverra ullamcorper quis vitae mi. Donec vitae risus aliquam, posuere urna fermentum, fermentum risus. ',
+  },
+];

--- a/GestureHandlerPropTypes.js
+++ b/GestureHandlerPropTypes.js
@@ -12,7 +12,7 @@ const GestureHandlerPropTypes = {
       PropTypes.oneOfType([PropTypes.string, PropTypes.object])
     ),
   ]),
-  waitForGroup: PropTypes.string,
+  waitForGroup: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
   simultaneousHandlers: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,

--- a/GestureHandlerPropTypes.js
+++ b/GestureHandlerPropTypes.js
@@ -12,6 +12,7 @@ const GestureHandlerPropTypes = {
       PropTypes.oneOfType([PropTypes.string, PropTypes.object])
     ),
   ]),
+  waitForGroup: PropTypes.string,
   simultaneousHandlers: PropTypes.oneOfType([
     PropTypes.string,
     PropTypes.object,

--- a/WaitForGroup.js
+++ b/WaitForGroup.js
@@ -1,0 +1,22 @@
+import React, { useEffect } from 'react';
+
+let groupTag = 1;
+
+export class WaitForGroup extends React.Component {
+  constructor(props) {
+    super(props);
+    this._groupTag = `${groupTag++}`;
+  }
+
+  render() {
+    return false;
+  }
+}
+
+export function useWaitForGroup() {
+  useEffect(() => {
+    groupTag++;
+  });
+
+  return `${groupTag}`;
+}

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.java
@@ -62,6 +62,7 @@ public class GestureHandler<T extends GestureHandler> {
 
   private boolean mShouldCancelWhenOutside;
   private int mNumberOfPointers = 0;
+  private String mWaitForGroup;
 
   private GestureHandlerOrchestrator mOrchestrator;
   private OnTouchEventListener<T> mListener;
@@ -146,6 +147,14 @@ public class GestureHandler<T extends GestureHandler> {
   public T setInteractionController(GestureHandlerInteractionController controller) {
     mInteractionController = controller;
     return (T) this;
+  }
+
+  public void setWaitForGroup(String waitForGroup) {
+    mWaitForGroup = waitForGroup;
+  }
+
+  public String getWaitForGroup() {
+    return mWaitForGroup;
   }
 
   public void setTag(int tag) {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
@@ -509,7 +509,10 @@ public class GestureHandlerOrchestrator {
 
   private static boolean shouldHandlerWaitForOther(GestureHandler handler, GestureHandler other) {
     return handler != other && (handler.shouldWaitForHandlerFailure(other)
-            || other.shouldRequireToWaitForFailure(handler));
+            || other.shouldRequireToWaitForFailure(handler)
+            || (handler.getWaitForGroup() != null
+                && !other.mIsAwaiting
+                && handler.getWaitForGroup().equals(other.getWaitForGroup())));
   }
 
   private static boolean canRunSimultaneously(GestureHandler a, GestureHandler b) {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.java
@@ -82,6 +82,7 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
   private static final String KEY_PAN_AVG_TOUCHES = "avgTouches";
   private static final String KEY_NUMBER_OF_POINTERS = "numberOfPointers";
   private static final String KEY_DIRECTION= "direction";
+  private static final String KEY_WAIT_FOR_GROUP = "waitForGroup";
 
   private abstract static class HandlerFactory<T extends GestureHandler>
           implements RNGestureHandlerEventDataExtractor<T> {
@@ -101,6 +102,9 @@ public class RNGestureHandlerModule extends ReactContextBaseJavaModule {
       }
       if (config.hasKey(KEY_HIT_SLOP)) {
         handleHitSlopProperty(handler, config);
+      }
+      if (config.hasKey(KEY_WAIT_FOR_GROUP)) {
+        handler.setWaitForGroup(config.getString(KEY_WAIT_FOR_GROUP));
       }
     }
 

--- a/createHandler.js
+++ b/createHandler.js
@@ -77,6 +77,9 @@ function filterConfig(props, validProps, defaults = {}) {
       let value = props[key];
       if (key === 'simultaneousHandlers' || key === 'waitFor') {
         value = transformIntoHandlerTags(props[key]);
+      } else if (key === 'waitForGroup') {
+        const group = props[key];
+        value = typeof group === 'string' ? group : group?.current?._groupTag;
       } else if (key === 'hitSlop') {
         if (typeof value !== 'object') {
           value = { top: value, left: value, bottom: value, right: value };
@@ -114,7 +117,11 @@ function hasUnresolvedRefs(props) {
     }
     return refs.some(r => r && r.current === null);
   };
-  return extract(props['simultaneousHandlers']) || extract(props['waitFor']);
+  return (
+    extract(props['simultaneousHandlers']) ||
+    extract(props['waitFor']) ||
+    extract(props['waitForGroup'])
+  );
 }
 
 const stateToPropMappings = {

--- a/createNativeWrapper.js
+++ b/createNativeWrapper.js
@@ -14,6 +14,7 @@ const NATIVE_WRAPPER_PROPS_FILTER = [
   'minPointers',
   'enabled',
   'waitFor',
+  'waitForGroup',
   'simultaneousHandlers',
   'shouldCancelWhenOutside',
   'hitSlop',

--- a/docs/handler-common.md
+++ b/docs/handler-common.md
@@ -46,7 +46,7 @@ Accepts a react ref object or an array of refs to other handler components (refs
 ---
 ### `waitForGroup`
 
-Accepts a string or a react ref to `WaitForGroup` element. Handlers that have `waitForGroup` prop set to the same object can't be active simultaneously. This prop is intended to simplify prevention of simultaneous activation for handlers located inside `FlatList` item views. Value for this prop can also be obtained from `useWaitForGroup` hook - [usage example](../Example/swipeableAndWaitForGroup/index.js).
+Accepts a string or a react ref to `WaitForGroup` element. Handlers that have `waitForGroup` prop set to the same object can't be active simultaneously. This prop is intended to simplify prevention of simultaneous activation for handlers located inside `FlatList` item views. Value for this prop can also be obtained from `useWaitForGroup` hook - [usage example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/swipeableAndWaitForGroup/index.js).
 
 ---
 ### `hitSlop`

--- a/docs/handler-common.md
+++ b/docs/handler-common.md
@@ -44,6 +44,11 @@ Accepts a react ref object or an array of refs to other handler components (refs
 Accepts a react ref object or an array of refs to other handler components (refs should be created using [`React.createRef()`](https://reactjs.org/docs/refs-and-the-dom.html)). When set the handler will not [activate](state.md#active) as long as the handlers provided by their refs are in [began](state.md#began) state. Read more in the [cross handler interaction](interactions.md#awaiting-other-handlers) section.
 
 ---
+### `waitForGroup`
+
+Accepts a string. Handlers that have `waitForGroup` prop set to the same string can't be active simultaneously. This prop is intended to simplify prevention of simultaneous activation for handlers located inside `FlatList` item views.
+
+---
 ### `hitSlop`
 
 This parameter enables control over what part of the connected view area can be used to [begin](state.md#began) recognizing the gesture.

--- a/docs/handler-common.md
+++ b/docs/handler-common.md
@@ -16,7 +16,6 @@ They do not map directly to physical pixels but instead to [iOS's points](https:
 
 This section describes properties that can be used with all gesture handler components:
 
----
 ### `enabled`
 
 Takes a boolean value.
@@ -25,7 +24,6 @@ When set to `false` we can be sure that the handler will never [activate](state.
 If the value gets updated while the handler already started recognizing gesture it will immediately [fail](state.md#failed) or [cancel](state.md#cancelled) recognizing depending on its current state.
 Default value is `true`.
 
----
 ### `shouldCancelWhenOutside`
 
 Takes a boolean value.
@@ -33,22 +31,18 @@ When `true` the handler will [cancel](state.md#cancelled) or [fail](state.md#fai
 Default value of this property is different depending on the handler type.
 Most of the handlers defaults to `false` but in case of the [`LongPressGestureHandler`](handler-longpress.md) and [`TapGestureHandler`](handler-tap.md) it defaults to `true`.
 
----
 ### `simultaneousHandlers`
 
 Accepts a react ref object or an array of refs to other handler components (refs should be created using [`React.createRef()`](https://reactjs.org/docs/refs-and-the-dom.html)). When set the handler will be allowed to [activate](state.md#active) even if one or more of the handlers provided by their refs are [active](state.md#active). It will also prevent the provided handlers from [cancelling](state.md#cancelled) current handler when they [activate](state.md#active). Read more in the [cross handler interaction](interactions.md#simultaneous-recognition) section.
 
----
 ### `waitFor`
 
 Accepts a react ref object or an array of refs to other handler components (refs should be created using [`React.createRef()`](https://reactjs.org/docs/refs-and-the-dom.html)). When set the handler will not [activate](state.md#active) as long as the handlers provided by their refs are in [began](state.md#began) state. Read more in the [cross handler interaction](interactions.md#awaiting-other-handlers) section.
 
----
 ### `waitForGroup`
 
 Accepts a string or a react ref to `WaitForGroup` element. Handlers that have `waitForGroup` prop set to the same object can't be active simultaneously. This prop is intended to simplify prevention of simultaneous activation for handlers located inside `FlatList` item views. Value for this prop can also be obtained from `useWaitForGroup` hook - [usage example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/swipeableAndWaitForGroup/index.js).
 
----
 ### `hitSlop`
 
 This parameter enables control over what part of the connected view area can be used to [begin](state.md#began) recognizing the gesture.
@@ -61,16 +55,14 @@ When `width` is set it is only allow to specify one of the sides `right` or `lef
 Similarly when `height` is provided only `top` or `bottom` can be set.
 Specifying `width` or `height` is useful if we only want the gesture to activate on the edge of the view. In which case for example we can set `left: 0` and `width: 20` which would make it possible for the gesture to be recognize when started no more than 20 points from the left edge.
 
-__IMPORTANT:__ Note that this parameter is primarily designed to reduce the area where gesture can activate. Hence it is only supported for all the values (except `width` and `height`) to be non positive (0 or lower). Although on Android it is supported for the values to also be positive and therefore allow to expand beyond view bounds but not further than the parent view bounds. To achieve this effect on both platforms you can use React Native's View [hitSlop](https://facebook.github.io/react-native/docs/view.html#props) property.
+**IMPORTANT:** Note that this parameter is primarily designed to reduce the area where gesture can activate. Hence it is only supported for all the values (except `width` and `height`) to be non positive (0 or lower). Although on Android it is supported for the values to also be positive and therefore allow to expand beyond view bounds but not further than the parent view bounds. To achieve this effect on both platforms you can use React Native's View [hitSlop](https://facebook.github.io/react-native/docs/view.html#props) property.
 
----
 ### `onGestureEvent`
 
 Takes a callback that is going to be triggered for each subsequent touch event while the handler is in an [ACTIVE](state.md#active) state. Event payload depends on the particular handler type. Common set of event data attributes is documented [below](#event-data) and handler specific attributes are documented on the corresponding handler pages. E.g. event payload for [`PinchGestureHandler`](handler-rotation.md#event-data) contains `scale` attribute that represents how the distance between fingers changed since when the gesture started.
 
-Instead of a callback [`Animated.event`](https://facebook.github.io/react-native/docs/animated.html#event) object can be used. Also Animated events with `useNativeDriver` flag enabled __are fully supported__.
+Instead of a callback [`Animated.event`](https://facebook.github.io/react-native/docs/animated.html#event) object can be used. Also Animated events with `useNativeDriver` flag enabled **are fully supported**.
 
----
 ### `onHandlerStateChange`
 
 Takes a callback that is going to be triggered when [state](state.md) of the given handler changes.
@@ -79,21 +71,16 @@ The event payload contains the same payload as in case of [`onGestureEvent`](#on
 
 In addition `onHandlerStateChange` event payload contains `oldState` attribute which represents the [state](state.md) of the handler right before the change.
 
-Instead of a callback [`Animated.event`](https://facebook.github.io/react-native/docs/animated.html#event) object can be used. Also Animated events with `useNativeDriver` flag enabled __are fully supported__.
+Instead of a callback [`Animated.event`](https://facebook.github.io/react-native/docs/animated.html#event) object can be used. Also Animated events with `useNativeDriver` flag enabled **are fully supported**.
 
 ## Event data
 
 This section describes the attributes of event object being provided to [`onGestureEvent`](#ongestureevent) and [`onHandlerStateChange`](#onhandlerstatechange) callbacks:
 
----
 ### `state`
 
 Current [state](state.md) of the handler. Expressed as one of the constants exported under `State` object by the library. Refer to the section about [handler state](state.md) to learn more about how to use it.
 
----
 ### `numberOfPointers`
 
 Represents the number of pointers (fingers) currently placed on the screen.
-
-
-

--- a/docs/handler-common.md
+++ b/docs/handler-common.md
@@ -46,7 +46,7 @@ Accepts a react ref object or an array of refs to other handler components (refs
 ---
 ### `waitForGroup`
 
-Accepts a string. Handlers that have `waitForGroup` prop set to the same string can't be active simultaneously. This prop is intended to simplify prevention of simultaneous activation for handlers located inside `FlatList` item views.
+Accepts a string or a react ref to `WaitForGroup` element. Handlers that have `waitForGroup` prop set to the same object can't be active simultaneously. This prop is intended to simplify prevention of simultaneous activation for handlers located inside `FlatList` item views. Value for this prop can also be obtained from `useWaitForGroup` hook - [usage example](../Example/swipeableAndWaitForGroup/index.js).
 
 ---
 ### `hitSlop`

--- a/index.js
+++ b/index.js
@@ -2,3 +2,4 @@ export { default as Swipeable } from './Swipeable';
 export { default as DrawerLayout } from './DrawerLayout';
 export * from './GestureHandler';
 export * from './touchables';
+export * from './WaitForGroup';

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -58,6 +58,7 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
     return rect;
 }
 
+static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 @implementation RNGestureHandler {
     NSArray<NSNumber *> *_handlersToWaitFor;
@@ -72,6 +73,13 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
         _tag = tag;
         _lastState = RNGestureHandlerStateUndetermined;
         _hitSlop = RNGHHitSlopEmpty;
+
+        static dispatch_once_t onceToken;
+        dispatch_once(&onceToken, ^{
+            allGestureHandlers = [NSHashTable weakObjectsHashTable];
+        });
+
+        [allGestureHandlers addObject:self];
     }
     return self;
 }
@@ -166,7 +174,7 @@ CGRect RNGHHitSlopInsetRect(CGRect rect, RNGHHitSlop hitSlop) {
             // generated faster than they can be treated by JS thread
             static uint16_t nextEventCoalescingKey = 0;
             self->_eventCoalescingKey = nextEventCoalescingKey++;
-            
+
         } else if (state == RNGestureHandlerStateEnd && _lastState != RNGestureHandlerStateActive) {
             [self.emitter sendStateChangeEvent:[[RNGestureHandlerStateChange alloc] initWithReactTag:reactTag
                                                                                           handlerTag:_tag
@@ -302,6 +310,20 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
     [self reset];
+
+    if ([_handlersToWaitFor count]) {
+        for (RNGestureHandler *handler in [allGestureHandlers allObjects]) {
+            if (handler != nil
+                && (handler.state == RNGestureHandlerStateActive || handler->_recognizer.state == UIGestureRecognizerStateBegan)) {
+                for (NSNumber *handlerTag in _handlersToWaitFor) {
+                    if ([handler.tag isEqual:handlerTag]) {
+                        return NO;
+                    }
+                }
+            }
+        }
+    }
+
     return YES;
 }
 

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "jestSetup.js",
     "RNGestureHandler.podspec",
     "State.js",
-    "Swipeable.js"
+    "Swipeable.js",
+    "WaitForGroup.js"
   ],
   "repository": {
     "type": "git",

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -220,7 +220,7 @@ declare module 'react-native-gesture-handler' {
     id?: string;
     enabled?: boolean;
     waitFor?: React.Ref<any> | React.Ref<any>[];
-    waitForGroup?: string;
+    waitForGroup?: string | React.Ref<WaitForGroup>;
     simultaneousHandlers?: React.Ref<any> | React.Ref<any>[];
     shouldCancelWhenOutside?: boolean;
     hitSlop?:
@@ -466,6 +466,10 @@ declare module 'react-native-gesture-handler' {
     Component: React.ComponentType<P>,
     config: NativeViewGestureHandlerProperties
   ): React.ComponentType<P>;
+
+  export class WaitForGroup extends React.Component<{}> {}
+
+  export function useWaitForGroup(): string
 }
 
 declare module 'react-native-gesture-handler/Swipeable' {

--- a/react-native-gesture-handler.d.ts
+++ b/react-native-gesture-handler.d.ts
@@ -220,6 +220,7 @@ declare module 'react-native-gesture-handler' {
     id?: string;
     enabled?: boolean;
     waitFor?: React.Ref<any> | React.Ref<any>[];
+    waitForGroup?: string;
     simultaneousHandlers?: React.Ref<any> | React.Ref<any>[];
     shouldCancelWhenOutside?: boolean;
     hitSlop?:


### PR DESCRIPTION
When dealing with gesture handlers as FlatList item views it is quite hard to prevent simultaneous activation of several handlers by using `waitFor` and arrays of refs. `waitForGroup` prop is intended to simplify this task - handlers that have `waitForGroup` prop set to the same string can't be active simultaneously.

This PR also includes all changes from #1043