### PR TITLE
Resolve version of graceful-fs to ^4.2.4 in Example

### DIFF
--- a/Example/package.json
+++ b/Example/package.json
@@ -36,5 +36,8 @@
     "jest": "^24.9.0",
     "metro-react-native-babel-preset": "0.45.2",
     "react-test-renderer": "16.9.0"
+  },
+  "resolutions": {
+    "**/graceful-fs": "^4.2.4"
   }
 }

--- a/Example/yarn.lock
+++ b/Example/yarn.lock
@@ -2749,13 +2749,10 @@ globals@^11.1.0:
   version "11.7.0"
   resolved "https://registry.yarnpkg.com/globals/-/globals-11.7.0.tgz#a583faa43055b1aca771914bf68258e2fc125673"
 
-graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
-  version "4.1.11"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
-graceful-fs@^4.1.15:
-  version "4.1.15"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
+graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3, graceful-fs@^4.1.6, graceful-fs@^4.1.9, graceful-fs@^4.2.4:
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
+  integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
 growly@^1.3.0:
   version "1.3.0"


### PR DESCRIPTION
## Description

When running Example it often failed with `TypeError: cb.apply is not a function` coming from graceful-fs. This PR pins this package to a known working version.