### PR TITLE
Fix installation and documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,11 @@ It makes touch interactions and gesture tracking not only smooth, but also depen
 
 ## Installation
 
-Check [getting started](https://docs.swmansion.com/react-native-gesture-handler/docs/getting-started.html) section of our docs for the detailed installation instructions.
+Check [getting started](https://docs.swmansion.com/react-native-gesture-handler/docs/#installation) section of our docs for the detailed installation instructions.
 
 ## Documentation
 
-Check out our dedicated documentation page for info about this library, API reference and more: [https://docs.swmansion.com/react-native-gesture-handler/](https://docs.swmansion.com/react-native-gesture-handler)
+Check out our dedicated documentation page for info about this library, API reference and more: [https://docs.swmansion.com/react-native-gesture-handler/docs/](https://docs.swmansion.com/react-native-gesture-handler/docs/)
 
 ## Examples
 
@@ -49,5 +49,5 @@ Gesture handler library is licensed under [The MIT License](LICENSE).
 
 This project is supported by amazing people from [Expo.io](https://expo.io) and [Software Mansion](https://swmansion.com)
 
-[![expo](https://avatars2.githubusercontent.com/u/12504344?v=3&s=100 "Expo.io")](https://expo.io)
-[![swm](https://logo.swmansion.com/logo?color=white&variant=desktop&width=150&tag=react-native-gesture-handler-github "Software Mansion")](https://swmansion.com)
+[![expo](https://avatars2.githubusercontent.com/u/12504344?v=3&s=100 'Expo.io')](https://expo.io)
+[![swm](https://logo.swmansion.com/logo?color=white&variant=desktop&width=150&tag=react-native-gesture-handler-github 'Software Mansion')](https://swmansion.com)


### PR DESCRIPTION
## Description

Fixed two broken links.

btw when clicking in `Basics > Getting Started` [here](https://docs.swmansion.com/react-native-gesture-handler/docs/), it redirects to a 404 page.