### PR TITLE
Fix iteration over argument mapping on web

### DIFF
--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -466,8 +466,7 @@ function invokeNullableMethod(
         if ('__nodeConfig' in method) {
           const { argMapping } = method.__nodeConfig;
           if (Array.isArray(argMapping)) {
-            for (const index in argMapping) {
-              const [key, value] = argMapping[index];
+            for (const [index, [key, value]] of argMapping.entries()) {
               if (key in event.nativeEvent) {
                 // @ts-ignore fix method type
                 const nativeValue = event.nativeEvent[key];


### PR DESCRIPTION
## URGENT

`index of` was reading properties and indexes instead of reading only indexes which made the next line `const [key, value] = argMapping[index]` crash

![Screen Shot 2021-07-14 at 17 06 21](https://user-images.githubusercontent.com/22295901/125635974-954717da-98f6-4015-88e2-a4c021e239af.png)
