### PR TITLE
Support RN headers in both namespaces on iOS

### DIFF
--- a/ios/RNGestureHandlerManager.m
+++ b/ios/RNGestureHandlerManager.m
@@ -5,9 +5,14 @@
 #import <React/RCTComponent.h>
 #import <React/RCTRootView.h>
 #import <React/RCTTouchHandler.h>
-#import <React/RCTRootContentView.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTEventDispatcher.h>
+
+#if __has_include(<React/RCTRootContentView.h>)
+#import <React/RCTRootContentView.h>
+#else
+#import "RCTRootContentView.h"
+#endif
 
 #import "RNGestureHandlerState.h"
 #import "RNGestureHandler.h"


### PR DESCRIPTION
Fixes #816 

Support RN headers both in the React namespace and no namespace, for older versions of RN.
