### PR TITLE
Revert "Don't fail PanGestureHandler on tap (#603)"

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java
@@ -272,7 +272,7 @@ public class PanGestureHandler extends GestureHandler<PanGestureHandler> {
     }
 
     if (action == MotionEvent.ACTION_UP) {
-      if (state == STATE_ACTIVE || state == STATE_BEGAN) {
+      if (state == STATE_ACTIVE) {
         end();
       } else {
         fail();


### PR DESCRIPTION
## Description

The change that this PR reverts was made to fix [this issue](https://github.com/osdnk/react-native-reanimated-bottom-sheet/issues/15) ([which seems to be fixed already](https://github.com/osdnk/react-native-reanimated-bottom-sheet/pull/150)). But by allowing the `PanGestureHandler` to transition from `BEGAN` to the `END` state it introduced a new problem: when a `TapGestureHandler` has a `waitFor` property set with a reference to a `PanGestureHandler` the `TapGestureHandler` will not activate.

Here is a quick summary of why it happens:

1. User touches the screen, `ACTION_DOWN` event is sent
2. Both `TapGestureHandler` and `PanGestureHandler` go to `BEGAN` state
3. User lifts the finger, `ACTION_UP` event is sent
4. `TapGestureHandler` tries to become active but has to wait for the `PanGestureHandler` to resolve
5. `PanGestureHandler` transitions to the `END` state
6. Because `PanGestureHandler` did not fail it is assumed it was recognized and all handlers waiting for it are cancelled

With this change at step 5. `PanGestureHandler` transitions to the `FAILED` state, and `TapGestureHandler` becomes active, which is expected behavior.

Besides that, [the original problem seems to be fixed in another way](https://github.com/osdnk/react-native-reanimated-bottom-sheet/pull/150).

## Test plan

This code sample demonstrates the problem and allows to check the solution:
```js
import React, { Component } from 'react';
import { createRef } from 'react';
import { StyleSheet, View } from 'react-native';

import {
  TapGestureHandler,
  PanGestureHandler,
} from 'react-native-gesture-handler';

function getState(s: number) {
  switch (s) {
    case 0: return "Undetermined";
    case 1: return "Failed";
    case 2: return "Began";
    case 3: return "Cancelled";
    case 4: return "Active";
    case 5: return "End";
  }
  return s;
}
export default class Example extends Component {
  constructor(props: Record<string, never>) {
    super(props);

    this.panHandler = createRef<PanGestureHandler>();
  }

  render() {

    return (
      <PanGestureHandler
        onHandlerStateChange={(e) => console.log(`Pan: ${getState(e.nativeEvent.state)}`)}
        ref={this.panHandler}>
        
        <View style={styles.home}>
          <TapGestureHandler
            onHandlerStateChange={(e) => console.log(`Tap: ${getState(e.nativeEvent.state)}`)}
            waitFor={this.panHandler}>
            <View 
              style={styles.button} />
          </TapGestureHandler>
        </View>

      </PanGestureHandler>
    );
  }
}

const styles = StyleSheet.create({
  home: {
    width: '100%',
    height: '100%',
    alignSelf: 'center',
    backgroundColor: 'plum',
  },
  button: {
    width: 100,
    height: 100,
    backgroundColor: 'green',
    alignSelf: 'center',
  },
});
```
