### PR TITLE
Rename composition methods

### DIFF
--- a/docs/docs/api2/composing-gestures.md
+++ b/docs/docs/api2/composing-gestures.md
@@ -4,14 +4,14 @@ title: Composing gestures
 sidebar_label: Composing gestures
 ---
 
-Composing gestures is much simpler in RNGH2, you don't need to create a ref for every gesture that depends on another one. Instead you can use `OneOf`, `Simultaneous` and `Exclusive` methods provided by the `Gesture` object.
+Composing gestures is much simpler in RNGH2, you don't need to create a ref for every gesture that depends on another one. Instead you can use `Race`, `Simultaneous` and `Exclusive` methods provided by the `Gesture` object.
 
-## OneOf
+## Race
 
 Only one of the provided gestures can become active at the same time. The fist gesture to become active will cancel the rest of the gestures. It accepts variable number of arguments.
 It is the equivalent to having more than one gesture handler without defining `simultaneousHandlers` and `waitFor` props.
 
-For example, lets say that you have a component that you want to make draggable but you also want to show additional options on long press. Presumably you would not want the component to move after the long press activates. You can accomplish this using `OneOf`:
+For example, lets say that you have a component that you want to make draggable but you also want to show additional options on long press. Presumably you would not want the component to move after the long press activates. You can accomplish this using `Race`:
 
 ```js
 const offset = useSharedValue({ x: 0, y: 0 });
@@ -61,7 +61,7 @@ const longPressGesture = Gesture.LongPress().onStart((_event) => {
   popupAlpha.value = withTiming(1);
 });
 
-const composed = Gesture.OneOf(dragGesture, longPressGesture);
+const composed = Gesture.Race(dragGesture, longPressGesture);
 
 return (
   <Animated.View>

--- a/docs/docs/api2/composing-gestures.md
+++ b/docs/docs/api2/composing-gestures.md
@@ -4,13 +4,14 @@ title: Composing gestures
 sidebar_label: Composing gestures
 ---
 
-Composing gestures is much simpler in RNGH2, you don't need to create a ref for every gesture that depends on another one. Instead you can use `Exclusive`, `Simultaneous` and `RequireToFail` methods provided by the `Gesture` object.
+Composing gestures is much simpler in RNGH2, you don't need to create a ref for every gesture that depends on another one. Instead you can use `FirstOf`, `Simultaneous` and `Exclusive` methods provided by the `Gesture` object.
 
-## Exclusive
+## FirstOf
 
-Is the equivalent to just having more than one gesture handler without defining `simultaneousHandlers` and `waitFor` props. It means that only one of the provided gestures can become active at the same time. It accepts variable number of arguments.
+Only one of the provided gestures can become active at the same time. The fist gesture to become active will cancel the rest of the gestures. It accepts variable number of arguments.
+It is the equivalent to having more than one gesture handler without defining `simultaneousHandlers` and `waitFor` props.
 
-For example, lets say that you have a component that you want to make draggable but you also want to show additional options on long press. Presumably you would not want the component to move after the long press activates. You can accomplish this using `Exclusive`:
+For example, lets say that you have a component that you want to make draggable but you also want to show additional options on long press. Presumably you would not want the component to move after the long press activates. You can accomplish this using `FirstOf`:
 
 ```js
 const offset = useSharedValue({ x: 0, y: 0 });
@@ -54,19 +55,18 @@ const dragGesture = Gesture.Pan()
     };
   });
 
-const longPressGesture = Gesture.LongPress()
-  .onStart((_event) => {
-    'worklet';
-    popupPosition.value = { x: offset.value.x, y: offset.value.y };
-    popupAlpha.value = withTiming(1);
-  });
+const longPressGesture = Gesture.LongPress().onStart((_event) => {
+  'worklet';
+  popupPosition.value = { x: offset.value.x, y: offset.value.y };
+  popupAlpha.value = withTiming(1);
+});
 
