### PR TITLE
Update Wix RN Navigation integration steps

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -141,14 +141,17 @@ import PushedScreen from './PushedScreen';
 
 // register all screens of the app (including internal ones)
 export function registerScreens() {
-  Navigation.registerComponent('example.FirstTabScreen', () =>
-    gestureHandlerRootHOC(FirstTabScreen)
+  Navigation.registerComponent('example.FirstTabScreen', 
+    () => gestureHandlerRootHOC(FirstTabScreen),
+    () => FirstTabScreen
   );
-  Navigation.registerComponent('example.SecondTabScreen', () =>
-    gestureHandlerRootHOC(SecondTabScreen)
+  Navigation.registerComponent('example.SecondTabScreen', 
+    () => gestureHandlerRootHOC(SecondTabScreen),
+    () => SecondTabScreen
   );
-  Navigation.registerComponent('example.PushedScreen', () =>
-    gestureHandlerRootHOC(PushedScreen)
+  Navigation.registerComponent('example.PushedScreen', 
+    () => gestureHandlerRootHOC(PushedScreen),
+    () => PushedScreen
   );
 }
 ```


### PR DESCRIPTION
## Description

When registering rnn components that are wrapped in providers, the third param needs to provide the concrete component.
See https://wix.github.io/react-native-navigation/api/component#registercomponent

