### PR TITLE
Fix PanGestureHandler custom activation criteria and no minDist set

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -198,7 +198,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) : ReactCont
       if (config.hasKey(KEY_PAN_MIN_DIST)) {
         handler.setMinDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_DIST)))
       } else if (hasCustomActivationCriteria) {
-        handler.setMinDist(Float.MAX_VALUE)
+        handler.setMinDist(Float.MIN_VALUE)
       }
       if (config.hasKey(KEY_PAN_MIN_POINTERS)) {
         handler.setMinPointers(config.getInt(KEY_PAN_MIN_POINTERS))


### PR DESCRIPTION
## Description

When using custom activation (or failure) criteria, without setting the `minDist` prop, the default value would default to `Float.MAX_VALUE`, making it impossible to activate the handler. This pull request changes it to `Float.MIN_VALUE` which is also the default value in the `resetConfig` method.

This fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1588.

## Test plan

Tested on the Example app
