### PR TITLE
Fix compatibility with React 18

### DIFF
--- a/src/web/NodeManager.ts
+++ b/src/web/NodeManager.ts
@@ -22,6 +22,8 @@ export function createGestureHandler(
 }
 
 export function dropGestureHandler(handlerTag: number) {
+  // Since React 18, there are cases where componentWillUnmount gets called twice in a row
+  // so skip this if the tag was already removed.
   if (!(handlerTag in gestures)) {
     return;
   }

--- a/src/web/NodeManager.ts
+++ b/src/web/NodeManager.ts
@@ -22,6 +22,9 @@ export function createGestureHandler(
 }
 
 export function dropGestureHandler(handlerTag: number) {
+  if (!(handlerTag in gestures)) {
+    return;
+  }
   getHandler(handlerTag).destroy();
   // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
   delete gestures[handlerTag];


### PR DESCRIPTION
## Description

On web, there are cases now in React 18 where `componentWillUnmount` gets called twice in a row. I think it is related to https://github.com/reactwg/react-18/discussions/31. This causes a `No handler for tag` error since the handler was cleaned up already in the first `componentWillUnmount` call.

To workaround the issue I added a check to no-op of the handler tag is not found. I think this is fine in that case and simpler than tracking whether the handler was cleaned up in the `createHandler` component.

## Test plan

I don't have a simple repro case, but seems to happen when a component suspends, then immediatly gets unmounted. In my case this happens with navigation.

Tested that this fixes the crash in my app.
