### PR TITLE
Update expo links in the Example app

### DIFF
--- a/docs/docs/component-drawer-layout.mdx
+++ b/docs/docs/component-drawer-layout.mdx
@@ -80,7 +80,7 @@ component or function. Children is a component which is rendered by default and 
 
 ## Example:
 
-See the [drawer example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/horizontalDrawer/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the [drawer example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/horizontalDrawer/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 class Drawerable extends Component {

--- a/docs/docs/component-swipeable.md
+++ b/docs/docs/component-swipeable.md
@@ -169,7 +169,7 @@ method that opens component on right side.
 
 ### Example:
 
-See the [swipeable example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/swipeable/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the [swipeable example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/swipeable/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 import React, { Component } from 'react';

--- a/docs/docs/example.md
+++ b/docs/docs/example.md
@@ -17,7 +17,7 @@ Each example is located under a separate folder under [`Example/`](https://githu
 
 ## Running example app on Expo
 
-You can run example app on [Expo](https://expo.io). Follow instructions under [this link](https://expo.io/@sauzy3450/react-native-gesture-handler-demo) to do so. Note that the app published to Expo is not the most up to date version. We publish updates whenever new version of Expo SDK is released. If you wish to try the most up to date version you will have to run example app locally. For that see below 👇
+You can run example app on [Expo](https://expo.io). Follow instructions under [this link](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo) to do so. Note that the app published to Expo is not the most up to date version. We publish updates whenever new version of Expo SDK is released. If you wish to try the most up to date version you will have to run example app locally. For that see below 👇
 
 ## Running example app locally
 

--- a/docs/docs/handler-fling.md
+++ b/docs/docs/handler-fling.md
@@ -57,7 +57,7 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ## Example
 
-See the [fling  example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/fling/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the [fling  example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/fling/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 const LongPressButton = () => (

--- a/docs/docs/handler-force.md
+++ b/docs/docs/handler-force.md
@@ -44,7 +44,7 @@ You may check if it's possible to use `ForceTouchGestureHandler` with `ForceTouc
 
 ## Example
 
-See the [force touch handler example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/forcetouch/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the [force touch handler example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/forcetouch/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 <ForceTouchGestureHandler

--- a/docs/docs/handler-longpress.md
+++ b/docs/docs/handler-longpress.md
@@ -50,7 +50,7 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ## Example
 
-See the [multitap example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the [multitap example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 const LongPressButton = () => (

--- a/docs/docs/handler-pan.md
+++ b/docs/docs/handler-pan.md
@@ -175,7 +175,7 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ## Example
 
-See the [draggable example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/draggable/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the [draggable example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/draggable/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 const circleRadius = 30;

--- a/docs/docs/handler-pinch.md
+++ b/docs/docs/handler-pinch.md
@@ -41,7 +41,7 @@ Position expressed in points along Y axis of center anchor point of gesture
 
 ## Example
 
-See the [scale and rotation example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the [scale and rotation example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 export class PinchableBox extends React.Component {

--- a/docs/docs/handler-rotation.md
+++ b/docs/docs/handler-rotation.md
@@ -37,7 +37,7 @@ Position expressed in points along Y axis of center anchor point of gesture
 
 ## Example
 
-See the [scale and rotation example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the [scale and rotation example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 class RotableBox extends React.Component {

--- a/docs/docs/handler-tap.md
+++ b/docs/docs/handler-tap.md
@@ -74,7 +74,7 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ## Example
 
-See the [multitap example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the [multitap example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 export class PressBox extends Component {

--- a/docs/docs/interactions.md
+++ b/docs/docs/interactions.md
@@ -29,7 +29,7 @@ In this case we would use a [`PinchGestureHandler`](handler-pinch.md), [`Rotatio
 ---
 ### Example
 
-See the ["Scale, rotate & tilt" example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the ["Scale, rotate & tilt" example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/scaleAndRotate/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 class PinchableBox extends React.Component {
@@ -74,7 +74,7 @@ Otherwise if we try to perform a double tap the single tap handler will fire jus
 ---
 ### Example
 
-See the ["Multitap" example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo).
+See the ["Multitap" example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example/multitap/index.js) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 const doubleTap = React.createRef();

--- a/docs/docs/resources.md
+++ b/docs/docs/resources.md
@@ -7,7 +7,7 @@ title: Learning Resources
 
 [Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/master/Example) – official gesture handler "showcase" app.
 
-[Gesture Handler Example on Expo](https://expo.io/@sauzy3450/react-native-gesture-handler-demo) – the official app you can install and play with using [Expo](https://expo.io).
+[Gesture Handler Example on Expo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo) – the official app you can install and play with using [Expo](https://expo.io).
 
 ## Talks and workshops
 


### PR DESCRIPTION
Changing links to demo app in docs. New address is https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo.