### PR TITLE
Remove implicit inclusion of types

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "esModuleInterop": true,
     "jsx": "react-native",
     "lib": ["esnext"],
+    "types": [],
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
@@ -12,6 +13,7 @@
     "target": "esnext",
     "declaration": true,
     "declarationMap": false,
+
     "noStrictGenericChecks": false,
     "forceConsistentCasingInFileNames": true,
     "noImplicitUseStrict": false,


### PR DESCRIPTION
## Description

Typescript includes types even if they're not explicitly imported. This behavior makes some declaration types in Gesture Handler include node's typings which isn't desired since React Native shadows some declarations from Node (e.g. [`setInterval`](https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/react-native/globals.d.ts#L12)).

We're utilizing [`types`](https://www.typescriptlang.org/tsconfig#types) property to prevent TS from including all definitions from `node_modules/@types`.

Hopefully, finally fixes #1384

### References

- [Discussion about _excluding_ some packages' definitions and TS maintainer response](https://github.com/microsoft/TypeScript/issues/18588#issuecomment-704482601)
- [PR in TS introducing opaque type definitions](https://github.com/microsoft/TypeScript/issues/31894) - this can prevent those type of issues in the future

## Test plan

`yarn bob build`ed `GenericTouchable.d.ts` before and after:

### Before

```js
/// <reference types="node" />
import { Component } from 'react';
import { StyleProp, ViewStyle, TouchableWithoutFeedbackProps } from 'react-native';
import { GestureEvent, HandlerStateChangeEvent } from '../../handlers/gestureHandlers';
// (...)
```

### After

```js
import { Component } from 'react';
import { StyleProp, ViewStyle, TouchableWithoutFeedbackProps } from 'react-native';
import { GestureEvent, HandlerStateChangeEvent } from '../../handlers/gestureHandlers';
// (...)
```