### PR TITLE
Improve type definitions of wrapped Gesture Components

### DIFF
--- a/examples/Example/src/App.tsx
+++ b/examples/Example/src/App.tsx
@@ -135,7 +135,7 @@ function MainScreen({ navigation }: StackScreenProps<ParamListBase>) {
       renderItem={(props) => (
         <MainScreenItem
           {...props}
-          onPressItem={({ key }: { key: string }) => navigation.navigate(key)}
+          onPressItem={({ key }) => navigation.navigate(key)}
         />
       )}
       renderScrollComponent={(props) => <ScrollView {...props} />}

--- a/src/components/GestureComponents.tsx
+++ b/src/components/GestureComponents.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { PropsWithChildren } from 'react';
+import {
+  PropsWithChildren,
+  ForwardedRef,
+  RefAttributes,
+  ReactElement,
+} from 'react';
 import {
   ScrollView as RNScrollView,
   ScrollViewProps as RNScrollViewProps,
@@ -24,15 +29,9 @@ export const ScrollView = createNativeWrapper<
   shouldCancelWhenOutside: false,
 });
 // backward type compatibility with https://github.com/software-mansion/react-native-gesture-handler/blob/db78d3ca7d48e8ba57482d3fe9b0a15aa79d9932/react-native-gesture-handler.d.ts#L440-L457
+// include methods of wrapped components by creating an intersection type with the RN component instead of duplicating them.
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export type ScrollView = typeof ScrollView & {
-  scrollTo(
-    y?: number | { x?: number; y?: number; animated?: boolean },
-    x?: number,
-    animated?: boolean
-  ): void;
-  scrollToEnd(options?: { animated: boolean }): void;
-};
+export type ScrollView = typeof ScrollView & RNScrollView;
 
 export const Switch = createNativeWrapper<RNSwitchProps>(RNSwitch, {
   shouldCancelWhenOutside: false,
@@ -40,47 +39,32 @@ export const Switch = createNativeWrapper<RNSwitchProps>(RNSwitch, {
   disallowInterruption: true,
 });
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export type Switch = typeof Switch;
+export type Switch = typeof Switch & RNSwitch;
 
 export const TextInput = createNativeWrapper<RNTextInputProps>(RNTextInput);
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export type TextInput = typeof TextInput;
+export type TextInput = typeof TextInput & RNTextInput;
 
 export const DrawerLayoutAndroid = createNativeWrapper<
   PropsWithChildren<RNDrawerLayoutAndroidProps>
 >(RNDrawerLayoutAndroid, { disallowInterruption: true });
-// we use literal object since TS gives error when using RN's `positions`
-// @ts-ignore FIXME(TS) maybe this should be removed?
-DrawerLayoutAndroid.positions = { Left: 'left', Right: 'right' };
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export type DrawerLayoutAndroid = typeof DrawerLayoutAndroid;
+export type DrawerLayoutAndroid = typeof DrawerLayoutAndroid &
+  RNDrawerLayoutAndroid;
 
-export const FlatList = React.forwardRef<RNFlatList<any>, RNFlatListProps<any>>(
-  (props, ref) => (
-    <RNFlatList
-      ref={ref}
-      {...props}
-      renderScrollComponent={(scrollProps) => <ScrollView {...scrollProps} />}
-    />
-  )
-);
+export const FlatList = React.forwardRef((props, ref) => (
+  <RNFlatList
+    ref={ref}
+    {...props}
+    renderScrollComponent={(scrollProps) => <ScrollView {...scrollProps} />}
+  />
+)) as <ItemT = any>(
+  props: PropsWithChildren<
+    RNFlatListProps<ItemT> &
+      RefAttributes<FlatList<ItemT>> &
+      NativeViewGestureHandlerProps
+  >,
+  ref: ForwardedRef<FlatList<ItemT>>
+) => ReactElement | null;
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export type FlatList<ItemT> = React.ComponentType<
-  RNFlatListProps<ItemT> &
-    NativeViewGestureHandlerProps &
-    React.RefAttributes<any>
-> & {
-  scrollToEnd: (params?: { animated?: boolean }) => void;
-  scrollToIndex: (params: {
-    animated?: boolean;
-    index: number;
-    viewOffset?: number;
-    viewPosition?: number;
-  }) => void;
-  scrollToItem: (params: {
-    animated?: boolean;
-    item: ItemT;
-    viewPosition?: number;
-  }) => void;
-  scrollToOffset: (params: { animated?: boolean; offset: number }) => void;
-};
+export type FlatList<ItemT = any> = typeof FlatList & RNFlatList<ItemT>;


### PR DESCRIPTION
## Description
Continuation of #1373

Fixes #1371 
Fixes #1349 

### Include all methods of wrapped component in exported type (#1371)
The types for the wrapped gesture components exported by this library were missing some of the methods provided by those components. This resulted in TypeScript errors being raised when trying to call them on a `ref` and prevented IntelliSense from suggesting those methods for auto-completion.

```typescript
const ref = useRef<TextInput>(null);

const blurInput = () => ref.current?.blur(); // Property 'blur' does not exist on type [...]

```

This was already partially prevented for `ScrollView` and `FlatList` by [duplicating the methods](https://github.com/software-mansion/react-native-gesture-handler/blob/b9bd04eefdb078c69794639503c5073845e7b36c/src/components/GestureComponents.tsx#L28) from React Native.

But instead of duplicating all the methods for the other components as well I created an intersection type with the wrapped component for each of them. Since the type of the wrapped component (e.g. `RNTextInput`) is just an interface with all public methods and variables exposed by the class this achieves the same result as manually duplicating them in a much cleaner way. 
```typescript
export type TextInput = typeof TextInput & RNTextInput;

// Achieves the same result as:
export type TextInput = typeof TextInput & { // All methods of RNTextInput }:
```

With these changes in place I also removed `DrawerLayoutAndroid.positions = { Left: 'left', Right: 'right' }` based on [this comment](https://github.com/software-mansion/react-native-gesture-handler/pull/1373#discussion_r589326907), as it should no longer be needed since `positions` is now duplicated from the React Native type.

### Add support for generic parameter to wrapped FlatList (#1349)
The wrapped `FlatList` component exported by this library was missing the generic `ItemT` parameter, which prevented the type of `item` in `renderItem` from being inferred correctly.

Since `forwardRef()` doesn't work with generic parameters I casted the function returned by it to achieve this.

## Test plan
I tested the changes with the minimal code examples from the linked issues and also tried a few different configurations for both. In all cases no invalid TypeScript errors were raised and the type checking behaved like expected / consistent with the non-wrapped components from React Native.
