### PR TITLE
Allow minDurationMs=0 in LongPressGestureHandler

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
@@ -42,7 +42,7 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
             activate();
           }
         }, mMinDurationMs);
-      } else {
+      } else if (mMinDurationMs == 0) {
         activate();
       }
     }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java
@@ -35,12 +35,16 @@ public class LongPressGestureHandler extends GestureHandler<LongPressGestureHand
       mStartX = event.getRawX();
       mStartY = event.getRawY();
       mHandler = new Handler();
-      mHandler.postDelayed(new Runnable() {
-        @Override
-        public void run() {
-          activate();
-        }
-      }, mMinDurationMs);
+      if (mMinDurationMs > 0) {
+        mHandler.postDelayed(new Runnable() {
+          @Override
+          public void run() {
+            activate();
+          }
+        }, mMinDurationMs);
+      } else {
+        activate();
+      }
     }
     if (event.getActionMasked() == MotionEvent.ACTION_UP) {
       if (mHandler != null) {


### PR DESCRIPTION
## Description

For scrub gestures (on iOS at least), I used a `LongPressGestureHandler` with a `minDurationMs` set to `0` so it activates immediately. However, it seems a bit flaky on Android. This seems to fix it.

## Test plan

```jsx
/*
To test this change run example on android, click anywhere on the screen and notice that square doesn't change color. 
Now, move your finger a bit and you'll notice that gesture is recognized.
*/
import React from 'react';
import { AppRegistry, View, useWindowDimensions } from 'react-native';
import { LongPressGestureHandler, State } from 'react-native-gesture-handler';

const Example = () => {
  const { width, height } = useWindowDimensions();
  const [x, setX] = React.useState(undefined);
  const [y, setY] = React.useState(undefined);
  const yRows = 8;
  const xRows = 4;

  const backgroundContent = Array.from(new Array(yRows), (_, yPos) => (
    <View key={yPos} style={{ flex: 1, flexDirection: 'row' }}>
      {Array.from(new Array(xRows), (__, xPos) => {
        const isActive = xPos === x && yPos === y;
        const backgroundColor = isActive ? '#eee' : 'pink';

        return (
          <View key={xPos} style={{ flex: 1, backgroundColor, margin: 2 }} />
        );
      })}
    </View>
  ));

  return (
    <LongPressGestureHandler
      onGestureEvent={e => {
        setX(Math.trunc((e.nativeEvent.x * xRows) / width));
        setY(Math.trunc((e.nativeEvent.y * yRows) / height));
      }}
      onHandlerStateChange={e => {
        if (e.nativeEvent.state === State.END) {
          setX(undefined);
          setY(undefined);
        }
      }}
      minDurationMs={0}
      maxDist={1e9}
      shouldCancelWhenOutside={false}>
      <View style={{ flex: 1 }}>{backgroundContent}</View>
    </LongPressGestureHandler>
  );
};

AppRegistry.registerComponent('Example', () => Example);
```