### PR TITLE
Fix gesture handlers not working when children overflow their parent

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -364,12 +364,10 @@ class GestureHandlerOrchestrator(
 
   private fun recordViewHandlersForPointer(view: View, coords: FloatArray, pointerId: Int): Boolean {
     var found = false
-
     handlerRegistry.getHandlersForView(view)?.let {
       val size = it.size
       for (i in 0 until size) {
         val handler = it[i]
-
         if (handler.isEnabled && handler.isWithinBounds(view, coords[0], coords[1])) {
           recordHandlerIfNotPresent(handler, view)
           handler.startTrackingPointer(pointerId)

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -322,12 +322,54 @@ class GestureHandlerOrchestrator(
     handler.prepare(view, this)
   }
 
+  private fun isViewOverflowingParent(view: View): Boolean {
+    val parent = view.parent as? ViewGroup ?: return false
+    val matrix = view.matrix
+    val localXY = matrixTransformCoords
+    localXY[0] = 0f
+    localXY[1] = 0f
+    matrix.mapPoints(localXY)
+    val left = localXY[0] + view.left
+    val top = localXY[1] + view.top
+
+    return left < 0f || left + view.width > parent.width || top < 0f || top + view.height > parent.height
+  }
+
+  private fun extractAncestorHandlers(view: View, coords: FloatArray, pointerId: Int): Boolean {
+    var found = false
+    var parent = view.parent
+
+    while (parent != null) {
+      if (parent is ViewGroup) {
+        val parentViewGroup: ViewGroup = parent
+
+        handlerRegistry.getHandlersForView(parent)?.let {
+          for (i in 0 until it.size) {
+            val handler = it[i]
+
+            if (handler.isEnabled && handler.isWithinBounds(view, coords[0], coords[1])) {
+              found = true
+              recordHandlerIfNotPresent(handler, parentViewGroup)
+              handler.startTrackingPointer(pointerId)
+            }
+          }
+        }
+      }
+
+      parent = parent.parent
+    }
+
+    return found
+  }
+
   private fun recordViewHandlersForPointer(view: View, coords: FloatArray, pointerId: Int): Boolean {
     var found = false
+
     handlerRegistry.getHandlersForView(view)?.let {
       val size = it.size
       for (i in 0 until size) {
         val handler = it[i]
+
         if (handler.isEnabled && handler.isWithinBounds(view, coords[0], coords[1])) {
           recordHandlerIfNotPresent(handler, view)
           handler.startTrackingPointer(pointerId)
@@ -335,6 +377,14 @@ class GestureHandlerOrchestrator(
         }
       }
     }
+
+    // if the pointer is inside the view but it overflows its parent, handlers attached to the parent
+    // might not have been extracted (pointer might be in a child, but may be outside parent)
+    if (coords[0] in 0f..view.width.toFloat() && coords[1] in 0f..view.height.toFloat()
+      && isViewOverflowingParent(view) && extractAncestorHandlers(view, coords, pointerId)) {
+        found = true
+    }
+
     return found
   }
 


### PR DESCRIPTION
## Description

On Android to get all handlers that could want events from the pointer the view tree is traversed and when a view contains the pointer, all handlers attached to that view are extracted. This works fine as long as children do not overflow the parent, when that happens the handlers attached to the ancestors may not be extracted because the pointer may not be inside them (but may be inside a child view).
This change adds a check inside the method responsible for extracting handlers to see if the current view is overflowing its parent. It it is, all gesture handlers attached to its ancestor views are also extracted (it may be nested deeper than one level).

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1532

## Test plan

Tested on the Example app and on this code:

```js
import React from 'react';
import { StyleSheet } from 'react-native';
import {
  PanGestureHandler,
  TapGestureHandler,
} from 'react-native-gesture-handler';
import Animated, {
  useSharedValue,
  useAnimatedStyle,
  useAnimatedGestureHandler,
} from 'react-native-reanimated';

export default function Example() {
  const offsetX = useSharedValue(0);
  const offsetY = useSharedValue(0);
  const startX = useSharedValue(0);
  const startY = useSharedValue(0);

  const smallOffsetX = useSharedValue(0);
  const smallOffsetY = useSharedValue(0);
  const smallStartX = useSharedValue(0);
  const smallStartY = useSharedValue(0);

  const animatedStyles = useAnimatedStyle(() => {
    return {
      transform: [{ translateX: offsetX.value }, { translateY: offsetY.value }],
    };
  });

  const smanimatedStyles = useAnimatedStyle(() => {
    return {
      transform: [
        { translateX: smallOffsetX.value },
        { translateY: smallOffsetY.value },
      ],
    };
  });

  const handler = useAnimatedGestureHandler({
    onEnd: (_e) => {
      startX.value = offsetX.value;
      startY.value = offsetY.value;
    },
    onActive: (e) => {
      offsetX.value = e.translationX + startX.value;
      offsetY.value = e.translationY + startY.value;
    },
  });

  const smhandler = useAnimatedGestureHandler({
    onEnd: (_e) => {
      smallStartX.value = smallOffsetX.value;
      smallStartY.value = smallOffsetY.value;
    },
    onActive: (e) => {
      smallOffsetX.value = e.translationX + smallStartX.value;
      smallOffsetY.value = e.translationY + smallStartY.value;
    },
  });

  return (
    <TapGestureHandler onActivated={() => console.log('tap')}>
      <Animated.View>
        <PanGestureHandler onGestureEvent={handler}>
          <Animated.View style={[styles.outerRect]}>
            <Animated.View style={[styles.rect]}>
              <Animated.View style={[styles.circle, animatedStyles]}>
                <PanGestureHandler onGestureEvent={smhandler}>
                  <Animated.View
                    style={[styles.smallCircle, smanimatedStyles]}
                  />
                </PanGestureHandler>
              </Animated.View>
            </Animated.View>
          </Animated.View>
        </PanGestureHandler>
      </Animated.View>
    </TapGestureHandler>
  );
}

const styles = StyleSheet.create({
  circle: {
    width: 75,
    height: 75,
    borderRadius: 100,
    backgroundColor: 'blue',
    alignSelf: 'center',
  },
  smallCircle: {
    width: 45,
    height: 45,
    borderRadius: 45,
    backgroundColor: 'cyan',
    alignSelf: 'center',
  },
  rect: {
    backgroundColor: 'green',
    height: 100,
  },
  outerRect: {
    padding: 25,
    backgroundColor: 'yellow',
  },
});
```