### PR TITLE
Fix Xcode 12 compatibility

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -14,6 +14,6 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/software-mansion/react-native-gesture-handler", :tag => "#{s.version}" }
   s.source_files = "ios/**/*.{h,m}"
 
-  s.dependency "React"
+  s.dependency "React-Core"
 
 end


### PR DESCRIPTION
## Description

Latest Xcode 12 fails to build while without a module to depend on `React-Core` directly hence this change is necessary for all native modules on iOS. For more details please check: https://github.com/facebook/react-native/issues/29633#issuecomment-694187116

## Test plan

Use this branch to install with an app running on Xcode 12.
