### PR TITLE
Use weak reference for storing rootViews in iOS

### DIFF
--- a/ios/RNGestureHandlerManager.m
+++ b/ios/RNGestureHandlerManager.m
@@ -40,7 +40,7 @@
 {
     RNGestureHandlerRegistry *_registry;
     RCTUIManager *_uiManager;
-    NSMutableSet<UIView*> *_rootViews;
+    NSHashTable<UIView *> *_rootViews;
     RCTEventDispatcher *_eventDispatcher;
 }
 
@@ -51,7 +51,7 @@
         _uiManager = uiManager;
         _eventDispatcher = eventDispatcher;
         _registry = [RNGestureHandlerRegistry new];
-        _rootViews = [NSMutableSet new];
+        _rootViews = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory];
     }
     return self;
 }


### PR DESCRIPTION
## Description

Please refer to [issue-1207](https://github.com/software-mansion/react-native-gesture-handler/issues/1207)

Fixes #1207

## Test plan

1. Create a RCTRootView, and cache the RCTBridge
2. Remove the RCTRootView, check the memory or the dealloc of RCTRootContentView
3. After my fix, the RCTRootContentView's dealloc will called.