### PR TITLE
Use PropsWithChildren in TouchableWithoutFeedback

### DIFF
--- a/src/components/touchables/TouchableWithoutFeedback.tsx
+++ b/src/components/touchables/TouchableWithoutFeedback.tsx
@@ -1,9 +1,9 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import GenericTouchable, { GenericTouchableProps } from './GenericTouchable';
 
 const TouchableWithoutFeedback = React.forwardRef<
   GenericTouchable,
-  GenericTouchableProps
+  PropsWithChildren<GenericTouchableProps>
 >((props, ref) => <GenericTouchable ref={ref} {...props} />);
 
 TouchableWithoutFeedback.defaultProps = GenericTouchable.defaultProps;


### PR DESCRIPTION
## Description

Fixes #1341.

This fixes a regression introduced in 1.10.0. Forward ref doesn't use children when passed a component so we wrap props with PropsWithChildren type.