### PR TITLE
Specify minimal SDK version for enableTrackpadTwoFingerGesture

### DIFF
--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -206,7 +206,7 @@
   APPLY_FLOAT_PROP(failOffsetYStart);
   APPLY_FLOAT_PROP(failOffsetYEnd);
 
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
   if (@available(iOS 13.4, *)) {
     bool enableTrackpadTwoFingerGesture = [RCTConvert BOOL:config[@"enableTrackpadTwoFingerGesture"]];
     if(enableTrackpadTwoFingerGesture){


### PR DESCRIPTION
## Description

`@available` only works at run time, it will still break on compile if this version of iOS is not available. 

Added `__IPHONE_OS_VERSION_MAX_ALLOWED >= 130400` so that older versions of Xcode can compile.

## Test plan

Successfully build with Xcode 11.3.1 
