### PR TITLE
Replace import React with import * as React

### DIFF
--- a/src/GestureHandlerRootView.android.tsx
+++ b/src/GestureHandlerRootView.android.tsx
@@ -1,4 +1,5 @@
-import React, { PropsWithChildren } from 'react';
+import * as React from 'react';
+import { PropsWithChildren } from 'react';
 import { View, requireNativeComponent } from 'react-native';
 
 const GestureHandlerRootViewNative = requireNativeComponent(

--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -6,7 +6,8 @@
 // to move faster and fix issues that may arise in gesture handler library
 // that could be found when using the drawer component
 
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import invariant from 'invariant';
 import {
   Animated,

--- a/src/components/GestureButtons.tsx
+++ b/src/components/GestureButtons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   Animated,
   Platform,

--- a/src/components/GestureComponents.tsx
+++ b/src/components/GestureComponents.tsx
@@ -1,4 +1,5 @@
-import React, { PropsWithChildren } from 'react';
+import * as React from 'react';
+import { PropsWithChildren } from 'react';
 import {
   ScrollView as RNScrollView,
   ScrollViewProps as RNScrollViewProps,

--- a/src/components/GestureComponents.web.tsx
+++ b/src/components/GestureComponents.web.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   DrawerLayoutAndroid as RNDrawerLayoutAndroid,
   FlatList as RNFlatList,

--- a/src/components/GestureHandlerButton.web.tsx
+++ b/src/components/GestureHandlerButton.web.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { View } from 'react-native';
 
 export default React.forwardRef<View>((props, ref) => (

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -2,7 +2,8 @@
 // separate repo. Although, keeping it here for the time being will allow us
 // to move faster and fix possible issues quicker
 
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import {
   Animated,
   StyleSheet,

--- a/src/components/touchables/GenericTouchable.tsx
+++ b/src/components/touchables/GenericTouchable.tsx
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import {
   Animated,
   Platform,

--- a/src/components/touchables/TouchableHighlight.tsx
+++ b/src/components/touchables/TouchableHighlight.tsx
@@ -1,4 +1,5 @@
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import GenericTouchable, {
   GenericTouchableProps,
   TOUCHABLE_STATE,

--- a/src/components/touchables/TouchableNativeFeedback.android.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.android.tsx
@@ -3,7 +3,8 @@ import {
   TouchableNativeFeedbackProps,
   ColorValue,
 } from 'react-native';
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 import GenericTouchable, { GenericTouchableProps } from './GenericTouchable';
 
 export type TouchableNativeFeedbackExtraProps = {

--- a/src/components/touchables/TouchableOpacity.tsx
+++ b/src/components/touchables/TouchableOpacity.tsx
@@ -9,7 +9,8 @@ import GenericTouchable, {
   TOUCHABLE_STATE,
   GenericTouchableProps,
 } from './GenericTouchable';
-import React, { Component } from 'react';
+import * as React from 'react';
+import { Component } from 'react';
 
 /**
  * TouchableOpacity bases on timing animation which has been used in RN's core

--- a/src/components/touchables/TouchableWithoutFeedback.tsx
+++ b/src/components/touchables/TouchableWithoutFeedback.tsx
@@ -1,4 +1,5 @@
-import React, { PropsWithChildren } from 'react';
+import * as React from 'react';
+import { PropsWithChildren } from 'react';
 import GenericTouchable, { GenericTouchableProps } from './GenericTouchable';
 
 const TouchableWithoutFeedback = React.forwardRef<

--- a/src/gestureHandlerRootHOC.tsx
+++ b/src/gestureHandlerRootHOC.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import GestureHandlerRootView from './GestureHandlerRootView';

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import * as React from 'react';
 import {
   findNodeHandle as findNodeHandleRN,
   NativeModules,

--- a/src/handlers/createNativeWrapper.tsx
+++ b/src/handlers/createNativeWrapper.tsx
@@ -1,4 +1,5 @@
-import React, { useImperativeHandle, useRef } from 'react';
+import * as React from 'react';
+import { useImperativeHandle, useRef } from 'react';
 
 import {
   NativeViewGestureHandler,

--- a/src/handlers/gestureHandlers.ts
+++ b/src/handlers/gestureHandlers.ts
@@ -2,7 +2,7 @@
 // Without those types, we'd introduce breaking change, forcing users to prefix every handler type specification with typeof
 // e.g. React.createRef<TapGestureHandler> -> React.createRef<typeof TapGestureHandler>.
 // See https://www.typescriptlang.org/docs/handbook/classes.html#constructor-functions for reference.
-import React from 'react';
+import * as React from 'react';
 
 import createHandler from './createHandler';
 import PlatformConstants from '../PlatformConstants';


### PR DESCRIPTION
## Description

React doesn't have a default import so we should import it as all import.

This came up when writing PR adding [constants to Platform](https://github.com/DefinitelyTyped/DefinitelyTyped/pull/51146) in RN types.
```
Error: 1> node_modules/react-native-gesture-handler/dist/src/components/DrawerLayout.d.ts(1,8): error TS1259: Module '"/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/react/index"' can only be default-imported using the 'esModuleInterop' flag
Error: 1> node_modules/react-native-gesture-handler/dist/src/components/GestureButtons.d.ts(1,8): error TS1259: Module '"/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/react/index"' can only be default-imported using the 'esModuleInterop' flag
Error: 1> node_modules/react-native-gesture-handler/dist/src/components/GestureComponents.d.ts(1,8): error TS1259: Module '"/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/react/index"' can only be default-imported using the 'esModuleInterop' flag
Error: 1> node_modules/react-native-gesture-handler/dist/src/components/Swipeable.d.ts(1,8): error TS1259: Module '"/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/react/index"' can only be default-imported using the 'esModuleInterop' flag
Error: 1> node_modules/react-native-gesture-handler/dist/src/components/touchables/TouchableWithoutFeedback.d.ts(1,8): error TS1259: Module '"/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/react/index"' can only be default-imported using the 'esModuleInterop' flag
Error: 1> node_modules/react-native-gesture-handler/dist/src/gestureHandlerRootHOC.d.ts(1,8): error TS1259: Module '"/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/react/index"' can only be default-imported using the 'esModuleInterop' flag
Error: 1> node_modules/react-native-gesture-handler/dist/src/handlers/createNativeWrapper.d.ts(1,8): error TS1259: Module '"/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/react/index"' can only be default-imported using the 'esModuleInterop' flag
Error: 1> node_modules/react-native-gesture-handler/dist/src/handlers/gestureHandlers.d.ts(1,8): error TS1259: Module '"/home/runner/work/DefinitelyTyped/DefinitelyTyped/types/react/index"' can only be default-imported using the 'esModuleInterop' flag
```