### PR TITLE
Fix RNGestureHandlerManager to use explicit imports

### DIFF
--- a/ios/RNGestureHandlerManager.h
+++ b/ios/RNGestureHandlerManager.h
@@ -1,7 +1,9 @@
 #import <Foundation/Foundation.h>
 
 #import <React/RCTBridgeModule.h>
-#import <React/RCTUIManager.h>
+
+@class RCTUIManager;
+@class RCTEventDispatcher;
 
 @interface RNGestureHandlerManager : NSObject
 

--- a/ios/RNGestureHandlerManager.m
+++ b/ios/RNGestureHandlerManager.m
@@ -6,6 +6,8 @@
 #import <React/RCTRootView.h>
 #import <React/RCTTouchHandler.h>
 #import <React/RCTRootContentView.h>
+#import <React/RCTUIManager.h>
+#import <React/RCTEventDispatcher.h>
 
 #import "RNGestureHandlerState.h"
 #import "RNGestureHandler.h"


### PR DESCRIPTION
## Description

I work on RN Core at Facebook, and am encountering a unique problem. I'm trying to refactor `RCTEventDispatcher`, but cannot because of the implicit dependency on `RCTEventDispatcher` in `RNGestureHandlerManager`. We use rn-gesture-handler internally, and builds for it fail after the refactor. 

The fix is to explicitly depend on `RCTEventDispatcher` instead of relying on the `RCTUIManager -> RCTViewManager -> RCTEventDispatcher` import chain. 

## Test plan

I unfortunately did not test this. I can't get react-native-gesture-handler building locally. I assume that there are CI builds that would fail on a simple compilation error. 