### PR TITLE
Update PinchGestureHandler behavior

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/BaseGestureHandlerInteractionController.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/BaseGestureHandlerInteractionController.kt
@@ -15,4 +15,9 @@ abstract class BaseGestureHandlerInteractionController : GestureHandlerInteracti
     handler: GestureHandler<*>,
     otherHandler: GestureHandler<*>,
   ) = false
+
+  override fun canHandlerActivateAlongsideAlreadyActive(
+    handler: GestureHandler<*>,
+    otherHandler: GestureHandler<*>
+  ) = true
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/BaseGestureHandlerInteractionController.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/BaseGestureHandlerInteractionController.kt
@@ -16,8 +16,8 @@ abstract class BaseGestureHandlerInteractionController : GestureHandlerInteracti
     otherHandler: GestureHandler<*>,
   ) = false
 
-  override fun canHandlerActivateAlongsideAlreadyActive(
+  override fun needsToPreventOtherHandlerFromActivating(
     handler: GestureHandler<*>,
     otherHandler: GestureHandler<*>
-  ) = true
+  ) = false
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -330,6 +330,23 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     return interactionController?.shouldHandlerBeCancelledBy(this, handler) ?: false
   }
 
+  // this differs from shouldRecognizeSimultaneously because this method is called to check if there
+  // is an already active handler that prevents this from activating, while shouldRecognizeSimultaneously
+  // is called to check which handlers to cancel when a handler becoming active
+  // main reason behind this method is the fact that when a handler activates it cancels all other
+  // handlers that cannot be recognized simultaneously but when another pointer is placed on screen
+  // while it is already active it has no influence over the ones extracted from the new pointer.
+  // we could just use shouldRecognizeSimultaneously in this case but that would break things like
+  // separate draggable objects without `simultaneousHandlers` set, when the problem it's trying to
+  // solve is a scrollview activating when there is active PinchGH inside
+  open fun canActivateAlongsideAlreadyActive(handler: GestureHandler<*>): Boolean {
+    if (handler === this) {
+      return true
+    }
+
+    return interactionController?.canHandlerActivateAlongsideAlreadyActive(this, handler) ?: true
+  }
+
   fun isWithinBounds(view: View?, posX: Float, posY: Float): Boolean {
     var left = 0f
     var top = 0f

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -330,21 +330,12 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     return interactionController?.shouldHandlerBeCancelledBy(this, handler) ?: false
   }
 
-  // this differs from shouldRecognizeSimultaneously because this method is called to check if there
-  // is an already active handler that prevents this from activating, while shouldRecognizeSimultaneously
-  // is called to check which handlers to cancel when a handler becoming active
-  // main reason behind this method is the fact that when a handler activates it cancels all other
-  // handlers that cannot be recognized simultaneously but when another pointer is placed on screen
-  // while it is already active it has no influence over the ones extracted from the new pointer.
-  // we could just use shouldRecognizeSimultaneously in this case but that would break things like
-  // separate draggable objects without `simultaneousHandlers` set, when the problem it's trying to
-  // solve is a scrollview activating when there is active PinchGH inside
-  open fun canActivateAlongsideAlreadyActive(handler: GestureHandler<*>): Boolean {
+  open fun needsToPreventOtherFromActivating(handler: GestureHandler<*>): Boolean {
     if (handler === this) {
-      return true
+      return false
     }
 
-    return interactionController?.canHandlerActivateAlongsideAlreadyActive(this, handler) ?: true
+    return interactionController?.needsToPreventOtherHandlerFromActivating(this, handler) ?: false
   }
 
   fun isWithinBounds(view: View?, posX: Float, posY: Float): Boolean {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerInteractionController.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerInteractionController.kt
@@ -5,5 +5,5 @@ interface GestureHandlerInteractionController {
   fun shouldRequireHandlerToWaitForFailure(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
   fun shouldRecognizeSimultaneously(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
   fun shouldHandlerBeCancelledBy(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
-  fun canHandlerActivateAlongsideAlreadyActive(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
+  fun needsToPreventOtherHandlerFromActivating(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerInteractionController.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerInteractionController.kt
@@ -5,5 +5,11 @@ interface GestureHandlerInteractionController {
   fun shouldRequireHandlerToWaitForFailure(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
   fun shouldRecognizeSimultaneously(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
   fun shouldHandlerBeCancelledBy(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
+
+  /**
+   * This method allows already active handlers to influence the activation of the other ones.
+   * Its main purpose is to fix continuous multi-touch gestures inside of a scrollView that allow
+   * for some of the pointers to be lifted up and placed back down without ending the gesture.
+   */
   fun needsToPreventOtherHandlerFromActivating(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerInteractionController.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerInteractionController.kt
@@ -5,4 +5,5 @@ interface GestureHandlerInteractionController {
   fun shouldRequireHandlerToWaitForFailure(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
   fun shouldRecognizeSimultaneously(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
   fun shouldHandlerBeCancelledBy(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
+  fun canHandlerActivateAlongsideAlreadyActive(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -100,7 +100,26 @@ class GestureHandlerOrchestrator(
     return false
   }
 
+  private fun isThereActiveHandlerPreventingActivation(handler: GestureHandler<*>): Boolean {
+    for (i in 0 until gestureHandlersCount) {
+      val otherHandler = gestureHandlers[i] ?: continue
+      if (otherHandler.isActive && !handler.canActivateAlongsideAlreadyActive(otherHandler)) {
+        return true
+      }
+    }
+
+    return false
+  }
+
   private fun tryActivate(handler: GestureHandler<*>) {
+    // check if there already is active handler that prevents this one from activating
+    // if there is we need to cancel this one to prevent unexpected behavior
+    if (isThereActiveHandlerPreventingActivation(handler)) {
+      handler.cancel()
+      handler.isAwaiting = false
+      return
+    }
+
     // see if there is anyone else who we need to wait for
     if (hasOtherHandlerToWaitFor(handler)) {
       addAwaitingHandler(handler)

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -143,6 +143,10 @@ class GestureHandlerOrchestrator(
       if (handler.isActive) {
         handler.dispatchStateChange(newState, prevState)
       }
+    } else if (prevState == GestureHandler.STATE_UNDETERMINED) {
+      if (newState == GestureHandler.STATE_BEGAN) {
+        handler.dispatchStateChange(newState, prevState)
+      }
     } else {
       handler.dispatchStateChange(newState, prevState)
     }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -103,7 +103,7 @@ class GestureHandlerOrchestrator(
   private fun isThereActiveHandlerPreventingActivation(handler: GestureHandler<*>): Boolean {
     for (i in 0 until gestureHandlersCount) {
       val otherHandler = gestureHandlers[i] ?: continue
-      if (otherHandler.isActive && !handler.canActivateAlongsideAlreadyActive(otherHandler)) {
+      if (otherHandler.isActive && otherHandler.needsToPreventOtherFromActivating(handler)) {
         return true
       }
     }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.kt
@@ -95,16 +95,6 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     view!!.onTouchEvent(event)
   }
 
-  override fun canActivateAlongsideAlreadyActive(handler: GestureHandler<*>): Boolean {
-    // when there is an active PinchGH lifting finger up and placing it back on the screen activates
-    // scrollview alongside PinchGH resulting in weird behavior
-    if (handler is PinchGestureHandler) {
-      return false
-    }
-
-    return super.canActivateAlongsideAlreadyActive(handler)
-  }
-
   companion object {
     private fun tryIntercept(view: View, event: MotionEvent) =
       view is ViewGroup && view.onInterceptTouchEvent(event)

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.kt
@@ -95,6 +95,16 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     view!!.onTouchEvent(event)
   }
 
+  override fun canActivateAlongsideAlreadyActive(handler: GestureHandler<*>): Boolean {
+    // when there is an active PinchGH lifting finger up and placing it back on the screen activates
+    // scrollview alongside PinchGH resulting in weird behavior
+    if (handler is PinchGestureHandler) {
+      return false
+    }
+
+    return super.canActivateAlongsideAlreadyActive(handler)
+  }
+
   companion object {
     private fun tryIntercept(view: View, event: MotionEvent) =
       view is ViewGroup && view.onInterceptTouchEvent(event)

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -52,6 +52,7 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
   }
 
   override fun onHandle(event: MotionEvent) {
+    // begin pinch only when there are at least two active pointers on the screen
     if (state == STATE_UNDETERMINED && event.pointerCount >= 2) {
       val context = view!!.context
       velocity = 0.0

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -78,6 +78,14 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
     }
   }
 
+  override fun needsToPreventOtherFromActivating(handler: GestureHandler<*>): Boolean {
+    if (handler is NativeViewGestureHandler) {
+      return true
+    }
+
+    return super.needsToPreventOtherFromActivating(handler)
+  }
+
   override fun onReset() {
     scaleGestureDetector = null
     velocity = 0.0

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -1,6 +1,5 @@
 package com.swmansion.gesturehandler
 
-import android.util.Log
 import android.view.MotionEvent
 import android.view.ScaleGestureDetector
 import android.view.ScaleGestureDetector.OnScaleGestureListener

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -74,7 +74,7 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       if ((endOnFingerRelease && activePointers < 2) || activePointers == 0) {
         end()
       }
-    } else if (event.actionMasked == MotionEvent.ACTION_UP && state == STATE_BEGAN) {
+    } else if (event.actionMasked == MotionEvent.ACTION_UP) {
       fail()
     }
   }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
@@ -49,6 +49,8 @@ class RNGestureHandlerInteractionManager : GestureHandlerInteractionController {
     otherHandler: GestureHandler<*>,
   ) = simultaneousRelations[handler.tag]?.any { tag -> tag == otherHandler.tag } ?: false
 
+  override fun canHandlerActivateAlongsideAlreadyActive(handler: GestureHandler<*>, otherHandler: GestureHandler<*>) = true
+
   fun reset() {
     waitForRelations.clear()
     simultaneousRelations.clear()

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
@@ -49,7 +49,7 @@ class RNGestureHandlerInteractionManager : GestureHandlerInteractionController {
     otherHandler: GestureHandler<*>,
   ) = simultaneousRelations[handler.tag]?.any { tag -> tag == otherHandler.tag } ?: false
 
-  override fun canHandlerActivateAlongsideAlreadyActive(handler: GestureHandler<*>, otherHandler: GestureHandler<*>) = true
+  override fun needsToPreventOtherHandlerFromActivating(handler: GestureHandler<*>, otherHandler: GestureHandler<*>) = false
 
   fun reset() {
     waitForRelations.clear()

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -234,6 +234,13 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) : ReactCont
       return PinchGestureHandler()
     }
 
+    override fun configure(handler: PinchGestureHandler, config: ReadableMap) {
+      super.configure(handler, config)
+      if (config.hasKey(KEY_END_ON_FINGER_RELEASE)) {
+        handler.endOnFingerRelease = config.getBoolean(KEY_END_ON_FINGER_RELEASE)
+      }
+    }
+
     override fun extractEventData(handler: PinchGestureHandler, eventData: WritableMap) {
       super.extractEventData(handler, eventData)
       with(eventData) {
@@ -529,6 +536,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) : ReactCont
     private const val KEY_HIT_SLOP_HORIZONTAL = "horizontal"
     private const val KEY_HIT_SLOP_WIDTH = "width"
     private const val KEY_HIT_SLOP_HEIGHT = "height"
+    private const val KEY_END_ON_FINGER_RELEASE = "endOnFingerRelease"
     private const val KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START = "shouldActivateOnStart"
     private const val KEY_NATIVE_VIEW_DISALLOW_INTERRUPTION = "disallowInterruption"
     private const val KEY_TAP_NUMBER_OF_TAPS = "numberOfTaps"

--- a/ios/Handlers/RNPinchHandler.m
+++ b/ios/Handlers/RNPinchHandler.m
@@ -35,7 +35,7 @@
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   _pointers++;
-  NSLog(@"end: %d", _endOnFingerRelease);
+
   [super touchesBegan:touches withEvent:event];
 }
 

--- a/ios/Handlers/RNPinchHandler.m
+++ b/ios/Handlers/RNPinchHandler.m
@@ -48,10 +48,8 @@
   if (_pointers < 2 && _endOnFingerRelease) {
     if (self.state == UIGestureRecognizerStateChanged) {
       self.state = UIGestureRecognizerStateEnded;
-      [self reset];
-    } else {
-      [self reset];
     }
+    [self reset];
   }
 }
 

--- a/src/handlers/PinchGestureHandler.ts
+++ b/src/handlers/PinchGestureHandler.ts
@@ -4,6 +4,8 @@ import {
   baseGestureHandlerProps,
 } from './gestureHandlerCommon';
 
+export const pinchGestureHandlerProps = ['endOnFingerRelease'] as const;
+
 export type PinchGestureHandlerEventPayload = {
   /**
    * The scale factor relative to the points of the two touches in screen
@@ -32,7 +34,9 @@ export type PinchGestureHandlerEventPayload = {
 };
 
 export interface PinchGestureHandlerProps
-  extends BaseGestureHandlerProps<PinchGestureHandlerEventPayload> {}
+  extends BaseGestureHandlerProps<PinchGestureHandlerEventPayload> {
+  endOnFingerRelease?: boolean;
+}
 
 export type PinchGestureHandler = typeof PinchGestureHandler;
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; see description on the top of gestureHandlerCommon.ts file
@@ -41,6 +45,6 @@ export const PinchGestureHandler = createHandler<
   PinchGestureHandlerEventPayload
 >({
   name: 'PinchGestureHandler',
-  allowedProps: baseGestureHandlerProps,
+  allowedProps: [...baseGestureHandlerProps, ...pinchGestureHandlerProps],
   config: {},
 });


### PR DESCRIPTION
## Description

PinchGestureHandler has been working differently on iOS and on Android.
On Android PinchGestureHandler was transitioning to `BEGAN` state immediately after first pointer down and transitioning to `END` if the pointer was pulled up.
On iOS it is transitioning to `BEGAN` just before it activates and was allowing to continue the gesture after one of the pointers was pulled up.

This PR modifies both of the platforms to be much more consistent:
- (Android) add requirement for at least two active pointers on screen before PinchGH can begin
- (Android) add condition in Orchestrator to not send state change event from `UNDETERMINED` state only to `BEGAN` state and ignore others. Internally the logic stays the same but it prevents sending `UNDETERMINED` -> `FAILED` or `CANCELLED` which IMO is the correct behavior (it wasn't required before because all handlers went to `BEGAN` state on touch start, but this PR allows PinchGH to stay in the `UNDETERMINED` state).
- (Android) make PinchGH mimic the iOS behavior by default - when the gesture is active it will not end while there is a pointer on the component inside gesture handler
- (Android) add new `canActivateAlongsideAlreadyActive` method to base `GestureHandler` class. While `shouldRecognizeSimultaneously` is called on handler activation to cancel other handlers that cannot be recognized at the same time, when a new pointer appears on the screen it may extract previously cancelled handlers again. This method adds option to prevent a handler from activating in that case. (Fixes a bug where `ScrollView` would activate when `PinchGH` was inside of it with `endOnFingerRelease` set to false)
- (Both platforms) add a new `endOnFingerRelease` prop to PinchGH which changes behavior of the handler to match the original Android behavior - gesture will end when any of the fingers is released

## Test plan

Tested on the Example app
