### PR TITLE
Fix mocks import in jestSetup.js

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -1,1 +1,7 @@
-jest.mock('./src/RNGestureHandlerModule');
+jest.mock('./src/RNGestureHandlerModule', () => require('./src/mocks'));
+jest.mock('./lib/commonjs/RNGestureHandlerModule', () =>
+  require('./lib/commonjs/mocks')
+);
+jest.mock('./lib/module/RNGestureHandlerModule', () =>
+  require('./lib/module/mocks')
+);

--- a/src/__mocks__/RNGestureHandlerModule.ts
+++ b/src/__mocks__/RNGestureHandlerModule.ts
@@ -1,27 +1,5 @@
-import { View, ScrollView } from 'react-native';
-
-const NOOP = () => {
-  // do nothing
-};
+import Mocks from '../mocks';
 
 export default {
-  ScrollView,
-  PanGestureHandler: View,
-  attachGestureHandler: NOOP,
-  createGestureHandler: NOOP,
-  dropGestureHandler: NOOP,
-  updateGestureHandler: NOOP,
-  Direction: {
-    RIGHT: 1,
-    LEFT: 2,
-    UP: 4,
-    DOWN: 8,
-  },
-  State: {
-    BEGAN: 'BEGAN',
-    FAILED: 'FAILED',
-    ACTIVE: 'ACTIVE',
-    END: 'END',
-    UNDETERMINED: 'UNDETERMINED',
-  },
+  ...Mocks,
 };

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -1,0 +1,25 @@
+import { View, ScrollView as RNScrollView } from 'react-native';
+import { State } from './State';
+import { Directions } from './Directions';
+
+const NOOP = () => {
+  // do nothing
+};
+const ScrollView = RNScrollView;
+const PanGestureHandler = View;
+const attachGestureHandler = NOOP;
+const createGestureHandler = NOOP;
+const dropGestureHandler = NOOP;
+const updateGestureHandler = NOOP;
+
+export default {
+  ScrollView,
+  PanGestureHandler,
+  attachGestureHandler,
+  createGestureHandler,
+  dropGestureHandler,
+  updateGestureHandler,
+  // probably can be removed
+  Directions,
+  State,
+} as const;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,5 +18,5 @@
     "noUnusedParameters": true,
     "noUnusedLocals": true
   },
-  "include": ["src/**/*.ts", "src/**/*.tsx"]
+  "include": ["src/**/*.ts", "src/**/*.tsx", "jestSetup.js"]
 }


### PR DESCRIPTION
## Description

Fixes #1368.
In 8809501f5095045bb5d9454a0ef858a68ea5bc5a we moved __mocks__ to the src/ dir and didn't update jestSetup.js. After that, Bob has been introduced, so this PR create a new file with exported mocks and requires it in the proper locations:

- `./src/RNGestureHandlerModule`
- `./lib/commonjs/RNGestureHandlerModule`
- `./lib/module/RNGestureHandlerModule`

The last two locations are generated but there's no need to include mocks in all locations programmatically yet.

## Test plan

Packed a library and used `yarn test` in generated TS example RN app. Jest runs code from `commonjs` dir.
