### PR TITLE
Add older way to get UIManger constants

### DIFF
--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -43,11 +43,15 @@ UIManager.genericDirectEventTypes = {
   ...customGHEventsConfig,
 };
 // In newer versions of RN the `genericDirectEventTypes` is located in the object
-// returned by UIManager.getViewManagerConfig('getConstants'), we need to add it there as well to make
+// returned by UIManager.getViewManagerConfig('getConstants') or in older RN UIManager.getConstants(), we need to add it there as well to make
 // it compatible with RN 61+
-if (UIManager.getViewManagerConfig) {
-  UIManager.getViewManagerConfig('getConstants').genericDirectEventTypes = {
-    ...UIManager.getViewManagerConfig('getConstants').genericDirectEventTypes,
+const UIManagerConstants =
+  UIManager.getViewManagerConfig?.('getConstants') ??
+  UIManager.getConstants?.();
+
+if (UIManagerConstants) {
+  UIManagerConstants.genericDirectEventTypes = {
+    ...UIManagerConstants.genericDirectEventTypes,
     ...customGHEventsConfig,
   };
 }


### PR DESCRIPTION
## Description

After merging #1379 I noticed we removed the older way to get constants. To keep backward compact we first try to use `getViewManagerConfig` and if it's not available we fall back to `getConstants`.

## Test plan

Tested if Example App still works.