### PR TITLE
fix LongPressGestureHandler web discrepancy on move events

### DIFF
--- a/createHandler.js
+++ b/createHandler.js
@@ -236,7 +236,10 @@ export default function createHandler(
       this._createGestureHandler(
         filterConfig(
           transformProps ? transformProps(this.props) : this.props,
-          { ...this.constructor.propTypes, ...customNativeProps },
+          {
+            ...(this.constructor.propTypes || propTypes),
+            ...customNativeProps,
+          },
           config
         )
       );
@@ -254,7 +257,7 @@ export default function createHandler(
     _update() {
       const newConfig = filterConfig(
         transformProps ? transformProps(this.props) : this.props,
-        { ...this.constructor.propTypes, ...customNativeProps },
+        { ...(this.constructor.propTypes || propTypes), ...customNativeProps },
         config
       );
       if (!deepEqual(this._config, newConfig)) {
@@ -266,7 +269,7 @@ export default function createHandler(
       const mergedProps = { ...this.props, ...updates };
       const newConfig = filterConfig(
         transformProps ? transformProps(mergedProps) : mergedProps,
-        { ...this.constructor.propTypes, ...customNativeProps },
+        { ...(this.constructor.propTypes || propTypes), ...customNativeProps },
         config
       );
       this._updateGestureHandler(newConfig);

--- a/web/PressGestureHandler.js
+++ b/web/PressGestureHandler.js
@@ -104,24 +104,32 @@ class PressGestureHandler extends DiscreteGestureHandler {
 
   onRawEvent(ev) {
     super.onRawEvent(ev);
-    if (ev.isFinal && this.isGestureRunning) {
-      let timeout;
-      if (this.visualFeedbackTimer) {
-        // Aesthetic timing for a quick tap.
-        // We haven't activated the tap right away to emulate iOS `delaysContentTouches`
-        // Now we must send the initial activation event and wait a set amount of time before firing the end event.
-        timeout = CONTENT_TOUCHES_QUICK_TAP_END_DELAY;
-        this.sendGestureStartedEvent(this.initialEvent);
-        this.initialEvent = null;
-      }
-      fireAfterInterval(() => {
+    if (this.isGestureRunning) {
+      if (ev.isFinal) {
+        let timeout;
+        if (this.visualFeedbackTimer) {
+          // Aesthetic timing for a quick tap.
+          // We haven't activated the tap right away to emulate iOS `delaysContentTouches`
+          // Now we must send the initial activation event and wait a set amount of time before firing the end event.
+          timeout = CONTENT_TOUCHES_QUICK_TAP_END_DELAY;
+          this.sendGestureStartedEvent(this.initialEvent);
+          this.initialEvent = null;
+        }
+        fireAfterInterval(() => {
+          this.sendEvent({
+            ...ev,
+            eventType: Hammer.INPUT_END,
+            isFinal: true,
+          });
+          this.onGestureEnded();
+        }, timeout);
+      } else {
         this.sendEvent({
           ...ev,
-          eventType: Hammer.INPUT_END,
-          isFinal: true,
+          eventType: Hammer.INPUT_MOVE,
+          isFinal: false,
         });
-        this.onGestureEnded();
-      }, timeout);
+      }
     }
   }
 


### PR DESCRIPTION
This PR fixes the following issues for the web implementation

1. The LongPressGuestureHandler on mobile (ios/android) emits move events after being activated but the web implementation does not. Modified the `PressGestureHandler.onRawEvent` to pass along the move event.
1. in `createHander` static class proprType is not supported in `react-native-web`, fixed in `createHander`

fix #1097