### PR TITLE
Fix TouchableOpacity visuals

### DIFF
--- a/src/components/touchables/TouchableOpacity.tsx
+++ b/src/components/touchables/TouchableOpacity.tsx
@@ -36,7 +36,7 @@ export default class TouchableOpacity extends Component<
       toValue: value,
       duration: duration,
       easing: Easing.inOut(Easing.quad),
-      useNativeDriver: true,
+      useNativeDriver: false,
     }).start();
   };
 


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/578#issuecomment-680028832

TouchableOpacity didn't have opacity visuals.

## Test plan

```ts
import React from 'react';
import { SafeAreaView, Text, Platform } from 'react-native';
import { TouchableOpacity } from 'react-native-gesture-handler';

export default () => {
  return (
    <SafeAreaView style={styles.container}>
      <TouchableOpacity
        style={[styles.rectangle]}
        onPress={() => console.log('Touch', Platform.OS)}>
        <Text>Press me!</Text>
      </TouchableOpacity>
    </SafeAreaView>
  );
};

const styles = {
  container: {
    flex: 1,
    justifyContent: 'center' as const,
    alignItems: 'center' as const,
  },
  rectangle: {
    backgroundColor: 'pink',
    width: 100,
    height: 100,
    alignItems: 'center' as const,
    justifyContent: 'center' as const,
  },
};
```