### PR TITLE
Fix Example app on iOS

### DIFF
--- a/Example/App.js
+++ b/Example/App.js
@@ -133,7 +133,7 @@ class MainScreenItem extends React.Component {
     const { title, isDisabled } = this.props.item;
     return (
       <RectButton
-        pointerEvents={isDisabled ? 'none' : 'auto'}
+        {...(isDisabled && { pointerEvents: 'none' })}
         style={[styles.button, isDisabled && { opacity: 0.5 }]}
         onPress={this._onPress}>
         <Text style={styles.buttonText}>{title}</Text>


### PR DESCRIPTION
Apparently, RN doesn't support setting `pointerEvents` to 'auto', so we have to set 'none' conditionally

Reference: https://github.com/facebook/react-native/blob/0060b5de559cd9c785a2a2a6c66f58088fea4dd2/React/Views/RCTViewManager.m#L250-L254
