### PR TITLE
Rename _handlerTag to handlerTag

### DIFF
--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -194,7 +194,6 @@ export default function createHandler<
       this.handlerTag = handlerTag++;
       this.config = {};
       this.propsRef = React.createRef();
-      
       if (props.id) {
         if (handlerIDToTag[props.id] !== undefined) {
           throw new Error(`Handler with ID "${props.id}" already registered`);

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -122,7 +122,7 @@ function transformIntoHandlerTags(handlerIDs: any) {
   return handlerIDs
     .map(
       (handlerID: any) =>
-        handlerIDToTag[handlerID] || handlerID.current?._handlerTag || -1
+        handlerIDToTag[handlerID] || handlerID.current?.handlerTag || -1
     )
     .filter((handlerTag: number) => handlerTag > 0);
 }
@@ -194,7 +194,7 @@ export default function createHandler<
       this.handlerTag = handlerTag++;
       this.config = {};
       this.propsRef = React.createRef();
-
+      
       if (props.id) {
         if (handlerIDToTag[props.id] !== undefined) {
           throw new Error(`Handler with ID "${props.id}" already registered`);

--- a/src/handlers/createNativeWrapper.tsx
+++ b/src/handlers/createNativeWrapper.tsx
@@ -51,7 +51,7 @@ export default function createNativeWrapper<P>(
         // add handlerTag for relations config
         if (_ref.current && node) {
           // @ts-ignore FIXME(TS) think about createHandler return type
-          _ref.current._handlerTag = node._handlerTag;
+          _ref.current.handlerTag = node.handlerTag;
           return _ref.current;
         }
         return null;

--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -506,10 +506,10 @@ function ensureConfig(config: Config): Required<Config> {
   }
   if ('waitFor' in config) {
     props.waitFor = asArray(config.waitFor)
-      .map(({ _handlerTag }: { _handlerTag: number }) =>
-        NodeManager.getHandler(_handlerTag)
+      .map(({ handlerTag }: { handlerTag: number }) =>
+        NodeManager.getHandler(handlerTag)
       )
-      .filter((v) => v);
+      .filter(v => v);
   } else {
     props.waitFor = null;
   }

--- a/src/web/NativeViewGestureHandler.ts
+++ b/src/web/NativeViewGestureHandler.ts
@@ -15,7 +15,7 @@ class NativeViewGestureHandler extends PressGestureHandler {
         // @ts-ignore FIXME(TS) config type
         if (this.config.disallowInterruption) {
           const gestures = Object.values(NodeManager.getNodes()).filter(
-            (gesture) => {
+            gesture => {
               const { handlerTag, view, isGestureRunning } = gesture;
               return (
                 // Check if this gesture isn't self


### PR DESCRIPTION
## Description

Fixes #1354.

We didn't rename all instances of `_handlerTag` to `handlerTag`. That caused `waitFor` tag resolution to fail and this prop was ignored.

## Test code

```ts
import React, {useRef} from 'react';
import {StyleSheet, View, ScrollView, Text} from 'react-native';
import {
  NativeViewGestureHandler,
  PanGestureHandler,
} from 'react-native-gesture-handler';

const App = () => {
  const panRef = useRef<PanGestureHandler>(null);
  return (
    <View style={styles.container}>
      <PanGestureHandler ref={panRef}>
        <NativeViewGestureHandler waitFor={panRef}>
          <ScrollView style={styles.container}>
            {Array(50)
              .fill(0)
              .map((_, index) => (
                <Text
                  key={`item-${index}`}
                  style={styles.item}>{`item-${index}`}</Text>
              ))}
          </ScrollView>
        </NativeViewGestureHandler>
      </PanGestureHandler>
    </View>
  );
};

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
  item: {
    padding: 6,
    margin: 3,
    backgroundColor: '#999',
  },
});
export default App;
```