### PR TITLE
Guard against null event handler to prevent android crash

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java
@@ -276,6 +276,9 @@ public class GestureHandlerOrchestrator {
   }
 
   private void deliverEventToGestureHandler(GestureHandler handler, MotionEvent event) {
+    if (handler == null) {
+      return;
+    }
     if (!isViewAttachedUnderWrapper(handler.getView())) {
       handler.cancel();
       return;

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.java
@@ -72,6 +72,8 @@ public class RNGestureHandlerEvent extends Event<RNGestureHandlerEvent> {
 
   @Override
   public void dispatch(RCTEventEmitter rctEventEmitter) {
-    rctEventEmitter.receiveEvent(getViewTag(), EVENT_NAME, mExtraData);
+    if (mExtraData != null) {
+      rctEventEmitter.receiveEvent(getViewTag(), EVENT_NAME, mExtraData);
+    }
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.java
@@ -77,6 +77,8 @@ public class RNGestureHandlerStateChangeEvent extends Event<RNGestureHandlerStat
 
   @Override
   public void dispatch(RCTEventEmitter rctEventEmitter) {
-    rctEventEmitter.receiveEvent(getViewTag(), EVENT_NAME, mExtraData);
+    if (mExtraData != null) {
+      rctEventEmitter.receiveEvent(getViewTag(), EVENT_NAME, mExtraData);
+    }
   }
 }


### PR DESCRIPTION
This PR adds a patch from https://github.com/kaiterra/react-native-gesture-handler/commit/99d4ddcbc2128ad4634a28caf2011eaaa9d2f1b0 /  https://github.com/getdelta/react-native-gesture-handler/commit/311da062a679a81f6d3578cacb44c81aa29ede95 to prevent an exception like the following:

```
com.swmansion.reanimated.nodes.EventNode.receiveEvent
EventNode.java, line 63
java.lang.IllegalArgumentException: Animated events must have event data.
```

The crash is mentioned in the following issues:
* https://github.com/react-navigation/react-navigation/issues/6403
* https://github.com/react-native-community/react-native-tab-view/issues/976
* https://github.com/software-mansion/react-native-reanimated/issues/704