### PR TITLE
Update deprecated getConstants() call

### DIFF
--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -43,11 +43,11 @@ UIManager.genericDirectEventTypes = {
   ...customGHEventsConfig,
 };
 // In newer versions of RN the `genericDirectEventTypes` is located in the object
-// returned by UIManager.getConstants(), we need to add it there as well to make
+// returned by UIManager.getViewManagerConfig('getConstants'), we need to add it there as well to make
 // it compatible with RN 61+
-if (UIManager.getConstants) {
-  UIManager.getConstants().genericDirectEventTypes = {
-    ...UIManager.getConstants().genericDirectEventTypes,
+if (UIManager.getViewManagerConfig) {
+  UIManager.getViewManagerConfig('getConstants').genericDirectEventTypes = {
+    ...UIManager.getViewManagerConfig('getConstants').genericDirectEventTypes,
     ...customGHEventsConfig,
   };
 }


### PR DESCRIPTION
## Description

Fixes #742 

React Native displays this warning

![Screen Shot 2021-02-22 at 3 36 39 PM](https://user-images.githubusercontent.com/36489467/108904838-3c4f0a80-75dc-11eb-9d0f-0d1be34def94.png)

*"Accessing view manager configs directly off UIManager via UIManager['getConstants'] is no longer supported. Use UIManager.getViewManagerConfig('getConstants') instead."*

when using `react-navigation` with `react-native-gesture-handler` in an app. Thanks to [this comment](https://github.com/software-mansion/react-native-gesture-handler/issues/742#issuecomment-570094380) by @RandomToni, I was able to update the code to use `UIManager.getViewManagerConfig('getConstants')` instead of `UIManager['getConstants']`.

Unfortunately, when I try to use this fork in our `package.json` by referencing commit 87bee84a, the Android build fails with the error

*cannot find symbol import com.swmansion.gesturehandler.RNGestureHandlerPackage*

This issue was logged in #1250, but doesn't seem to be resolved yet, so I had to use `patch-package` to implement the change until this PR is merged. Here is the patch for reference:

```js
diff --git a/node_modules/react-native-gesture-handler/src/handlers/createHandler.ts b/node_modules/react-native-gesture-handler/src/handlers/createHandler.ts
index 9e536f0..96df18b 100644
--- a/node_modules/react-native-gesture-handler/src/handlers/createHandler.ts
+++ b/node_modules/react-native-gesture-handler/src/handlers/createHandler.ts
@@ -43,11 +43,11 @@ UIManager.genericDirectEventTypes = {
   ...customGHEventsConfig,
 };
 // In newer versions of RN the `genericDirectEventTypes` is located in the object
-// returned by UIManager.getConstants(), we need to add it there as well to make
+// returned by UIManager.getViewManagerConfig('getConstants'), we need to add it there as well to make
 // it compatible with RN 61+
-if (UIManager.getConstants) {
-  UIManager.getConstants().genericDirectEventTypes = {
-    ...UIManager.getConstants().genericDirectEventTypes,
+if (UIManager.getViewManagerConfig) {
+  UIManager.getViewManagerConfig('getConstants').genericDirectEventTypes = {
+    ...UIManager.getViewManagerConfig('getConstants').genericDirectEventTypes,
     ...customGHEventsConfig,
   };
 }
```

## Test plan

`react-navigation` continued to work, and the warning was gone after this change was implemented.
