### PR TITLE
Fix gestureHandlerRootHOC types

### DIFF
--- a/src/gestureHandlerRootHOC.tsx
+++ b/src/gestureHandlerRootHOC.tsx
@@ -3,7 +3,9 @@ import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import GestureHandlerRootView from './GestureHandlerRootView';
 
-export default function gestureHandlerRootHOC<P extends Record<string, unknown>>(
+export default function gestureHandlerRootHOC<
+  P extends Record<string, unknown>
+>(
   Component: React.ComponentType<P>,
   containerStyles?: StyleProp<ViewStyle>
 ): React.ComponentType<P> {

--- a/src/gestureHandlerRootHOC.tsx
+++ b/src/gestureHandlerRootHOC.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import GestureHandlerRootView from './GestureHandlerRootView';
 
-export default function gestureHandlerRootHOC<P>(
+export default function gestureHandlerRootHOC<P extends object>(
   Component: React.ComponentType<P>,
   containerStyles?: StyleProp<ViewStyle>
 ): React.ComponentType<P> {

--- a/src/gestureHandlerRootHOC.tsx
+++ b/src/gestureHandlerRootHOC.tsx
@@ -3,7 +3,7 @@ import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import GestureHandlerRootView from './GestureHandlerRootView';
 
-export default function gestureHandlerRootHOC<P extends object>(
+export default function gestureHandlerRootHOC<P extends Record<string, unknown>>(
   Component: React.ComponentType<P>,
   containerStyles?: StyleProp<ViewStyle>
 ): React.ComponentType<P> {

--- a/src/gestureHandlerRootHOC.tsx
+++ b/src/gestureHandlerRootHOC.tsx
@@ -3,11 +3,11 @@ import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import GestureHandlerRootView from './GestureHandlerRootView';
 
-export default function gestureHandlerRootHOC(
-  Component: React.ComponentType<Record<string, unknown>>,
+export default function gestureHandlerRootHOC<P>(
+  Component: React.ComponentType<P>,
   containerStyles?: StyleProp<ViewStyle>
-): React.ComponentType<Record<string, unknown>> {
-  function Wrapper(props: Record<string, unknown>) {
+): React.ComponentType<P> {
+  function Wrapper(props: P) {
     return (
       <GestureHandlerRootView style={[styles.container, containerStyles]}>
         <Component {...props} />


### PR DESCRIPTION
## Description

With the most recent update, `gestureHandlerRootHOC()` gives errors like:
```
Argument of type 'typeof HomeScreen' is not assignable to parameter of type 'ComponentType<Record<string, unknown>>'.
  Type 'typeof HomeScreen' is not assignable to type 'FunctionComponent<Record<string, unknown>>'.
    Types of parameters 'props' and 'props' are incompatible.
```

## Test plan

<!--
Describe how did you test this change here.
-->

`yarn ts-check`

The only change is typings which now allow my project to run clean.