-const exclusive = Gesture.Exclusive(dragGesture, longPressGesture);
+const composed = Gesture.FirstOf(dragGesture, longPressGesture);
 
 return (
   <Animated.View>
     <Popup style={animatedPopupStyles} />
-    <GestureDetector gesture={exclusive}>
+    <GestureDetector gesture={composed}>
       <Component style={animatedStyles} />
     </GestureDetector>
   </Animated.View>
@@ -75,7 +75,8 @@ return (
 
 ## Simultaneous
 
-It accepts 2 arguments and it is the equivalent to having two gesture handlers, each with `simultaneousHandlers` prop set to the other handler.
+It accepts 2 arguments and both of the provided gestures can activate at the same time. Activation of one will not cancel the other.
+It is the equivalent to having two gesture handlers, each with `simultaneousHandlers` prop set to the other handler.
 
 For example, if you want to make a gallery app, you might want user to be able to zoom, rotate and pan around photos. You can do it with `Simultaneous`:
 
@@ -135,25 +136,26 @@ const rotateGesture = Gesture.Rotation()
     savedRotation.value = rotation.value;
   });
 
-const simultaneous = Gesture.Simultaneous(
+const composed = Gesture.Simultaneous(
   dragGesture,
   Gesture.Simultaneous(zoomGesture, rotateGesture)
 );
 
 return (
   <Animated.View>
-    <GestureDetector gesture={simultaneous}>
-    	<Photo style={animatedStyles} />
+    <GestureDetector gesture={composed}>
+      <Photo style={animatedStyles} />
     </GestureDetector>
   </Animated.View>
 );
 ```
 
-## RequireToFail
+## Exclusive
 
-It accepts 2 arguments and it is equivalent to having two gesture handlers where the first one has the `waitFor` prop set to the other handler. We hope that the changed name will be less ambigous than `waitFor`, which could be interpreted both as `wait for other handler to fail` or `wait for other handler to activate`.
+It accepts 2 arguments and only one of them can become active, with the first one having a higher priority than the second one (if both gestures are still possible, the second one will wait for the first one to fail before it activates).
+It is equivalent to having two gesture handlers where the second one has the `waitFor` prop set to the other handler.
 
-For example, if you want to make a component that responds to single tap as well as to a double tap, you can accomplish that using `RequireToFail`:
+For example, if you want to make a component that responds to single tap as well as to a double tap, you can accomplish that using `Exclusive`:
 
 ```js
 const singleTap = Gesture.Tap().onEnd((_event, success) => {
@@ -169,7 +171,7 @@ const doubleTap = Gesture.Tap()
     }
   });
 
