### PR TITLE
Remove InteractionBuilder and replace it with explicit interactions

### DIFF
--- a/examples/Example/src/new_api/camera/index.tsx
+++ b/examples/Example/src/new_api/camera/index.tsx
@@ -54,7 +54,7 @@ export default function Home() {
     });
 
   const buttonPanGesture = Gesture.pan()
-    .addSimultaneousGesture(filtersPanGesture)
+    .simulteneousWithExternalGesture(filtersPanGesture)
     .onUpdate((e) => {
       'worklet';
       if (isRecording) {
@@ -87,10 +87,13 @@ export default function Home() {
       zoom.value = scale * e.scale;
     });
 
-  const buttonGesture = buttonTapGesture
-    .requireToFail(buttonDoubleTapGesture)
-    .requireToFail(buttonPanGesture)
-    .simultaneousWith(buttonLongPressGesture);
+  const buttonGesture = Gesture.simultaneous(
+    buttonLongPressGesture,
+    Gesture.exclusive(
+      Gesture.requireToFail(buttonTapGesture, buttonDoubleTapGesture),
+      buttonPanGesture
+    )
+  );
 
   function stopFilterScroll() {
     filter.value = withTiming(updateSelectedFilter(), { duration: 200 });

--- a/examples/Example/src/new_api/transformations/index.tsx
+++ b/examples/Example/src/new_api/transformations/index.tsx
@@ -27,7 +27,7 @@ function Photo() {
     };
   });
 
-  const gesture = Gesture.rotation()
+  const rotationGesture = Gesture.rotation()
     .onUpdate((e) => {
       'worklet';
       rotation.value = savedRotation.value + e.rotation;
@@ -35,42 +35,47 @@ function Photo() {
     .onEnd(() => {
       'worklet';
       savedRotation.value = rotation.value;
+    });
+
+  const scaleGesture = Gesture.pinch()
+    .onUpdate((e) => {
+      'worklet';
+      scale.value = savedScale.value * e.scale;
     })
-    .simultaneousWith(
-      Gesture.pinch()
-        .onUpdate((e) => {
-          'worklet';
-          scale.value = savedScale.value * e.scale;
-        })
-        .onEnd(() => {
-          'worklet';
-          savedScale.value = scale.value;
-        })
+    .onEnd(() => {
+      'worklet';
+      savedScale.value = scale.value;
+    });
+
+  const panGesture = Gesture.pan()
+    .averageTouches(true)
+    .onUpdate((e) => {
+      'worklet';
+      translationX.value = offsetX.value + e.translationX;
+      translationY.value = offsetY.value + e.translationY;
+    })
+    .onEnd(() => {
+      'worklet';
+      offsetX.value = translationX.value;
+      offsetY.value = translationY.value;
+    });
+
+  const doubleTapGesture = Gesture.tap()
+    .numberOfTaps(2)
+    .onEnd((_e, success) => {
+      'worklet';
+      if (success) {
+        scale.value = scale.value * 1.25;
+      }
+    });
+
+  const gesture = Gesture.simultaneous(
+    rotationGesture,
+    Gesture.simultaneous(
+      scaleGesture,
+      Gesture.simultaneous(panGesture, doubleTapGesture)
     )
-    .simultaneousWith(
-      Gesture.pan()
-        .averageTouches(true)
-        .onUpdate((e) => {
-          'worklet';
-          translationX.value = offsetX.value + e.translationX;
-          translationY.value = offsetY.value + e.translationY;
-        })
-        .onEnd(() => {
-          'worklet';
-          offsetX.value = translationX.value;
-          offsetY.value = translationY.value;
-        })
-    )
-    .simultaneousWith(
-      Gesture.tap()
-        .numberOfTaps(2)
-        .onEnd((_e, success) => {
-          'worklet';
-          if (success) {
-            scale.value = scale.value * 1.25;
-          }
-        })
-    );
+  );
 
   return (
     <GestureMonitor animatedGesture={gesture}>

--- a/src/handlers/gestures/GestureMonitor.tsx
+++ b/src/handlers/gestures/GestureMonitor.tsx
@@ -342,7 +342,7 @@ export const GestureMonitor: React.FunctionComponent<GestureMonitorProps> = (
 ) => {
   const useAnimated = props.animatedGesture != null;
   const gestureConfig = props.animatedGesture ?? props.gesture;
-  const gesture = gestureConfig?.configure?.() ?? [];
+  const gesture = gestureConfig?.toGestureArray?.() ?? [];
   const viewRef = useRef(null);
   const firstRenderRef = useRef(true);
 

--- a/src/handlers/gestures/GestureMonitor.tsx
+++ b/src/handlers/gestures/GestureMonitor.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useRef } from 'react';
 import {
-  InteractionBuilder,
   GestureType,
   HandlerCallbacks,
   BaseGesture,
@@ -26,6 +25,7 @@ import {
 } from '../PanGestureHandler';
 import { tapGestureHandlerProps } from '../TapGestureHandler';
 import { State } from '../../State';
+import { ComposedGesture } from './gestureInteractions';
 
 const ALLOWED_PROPS = [
   ...baseGestureHandlerWithMonitorProps,
@@ -73,7 +73,7 @@ function dropHandlers(preparedGesture: GestureConfigReference) {
 
 interface AttachHandlersConfig {
   preparedGesture: GestureConfigReference;
-  gestureConfig: InteractionBuilder | GestureType | undefined;
+  gestureConfig: ComposedGesture | GestureType | undefined;
   gesture: GestureType[];
   viewTag: number;
   useAnimated: boolean;
@@ -92,6 +92,12 @@ function attachHandlers({
     preparedGesture.firstExecution = false;
   }
 
+  // use setImmediate to extract handlerTags, because all refs should be initialized
+  // when it's ran
+  setImmediate(() => {
+    gestureConfig?.prepare();
+  });
+
   for (const handler of gesture) {
     RNGestureHandlerModule.createGestureHandler(
       handler.handlerName,
@@ -104,8 +110,6 @@ function attachHandlers({
     // use setImmediate to extract handlerTags, because all refs should be initialized
     // when it's ran
     setImmediate(() => {
-      gestureConfig?.prepare();
-
       let requireToFail: number[] = [];
       if (handler.config.requireToFail) {
         requireToFail = extractValidHandlerTags(handler.config.requireToFail);
@@ -146,7 +150,7 @@ function attachHandlers({
 
 function updateHandlers(
   preparedGesture: GestureConfigReference,
-  gestureConfig: InteractionBuilder | GestureType | undefined,
+  gestureConfig: ComposedGesture | GestureType | undefined,
   gesture: GestureType[]
 ) {
   gestureConfig?.prepare();
@@ -330,8 +334,8 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
 }
 
 interface GestureMonitorProps {
-  gesture?: InteractionBuilder | GestureType;
-  animatedGesture?: InteractionBuilder | GestureType;
+  gesture?: ComposedGesture | GestureType;
+  animatedGesture?: ComposedGesture | GestureType;
 }
 export const GestureMonitor: React.FunctionComponent<GestureMonitorProps> = (
   props

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -64,7 +64,7 @@ export abstract class Gesture {
    * Return array of gestures, providing the same interface for creating and updating
    * handlers, no matter which object was used to create gesture instance.
    */
-  abstract configure(): GestureType[];
+  abstract toGestureArray(): GestureType[];
 
   /**
    * Assign handlerTag to the gesture instance and set ref.current (if a ref is set)
@@ -187,7 +187,7 @@ export abstract class BaseGesture<
     }
   }
 
-  configure(): GestureType[] {
+  toGestureArray(): GestureType[] {
     return [this as GestureType];
   }
 

--- a/src/handlers/gestures/gestureInteractions.ts
+++ b/src/handlers/gestures/gestureInteractions.ts
@@ -1,0 +1,115 @@
+/* eslint-disable no-useless-constructor */
+/* eslint-disable @typescript-eslint/no-useless-constructor */
+// eslint is convinced that constructor limiting the number of arguments an
+// inheriting class can accept is useless
+import { BaseGesture, Gesture, GestureRef, GestureType } from './gesture';
+
+function extendRelation(
+  currentRelation: GestureRef[] | undefined,
+  extendWith: GestureType[]
+) {
+  if (currentRelation === undefined) {
+    return [...extendWith];
+  } else {
+    return [...currentRelation, ...extendWith];
+  }
+}
+
+export class ComposedGesture extends Gesture {
+  protected gestures: Gesture[] = [];
+  protected simultaneousGestures: GestureType[] = [];
+  protected requireGesturesToFail: GestureType[] = [];
+
+  constructor(...gestures: Gesture[]) {
+    super();
+    this.gestures = gestures;
+  }
+
+  protected prepareSingleGesture(
+    gesture: Gesture,
+    simultaneousGestures: GestureType[],
+    requireGesturesToFail: GestureType[]
+  ) {
+    if (gesture instanceof BaseGesture) {
+      const newConfig = { ...gesture.config };
+
+      newConfig.simultaneousWith = extendRelation(
+        newConfig.simultaneousWith,
+        simultaneousGestures
+      );
+      newConfig.requireToFail = extendRelation(
+        newConfig.requireToFail,
+        requireGesturesToFail
+      );
+
+      gesture.config = newConfig;
+    } else if (gesture instanceof ComposedGesture) {
+      gesture.simultaneousGestures = simultaneousGestures;
+      gesture.requireGesturesToFail = requireGesturesToFail;
+      gesture.prepare();
+    }
+  }
+
+  prepare() {
+    for (const gesture of this.gestures) {
+      this.prepareSingleGesture(
+        gesture,
+        this.simultaneousGestures,
+        this.requireGesturesToFail
+      );
+    }
+  }
+
+  initialize() {
+    for (const gesture of this.gestures) {
+      gesture.initialize();
+    }
+  }
+
+  configure(): GestureType[] {
+    return this.gestures.map((gesture) => gesture.configure()).flat();
+  }
+}
+
+export class SimultaneousGesture extends ComposedGesture {
+  constructor(first: Gesture, second: Gesture) {
+    super(first, second);
+  }
+
+  prepare() {
+    const leftSide = this.gestures[0].configure();
+    const rightSide = this.gestures[1].configure();
+
+    this.prepareSingleGesture(
+      this.gestures[0],
+      this.simultaneousGestures.concat(rightSide),
+      this.requireGesturesToFail
+    );
+    this.prepareSingleGesture(
+      this.gestures[1],
+      this.simultaneousGestures.concat(leftSide),
+      this.requireGesturesToFail
+    );
+  }
+}
+
+export class RequireToFailGesture extends ComposedGesture {
+  constructor(first: Gesture, second: Gesture) {
+    super(first, second);
+  }
+
+  prepare() {
+    const rightSide = this.gestures[1].configure();
+
+    this.prepareSingleGesture(
+      this.gestures[0],
+      this.simultaneousGestures,
+      this.requireGesturesToFail.concat(rightSide)
+    );
+    this.prepareSingleGesture(
+      this.gestures[1],
+      this.simultaneousGestures,
+      this.requireGesturesToFail
+    );
+  }
+}

--- a/src/handlers/gestures/gestureInteractions.ts
+++ b/src/handlers/gestures/gestureInteractions.ts
@@ -66,8 +66,8 @@ export class ComposedGesture extends Gesture {
     }
   }
 
-  configure(): GestureType[] {
-    return this.gestures.map((gesture) => gesture.configure()).flat();
+  toGestureArray(): GestureType[] {
+    return this.gestures.map((gesture) => gesture.toGestureArray()).flat();
   }
 }
 
@@ -77,8 +77,8 @@ export class SimultaneousGesture extends ComposedGesture {
   }
 
   prepare() {
-    const leftSide = this.gestures[0].configure();
-    const rightSide = this.gestures[1].configure();
+    const leftSide = this.gestures[0].toGestureArray();
+    const rightSide = this.gestures[1].toGestureArray();
 
     this.prepareSingleGesture(
       this.gestures[0],
@@ -99,7 +99,7 @@ export class RequireToFailGesture extends ComposedGesture {
   }
 
   prepare() {
-    const rightSide = this.gestures[1].configure();
+    const rightSide = this.gestures[1].toGestureArray();
 
     this.prepareSingleGesture(
       this.gestures[0],

--- a/src/handlers/gestures/gestureObjects.ts
+++ b/src/handlers/gestures/gestureObjects.ts
@@ -1,5 +1,11 @@
 import { FlingGesture } from './flingGesture';
 import { ForceTouchGesture } from './forceTouchGesture';
+import { Gesture } from './gesture';
+import {
+  ComposedGesture,
+  RequireToFailGesture,
+  SimultaneousGesture,
+} from './gestureInteractions';
 import { LongPressGesture } from './longPressGesture';
 import { PanGesture } from './panGesture';
 import { PinchGesture } from './pinchGesture';
@@ -33,5 +39,17 @@ export const GestureObjects = {
 
   forceTouch() {
     return new ForceTouchGesture();
+  },
+
+  exclusive(...gestures: Gesture[]) {
+    return new ComposedGesture(...gestures);
+  },
+
+  simultaneous(first: Gesture, second: Gesture) {
+    return new SimultaneousGesture(first, second);
+  },
+
+  requireToFail(first: Gesture, second: Gesture) {
+    return new RequireToFailGesture(first, second);
   },
 };

--- a/src/handlers/gestures/gestureObjects.ts
+++ b/src/handlers/gestures/gestureObjects.ts
@@ -41,14 +41,33 @@ export const GestureObjects = {
     return new ForceTouchGesture();
   },
 
+  /**
+   * Builds a composed gesture consisting of gestures provided as parameters.
+   * Only one of them can become active at the same time, the rest will be cancelled.
+   */
   exclusive(...gestures: Gesture[]) {
     return new ComposedGesture(...gestures);
   },
 
+  /**
+   * Builds a composed gesture that allows its two base gestures to run simultaneously.
+   * @param first A gesture to run simultaneously with the second one
+   * @param second A gesture to run simultaneously with the first one
+   * @returns ComposedGesture consisting of the gestures provided as parameters.
+   */
   simultaneous(first: Gesture, second: Gesture) {
     return new SimultaneousGesture(first, second);
   },
 
+  /**
+   * Builds a composed gesture that makes the first gesture wait with activation until
+   * the second one fails.
+   * For example, to make a gesture that recognizes both single and double tap you need
+   * to call requireToFail(singleTap, doubleTap).
+   * @param first A gesture that requires the second one to fail in order to activate
+   * @param second A gesture that is required to fail by the first one to activate.
+   * @returns ComposedGesture consisting of the gestures provided as parameters.
+   */
   requireToFail(first: Gesture, second: Gesture) {
     return new RequireToFailGesture(first, second);
   },


### PR DESCRIPTION
## Description

Remove `InteractionBuilder` because the way it was building relations between gestures was not obvious.
Add `Gesture.exclusive`, `Gesture.simultaneous` and `Gesture.requireToFail` methods for more explicit way of composing gestures. While this method is more verbose (and may not look so nice 😢), it should be easily understandable.

## Test plan

Updated examples and tested on the Example app.
