### PR TITLE
Fix destructuring `ref.props` on the web

### DIFF
--- a/RNGestureHandlerModule.web.js
+++ b/RNGestureHandlerModule.web.js
@@ -39,8 +39,8 @@ export default {
   attachGestureHandler(handlerTag, newView, props) {
     NodeManager.getHandler(handlerTag).setView(newView, props);
   },
-  updateGestureHandler(handlerTag, newConfig) {
-    NodeManager.getHandler(handlerTag).updateGestureConfig(newConfig);
+  updateGestureHandler(handlerTag, newConfig, props) {
+    NodeManager.getHandler(handlerTag).updateGestureConfig(newConfig, props);
   },
   getGestureHandlerNode(handlerTag) {
     return NodeManager.getHandler(handlerTag);

--- a/RNGestureHandlerModule.web.js
+++ b/RNGestureHandlerModule.web.js
@@ -27,20 +27,20 @@ export default {
   handleClearJSResponder() {
     console.warn('handleClearJSResponder: ');
   },
-  createGestureHandler(handlerName, handlerTag, config) {
+  createGestureHandler(handlerName, handlerTag, config, events) {
     if (!(handlerName in Gestures))
       throw new Error(
         `react-native-gesture-handler: ${handlerName} is not supported on web.`
       );
     const GestureClass = Gestures[handlerName];
     NodeManager.createGestureHandler(handlerTag, new GestureClass());
-    this.updateGestureHandler(handlerTag, config);
+    this.updateGestureHandler(handlerTag, config, events);
   },
-  attachGestureHandler(handlerTag, newView, props) {
-    NodeManager.getHandler(handlerTag).setView(newView, props);
+  attachGestureHandler(handlerTag, newView, events) {
+    NodeManager.getHandler(handlerTag).setView(newView, events);
   },
-  updateGestureHandler(handlerTag, newConfig, props) {
-    NodeManager.getHandler(handlerTag).updateGestureConfig(newConfig, props);
+  updateGestureHandler(handlerTag, newConfig, events) {
+    NodeManager.getHandler(handlerTag).updateGestureConfig(newConfig, events);
   },
   getGestureHandlerNode(handlerTag) {
     return NodeManager.getHandler(handlerTag);

--- a/RNGestureHandlerModule.web.js
+++ b/RNGestureHandlerModule.web.js
@@ -29,13 +29,15 @@ export default {
   },
   createGestureHandler(handlerName, handlerTag, config) {
     if (!(handlerName in Gestures))
-      throw new Error(`react-native-gesture-handler: ${handlerName} is not supported on web.`);
+      throw new Error(
+        `react-native-gesture-handler: ${handlerName} is not supported on web.`
+      );
     const GestureClass = Gestures[handlerName];
     NodeManager.createGestureHandler(handlerTag, new GestureClass());
     this.updateGestureHandler(handlerTag, config);
   },
-  attachGestureHandler(handlerTag, newView) {
-    NodeManager.getHandler(handlerTag).setView(newView);
+  attachGestureHandler(handlerTag, newView, props) {
+    NodeManager.getHandler(handlerTag).setView(newView, props);
   },
   updateGestureHandler(handlerTag, newConfig) {
     NodeManager.getHandler(handlerTag).updateGestureConfig(newConfig);

--- a/RNGestureHandlerModule.web.js
+++ b/RNGestureHandlerModule.web.js
@@ -27,20 +27,20 @@ export default {
   handleClearJSResponder() {
     console.warn('handleClearJSResponder: ');
   },
-  createGestureHandler(handlerName, handlerTag, config, events) {
+  createGestureHandler(handlerName, handlerTag, config) {
     if (!(handlerName in Gestures))
       throw new Error(
         `react-native-gesture-handler: ${handlerName} is not supported on web.`
       );
     const GestureClass = Gestures[handlerName];
     NodeManager.createGestureHandler(handlerTag, new GestureClass());
-    this.updateGestureHandler(handlerTag, config, events);
+    this.updateGestureHandler(handlerTag, config);
   },
-  attachGestureHandler(handlerTag, newView, events) {
-    NodeManager.getHandler(handlerTag).setView(newView, events);
+  attachGestureHandler(handlerTag, newView, propsRef) {
+    NodeManager.getHandler(handlerTag).setView(newView, propsRef);
   },
-  updateGestureHandler(handlerTag, newConfig, events) {
-    NodeManager.getHandler(handlerTag).updateGestureConfig(newConfig, events);
+  updateGestureHandler(handlerTag, newConfig) {
+    NodeManager.getHandler(handlerTag).updateGestureConfig(newConfig);
   },
   getGestureHandlerNode(handlerTag) {
     return NodeManager.getHandler(handlerTag);

--- a/createHandler.js
+++ b/createHandler.js
@@ -189,46 +189,36 @@ export default function createHandler(
 
     _createGestureHandler = newConfig => {
       this._config = newConfig;
+      this._events = this._getEventProps();
 
       RNGestureHandlerModule.createGestureHandler(
         handlerName,
         this._handlerTag,
-        newConfig
+        newConfig,
+        Platform.OS === 'web' ? this._events : undefined
       );
     };
 
     _attachGestureHandler = newViewTag => {
       this._viewTag = newViewTag;
+      this._events = this._getEventProps();
 
-      if (Platform.OS === 'web') {
-        RNGestureHandlerModule.attachGestureHandler(
-          this._handlerTag,
-          newViewTag,
-          this.props
-        );
-      } else {
-        RNGestureHandlerModule.attachGestureHandler(
-          this._handlerTag,
-          newViewTag
-        );
-      }
+      RNGestureHandlerModule.attachGestureHandler(
+        this._handlerTag,
+        newViewTag,
+        Platform.OS === 'web' ? this._events : undefined
+      );
     };
 
     _updateGestureHandler = newConfig => {
+      this._events = this._getEventProps();
       this._config = newConfig;
 
-      if (Platform.OS === 'web') {
-        RNGestureHandlerModule.updateGestureHandler(
-          this._handlerTag,
-          newConfig,
-          this.props
-        );
-      } else {
-        RNGestureHandlerModule.updateGestureHandler(
-          this._handlerTag,
-          newConfig
-        );
-      }
+      RNGestureHandlerModule.updateGestureHandler(
+        this._handlerTag,
+        newConfig,
+        Platform.OS === 'web' ? this._events : undefined
+      );
     };
 
     componentWillUnmount() {
@@ -282,9 +272,24 @@ export default function createHandler(
         { ...(this.constructor.propTypes || propTypes), ...customNativeProps },
         config
       );
-      if (!deepEqual(this._config, newConfig)) {
+      if (!deepEqual(this._config, newConfig) || this._isEventsPropsUpdated()) {
         this._updateGestureHandler(newConfig);
       }
+    }
+
+    _getEventProps() {
+      const { onHandlerStateChange, onGestureEvent } = this.props;
+      return { onHandlerStateChange, onGestureEvent };
+    }
+
+    _isEventsPropsUpdated() {
+      if (Platform.OS !== 'web') {
+        return false;
+      }
+
+      const _events = this._getEventProps();
+
+      return !deepEqual(this._events, _events);
     }
 
     setNativeProps(updates) {

--- a/createHandler.js
+++ b/createHandler.js
@@ -217,7 +217,18 @@ export default function createHandler(
     _updateGestureHandler = newConfig => {
       this._config = newConfig;
 
-      RNGestureHandlerModule.updateGestureHandler(this._handlerTag, newConfig);
+      if (Platform.OS === 'web') {
+        RNGestureHandlerModule.updateGestureHandler(
+          this._handlerTag,
+          newConfig,
+          this.props
+        );
+      } else {
+        RNGestureHandlerModule.updateGestureHandler(
+          this._handlerTag,
+          newConfig
+        );
+      }
     };
 
     componentWillUnmount() {

--- a/createHandler.js
+++ b/createHandler.js
@@ -202,11 +202,18 @@ export default function createHandler(
     _attachGestureHandler = newViewTag => {
       this._viewTag = newViewTag;
 
-      RNGestureHandlerModule.attachGestureHandler(
-        this._handlerTag,
-        newViewTag,
-        Platform.OS === 'web' ? this._propsRef : undefined
-      );
+      if (Platform.OS === 'web') {
+        RNGestureHandlerModule.attachGestureHandler(
+          this._handlerTag,
+          newViewTag,
+          this._propsRef
+        );
+      } else {
+        RNGestureHandlerModule.attachGestureHandler(
+          this._handlerTag,
+          newViewTag
+        );
+      }
     };
 
     _updateGestureHandler = newConfig => {

--- a/createHandler.js
+++ b/createHandler.js
@@ -200,7 +200,18 @@ export default function createHandler(
     _attachGestureHandler = newViewTag => {
       this._viewTag = newViewTag;
 
-      RNGestureHandlerModule.attachGestureHandler(this._handlerTag, newViewTag);
+      if (Platform.OS === 'web') {
+        RNGestureHandlerModule.attachGestureHandler(
+          this._handlerTag,
+          newViewTag,
+          this.props
+        );
+      } else {
+        RNGestureHandlerModule.attachGestureHandler(
+          this._handlerTag,
+          newViewTag
+        );
+      }
     };
 
     _updateGestureHandler = newConfig => {

--- a/createHandler.js
+++ b/createHandler.js
@@ -256,14 +256,11 @@ export default function createHandler(
           config
         )
       );
-      this._propsRef.current = this.props;
 
       this._attachGestureHandler(findNodeHandle(this._viewNode));
     }
 
     componentDidUpdate() {
-      this._propsRef.current = this.props;
-
       const viewTag = findNodeHandle(this._viewNode);
       if (this._viewTag !== viewTag) {
         this._attachGestureHandler(viewTag);
@@ -338,6 +335,12 @@ export default function createHandler(
           );
         }
       }
+      const events = {
+        onGestureHandlerEvent: gestureEventHandler,
+        onGestureHandlerStateChange: gestureStateEventHandler,
+      };
+
+      this._propsRef.current = events;
 
       const child = React.Children.only(this.props.children);
       let grandChildren = child.props.children;
@@ -356,13 +359,13 @@ export default function createHandler(
           })
         );
       }
+
       return React.cloneElement(
         child,
         {
           ref: this._refHandler,
           collapsable: false,
-          onGestureHandlerEvent: gestureEventHandler,
-          onGestureHandlerStateChange: gestureStateEventHandler,
+          ...events,
         },
         grandChildren
       );

--- a/web/GestureHandler.js
+++ b/web/GestureHandler.js
@@ -72,7 +72,8 @@ class GestureHandler {
     }
   };
 
-  updateGestureConfig({ enabled = true, ...props }) {
+  updateGestureConfig({ enabled = true, ...props }, _props) {
+    this._props = _props;
     this.clearSelfAsPending();
 
     this.config = ensureConfig({ enabled, ...props });

--- a/web/GestureHandler.js
+++ b/web/GestureHandler.js
@@ -72,8 +72,7 @@ class GestureHandler {
     }
   };
 
-  updateGestureConfig({ enabled = true, ...props }, events) {
-    this._events = events;
+  updateGestureConfig({ enabled = true, ...props }) {
     this.clearSelfAsPending();
 
     this.config = ensureConfig({ enabled, ...props });
@@ -148,7 +147,7 @@ class GestureHandler {
   }
 
   sendEvent = nativeEvent => {
-    const { onHandlerStateChange, onGestureEvent } = this._events;
+    const { onHandlerStateChange, onGestureEvent } = this._propsRef.current;
 
     const event = this.transformEventData(nativeEvent);
 
@@ -204,14 +203,14 @@ class GestureHandler {
     }
   }
 
-  setView(ref, events) {
+  setView(ref, propsRef) {
     if (ref == null) {
       this.destroy();
       this.view = null;
       return;
     }
 
-    this._events = events;
+    this._propsRef = propsRef;
     this.ref = ref;
 
     this.view = findNodeHandle(ref);

--- a/web/GestureHandler.js
+++ b/web/GestureHandler.js
@@ -147,7 +147,7 @@ class GestureHandler {
   }
 
   sendEvent = nativeEvent => {
-    const { onHandlerStateChange, onGestureEvent } = this._propsRef.current;
+    const { onHandlerStateChange, onGestureEvent } = this.propsRef.current;
 
     const event = this.transformEventData(nativeEvent);
 
@@ -210,7 +210,7 @@ class GestureHandler {
       return;
     }
 
-    this._propsRef = propsRef;
+    this.propsRef = propsRef;
     this.ref = ref;
 
     this.view = findNodeHandle(ref);

--- a/web/GestureHandler.js
+++ b/web/GestureHandler.js
@@ -147,14 +147,21 @@ class GestureHandler {
   }
 
   sendEvent = nativeEvent => {
-    const { onHandlerStateChange, onGestureEvent } = this.propsRef.current;
+    const {
+      onGestureHandlerEvent,
+      onGestureHandlerStateChange,
+    } = this.propsRef.current;
 
     const event = this.transformEventData(nativeEvent);
 
-    invokeNullableMethod('onGestureEvent', onGestureEvent, event);
+    invokeNullableMethod('onGestureEvent', onGestureHandlerEvent, event);
     if (this.lastSentState !== event.nativeEvent.state) {
       this.lastSentState = event.nativeEvent.state;
-      invokeNullableMethod('onHandlerStateChange', onHandlerStateChange, event);
+      invokeNullableMethod(
+        'onHandlerStateChange',
+        onGestureHandlerStateChange,
+        event
+      );
     }
   };
 

--- a/web/GestureHandler.js
+++ b/web/GestureHandler.js
@@ -147,10 +147,7 @@ class GestureHandler {
   }
 
   sendEvent = nativeEvent => {
-    const {
-      onGestureHandlerStateChange: onHandlerStateChange,
-      onGestureHandlerEvent: onGestureEvent,
-    } = this.ref.props;
+    const { onHandlerStateChange, onGestureEvent } = this._props;
 
     const event = this.transformEventData(nativeEvent);
 
@@ -206,13 +203,14 @@ class GestureHandler {
     }
   }
 
-  setView(ref) {
+  setView(ref, props) {
     if (ref == null) {
       this.destroy();
       this.view = null;
       return;
     }
 
+    this._props = props;
     this.ref = ref;
 
     this.view = findNodeHandle(ref);

--- a/web/GestureHandler.js
+++ b/web/GestureHandler.js
@@ -72,8 +72,8 @@ class GestureHandler {
     }
   };
 
-  updateGestureConfig({ enabled = true, ...props }, _props) {
-    this._props = _props;
+  updateGestureConfig({ enabled = true, ...props }, events) {
+    this._events = events;
     this.clearSelfAsPending();
 
     this.config = ensureConfig({ enabled, ...props });
@@ -148,7 +148,7 @@ class GestureHandler {
   }
 
   sendEvent = nativeEvent => {
-    const { onHandlerStateChange, onGestureEvent } = this._props;
+    const { onHandlerStateChange, onGestureEvent } = this._events;
 
     const event = this.transformEventData(nativeEvent);
 
@@ -204,14 +204,14 @@ class GestureHandler {
     }
   }
 
-  setView(ref, props) {
+  setView(ref, events) {
     if (ref == null) {
       this.destroy();
       this.view = null;
       return;
     }
 
-    this._props = props;
+    this._events = events;
     this.ref = ref;
 
     this.view = findNodeHandle(ref);


### PR DESCRIPTION
## Description

Fixes #1164.

It seems there is no way to get props from ref after react-native-web migrate to functional component, so I passed props from Handler component to gestureHandler class. Now that works well.

## Test plan

```jsx
import React from "react";
import { Text, View } from "react-native";
import {
  PanGestureHandler,
  TapGestureHandler,
} from "react-native-gesture-handler";

function App() {
  return (
    <>
      <Text>Log PanGestureHandler </Text>
      <View
        style={{
          backgroundColor: "yellow",
          overflow: "hidden",
        }}
      >
        <PanGestureHandler
          onGestureEvent={(gestureEvent) => {
            console.log({ gestureEvent });
          }}
        >
          <TapGestureHandler
            onHandlerStateChange={(stateEvent) => {
              console.log({ stateEvent });
            }}
          >
            <View
              style={{
                backgroundColor: "blue",
                height: 100,
                width: 200,
                margin: 20,
                alignItems: "center",
                justifyContent: "center",
              }}
            ></View>
          </TapGestureHandler>
        </PanGestureHandler>
      </View>
    </>
  );
}

export default App;
```