### PR TITLE
Clamp swipe animation in examples

### DIFF
--- a/examples/Example/swipeable/AppleStyleSwipeableRow.js
+++ b/examples/Example/swipeable/AppleStyleSwipeableRow.js
@@ -10,6 +10,7 @@ export default class AppleStyleSwipeableRow extends Component {
     const trans = dragX.interpolate({
       inputRange: [0, 50, 100, 101],
       outputRange: [-20, 0, 0, 1],
+      extrapolate: 'clamp'
     });
     return (
       <RectButton style={styles.leftAction} onPress={this.close}>


### PR DESCRIPTION
## Description

Currently, when using this example and you overshoot swiping left, it drags the buttons to the left and adds white space in the space between each of them. This clamps the animation so it doesn't move the buttons with the overshoot. All other behavior remains the same as before.

## Test plan

<!--
Describe how did you test this change here.
-->
