### PR TITLE
Improve wording and add defaults to TapHandler docs

### DIFF
--- a/docs/docs/handler-tap.md
+++ b/docs/docs/handler-tap.md
@@ -19,51 +19,51 @@ See [set of properties inherited from base handler class](handler-common.md#prop
 
 ### `minPointers`
 
-Minimum number of fingers required to be placed before the handler [activates](state.md#active). Should be a positive integer. Default is 1. 
+Minimum number of pointers (fingers) required to be placed before the handler [activates](state.md#active). Should be a positive integer. The default value is 1. 
 
 ### `maxDurationMs`
 
-Time expressed in milliseconds which defines how fast a finger has to be released after touch.
+Maximum time, expressed in milliseconds, that defines how fast a finger must be released after a touch. The default value is 500.
 
 ### `maxDelayMs`
 
-Time expressed in milliseconds which could pass before next tap if many taps are required. Default is 300ms. 
+Maximum time, expressed in milliseconds, that can pass before the next tap--if many taps are required. The default value is 500. 
 
 ### `numberOfTaps`
 
-Number of tap gestures required to [activate](state.md#active) the handler. Default is 1. 
+Number of tap gestures required to [activate](state.md#active) the handler. The default value is 1. 
 
 ### `maxDeltaX`
 
-When the finger travels the given distance expressed in points along X axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
+Maximum distance, expressed in points, that defines how far the finger is allowed to travel along the X axis during a tap gesture. If the finger travels further than the defined distance along the X axis and the handler hasn't yet [activated](state.md#active), it will fail to recognize the gesture. 
 
 ### `maxDeltaY`
 
-When the finger travels the given distance expressed in points along Y axis and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
+Maximum distance, expressed in points, that defines how far the finger is allowed to travel along the Y axis during a tap gesture. If the finger travels further than the defined distance along the Y axis and the handler hasn't yet [activated](state.md#active), it will fail to recognize the gesture. 
 
 ### `maxDist`
 
-When the finger travels the given distance expressed in points and handler hasn't yet [activated](state.md#active) it will fail recognizing the gesture.
+Maximum distance, expressed in points, that defines how far the finger is allowed to travel during a tap gesture. If the finger travels further than the defined distance and the handler hasn't yet [activated](state.md#active), it will fail to recognize the gesture. 
 
 ## Event data
 
-See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to `TapGestureHandler`:
+See [set of event attributes from base handler class](handler-common.md#event-data). Below is a list of gesture event attributes specific to the `TapGestureHandler` component:
 
 ### `x`
 
-X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler. Expressed in point units.
+X coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler.
 
 ### `y`
 
-Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler. Expressed in point units.
+Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the view attached to the handler. 
 
 ### `absoluteX`
 
-X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
+X coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. It is recommended to use this instead of [`x`](#x) in cases when the view attached to the handler can be transformed as an effect of the gesture.
 
 ### `absoluteY`
 
-Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
+Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. It is recommended to use this instead of [`y`](#y) in cases when the view attached to the handler can be transformed as an effect of the gesture.
 
 ## Example
 


### PR DESCRIPTION
changed default value mentioning to - "The default value is" in order to match the react natives docs
edited for more consistency in explanations
please review the default values because I'm not entirely sure... the information I got was from the android directory - android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.java

