### PR TITLE
Add JSDocs

### DIFF
--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -138,7 +138,10 @@ export interface DrawerLayoutProps {
   drawerContainerStyle?: StyleProp<ViewStyle>;
 
   /**
-   * Enables two-finger gestures on supported devices, for example iPads with trackpads. If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
+   * Enables two-finger gestures on supported devices, for example iPads with
+   * trackpads. If not enabled the gesture will require click + drag, with
+   * `enableTrackpadTwoFingerGesture` swiping with two fingers will also trigger
+   * the gesture.
    */
   enableTrackpadTwoFingerGesture?: boolean;
 

--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -1,10 +1,10 @@
 // This component is based on RN's DrawerLayoutAndroid API
 //
-// It perhaps deserves to be put in a separate repo, but since it relies
-// on react-native-gesture-handler library which isn't very popular at the
-// moment I decided to keep it here for the time being. It will allow us
-// to move faster and fix issues that may arise in gesture handler library
-// that could be found when using the drawer component
+// It perhaps deserves to be put in a separate repo, but since it relies on
+// react-native-gesture-handler library which isn't very popular at the moment I
+// decided to keep it here for the time being. It will allow us to move faster
+// and fix issues that may arise in gesture handler library that could be found
+// when using the drawer component
 
 import * as React from 'react';
 import { Component } from 'react';
@@ -54,16 +54,42 @@ export type DrawerLockMode = 'unlocked' | 'locked-closed' | 'locked-open';
 export type DrawerKeyboardDismissMode = 'none' | 'on-drag';
 
 export interface DrawerLayoutProps {
+  /**
+   * This attribute is present in the standard implementation already and is one
+   * of the required params. Gesture handler version of DrawerLayout make it
+   * possible for the function passed as `renderNavigationView` to take an
+   * Animated value as a parameter that indicates the progress of drawer
+   * opening/closing animation (progress value is 0 when closed and 1 when
+   * opened). This can be used by the drawer component to animated its children
+   * while the drawer is opening or closing.
+   */
   renderNavigationView: (
     progressAnimatedValue: Animated.Value
   ) => React.ReactNode;
+
   drawerPosition?: DrawerPosition;
+
   drawerWidth?: number;
+
   drawerBackgroundColor?: string;
+
   drawerLockMode?: DrawerLockMode;
+
   keyboardDismissMode?: DrawerKeyboardDismissMode;
+
+  /**
+   * Called when the drawer is closed.
+   */
   onDrawerClose?: () => void;
+
+  /**
+   * Called when the drawer is opened.
+   */
   onDrawerOpen?: () => void;
+
+  /**
+   * Called when the status of the drawer changes.
+   */
   onDrawerStateChanged?: (
     newState: DrawerState,
     drawerWillShow: boolean
@@ -71,15 +97,53 @@ export interface DrawerLayoutProps {
   useNativeAnimations?: boolean;
 
   drawerType?: DrawerType;
+
+  /**
+   * Defines how far from the edge of the content view the gesture should
+   * activate.
+   */
   edgeWidth?: number;
+
   minSwipeDistance?: number;
+
+  /**
+   * When set to true Drawer component will use
+   * {@link https://reactnative.dev/docs/statusbar StatusBar} API to hide the OS
+   * status bar whenever the drawer is pulled or when its in an "open" state.
+   */
   hideStatusBar?: boolean;
+
+  /**
+   * @default 'slide'
+   *
+   * Can be used when hideStatusBar is set to true and will select the animation
+   * used for hiding/showing the status bar. See
+   * {@link https://reactnative.dev/docs/statusbar StatusBar} documentation for
+   * more details
+   */
   statusBarAnimation?: StatusBarAnimation;
+
+  /**
+   * @default black
+   *
+   * Color of a semi-transparent overlay to be displayed on top of the content
+   * view when drawer gets open. A solid color should be used as the opacity is
+   * added by the Drawer itself and the opacity of the overlay is animated (from
+   * 0% to 70%).
+   */
   overlayColor?: string;
+
   contentContainerStyle?: StyleProp<ViewStyle>;
+
   drawerContainerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * Enables two-finger gestures on supported devices, for example iPads with trackpads. If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
+   */
   enableTrackpadTwoFingerGesture?: boolean;
+
   onDrawerSlide?: (position: number) => void;
+
   onGestureRef?: (ref: PanGestureHandler) => void;
 }
 
@@ -172,13 +236,12 @@ export default class DrawerLayout extends Component<
     let touchX = touchXValue;
 
     if (drawerPosition !== 'left') {
-      // Most of the code is written in a way to handle left-side drawer.
-      // In order to handle right-side drawer the only thing we need to
-      // do is to reverse events coming from gesture handler in a way they
-      // emulate left-side drawer gestures. E.g. dragX is simply -dragX, and
-      // touchX is calulcated by subtracing real touchX from the width of the
-      // container (such that when touch happens at the right edge the value
-      // is simply 0)
+      // Most of the code is written in a way to handle left-side drawer. In
+      // order to handle right-side drawer the only thing we need to do is to
+      // reverse events coming from gesture handler in a way they emulate
+      // left-side drawer gestures. E.g. dragX is simply -dragX, and touchX is
+      // calulcated by subtracing real touchX from the width of the container
+      // (such that when touch happens at the right edge the value is simply 0)
       dragX = Animated.multiply(
         new Animated.Value(-1),
         dragXValue
@@ -208,11 +271,12 @@ export default class DrawerLayout extends Component<
     //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
     //    +---------------+    +---------------+    +---------------+    +---------------+
     //
-    // For the above to work properly we define animated value that will keep start position
-    // of the gesture. Then we use that value to calculate how much we need to subtract from
-    // the dragX. If the gesture started on the greyed out area we take the distance from the
-    // edge of the drawer to the start position. Otherwise we don't subtract at all and the
-    // drawer be pulled back as soon as you start the pan.
+    // For the above to work properly we define animated value that will keep
+    // start position of the gesture. Then we use that value to calculate how
+    // much we need to subtract from the dragX. If the gesture started on the
+    // greyed out area we take the distance from the edge of the drawer to the
+    // start position. Otherwise we don't subtract at all and the drawer be
+    // pulled back as soon as you start the pan.
     //
     // This is used only when drawerType is "front"
     //
@@ -349,14 +413,14 @@ export default class DrawerLayout extends Component<
     });
     const { drawerPosition, minSwipeDistance, edgeWidth } = this.props;
     const fromLeft = drawerPosition === 'left';
-    // gestureOrientation is 1 if the expected gesture is from left to right and -1 otherwise
-    // e.g. when drawer is on the left and is closed we expect left to right gesture, thus
-    // orientation will be 1.
+    // gestureOrientation is 1 if the expected gesture is from left to right and
+    // -1 otherwise e.g. when drawer is on the left and is closed we expect left
+    // to right gesture, thus orientation will be 1.
     const gestureOrientation =
       (fromLeft ? 1 : -1) * (this.drawerShown ? -1 : 1);
-    // When drawer is closed we want the hitSlop to be horizontally shorter
-    // than the container size by the value of SLOP. This will make it only
-    // activate when gesture happens not further than SLOP away from the edge
+    // When drawer is closed we want the hitSlop to be horizontally shorter than
+    // the container size by the value of SLOP. This will make it only activate
+    // when gesture happens not further than SLOP away from the edge
     const hitSlop = fromLeft
       ? { left: 0, width: showing ? undefined : edgeWidth }
       : { right: 0, width: showing ? undefined : edgeWidth };
@@ -381,10 +445,10 @@ export default class DrawerLayout extends Component<
     if (fromValue != null) {
       let nextFramePosition = fromValue;
       if (this.props.useNativeAnimations) {
-        // When using native driver, we predict the next position of the animation
-        // because it takes one frame of a roundtrip to pass RELEASE event from
-        // native driver to JS before we can start animating. Without it, it is more
-        // noticable that the frame is dropped.
+        // When using native driver, we predict the next position of the
+        // animation because it takes one frame of a roundtrip to pass RELEASE
+        // event from native driver to JS before we can start animating. Without
+        // it, it is more noticable that the frame is dropped.
         if (fromValue < toValue && velocity > 0) {
           nextFramePosition = Math.min(fromValue + velocity / 60.0, toValue);
         } else if (fromValue > toValue && velocity < 0) {
@@ -426,7 +490,8 @@ export default class DrawerLayout extends Component<
       options.velocity ? options.velocity : 0
     );
 
-    // We need to force the update, otherwise the overlay is not rerendered and it would not be clickable
+    // We need to force the update, otherwise the overlay is not rerendered and
+    // it would not be clickable
     this.forceUpdate();
   };
 
@@ -434,7 +499,8 @@ export default class DrawerLayout extends Component<
     // TODO: decide if it should be null or undefined is the proper value
     this.animateDrawer(undefined, 0, options.velocity ? options.velocity : 0);
 
-    // We need to force the update, otherwise the overlay is not rerendered and it would be still clickable
+    // We need to force the update, otherwise the overlay is not rerendered and
+    // it would be still clickable
     this.forceUpdate();
   };
 
@@ -478,8 +544,8 @@ export default class DrawerLayout extends Component<
 
     // we rely on row and row-reverse flex directions to position the drawer
     // properly. Apparently for RTL these are flipped which requires us to use
-    // the opposite setting for the drawer to appear from left or right according
-    // to the drawerPosition prop
+    // the opposite setting for the drawer to appear from left or right
+    // according to the drawerPosition prop
     const reverseContentDirection = I18nManager.isRTL ? fromLeft : !fromLeft;
 
     const dynamicDrawerStyles = {
@@ -550,8 +616,8 @@ export default class DrawerLayout extends Component<
   };
 
   private setPanGestureRef = (ref: PanGestureHandler) => {
-    // TODO(TS): make sure it is OK
-    // taken from https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065#issuecomment-596081842
+    // TODO(TS): make sure it is OK taken from
+    // https://github.com/DefinitelyTyped/DefinitelyTyped/issues/31065#issuecomment-596081842
     (this
       .panGestureHandler as React.MutableRefObject<PanGestureHandler>).current = ref;
     this.props.onGestureRef?.(ref);
@@ -567,15 +633,15 @@ export default class DrawerLayout extends Component<
 
     const fromLeft = drawerPosition === 'left';
 
-    // gestureOrientation is 1 if the expected gesture is from left to right and -1 otherwise
-    // e.g. when drawer is on the left and is closed we expect left to right gesture, thus
-    // orientation will be 1.
+    // gestureOrientation is 1 if the expected gesture is from left to right and
+    // -1 otherwise e.g. when drawer is on the left and is closed we expect left
+    // to right gesture, thus orientation will be 1.
     const gestureOrientation =
       (fromLeft ? 1 : -1) * (this.drawerShown ? -1 : 1);
 
-    // When drawer is closed we want the hitSlop to be horizontally shorter
-    // than the container size by the value of SLOP. This will make it only
-    // activate when gesture happens not further than SLOP away from the edge
+    // When drawer is closed we want the hitSlop to be horizontally shorter than
+    // the container size by the value of SLOP. This will make it only activate
+    // when gesture happens not further than SLOP away from the edge
     const hitSlop = fromLeft
       ? { left: 0, width: this.drawerShown ? undefined : edgeWidth }
       : { right: 0, width: this.drawerShown ? undefined : edgeWidth };

--- a/src/components/GestureButtons.tsx
+++ b/src/components/GestureButtons.tsx
@@ -22,25 +22,67 @@ import {
 } from '../handlers/NativeViewGestureHandler';
 
 export interface RawButtonProps extends NativeViewGestureHandlerProps {
+  /**
+   * iOS only.
+   *
+   * Defines if more than one button could be pressed simultaneously. By default
+   * set true.
+   */
   exclusive?: boolean;
   // TODO: we should transform props in `createNativeWrapper`
+
+  /**
+   * Android only.
+   *
+   * Defines color of native ripple animation used since API level 21.
+   */
   rippleColor?: any; // it was present in BaseButtonProps before but is used here in code
 }
 
 export interface BaseButtonProps extends RawButtonProps {
+  /**
+   * Called when the button gets pressed (analogous to `onPress` in
+   * `TouchableHighlight` from RN core).
+   */
   onPress?: (pointerInside: boolean) => void;
+
+  /**
+   * Called when button changes from inactive to active and vice versa. It
+   * passes active state as a boolean variable as a first parameter for that
+   * method.
+   */
   onActiveStateChange?: (active: boolean) => void;
   style?: StyleProp<ViewStyle>;
   testID?: string;
 }
 
 export interface RectButtonProps extends BaseButtonProps {
+  /**
+   * Background color that will be dimmed when button is in active state.
+   */
   underlayColor?: string;
+
+  /**
+   * iOS only.
+   *
+   * Opacity applied to the underlay when button is in active state.
+   */
   activeOpacity?: number;
 }
 
 export interface BorderlessButtonProps extends BaseButtonProps {
+  /**
+   * Android only.
+   *
+   * Set this to false if you want the ripple animation to render only within view bounds.
+   */
   borderless?: boolean;
+
+  /**
+   * iOS only.
+   *
+   * Opacity applied to the button when it is in an active state.
+   */
   activeOpacity?: number;
 }
 
@@ -79,10 +121,10 @@ export class BaseButton extends React.Component<BaseButtonProps> {
     this.lastActive = active;
   };
 
-  // Normally, the parent would execute it's handler first,
-  // then forward the event to listeners. However, here our handler
-  // is virtually only forwarding events to listeners, so we reverse the order
-  // to keep the proper order of the callbacks (from "raw" ones to "processed").
+  // Normally, the parent would execute it's handler first, then forward the
+  // event to listeners. However, here our handler is virtually only forwarding
+  // events to listeners, so we reverse the order to keep the proper order of
+  // the callbacks (from "raw" ones to "processed").
   private onHandlerStateChange = (
     e: HandlerStateChangeEvent<NativeViewGestureHandlerPayload>
   ) => {

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -39,7 +39,10 @@ type SwipeableExcludes = Exclude<
 interface SwipeableProps
   extends Pick<PanGestureHandlerProps, SwipeableExcludes> {
   /**
-   * Enables two-finger gestures on supported devices, for example iPads with trackpads. If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
+   * Enables two-finger gestures on supported devices, for example iPads with
+   * trackpads. If not enabled the gesture will require click + drag, with
+   * `enableTrackpadTwoFingerGesture` swiping with two fingers will also trigger
+   * the gesture.
    */
   enableTrackpadTwoFingerGesture?: boolean;
 

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -1,6 +1,6 @@
 // Similarily to the DrawerLayout component this deserves to be put in a
-// separate repo. Although, keeping it here for the time being will allow us
-// to move faster and fix possible issues quicker
+// separate repo. Although, keeping it here for the time being will allow us to
+// move faster and fix possible issues quicker
 
 import * as React from 'react';
 import { Component } from 'react';
@@ -38,28 +38,100 @@ type SwipeableExcludes = Exclude<
 
 interface SwipeableProps
   extends Pick<PanGestureHandlerProps, SwipeableExcludes> {
+  /**
+   * Enables two-finger gestures on supported devices, for example iPads with trackpads. If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
+   */
   enableTrackpadTwoFingerGesture?: boolean;
+
+  /**
+   * Specifies how much the visual interaction will be delayed compared to the
+   * gesture distance. e.g. value of 1 will indicate that the swipeable panel
+   * should exactly follow the gesture, 2 means it is going to be two times
+   * "slower".
+   */
   friction?: number;
+
+  /**
+   * Distance from the left edge at which released panel will animate to the
+   * open state (or the open panel will animate into the closed state). By
+   * default it's a half of the panel's width.
+   */
   leftThreshold?: number;
+
+  /**
+   * Distance from the right edge at which released panel will animate to the
+   * open state (or the open panel will animate into the closed state). By
+   * default it's a half of the panel's width.
+   */
   rightThreshold?: number;
+
+  /**
+   * Value indicating if the swipeable panel can be pulled further than the left
+   * actions panel's width. It is set to true by default as long as the left
+   * panel render method is present.
+   */
   overshootLeft?: boolean;
+
+  /**
+   * Value indicating if the swipeable panel can be pulled further than the
+   * right actions panel's width. It is set to true by default as long as the
+   * right panel render method is present.
+   */
   overshootRight?: boolean;
+
+  /**
+   * Specifies how much the visual interaction will be delayed compared to the
+   * gesture distance at overshoot. Default value is 1, it mean no friction, for
+   * a native feel, try 8 or above.
+   */
   overshootFriction?: number;
+
+  /**
+   * Called when left action panel gets open.
+   */
   onSwipeableLeftOpen?: () => void;
+
+  /**
+   * Called when right action panel gets open.
+   */
   onSwipeableRightOpen?: () => void;
+
+  /**
+   * Called when action panel gets open (either right or left).
+   */
   onSwipeableOpen?: () => void;
+
+  /**
+   * Called when action panel is closed.
+   */
   onSwipeableClose?: () => void;
+
+  /**
+   * Called when left action panel starts animating on open.
+   */
   onSwipeableLeftWillOpen?: () => void;
+
+  /**
+   * Called when right action panel starts animating on open.
+   */
   onSwipeableRightWillOpen?: () => void;
+
+  /**
+   * Called when action panel starts animating on open (either right or left).
+   */
   onSwipeableWillOpen?: () => void;
+
+  /**
+   * Called when action panel starts animating on close.
+   */
   onSwipeableWillClose?: () => void;
+
   /**
    *
    * This map describes the values to use as inputRange for extra interpolation:
    * AnimatedValue: [startValue, endValue]
    *
-   * progressAnimatedValue: [0, 1]
-   * dragAnimatedValue: [0, +]
+   * progressAnimatedValue: [0, 1] dragAnimatedValue: [0, +]
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
@@ -72,8 +144,7 @@ interface SwipeableProps
    * This map describes the values to use as inputRange for extra interpolation:
    * AnimatedValue: [startValue, endValue]
    *
-   * progressAnimatedValue: [0, 1]
-   * dragAnimatedValue: [0, -]
+   * progressAnimatedValue: [0, 1] dragAnimatedValue: [0, -]
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
@@ -81,9 +152,21 @@ interface SwipeableProps
     progressAnimatedValue: Animated.AnimatedInterpolation,
     dragAnimatedValue: Animated.AnimatedInterpolation
   ) => React.ReactNode;
+
   useNativeAnimations?: boolean;
+
   animationOptions?: Record<string, unknown>;
+
+  /**
+   * Style object for the container (`Animated.View`), for example to override
+   * `overflow: 'hidden'`.
+   */
   containerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * Style object for the children container (`Animated.View`), for example to
+   * apply `flex: 1`
+   */
   childrenContainerStyle?: StyleProp<ViewStyle>;
 }
 
@@ -354,7 +437,9 @@ export default class Swipeable extends Component<
       <Animated.View
         style={[
           styles.leftActions,
-          // all those and below parameters can have ! since they are all asigned in constructor in `updateAnimatedEvent` but TS cannot spot it for some reason
+          // all those and below parameters can have ! since they are all
+          // asigned in constructor in `updateAnimatedEvent` but TS cannot spot
+          // it for some reason
           { transform: [{ translateX: this.leftActionTranslate! }] },
         ]}>
         {renderLeftActions(this.showLeftAction!, this.transX!)}

--- a/src/handlers/FlingGestureHandler.ts
+++ b/src/handlers/FlingGestureHandler.ts
@@ -18,7 +18,25 @@ export type FlingGestureHandlerEventPayload = {
 
 export interface FlingGestureHandlerProps
   extends BaseGestureHandlerProps<FlingGestureHandlerEventPayload> {
+  /**
+   * Expressed allowed direction of movement. It's possible to pass one or many
+   * directions in one parameter:
+   *
+   * ```js
+   * direction={Directions.RIGHT | Directions.LEFT}
+   * ```
+   *
+   * or
+   *
+   * ```js
+   * direction={Directions.DOWN}
+   * ```
+   */
   direction?: number;
+
+  /**
+   * Determine exact number of points required to handle the fling gesture.
+   */
   numberOfPointers?: number;
 }
 

--- a/src/handlers/ForceTouchGestureHandler.ts
+++ b/src/handlers/ForceTouchGestureHandler.ts
@@ -29,13 +29,32 @@ export type ForceTouchGestureHandlerEventPayload = {
   y: number;
   absoluteX: number;
   absoluteY: number;
+
+  /**
+   * The pressure of a touch.
+   */
   force: number;
 };
 
 export interface ForceTouchGestureHandlerProps
   extends BaseGestureHandlerProps<ForceTouchGestureHandlerEventPayload> {
+  /**
+   *
+   * A minimal pressure that is required before handler can activate. Should be a
+   * value from range `[0.0, 1.0]`. Default is `0.2`.
+   */
   minForce?: number;
+
+  /**
+   * A maximal pressure that could be applied for handler. If the pressure is
+   * greater, handler fails. Should be a value from range `[0.0, 1.0]`.
+   */
   maxForce?: number;
+
+  /**
+   * Boolean value defining if haptic feedback has to be performed on
+   * activation.
+   */
   feedbackOnActivation?: boolean;
 }
 

--- a/src/handlers/LongPressGestureHandler.ts
+++ b/src/handlers/LongPressGestureHandler.ts
@@ -10,16 +10,59 @@ export const longPressGestureHandlerProps = [
 ] as const;
 
 export type LongPressGestureHandlerEventPayload = {
+  /**
+   * X coordinate, expressed in points, of the current position of the pointer
+   * (finger or a leading pointer when there are multiple fingers placed)
+   * relative to the view attached to the handler.
+   */
   x: number;
+
+  /**
+   * Y coordinate, expressed in points, of the current position of the pointer
+   * (finger or a leading pointer when there are multiple fingers placed)
+   * relative to the view attached to the handler.
+   */
   y: number;
+
+  /**
+   * X coordinate, expressed in points, of the current position of the pointer
+   * (finger or a leading pointer when there are multiple fingers placed)
+   * relative to the root view. It is recommended to use `absoluteX` instead of
+   * `x` in cases when the view attached to the handler can be transformed as an
+   * effect of the gesture.
+   */
   absoluteX: number;
+
+  /**
+   * Y coordinate, expressed in points, of the current position of the pointer
+   * (finger or a leading pointer when there are multiple fingers placed)
+   * relative to the root view. It is recommended to use `absoluteY` instead of
+   * `y` in cases when the view attached to the handler can be transformed as an
+   * effect of the gesture.
+   */
   absoluteY: number;
+
+  /**
+   * Duration of the long press (time since the start of the event), expressed
+   * in milliseconds.
+   */
   duration: number;
 };
 
 export interface LongPressGestureHandlerProps
   extends BaseGestureHandlerProps<LongPressGestureHandlerEventPayload> {
+  /**
+   * Minimum time, expressed in milliseconds, that a finger must remain pressed on
+   * the corresponding view. The default value is 500.
+   */
   minDurationMs?: number;
+
+  /**
+   * Maximum distance, expressed in points, that defines how far the finger is
+   * allowed to travel during a long press gesture. If the finger travels
+   * further than the defined distance and the handler hasn't yet activated, it
+   * will fail to recognize the gesture. The default value is 10.
+   */
   maxDist?: number;
 }
 

--- a/src/handlers/NativeViewGestureHandler.ts
+++ b/src/handlers/NativeViewGestureHandler.ts
@@ -10,11 +10,25 @@ export const nativeViewGestureHandlerProps = [
 ] as const;
 export interface NativeViewGestureHandlerProps
   extends BaseGestureHandlerProps<NativeViewGestureHandlerPayload> {
+  /**
+   * Android only.
+   *
+   * Determines whether the handler should check for an existing touch event on
+   * instantiation.
+   */
   shouldActivateOnStart?: boolean;
+
+  /**
+   * When `true`, cancels all other gesture handlers when this
+   * `NativeViewGestureHandler` receives an `ACTIVE` state event.
+   */
   disallowInterruption?: boolean;
 }
 
 export type NativeViewGestureHandlerPayload = {
+  /**
+   * True if gesture was performed inside of containing view, false otherwise.
+   */
   pointerInside: boolean;
 };
 

--- a/src/handlers/PanGestureHandler.ts
+++ b/src/handlers/PanGestureHandler.ts
@@ -31,41 +31,205 @@ export const panGestureHandlerCustomNativeProps = [
 ] as const;
 
 export type PanGestureHandlerEventPayload = {
+  /**
+   * X coordinate of the current position of the pointer (finger or a leading
+   * pointer when there are multiple fingers placed) relative to the view
+   * attached to the handler. Expressed in point units.
+   */
   x: number;
+
+  /**
+   * Y coordinate of the current position of the pointer (finger or a leading
+   * pointer when there are multiple fingers placed) relative to the view
+   * attached to the handler. Expressed in point units.
+   */
   y: number;
+
+  /**
+   * X coordinate of the current position of the pointer (finger or a leading
+   * pointer when there are multiple fingers placed) relative to the root view.
+   * The value is expressed in point units. It is recommended to use it instead
+   * of `x` in cases when the original view can be transformed as an effect of
+   * the gesture.
+   */
   absoluteX: number;
+
+  /**
+   * Y coordinate of the current position of the pointer (finger or a leading
+   * pointer when there are multiple fingers placed) relative to the root view.
+   * The value is expressed in point units. It is recommended to use it instead
+   * of `y` in cases when the original view can be transformed as an
+   * effect of the gesture.
+   */
   absoluteY: number;
+
+  /**
+   * Translation of the pan gesture along X axis accumulated over the time of
+   * the gesture. The value is expressed in the point units.
+   */
   translationX: number;
+
+  /**
+   * Translation of the pan gesture along Y axis accumulated over the time of
+   * the gesture. The value is expressed in the point units.
+   */
   translationY: number;
+
+  /**
+   * Velocity of the pan gesture along the X axis in the current moment. The
+   * value is expressed in point units per second.
+   */
   velocityX: number;
+
+  /**
+   * Velocity of the pan gesture along the Y axis in the current moment. The
+   * value is expressed in point units per second.
+   */
   velocityY: number;
 };
 
 export interface PanGestureHandlerProps
   extends BaseGestureHandlerProps<PanGestureHandlerEventPayload> {
-  /** @deprecated  use activeOffsetX*/
+  /**
+   * @deprecated Instead of `minDeltaX={N}` use `activeOffsetX={[-N, N]}`.
+   *
+   * Minimum distance along X (in points) axis the finger (or multiple finger)
+   * need to travel (left or right) before the handler activates. Unlike
+   * `minOffsetX` this parameter accepts only non-lower or equal to 0 numbers
+   * that represents the distance in point units. If you want for the handler to
+   * activate for the movement in one particular direction use `minOffsetX`
+   * instead.
+   */
   minDeltaX?: number;
-  /** @deprecated  use activeOffsetY*/
+
+  /**
+   * @deprecated Instead of `minDeltaY={N}` use `activeOffsetY={[-N, N]}`.
+   *
+   * Minimum distance along Y (in points) axis the finger (or multiple finger)
+   * need to travel (left or right) before the handler activates. Unlike
+   * `minOffsetY` this parameter accepts only non-lower or equal to 0 numbers
+   * that represents the distance in point units. If you want for the handler to
+   * activate for the movement in one particular direction use `minOffsetY`
+   * instead.
+   */
   minDeltaY?: number;
-  /** @deprecated  use failOffsetX*/
+
+  /**
+   * @deprecated Instead of `maxDeltaX={N}` use `failOffsetX={[-N, N]}`.
+   *
+   * When the finger travels the given distance expressed in points along X axis
+   * and handler hasn't yet activated it will fail
+   * recognizing the gesture.
+   */
   maxDeltaX?: number;
-  /** @deprecated  use failOffsetY*/
+
+  /**
+   * @deprecated Instead of `maxDeltaY={N}` use `failOffsetY={[-N, N]}`.
+   *
+   * When the finger travels the given distance expressed in points along Y axis
+   * and handler hasn't yet activated it will fail
+   * recognizing the gesture.
+   */
   maxDeltaY?: number;
-  /** @deprecated  use activeOffsetX*/
+
+  /**
+   * @deprecated Instead of `minOffsetX={N}` use `activeOffsetX={N}`.
+   *
+   * Minimum distance along X (in points) axis the finger (or multiple finger)
+   * need to travel before the handler activates. If set to a lower or equal to
+   * 0 value we expect the finger to travel "left" by the given distance. When
+   * set to a higher or equal to 0 number the handler will activate on a
+   * movement to the "right". If you wish for the movement direction to be
+   * ignored use `minDeltaX` instead.
+   */
   minOffsetX?: number;
-  /** @deprecated  use failOffsetY*/
+
+  /**
+   * @deprecated Instead of `minOffsetY={N}` use `activeOffsetY={N}`.
+   *
+   * Minimum distance along Y (in points) axis the finger (or multiple finger)
+   * need to travel before the handler activates. If set to a lower or equal to
+   * 0 value we expect the finger to travel "up" by the given distance. When
+   * set to a higher or equal to 0 number the handler will activate on a
+   * movement to the "bottom". If you wish for the movement direction to be
+   * ignored use `minDeltaY` instead.
+   */
   minOffsetY?: number;
+
+  /**
+   * Range along X axis (in points) where fingers travels without activation of
+   * handler. Moving outside of this range implies activation of handler. Range
+   * can be given as an array or a single number. If range is set as an array,
+   * first value must be lower or equal to 0, a the second one higher or equal
+   * to 0. If only one number `p` is given a range of `(-inf, p)` will be used
+   * if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
+   */
   activeOffsetY?: number | number[];
+
+  /**
+   * Range along X axis (in points) where fingers travels without activation of
+   * handler. Moving outside of this range implies activation of handler. Range
+   * can be given as an array or a single number. If range is set as an array,
+   * first value must be lower or equal to 0, a the second one higher or equal
+   * to 0. If only one number `p` is given a range of `(-inf, p)` will be used
+   * if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
+   */
   activeOffsetX?: number | number[];
+
+  /**
+   * When the finger moves outside this range (in points) along Y axis and
+   * handler hasn't yet activated it will fail recognizing the gesture. Range
+   * can be given as an array or a single number. If range is set as an array,
+   * first value must be lower or equal to 0, a the second one higher or equal
+   * to 0. If only one number `p` is given a range of `(-inf, p)` will be used
+   * if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
+   */
   failOffsetY?: number | number[];
+
+  /**
+   * When the finger moves outside this range (in points) along X axis and
+   * handler hasn't yet activated it will fail recognizing the gesture. Range
+   * can be given as an array or a single number. If range is set as an array,
+   * first value must be lower or equal to 0, a the second one higher or equal
+   * to 0. If only one number `p` is given a range of `(-inf, p)` will be used
+   * if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
+   */
   failOffsetX?: number | number[];
+
+  /**
+   * Minimum distance the finger (or multiple finger) need to travel before the
+   * handler activates. Expressed in points.
+   */
   minDist?: number;
+
   minVelocity?: number;
   minVelocityX?: number;
   minVelocityY?: number;
+
+  /**
+   * A number of fingers that is required to be placed before handler can
+   * activate. Should be a higher or equal to 0 integer.
+   */
   minPointers?: number;
+
+  /**
+   * When the given number of fingers is placed on the screen and handler hasn't
+   * yet activated it will fail recognizing the gesture. Should be a higher or
+   * equal to 0 integer.
+   */
   maxPointers?: number;
+
+  /**
+   * Android only.
+   */
   avgTouches?: boolean;
+
+  /**
+   * Enables two-finger gestures on supported devices, for example iPads with
+   * trackpads. If not enabled the gesture will require click + drag, with
+   * enableTrackpadTwoFingerGesture swiping with two fingers will also trigger
+   * the gesture.
+   */
   enableTrackpadTwoFingerGesture?: boolean;
 }
 

--- a/src/handlers/PinchGestureHandler.ts
+++ b/src/handlers/PinchGestureHandler.ts
@@ -5,9 +5,29 @@ import {
 } from './gestureHandlerCommon';
 
 export type PinchGestureHandlerEventPayload = {
+  /**
+   * The scale factor relative to the points of the two touches in screen
+   * coordinates.
+   */
   scale: number;
+
+  /**
+   * Position expressed in points along X axis of center anchor point of
+   * gesture.
+   */
   focalX: number;
+
+  /**
+   * Position expressed in points along Y axis of center anchor point of
+   * gesture.
+   */
   focalY: number;
+
+  /**
+   *
+   * Velocity of the pan gesture the current moment. The value is expressed in
+   * point units per second.
+   */
   velocity: number;
 };
 

--- a/src/handlers/RotationGestureHandler.ts
+++ b/src/handlers/RotationGestureHandler.ts
@@ -5,9 +5,29 @@ import {
 } from './gestureHandlerCommon';
 
 export type RotationGestureHandlerEventPayload = {
+  /**
+   * Amount rotated, expressed in radians, from the gesture's focal point
+   * (anchor).
+   */
   rotation: number;
+
+  /**
+   * X coordinate, expressed in points, of the gesture's central focal point
+   * (anchor).
+   */
   anchorX: number;
+
+  /**
+   * Y coordinate, expressed in points, of the gesture's central focal point
+   * (anchor).
+   */
   anchorY: number;
+
+  /**
+   *
+   * Instantaneous velocity, expressed in point units per second, of the
+   * gesture.
+   */
   velocity: number;
 };
 

--- a/src/handlers/TapGestureHandler.ts
+++ b/src/handlers/TapGestureHandler.ts
@@ -23,12 +23,53 @@ export type TapGestureHandlerEventPayload = {
 
 export interface TapGestureHandlerProps
   extends BaseGestureHandlerProps<TapGestureHandlerEventPayload> {
+  /**
+   * Minimum number of pointers (fingers) required to be placed before the
+   * handler activates. Should be a positive integer.
+   * The default value is 1.
+   */
   minPointers?: number;
+
+  /**
+   * Maximum time, expressed in milliseconds, that defines how fast a finger
+   * must be released after a touch. The default value is 500.
+   */
   maxDurationMs?: number;
+
+  /**
+   * Maximum time, expressed in milliseconds, that can pass before the next tap
+   * if many taps are required. The default value is 500.
+   */
   maxDelayMs?: number;
+
+  /**
+   * Number of tap gestures required to activate the handler. The default value
+   * is 1.
+   */
   numberOfTaps?: number;
+
+  /**
+   * Maximum distance, expressed in points, that defines how far the finger is
+   * allowed to travel along the X axis during a tap gesture. If the finger
+   * travels further than the defined distance along the X axis and the handler
+   * hasn't yet activated, it will fail to recognize the gesture.
+   */
   maxDeltaX?: number;
+
+  /**
+   * Maximum distance, expressed in points, that defines how far the finger is
+   * allowed to travel along the Y axis during a tap gesture. If the finger
+   * travels further than the defined distance along the Y axis and the handler
+   * hasn't yet activated, it will fail to recognize the gesture.
+   */
   maxDeltaY?: number;
+
+  /**
+   * Maximum distance, expressed in points, that defines how far the finger is
+   * allowed to travel during a tap gesture. If the finger travels further than
+   * the defined distance and the handler hasn't yet
+   * activated, it will fail to recognize the gesture.
+   */
   maxDist?: number;
 }
 


### PR DESCRIPTION
## Description

Copied most API docs inline. This helps editors show documentation when hovering on a property:
![image](https://user-images.githubusercontent.com/12465392/129475544-9dc8af16-c19e-47a5-b321-a09a5a30fb6f.png)


## Test plan

None.
