### PR TITLE
Update PanGestureHandler on iOS

### DIFF
--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -61,6 +61,11 @@
   return self;
 }
 
+- (void)triggerAction
+{
+  [_gestureHandler handleGesture:self];
+}
+
 - (void)setMinimumNumberOfTouches:(NSUInteger)minimumNumberOfTouches
 {
   _realMinimumNumberOfTouches = minimumNumberOfTouches;
@@ -68,6 +73,7 @@
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
+  [_gestureHandler reset];
 #if !TARGET_OS_TV
   if (_hasCustomActivationCriteria) {
     // We use "minimumNumberOfTouches" property to prevent pan handler from recognizing
@@ -79,6 +85,7 @@
   }
 #endif
   [super touchesBegan:touches withEvent:event];
+  [self triggerAction];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
@@ -114,6 +121,7 @@
 
 - (void)reset
 {
+  [self triggerAction];
   self.enabled = YES;
   [super reset];
 }
@@ -256,6 +264,15 @@
     recognizer.minVelocitySq = velocity * velocity;
   }
   [recognizer updateHasCustomActivationCriteria];
+}
+
+- (BOOL) gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+  RNGestureHandlerState savedState = _lastState;
+  BOOL originalResult = [super gestureRecognizerShouldBegin:gestureRecognizer];
+  _lastState = savedState;
+  
+  return originalResult;
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIPanGestureRecognizer *)recognizer


### PR DESCRIPTION
## Description

Update PanGestureHandler on iOS to send `UNDETERMINED` -> `BEGAN` state change event on pointer down, not just before activation.

## Test plan

Tested on the Example app