### PR TITLE
Annotate extraData with nonnull

### DIFF
--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -67,7 +67,7 @@ if (value != nil) recognizer.prop = [RCTConvert type:value]; \
 - (void)reset;
 - (void)sendEventsInState:(RNGestureHandlerState)state
            forViewWithTag:(nonnull NSNumber *)reactTag
-            withExtraData:(RNGestureHandlerEventExtraData *)extraData;
+            withExtraData:(nonnull RNGestureHandlerEventExtraData *)extraData;
 
 @end
 


### PR DESCRIPTION
## Description
Fixes #1138.
Due to compat with Swift, `extraData` argument was issuing a warning.
