### PR TITLE
Move types to type exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,8 +2,7 @@ export { Directions } from './Directions';
 export { State } from './State';
 export { default as gestureHandlerRootHOC } from './gestureHandlerRootHOC';
 export { default as GestureHandlerRootView } from './GestureHandlerRootView';
-
-export {
+export type {
   // event types
   GestureEvent,
   HandlerStateChangeEvent,
@@ -25,7 +24,8 @@ export {
   PinchGestureHandlerProps,
   RotationGestureHandlerProps,
   FlingGestureHandlerProps,
-  // gesture handlers
+} from './handlers/gestureHandlers';
+export {
   TapGestureHandler,
   ForceTouchGestureHandler,
   LongPressGestureHandler,
@@ -35,19 +35,18 @@ export {
   FlingGestureHandler,
 } from './handlers/gestureHandlers';
 export { default as createNativeWrapper } from './handlers/createNativeWrapper';
-export {
-  NativeViewGestureHandler,
+export type {
   NativeViewGestureHandlerPayload,
   NativeViewGestureHandlerProps,
 } from './handlers/NativeViewGestureHandler';
-
-export {
-  // buttons props
+export { NativeViewGestureHandler } from './handlers/NativeViewGestureHandler';
+export type {
   RawButtonProps,
   BaseButtonProps,
   RectButtonProps,
   BorderlessButtonProps,
-  // buttons
+} from './components/GestureButtons';
+export {
   RawButton,
   BaseButton,
   RectButton,
@@ -66,7 +65,7 @@ export {
   DrawerLayoutAndroid,
   FlatList,
 } from './components/GestureComponents';
-export {
+export type {
   //events
   GestureHandlerGestureEvent,
   GestureHandlerStateChangeEvent,
@@ -98,7 +97,7 @@ export {
   RotationGestureHandlerProperties,
   FlingGestureHandlerProperties,
   ForceTouchGestureHandlerProperties,
-  // buttons
+  // buttons props
   RawButtonProperties,
   BaseButtonProperties,
   RectButtonProperties,
@@ -106,8 +105,7 @@ export {
 } from './handlers/gestureHandlerTypesCompat';
 
 export { default as Swipeable } from './components/Swipeable';
-export {
-  default as DrawerLayout,
+export type {
   DrawerLayoutProps,
   DrawerPosition,
   DrawerState,
@@ -115,3 +113,4 @@ export {
   DrawerLockMode,
   DrawerKeyboardDismissMode,
 } from './components/DrawerLayout';
+export { default as DrawerLayout } from './components/DrawerLayout';


### PR DESCRIPTION
## Description

Fixes #1388.
Babel TS types plugin doesn't check if something is a value or a type so types in export weren't stripped.
