### PR TITLE
Prop for ending pinching gesture when one finger is lifted (iOS)

### DIFF
--- a/ios/Handlers/RNPinchHandler.m
+++ b/ios/Handlers/RNPinchHandler.m
@@ -8,17 +8,69 @@
 
 #import "RNPinchHandler.h"
 
+#import <UIKit/UIGestureRecognizerSubclass.h>
+
+@interface RNBetterPinchGestureRecognizer : UIPinchGestureRecognizer
+
+@property (nonatomic) BOOL twoPointersRequired;
+
+- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+
+@end
+
+@implementation RNBetterPinchGestureRecognizer {
+    __weak RNGestureHandler *_gestureHandler;
+}
+
+- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
+{
+    if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
+        _gestureHandler = gestureHandler;
+        _twoPointersRequired = NO;
+    }
+    return self;
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+    [super touchesEnded:touches withEvent:event];
+
+    // UIPinchGestureRecognizer ends pinching gesture when the user lifts BOTH fingers
+    // from the view. If twoPointersRequired prop is true, we end the gesture when the
+    // user lifts one finger from the view.
+    if (_twoPointersRequired) {
+        self.state = UIGestureRecognizerStateEnded;
+        [self reset];
+    }
+}
+
+@end
+
 @implementation RNPinchGestureHandler
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
     if ((self = [super initWithTag:tag])) {
 #if !TARGET_OS_TV
-        _recognizer = [[UIPinchGestureRecognizer alloc] initWithTarget:self action:@selector(handleGesture:)];
+        _recognizer = [[RNBetterPinchGestureRecognizer alloc] initWithGestureHandler:self];
 #endif
     }
     return self;
 }
+
+#if !TARGET_OS_TV
+- (void)configure:(NSDictionary *)config
+{
+    [super configure:config];
+    RNBetterPinchGestureRecognizer *recognizer = (RNBetterPinchGestureRecognizer *)_recognizer;
+    id prop = config[@"twoPointersRequired"];
+    if (prop != nil) {
+        recognizer.twoPointersRequired = [RCTConvert BOOL:prop];
+    } else {
+        recognizer.twoPointersRequired = NO;
+    }
+}
+#endif
 
 #if !TARGET_OS_TV
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIPinchGestureRecognizer *)recognizer

--- a/ios/Handlers/RNPinchHandler.m
+++ b/ios/Handlers/RNPinchHandler.m
@@ -38,7 +38,7 @@
     // UIPinchGestureRecognizer ends pinching gesture when the user lifts BOTH fingers
     // from the view. If twoPointersRequired prop is true, we end the gesture when the
     // user lifts one finger from the view.
-    if (_twoPointersRequired) {
+    if (_twoPointersRequired && self.state == UIGestureRecognizerStateChanged) {
         self.state = UIGestureRecognizerStateEnded;
         [self reset];
     }

--- a/src/handlers/gestureHandlers.ts
+++ b/src/handlers/gestureHandlers.ts
@@ -485,7 +485,10 @@ export const PinchGestureHandler = createHandler<
   PinchGestureHandlerEventPayload
 >({
   name: 'PinchGestureHandler',
-  allowedProps: baseProps,
+  allowedProps: [
+    ...baseProps,
+    'twoPointersRequired',
+  ] as const,
   config: {},
 });
 

--- a/src/handlers/gestureHandlers.ts
+++ b/src/handlers/gestureHandlers.ts
@@ -476,7 +476,9 @@ export type PinchGestureHandlerEventPayload = {
 };
 
 export interface PinchGestureHandlerProps
-  extends BaseGestureHandlerProps<PinchGestureHandlerEventPayload> {}
+  extends BaseGestureHandlerProps<PinchGestureHandlerEventPayload> {
+  twoPointersRequired?: boolean;
+}
 
 export type PinchGestureHandler = typeof PinchGestureHandler;
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; see description on the top of this file

--- a/src/handlers/gestureHandlers.ts
+++ b/src/handlers/gestureHandlers.ts
@@ -487,10 +487,7 @@ export const PinchGestureHandler = createHandler<
   PinchGestureHandlerEventPayload
 >({
   name: 'PinchGestureHandler',
-  allowedProps: [
-    ...baseProps,
-    'twoPointersRequired',
-  ] as const,
+  allowedProps: [...baseProps, 'twoPointersRequired'] as const,
   config: {},
 });
 


### PR DESCRIPTION
## Description

Fixes #1214.

Probably the maintainers don't want to alter the native iOS behavior with this PR, but this fork can be useful for those who want to avoid writing workarounds.

This fork adds a new boolean prop for PinchGestureHandler (iOS only): **twoPointersRequired**
* `false` (default): no change for behavior; lets [UIPinchGestureRecognizer](https://developer.apple.com/documentation/uikit/uipinchgesturerecognizer) end the gesture when the user lifts off **both** fingers from the view
* `true`: end the gesture when the user lifts off **one** finger from the view

<!--
Description and motivation for this PR.

Inlude 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

Tested on iPhone 6s Plus.

```js
<PinchGestureHandler twoPointersRequired={true}>
  ...
</PinchGestureHandler>
```

<!--
Describe how did you test this change here.
-->