-const taps = Gesture.RequireToFail(singleTap, doubleTap);
+const taps = Gesture.Exclusive(doubleTap, singleTap);
 
 return (
   <GestureDetector gesture={taps}>

--- a/docs/docs/api2/composing-gestures.md
+++ b/docs/docs/api2/composing-gestures.md
@@ -4,14 +4,14 @@ title: Composing gestures
 sidebar_label: Composing gestures
 ---
 
-Composing gestures is much simpler in RNGH2, you don't need to create a ref for every gesture that depends on another one. Instead you can use `FirstOf`, `Simultaneous` and `Exclusive` methods provided by the `Gesture` object.
+Composing gestures is much simpler in RNGH2, you don't need to create a ref for every gesture that depends on another one. Instead you can use `OneOf`, `Simultaneous` and `Exclusive` methods provided by the `Gesture` object.
 
-## FirstOf
+## OneOf
 
 Only one of the provided gestures can become active at the same time. The fist gesture to become active will cancel the rest of the gestures. It accepts variable number of arguments.
 It is the equivalent to having more than one gesture handler without defining `simultaneousHandlers` and `waitFor` props.
 
-For example, lets say that you have a component that you want to make draggable but you also want to show additional options on long press. Presumably you would not want the component to move after the long press activates. You can accomplish this using `FirstOf`:
+For example, lets say that you have a component that you want to make draggable but you also want to show additional options on long press. Presumably you would not want the component to move after the long press activates. You can accomplish this using `OneOf`:
 
 ```js
 const offset = useSharedValue({ x: 0, y: 0 });
@@ -61,7 +61,7 @@ const longPressGesture = Gesture.LongPress().onStart((_event) => {
   popupAlpha.value = withTiming(1);
 });
 
-const composed = Gesture.FirstOf(dragGesture, longPressGesture);
+const composed = Gesture.OneOf(dragGesture, longPressGesture);
 
 return (
   <Animated.View>

--- a/docs/docs/api2/gesture-detector.md
+++ b/docs/docs/api2/gesture-detector.md
@@ -10,7 +10,7 @@ sidebar_label: Gesture detector
 
 ### `gesture`
 
-A gesture object containing the configuration and callbacks. Can be any of the base gestures (`Tap`, `Pan`, `LongPress`, `Fling`, `Pinch`, `Rotation`, `ForceTouch`) or any `ComposedGesture` (`Exclusive`, `Simultaneous`, `RequireToFail`).
+A gesture object containing the configuration and callbacks. Can be any of the base gestures (`Tap`, `Pan`, `LongPress`, `Fling`, `Pinch`, `Rotation`, `ForceTouch`) or any `ComposedGesture` (`FirstOf`, `Simultaneous`, `Exclusive`).
 
 ### `animatedGesture`
 

--- a/docs/docs/api2/gesture-detector.md
+++ b/docs/docs/api2/gesture-detector.md
@@ -10,7 +10,7 @@ sidebar_label: Gesture detector
 
 ### `gesture`
 
-A gesture object containing the configuration and callbacks. Can be any of the base gestures (`Tap`, `Pan`, `LongPress`, `Fling`, `Pinch`, `Rotation`, `ForceTouch`) or any `ComposedGesture` (`OneOf`, `Simultaneous`, `Exclusive`).
+A gesture object containing the configuration and callbacks. Can be any of the base gestures (`Tap`, `Pan`, `LongPress`, `Fling`, `Pinch`, `Rotation`, `ForceTouch`) or any `ComposedGesture` (`Race`, `Simultaneous`, `Exclusive`).
 
 ### `animatedGesture`
 

--- a/docs/docs/api2/gesture-detector.md
+++ b/docs/docs/api2/gesture-detector.md
@@ -10,7 +10,7 @@ sidebar_label: Gesture detector
 
 ### `gesture`
 
-A gesture object containing the configuration and callbacks. Can be any of the base gestures (`Tap`, `Pan`, `LongPress`, `Fling`, `Pinch`, `Rotation`, `ForceTouch`) or any `ComposedGesture` (`FirstOf`, `Simultaneous`, `Exclusive`).
+A gesture object containing the configuration and callbacks. Can be any of the base gestures (`Tap`, `Pan`, `LongPress`, `Fling`, `Pinch`, `Rotation`, `ForceTouch`) or any `ComposedGesture` (`OneOf`, `Simultaneous`, `Exclusive`).
 
 ### `animatedGesture`
 

--- a/examples/Example/src/new_api/camera/index.tsx
+++ b/examples/Example/src/new_api/camera/index.tsx
@@ -90,7 +90,7 @@ export default function Home() {
   const buttonGesture = Gesture.Simultaneous(
     buttonLongPressGesture,
     Gesture.Exclusive(
-      Gesture.RequireToFail(buttonTapGesture, buttonDoubleTapGesture),
+      Gesture.Exclusive(buttonDoubleTapGesture, buttonTapGesture),
       buttonPanGesture
     )
   );

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -25,7 +25,7 @@ import {
 } from '../PanGestureHandler';
 import { tapGestureHandlerProps } from '../TapGestureHandler';
 import { State } from '../../State';
-import { ComposedGesture } from './gestureInteractions';
+import { ComposedGesture } from './gestureComposition';
 
 const ALLOWED_PROPS = [
   ...baseGestureHandlerWithMonitorProps,

--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -93,23 +93,23 @@ export class SimultaneousGesture extends ComposedGesture {
   }
 }
 
-export class RequireToFailGesture extends ComposedGesture {
+export class ExclusiveGesture extends ComposedGesture {
   constructor(first: Gesture, second: Gesture) {
     super(first, second);
   }
 
   prepare() {
-    const rightSide = this.gestures[1].toGestureArray();
+    const leftSide = this.gestures[0].toGestureArray();
 
     this.prepareSingleGesture(
       this.gestures[0],
       this.simultaneousGestures,
-      this.requireGesturesToFail.concat(rightSide)
+      this.requireGesturesToFail
     );
     this.prepareSingleGesture(
       this.gestures[1],
       this.simultaneousGestures,
-      this.requireGesturesToFail
+      this.requireGesturesToFail.concat(leftSide)
     );
   }
 }

--- a/src/handlers/gestures/gestureObjects.ts
+++ b/src/handlers/gestures/gestureObjects.ts
@@ -3,9 +3,9 @@ import { ForceTouchGesture } from './forceTouchGesture';
 import { Gesture } from './gesture';
 import {
   ComposedGesture,
-  RequireToFailGesture,
+  ExclusiveGesture,
   SimultaneousGesture,
-} from './gestureInteractions';
+} from './gestureComposition';
 import { LongPressGesture } from './longPressGesture';
 import { PanGesture } from './panGesture';
 import { PinchGesture } from './pinchGesture';
@@ -43,9 +43,9 @@ export const GestureObjects = {
 
   /**
    * Builds a composed gesture consisting of gestures provided as parameters.
-   * Only one of them can become active at the same time, the rest will be cancelled.
+   * The first one that becomes active cancels the rest of gestures.
    */
-  Exclusive(...gestures: Gesture[]) {
+  FirstOf(...gestures: Gesture[]) {
     return new ComposedGesture(...gestures);
   },
 
@@ -60,15 +60,16 @@ export const GestureObjects = {
   },
 
   /**
-   * Builds a composed gesture that makes the first gesture wait with activation until
-   * the second one fails.
+   * Builds a composed gesture where only one of the provided gestures can become active.
+   * Priority is decided through the order of gestures: the first one has higher priority
+   * than the second one.
    * For example, to make a gesture that recognizes both single and double tap you need
-   * to call requireToFail(singleTap, doubleTap).
-   * @param first A gesture that requires the second one to fail in order to activate
-   * @param second A gesture that is required to fail by the first one to activate.
+   * to call Exclusive(doubleTap, singleTap).
+   * @param first A gesture with higher priority
+   * @param second A gesture with lower priority
    * @returns ComposedGesture consisting of the gestures provided as parameters.
    */
-  RequireToFail(first: Gesture, second: Gesture) {
-    return new RequireToFailGesture(first, second);
+  Exclusive(first: Gesture, second: Gesture) {
+    return new ExclusiveGesture(first, second);
   },
 };

--- a/src/handlers/gestures/gestureObjects.ts
+++ b/src/handlers/gestures/gestureObjects.ts
@@ -45,7 +45,7 @@ export const GestureObjects = {
    * Builds a composed gesture consisting of gestures provided as parameters.
    * The first one that becomes active cancels the rest of gestures.
    */
-  FirstOf(...gestures: Gesture[]) {
+  OneOf(...gestures: Gesture[]) {
     return new ComposedGesture(...gestures);
   },
 

--- a/src/handlers/gestures/gestureObjects.ts
+++ b/src/handlers/gestures/gestureObjects.ts
@@ -45,7 +45,7 @@ export const GestureObjects = {
    * Builds a composed gesture consisting of gestures provided as parameters.
    * The first one that becomes active cancels the rest of gestures.
    */
-  OneOf(...gestures: Gesture[]) {
+  Race(...gestures: Gesture[]) {
     return new ComposedGesture(...gestures);
   },
 


### PR DESCRIPTION
## Description

Rename `Gesture.Exclusive` to `Gesture.Race`.
Rename `Gesture.RequireToFail` to `Gesture.Exclusive`.
Rename `gestureInteractions.ts` to `gestureComposition.ts`.

## Test plan

Updated examples and tested on the Example app, ran `npm pack`.
