### PR TITLE
Prevent inject `@types/node`

### DIFF
--- a/src/components/touchables/GenericTouchable.tsx
+++ b/src/components/touchables/GenericTouchable.tsx
@@ -57,7 +57,7 @@ interface InternalProps {
 
 // TODO: maybe can be better
 // TODO: all clearTimeout have ! added, maybe they shouldn't ?
-type Timeout = ReturnType<typeof setTimeout> | null | undefined;
+type Timeout = any;
 
 /**
  * GenericTouchable is not intented to be used as it is.


### PR DESCRIPTION
## Description

Currently, TS compiled GenericTouchable has `/// <reference types="node" />`.
It means project that depend to react-native-gesture-handler ( of course, react-navigation, too)
is injected `@types/node`. I think most developers don't expect it.

I know this p-r isn't good solution, but react-navigation also seems to use
similar solutions.

https://github.com/react-navigation/react-navigation/blob/038eb87c42564f9d733e6870826726d3fb0adaee/packages/stack/src/views/KeyboardManager.tsx#L24
https://github.com/react-navigation/react-navigation/blob/dd48fe9b158814cab272fb85c74fc7079e8cef27/packages/stack/src/views/Stack/Card.tsx#L328-L334


## Test plan

<!--
Describe how did you test this change here.
-->
