### PR TITLE
Create a BetterDrawerLayout component

### DIFF
--- a/examples/Example/src/App.tsx
+++ b/examples/Example/src/App.tsx
@@ -23,6 +23,7 @@ import { DraggableBox } from './basic/draggable';
 import MultiTap from './basic/multitap';
 import BouncingBox from './basic/bouncing';
 import PanResponder from './basic/panResponder';
+import BetterHorizontalDrawer from './basic/betterHorizontalDrawer';
 import HorizontalDrawer from './basic/horizontalDrawer';
 import PagerAndDrawer from './basic/pagerAndDrawer';
 import ForceTouch from './basic/forcetouch';
@@ -52,6 +53,10 @@ const EXAMPLES: ExamplesSection[] = [
       { name: 'Bouncing box', component: BouncingBox },
       { name: 'Pan responder', component: PanResponder },
       { name: 'Horizontal drawer', component: HorizontalDrawer },
+      {
+        name: 'Horizontal drawer (Reanimated 2 & RNGH 2)',
+        component: BetterHorizontalDrawer,
+      },
       { name: 'Pager & drawer', component: PagerAndDrawer },
       { name: 'Force touch', component: ForceTouch },
     ],

--- a/examples/Example/src/basic/betterHorizontalDrawer/index.tsx
+++ b/examples/Example/src/basic/betterHorizontalDrawer/index.tsx
@@ -11,7 +11,7 @@ import {
 import Animated, { useAnimatedStyle } from 'react-native-reanimated';
 
 const TYPES: DrawerType[] = ['front', 'back', 'back', 'slide'];
-const PARALLAX: boolean[] = [false, false, true, false];
+const PARALLAX = [false, false, true, false];
 
 interface PageProps {
   fromLeft: boolean;

--- a/examples/Example/src/basic/betterHorizontalDrawer/index.tsx
+++ b/examples/Example/src/basic/betterHorizontalDrawer/index.tsx
@@ -1,0 +1,160 @@
+import React, { useRef, useState } from 'react';
+
+import { StyleSheet, Text, View, TextInput } from 'react-native';
+
+import {
+  DrawerLayoutController,
+  DrawerType,
+  RectButton,
+  BetterDrawerLayout,
+} from 'react-native-gesture-handler';
+import Animated, { useAnimatedStyle } from 'react-native-reanimated';
+
+const TYPES: DrawerType[] = ['front', 'back', 'back', 'slide'];
+const PARALLAX: boolean[] = [false, false, true, false];
+
+interface PageProps {
+  fromLeft: boolean;
+  type: DrawerType;
+  parallaxOn: boolean;
+  flipSide: () => void;
+  nextType: () => void;
+  openDrawer: () => void;
+}
+
+function Page({
+  fromLeft,
+  type,
+  parallaxOn,
+  flipSide,
+  nextType,
+  openDrawer,
+}: PageProps) {
+  return (
+    <View style={styles.page}>
+      <Text style={styles.pageText}>Hi 👋</Text>
+      <RectButton style={styles.rectButton} onPress={flipSide}>
+        <Text style={styles.rectButtonText}>
+          Drawer to the {fromLeft ? 'left' : 'right'}! {'->'} Flip
+        </Text>
+      </RectButton>
+      <RectButton style={styles.rectButton} onPress={nextType}>
+        <Text style={styles.rectButtonText}>
+          Type {type} {parallaxOn && 'with parallax!'} -&gt; Next
+        </Text>
+      </RectButton>
+      <RectButton style={styles.rectButton} onPress={openDrawer}>
+        <Text style={styles.rectButtonText}>Open drawer</Text>
+      </RectButton>
+      <TextInput
+        style={styles.pageInput}
+        placeholder="Just an input field to test kb dismiss mode"
+      />
+    </View>
+  );
+}
+
+function DrawerContent(
+  offset: Animated.SharedValue<number>,
+  parralax: boolean,
+  fromLeft: boolean
+) {
+  const animatedStyles = useAnimatedStyle(() => ({
+    transform: [
+      {
+        translateX: parralax
+          ? Animated.interpolate(offset.value, [0, 1], [fromLeft ? -50 : 50, 0])
+          : 0,
+      },
+    ],
+  }));
+
+  return (
+    <Animated.View style={[styles.drawerContainer, animatedStyles]}>
+      <Text style={styles.drawerText}>
+        {parralax ? 'Drawer with parallax' : 'Drawer'}
+      </Text>
+    </Animated.View>
+  );
+}
+
+export default function Example() {
+  const [onLeft, setOnLeft] = useState(true);
+  const [type, setType] = useState(0);
+  const controller = useRef<DrawerLayoutController>(null);
+
+  return (
+    <View style={styles.container}>
+      <BetterDrawerLayout
+        drawerPosition={onLeft ? 'left' : 'right'}
+        drawerType={TYPES[type]}
+        renderNavigationView={(offset) => {
+          return DrawerContent(offset, PARALLAX[type], onLeft);
+        }}
+        keyboardDismissMode="on-drag"
+        drawerBackgroundColor="white"
+        ref={controller}>
+        <Page
+          fromLeft={onLeft}
+          flipSide={() => {
+            setOnLeft(!onLeft);
+          }}
+          type={TYPES[type]}
+          nextType={() => {
+            setType((type + 1) % TYPES.length);
+          }}
+          parallaxOn={PARALLAX[type]}
+          openDrawer={() => {
+            controller.current?.open();
+          }}
+        />
+      </BetterDrawerLayout>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  page: {
+    ...StyleSheet.absoluteFillObject,
+    alignItems: 'center',
+    paddingTop: 40,
+    backgroundColor: 'gray',
+  },
+  pageText: {
+    fontSize: 21,
+    color: 'white',
+  },
+  rectButton: {
+    height: 60,
+    padding: 10,
+    alignSelf: 'stretch',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 20,
+    backgroundColor: 'white',
+  },
+  rectButtonText: {
+    backgroundColor: 'transparent',
+  },
+  drawerContainer: {
+    flex: 1,
+    paddingTop: 10,
+  },
+  pageInput: {
+    height: 60,
+    padding: 10,
+    alignSelf: 'stretch',
+    alignItems: 'center',
+    justifyContent: 'center',
+    marginTop: 20,
+    backgroundColor: '#eee',
+  },
+  drawerText: {
+    margin: 10,
+    fontSize: 15,
+    textAlign: 'left',
+  },
+});

--- a/examples/Example/src/basic/betterHorizontalDrawer/index.tsx
+++ b/examples/Example/src/basic/betterHorizontalDrawer/index.tsx
@@ -56,13 +56,13 @@ function Page({
 
 function DrawerContent(
   offset: Animated.SharedValue<number>,
-  parralax: boolean,
+  parallax: boolean,
   fromLeft: boolean
 ) {
   const animatedStyles = useAnimatedStyle(() => ({
     transform: [
       {
-        translateX: parralax
+        translateX: parallax
           ? Animated.interpolate(offset.value, [0, 1], [fromLeft ? -50 : 50, 0])
           : 0,
       },
@@ -72,7 +72,7 @@ function DrawerContent(
   return (
     <Animated.View style={[styles.drawerContainer, animatedStyles]}>
       <Text style={styles.drawerText}>
-        {parralax ? 'Drawer with parallax' : 'Drawer'}
+        {parallax ? 'Drawer with parallax' : 'Drawer'}
       </Text>
     </Animated.View>
   );

--- a/src/components/BetterDrawerLayout.tsx
+++ b/src/components/BetterDrawerLayout.tsx
@@ -249,13 +249,13 @@ export const DrawerLayout = React.forwardRef<
     // this is required in addition to the similar call below, because the gesture
     // doesn't change `drawerVisible` state to prevent re-render during gesture
     // so when dragging from closed it wouldn't hide the status bar
-    if (props.hideStatusBar === true) {
+    if (props.hideStatusBar) {
       StatusBar.setHidden(true, props.statusBarAnimation ?? 'slide');
     }
   }
 
   function setState(newState: BetterDrawerState, willShow: boolean) {
-    if (props.hideStatusBar === true) {
+    if (props.hideStatusBar) {
       StatusBar.setHidden(willShow, props.statusBarAnimation ?? 'slide');
     }
 

--- a/src/components/BetterDrawerLayout.tsx
+++ b/src/components/BetterDrawerLayout.tsx
@@ -1,0 +1,611 @@
+import React, { useEffect, useState } from 'react';
+import {
+  I18nManager,
+  LayoutChangeEvent,
+  StatusBarAnimation,
+  StyleProp,
+  StyleSheet,
+  ViewStyle,
+  Keyboard,
+  StatusBar,
+} from 'react-native';
+import {
+  DrawerKeyboardDismissMode,
+  DrawerLockMode,
+  DrawerPosition,
+  DrawerState,
+  DrawerType,
+} from './DrawerLayout';
+import { GestureDetector } from '../handlers/gestures/GestureDetector';
+import { GestureObjects as Gesture } from '../handlers/gestures/gestureObjects';
+import Animated, {
+  runOnJS,
+  useAnimatedStyle,
+  useDerivedValue,
+  useSharedValue,
+  withSpring,
+} from 'react-native-reanimated';
+
+export interface BetterDrawerLayoutProps {
+  /**
+   * This attribute is present in the standard implementation already and is one
+   * of the required params. Gesture handler version of DrawerLayout make it
+   * possible for the function passed as `renderNavigationView` to take an
+   * Animated value as a parameter that indicates the progress of drawer
+   * opening/closing animation (progress value is 0 when closed and 1 when
+   * opened). This can be used by the drawer component to animated its children
+   * while the drawer is opening or closing.
+   */
+  renderNavigationView: (
+    progressAnimatedValue: Animated.SharedValue<number>
+  ) => React.ReactNode;
+
+  drawerPosition?: DrawerPosition;
+
+  drawerWidth?: number;
+
+  drawerBackgroundColor?: string;
+
+  drawerLockMode?: DrawerLockMode;
+
+  keyboardDismissMode?: DrawerKeyboardDismissMode;
+
+  /**
+   * Called when the drawer is closed.
+   */
+  onDrawerClose?: () => void;
+
+  /**
+   * Called when the drawer is opened.
+   */
+  onDrawerOpen?: () => void;
+
+  /**
+   * Called when the status of the drawer changes.
+   */
+  onDrawerStateChanged?: (
+    newState: DrawerState,
+    drawerWillShow: boolean
+  ) => void;
+
+  drawerType?: DrawerType;
+
+  /**
+   * Defines how far from the edge of the content view the gesture should
+   * activate.
+   */
+  edgeWidth?: number;
+
+  minSwipeDistance?: number;
+
+  /**
+   * When set to true Drawer component will use
+   * {@link https://reactnative.dev/docs/statusbar StatusBar} API to hide the OS
+   * status bar whenever the drawer is pulled or when its in an "open" state.
+   */
+  hideStatusBar?: boolean;
+
+  /**
+   * @default 'slide'
+   *
+   * Can be used when hideStatusBar is set to true and will select the animation
+   * used for hiding/showing the status bar. See
+   * {@link https://reactnative.dev/docs/statusbar StatusBar} documentation for
+   * more details
+   */
+  statusBarAnimation?: StatusBarAnimation;
+
+  /**
+   * @default black
+   *
+   * Color of a semi-transparent overlay to be displayed on top of the content
+   * view when drawer gets open. A solid color should be used as the opacity is
+   * added by the Drawer itself and the opacity of the overlay is animated (from
+   * 0% to 70%).
+   */
+  overlayColor?: string;
+
+  contentContainerStyle?: StyleProp<ViewStyle>;
+
+  drawerContainerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * Enables two-finger gestures on supported devices, for example iPads with
+   * trackpads. If not enabled the gesture will require click + drag, with
+   * `enableTrackpadTwoFingerGesture` swiping with two fingers will also trigger
+   * the gesture.
+   */
+  enableTrackpadTwoFingerGesture?: boolean;
+
+  /**
+   * Called when the pan gesture gets updated, position represents a fraction of
+   * the drawer that is visible
+   */
+  onDrawerSlide?: (position: number) => void;
+
+  children?: React.ReactNode;
+}
+
+const IDLE: DrawerState = 'Idle';
+const DRAGGING: DrawerState = 'Dragging';
+const SETTLING: DrawerState = 'Settling';
+
+interface OverlayProps {
+  drawerType: DrawerType;
+  color: string;
+  progress: Animated.SharedValue<number>;
+  lockMode: DrawerLockMode;
+  close: () => void;
+}
+
+function Overlay(props: OverlayProps) {
+  const overlayStyle = useAnimatedStyle(
+    () => ({
+      backgroundColor: props.color,
+      opacity: props.progress.value,
+      transform: [
+        {
+          translateX:
+            // when the overlay should not be visible move it off the screen
+            // to prevent it from intercepting touch events on Android
+            props.drawerType !== 'front' || props.progress.value === 0
+              ? 10000
+              : 0,
+        },
+      ],
+    }),
+    [props]
+  );
+
+  const tap = Gesture.Tap();
+  tap.onEnd((_event, success) => {
+    'worklet';
+    if (success && props.lockMode !== 'locked-open') {
+      // close the drawer when tapped on the overlay only if the gesture
+      // was not cancelled and it's not locked in opened state
+      props.close();
+    }
+  });
+
+  return (
+    <GestureDetector animatedGesture={tap}>
+      <Animated.View style={[styles.overlay, overlayStyle]} />
+    </GestureDetector>
+  );
+}
+
+export interface DrawerLayoutController {
+  open: () => void;
+  close: () => void;
+}
+
+export const DrawerLayout = React.forwardRef<
+  DrawerLayoutController,
+  BetterDrawerLayoutProps
+>((props, ref) => {
+  //default props
+  const drawerWidth = props.drawerWidth ?? 200;
+  const drawerPosition = props.drawerPosition ?? 'left';
+  const drawerType = props.drawerType ?? 'front';
+  const edgeWidth = props.edgeWidth ?? 20;
+  const minSwipeDistance = props.minSwipeDistance ?? 3;
+  const overlayColor = props.overlayColor ?? 'rgba(0, 0, 0, 0.7)';
+  const drawerLockMode = props.drawerLockMode ?? 'unlocked';
+  const enableTrackpadTwoFingerGesture =
+    props.enableTrackpadTwoFingerGesture ?? false;
+  const animationConfig = { damping: 30, stiffness: 250 };
+
+  const fromLeft = drawerPosition === 'left';
+  const drawerSlide = drawerType !== 'back';
+  const containerSlide = drawerType !== 'front';
+
+  // setting NaN as a starting value allows to tell when the value gets changes
+  // for the first time
+  const [containerWidth, setContainerWidth] = useState(Number.NaN);
+  const [drawerVisible, setDrawerVisible] = useState(false);
+
+  const drawerState = useSharedValue<DrawerState>(IDLE);
+  // between 0 and drawerWidth (drawer on the left) or -drawerWidth and 0 (drawer on the right)
+  const drawerOffset = useSharedValue(0);
+  // stores value of the offset at the start of the gesture
+  const drawerSavedOffset = useSharedValue(0);
+  // stores the translation that is supposed to be ignored (user tried to
+  // drag while animation was running)
+  const ignoredOffset = useSharedValue(0);
+  // stores the x coordinate of the drag starting point (to ignore dragging on the overlay)
+  const dragStartPosition = useSharedValue(0);
+  // between 0 and 1, 0 - closed, 1 - opened
+  const openingProgress = useDerivedValue(() => {
+    if (fromLeft) {
+      return drawerOffset.value / drawerWidth;
+    } else {
+      return -drawerOffset.value / drawerWidth;
+    }
+  }, [drawerOffset, containerWidth, drawerWidth, fromLeft]);
+
+  // we rely on row and row-reverse flex directions to position the drawer
+  // properly. Apparently for RTL these are flipped which requires us to use
+  // the opposite setting for the drawer to appear from left or right
+  // according to the drawerPosition prop
+  const reverseContentDirection = I18nManager.isRTL ? fromLeft : !fromLeft;
+
+  // set the drawer to closed position when the props change to prevent it from
+  // opening or moving on the screen
+  useEffect(() => {
+    drawerOffset.value = 0;
+    drawerSavedOffset.value = 0;
+
+    setDrawerVisible(false);
+  }, [props]);
+
+  // measure the container
+  function handleContainerLayout({ nativeEvent }: LayoutChangeEvent) {
+    setContainerWidth(nativeEvent.layout.width);
+  }
+
+  function onDragStart() {
+    if (props.keyboardDismissMode === 'on-drag') {
+      Keyboard.dismiss();
+    }
+
+    // this is required in addition to the similar call below, because the gesture
+    // doesn't change `drawerVisible` state to prevent re-render during gesture
+    // so when dragging from closed it wouldn't hide the status bar
+    if (props.hideStatusBar === true) {
+      StatusBar.setHidden(true, props.statusBarAnimation ?? 'slide');
+    }
+  }
+
+  function setState(newState: DrawerState, willShow: boolean) {
+    if (props.hideStatusBar === true) {
+      StatusBar.setHidden(willShow, props.statusBarAnimation ?? 'slide');
+    }
+
+    // dispach events
+    if (drawerState.value !== newState || drawerVisible !== willShow) {
+      // send state change event only when the state changed or the visibility of the
+      // drawer (for example when drawer is in SETTLING state after opening and the user
+      // taps on the overlay the state is still settling, but willShow is now false)
+      props.onDrawerStateChanged?.(newState, willShow);
+    }
+
+    if (drawerVisible !== willShow) {
+      setDrawerVisible(willShow);
+    }
+
+    if (newState === IDLE) {
+      if (willShow) {
+        props.onDrawerOpen?.();
+      } else {
+        props.onDrawerClose?.();
+      }
+    }
+
+    drawerState.value = newState;
+  }
+
+  function open() {
+    'worklet';
+    if (fromLeft && drawerOffset.value < drawerWidth) {
+      // drawer is on the left and is not fully opened
+      runOnJS(setState)(SETTLING, true);
+
+      drawerOffset.value = withSpring(
+        drawerWidth,
+        animationConfig,
+        (finished) => {
+          drawerSavedOffset.value = drawerOffset.value;
+          if (finished) {
+            // animation cannot be interrupted by a drag, but can be by
+            // calling close or open (through tap or a controller)
+            runOnJS(setState)(IDLE, true);
+          }
+        }
+      );
+    } else if (!fromLeft && drawerOffset.value > -drawerWidth) {
+      // drawer is on the right and is not fully opened
+      runOnJS(setState)(SETTLING, true);
+
+      drawerOffset.value = withSpring(
+        -drawerWidth,
+        animationConfig,
+        (finished) => {
+          drawerSavedOffset.value = drawerOffset.value;
+          if (finished) {
+            // animation cannot be interrupted by a drag, but can be by
+            // calling close or open (through tap or a controller)
+            runOnJS(setState)(IDLE, true);
+          }
+        }
+      );
+    } else {
+      // drawer is fully opened
+      runOnJS(setState)(IDLE, true);
+    }
+  }
+
+  function close() {
+    'worklet';
+    if (fromLeft && drawerOffset.value > 0) {
+      // drawer is on the left and is not fully closed
+      runOnJS(setState)(SETTLING, false);
+
+      drawerOffset.value = withSpring(0, animationConfig, (finished) => {
+        drawerSavedOffset.value = drawerOffset.value;
+        if (finished) {
+          // animation cannot be interrupted by a drag, but can be by
+          // calling close or open (through tap or a controller)
+          runOnJS(setState)(IDLE, false);
+        }
+      });
+    } else if (!fromLeft && drawerOffset.value < 0) {
+      // drawer is on the right and is not fully closed
+      runOnJS(setState)(SETTLING, false);
+
+      drawerOffset.value = withSpring(0, animationConfig, (finished) => {
+        drawerSavedOffset.value = drawerOffset.value;
+        if (finished) {
+          // animation cannot be interrupted by a drag, but can be by
+          // calling close or open (through tap or a controller)
+          runOnJS(setState)(IDLE, false);
+        }
+      });
+    } else {
+      // drawer is fully closed
+      runOnJS(setState)(IDLE, false);
+    }
+  }
+
+  // gestureOrientation is 1 if the expected gesture is from left to right and
+  // -1 otherwise e.g. when drawer is on the left and is closed we expect left
+  // to right gesture, thus orientation will be 1.
+  const gestureOrientation = (fromLeft ? 1 : -1) * (drawerVisible ? -1 : 1);
+
+  // When drawer is closed we want the hitSlop to be horizontally shorter than
+  // the container size by the value of SLOP. This will make it only activate
+  // when gesture happens not further than SLOP away from the edge
+  const hitSlop = fromLeft
+    ? { left: 0, width: drawerVisible ? undefined : edgeWidth }
+    : { right: 0, width: drawerVisible ? undefined : edgeWidth };
+
+  // *** THIS IS THE LARGE COMMENT ABOVE ***
+  //
+  // While closing the drawer when user starts gesture outside of its area (in greyed
+  // out part of the window), we want the drawer to follow only once finger reaches the
+  // edge of the drawer.
+  // E.g. on the diagram below drawer is illustrate by X signs and the greyed out area by
+  // dots. The touch gesture starts at '*' and moves left, touch path is indicated by
+  // an arrow pointing left
+  // 1) +---------------+ 2) +---------------+ 3) +---------------+ 4) +---------------+
+  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+  //    |XXXXXXXX|......|    |XXXXXXXX|.<-*..|    |XXXXXXXX|<--*..|    |XXXXX|<-----*..|
+  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+  //    +---------------+    +---------------+    +---------------+    +---------------+
+  //
+  // For the above to work properly we define animated value that will keep
+  // start position of the gesture. Then we use that value to calculate how
+  // much we need to subtract from the dragX. If the gesture started on the
+  // greyed out area we take the distance from the edge of the drawer to the
+  // start position. Otherwise we don't subtract at all and the drawer be
+  // pulled back as soon as you start the pan.
+  //
+  // This is used only when drawerType is "front"
+  //
+
+  const pan = Gesture.Pan();
+  pan.failOffsetY([-15, 15]);
+  pan.hitSlop(hitSlop);
+  pan.activeOffsetX(gestureOrientation * minSwipeDistance);
+  pan.enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture);
+  pan.enabled(
+    drawerLockMode !== 'locked-closed' && drawerLockMode !== 'locked-open'
+  );
+  pan.onStart((event) => {
+    'worklet';
+    ignoredOffset.value = 0;
+    dragStartPosition.value = event.x;
+  });
+  pan.onUpdate((event) => {
+    'worklet';
+    if (drawerState.value === IDLE) {
+      runOnJS(setState)(DRAGGING, drawerVisible);
+      runOnJS(onDragStart)();
+    }
+
+    if (drawerState.value === DRAGGING) {
+      let newOffset =
+        drawerSavedOffset.value + event.translationX - ignoredOffset.value;
+
+      if (fromLeft) {
+        // refer to the large comment above
+        if (
+          drawerType === 'front' &&
+          event.translationX < 0 &&
+          drawerOffset.value > 0
+        ) {
+          newOffset += dragStartPosition.value - drawerWidth;
+        }
+
+        // clamp the offset so the drawer does not move away from the edge
+        newOffset = Math.max(0, Math.min(drawerWidth, newOffset));
+      } else {
+        // refer to the large comment above
+        if (
+          drawerType === 'front' &&
+          event.translationX > 0 &&
+          drawerOffset.value < 0
+        ) {
+          newOffset += dragStartPosition.value - (containerWidth - drawerWidth);
+        }
+
+        // clamp the offset so the drawer does not move away from the edge
+        newOffset = Math.max(-drawerWidth, Math.min(0, newOffset));
+      }
+
+      drawerOffset.value = newOffset;
+
+      // send event if there is a listener
+      if (props.onDrawerSlide !== undefined) {
+        runOnJS(props.onDrawerSlide)(openingProgress.value);
+      }
+    } else {
+      // drawerState is SETTLING, save the translation to ignore it later
+      ignoredOffset.value = event.translationX;
+    }
+  });
+  pan.onEnd((_event) => {
+    'worklet';
+    if (drawerState.value === DRAGGING) {
+      // update offsets and animations only when the drag was not ignored
+      drawerSavedOffset.value = drawerOffset.value;
+
+      // if the drawer was dragged more than half of its width open it,
+      // otherwise close it
+      if (fromLeft) {
+        if (drawerOffset.value > drawerWidth / 2) {
+          open();
+        } else {
+          close();
+        }
+      } else {
+        if (drawerOffset.value < -drawerWidth / 2) {
+          open();
+        } else {
+          close();
+        }
+      }
+    }
+  });
+
+  const dynamicDrawerStyles = {
+    backgroundColor: props.drawerBackgroundColor,
+    width: drawerWidth,
+  };
+
+  const drawerStyle = useAnimatedStyle(() => {
+    let translation = 0;
+
+    if (drawerSlide) {
+      // drawer is supposed to be moved with the gesture (in this case
+      // drawer is anchored to be off the screen when not opened)
+      if (fromLeft) {
+        translation = -drawerWidth;
+      } else {
+        translation = containerWidth;
+      }
+      translation += drawerOffset.value;
+    } else {
+      // drawer is stationary (in this case drawer is below the content
+      // so it's anchored left edge to left edge or right to right)
+      if (fromLeft) {
+        translation = 0;
+      } else {
+        translation = containerWidth - drawerWidth;
+      }
+    }
+
+    // if the drawer is not visible move it off the screen to prevent it
+    // from intercepting touch events on Android
+    if (drawerOffset.value === 0) {
+      translation = 10000;
+    }
+
+    return {
+      flexDirection: reverseContentDirection ? 'row-reverse' : 'row',
+      transform: [{ translateX: translation }],
+    };
+  }, [drawerSlide, drawerWidth, containerWidth, fromLeft]);
+
+  const containerStyle = useAnimatedStyle(() => {
+    let translation = 0;
+
+    if (containerSlide) {
+      // the container should be moved with the gesture
+      translation = drawerOffset.value;
+    }
+
+    return {
+      transform: [{ translateX: translation }],
+    };
+  }, [containerSlide]);
+
+  if (ref != null) {
+    // ref is set, create a controller and pass it
+    const controller: DrawerLayoutController = {
+      open: () => {
+        open();
+      },
+      close: () => {
+        close();
+      },
+    };
+
+    if (typeof ref === 'function') {
+      ref(controller);
+    } else {
+      ref.current = controller;
+    }
+  }
+
+  return (
+    <GestureDetector animatedGesture={pan}>
+      <Animated.View style={styles.main} onLayout={handleContainerLayout}>
+        <Animated.View
+          style={[
+            drawerType === 'front'
+              ? styles.containerOnBack
+              : styles.containerInFront,
+            props.contentContainerStyle,
+            containerStyle,
+          ]}>
+          {props.children}
+          <Overlay
+            drawerType={drawerType}
+            color={overlayColor}
+            progress={openingProgress}
+            lockMode={drawerLockMode}
+            close={close}
+          />
+        </Animated.View>
+
+        <Animated.View
+          style={[
+            styles.drawerContainer,
+            props.drawerContainerStyle,
+            dynamicDrawerStyles,
+            drawerStyle,
+          ]}>
+          {props.renderNavigationView(openingProgress)}
+        </Animated.View>
+      </Animated.View>
+    </GestureDetector>
+  );
+});
+
+const styles = StyleSheet.create({
+  drawerContainer: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 1001,
+    flexDirection: 'row',
+  },
+  containerInFront: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 1002,
+  },
+  containerOnBack: {
+    ...StyleSheet.absoluteFillObject,
+  },
+  main: {
+    flex: 1,
+    zIndex: 0,
+    overflow: 'hidden',
+  },
+  overlay: {
+    ...StyleSheet.absoluteFillObject,
+    zIndex: 1000,
+  },
+});

--- a/src/components/BetterDrawerLayout.tsx
+++ b/src/components/BetterDrawerLayout.tsx
@@ -531,7 +531,7 @@ export const DrawerLayout = React.forwardRef<
     };
   });
 
-  if (ref != null) {
+  if (ref !== null) {
     // ref is set, create a controller and pass it
     const controller: DrawerLayoutController = {
       open: () => {

--- a/src/components/BetterDrawerLayout.tsx
+++ b/src/components/BetterDrawerLayout.tsx
@@ -485,49 +485,49 @@ export const DrawerLayout = React.forwardRef<
   };
 
   const drawerStyle = useAnimatedStyle(() => {
-    let translation = 0;
+    let translateX = 0;
 
     if (drawerSlide) {
       // drawer is supposed to be moved with the gesture (in this case
       // drawer is anchored to be off the screen when not opened)
       if (fromLeft) {
-        translation = -drawerWidth;
+        translateX = -drawerWidth;
       } else {
-        translation = containerWidth;
+        translateX = containerWidth;
       }
-      translation += drawerOffset.value;
+      translateX += drawerOffset.value;
     } else {
       // drawer is stationary (in this case drawer is below the content
       // so it's anchored left edge to left edge or right to right)
       if (fromLeft) {
-        translation = 0;
+        translateX = 0;
       } else {
-        translation = containerWidth - drawerWidth;
+        translateX = containerWidth - drawerWidth;
       }
     }
 
     // if the drawer is not visible move it off the screen to prevent it
     // from intercepting touch events on Android
     if (drawerOffset.value === 0) {
-      translation = 10000;
+      translateX = 10000;
     }
 
     return {
       flexDirection: reverseContentDirection ? 'row-reverse' : 'row',
-      transform: [{ translateX: translation }],
+      transform: [{ translateX }],
     };
   });
 
   const containerStyle = useAnimatedStyle(() => {
-    let translation = 0;
+    let translateX = 0;
 
     if (containerSlide) {
       // the container should be moved with the gesture
-      translation = drawerOffset.value;
+      translateX = drawerOffset.value;
     }
 
     return {
-      transform: [{ translateX: translation }],
+      transform: [{ translateX }],
     };
   });
 

--- a/src/components/BetterDrawerLayout.tsx
+++ b/src/components/BetterDrawerLayout.tsx
@@ -140,23 +140,20 @@ interface OverlayProps {
 }
 
 function Overlay(props: OverlayProps) {
-  const overlayStyle = useAnimatedStyle(
-    () => ({
-      backgroundColor: props.color,
-      opacity: props.progress.value,
-      transform: [
-        {
-          translateX:
-            // when the overlay should not be visible move it off the screen
-            // to prevent it from intercepting touch events on Android
-            props.drawerType !== 'front' || props.progress.value === 0
-              ? 10000
-              : 0,
-        },
-      ],
-    }),
-    [props]
-  );
+  const overlayStyle = useAnimatedStyle(() => ({
+    backgroundColor: props.color,
+    opacity: props.progress.value,
+    transform: [
+      {
+        translateX:
+          // when the overlay should not be visible move it off the screen
+          // to prevent it from intercepting touch events on Android
+          props.drawerType !== 'front' || props.progress.value === 0
+            ? 10000
+            : 0,
+      },
+    ],
+  }));
 
   const tap = Gesture.Tap();
   tap.onEnd((_event, success) => {
@@ -519,7 +516,7 @@ export const DrawerLayout = React.forwardRef<
       flexDirection: reverseContentDirection ? 'row-reverse' : 'row',
       transform: [{ translateX: translation }],
     };
-  }, [drawerSlide, drawerWidth, containerWidth, fromLeft]);
+  });
 
   const containerStyle = useAnimatedStyle(() => {
     let translation = 0;
@@ -532,7 +529,7 @@ export const DrawerLayout = React.forwardRef<
     return {
       transform: [{ translateX: translation }],
     };
-  }, [containerSlide]);
+  });
 
   if (ref != null) {
     // ref is set, create a controller and pass it

--- a/src/components/BetterDrawerLayout.tsx
+++ b/src/components/BetterDrawerLayout.tsx
@@ -180,409 +180,426 @@ export interface DrawerLayoutController {
 export const DrawerLayout = React.forwardRef<
   DrawerLayoutController,
   BetterDrawerLayoutProps
->((props, ref) => {
-  //default props
-  const drawerWidth = props.drawerWidth ?? 200;
-  const drawerPosition = props.drawerPosition ?? 'left';
-  const drawerType = props.drawerType ?? 'front';
-  const edgeWidth = props.edgeWidth ?? 20;
-  const minSwipeDistance = props.minSwipeDistance ?? 3;
-  const overlayColor = props.overlayColor ?? 'rgba(0, 0, 0, 0.7)';
-  const drawerLockMode = props.drawerLockMode ?? 'unlocked';
-  const enableTrackpadTwoFingerGesture =
-    props.enableTrackpadTwoFingerGesture ?? false;
-  const animationConfig = { damping: 30, stiffness: 250 };
+>(
+  (
+    {
+      drawerWidth = 200,
+      drawerPosition = 'left',
+      drawerType = 'front',
+      edgeWidth = 20,
+      minSwipeDistance = 3,
+      overlayColor = 'rgba(0, 0, 0, 0.7)',
+      drawerLockMode = 'unlocked',
+      enableTrackpadTwoFingerGesture = false,
+      keyboardDismissMode,
+      statusBarAnimation,
+      hideStatusBar,
+      drawerBackgroundColor,
+      drawerContainerStyle,
+      contentContainerStyle,
+      children,
+      renderNavigationView,
+      onDrawerClose,
+      onDrawerOpen,
+      onDrawerSlide,
+      onDrawerStateChanged,
+    }: BetterDrawerLayoutProps,
+    ref
+  ) => {
+    const animationConfig = { damping: 30, stiffness: 250 };
 
-  const fromLeft = drawerPosition === 'left';
-  const drawerSlide = drawerType !== 'back';
-  const containerSlide = drawerType !== 'front';
+    const fromLeft = drawerPosition === 'left';
+    const drawerSlide = drawerType !== 'back';
+    const containerSlide = drawerType !== 'front';
 
-  // setting NaN as a starting value allows to tell when the value gets changes
-  // for the first time
-  const [containerWidth, setContainerWidth] = useState(Number.NaN);
-  const [drawerVisible, setDrawerVisible] = useState(false);
+    // setting NaN as a starting value allows to tell when the value gets changes
+    // for the first time
+    const [containerWidth, setContainerWidth] = useState(Number.NaN);
+    const [drawerVisible, setDrawerVisible] = useState(false);
 
-  const drawerState = useSharedValue(BetterDrawerState.IDLE);
-  // between 0 and drawerWidth (drawer on the left) or -drawerWidth and 0 (drawer on the right)
-  const drawerOffset = useSharedValue(0);
-  // stores value of the offset at the start of the gesture
-  const drawerSavedOffset = useSharedValue(0);
-  // stores the translation that is supposed to be ignored (user tried to
-  // drag while animation was running)
-  const ignoredOffset = useSharedValue(0);
-  // stores the x coordinate of the drag starting point (to ignore dragging on the overlay)
-  const dragStartPosition = useSharedValue(0);
-  // between 0 and 1, 0 - closed, 1 - opened
-  const openingProgress = useDerivedValue(() => {
-    if (fromLeft) {
-      return drawerOffset.value / drawerWidth;
-    } else {
-      return -drawerOffset.value / drawerWidth;
-    }
-  }, [drawerOffset, containerWidth, drawerWidth, fromLeft]);
-
-  // we rely on row and row-reverse flex directions to position the drawer
-  // properly. Apparently for RTL these are flipped which requires us to use
-  // the opposite setting for the drawer to appear from left or right
-  // according to the drawerPosition prop
-  const reverseContentDirection = I18nManager.isRTL ? fromLeft : !fromLeft;
-
-  // set the drawer to closed position when the props change to prevent it from
-  // opening or moving on the screen
-  useEffect(() => {
-    drawerOffset.value = 0;
-    drawerSavedOffset.value = 0;
-
-    setDrawerVisible(false);
-  }, [props]);
-
-  // measure the container
-  function handleContainerLayout({ nativeEvent }: LayoutChangeEvent) {
-    setContainerWidth(nativeEvent.layout.width);
-  }
-
-  function onDragStart() {
-    if (props.keyboardDismissMode === 'on-drag') {
-      Keyboard.dismiss();
-    }
-
-    // this is required in addition to the similar call below, because the gesture
-    // doesn't change `drawerVisible` state to prevent re-render during gesture
-    // so when dragging from closed it wouldn't hide the status bar
-    if (props.hideStatusBar) {
-      StatusBar.setHidden(true, props.statusBarAnimation ?? 'slide');
-    }
-  }
-
-  function setState(newState: BetterDrawerState, willShow: boolean) {
-    if (props.hideStatusBar) {
-      StatusBar.setHidden(willShow, props.statusBarAnimation ?? 'slide');
-    }
-
-    // dispach events
-    if (drawerState.value !== newState || drawerVisible !== willShow) {
-      // send state change event only when the state changed or the visibility of the
-      // drawer (for example when drawer is in SETTLING state after opening and the user
-      // taps on the overlay the state is still settling, but willShow is now false)
-      props.onDrawerStateChanged?.(newState, willShow);
-    }
-
-    if (drawerVisible !== willShow) {
-      setDrawerVisible(willShow);
-    }
-
-    if (newState === BetterDrawerState.IDLE) {
-      if (willShow) {
-        props.onDrawerOpen?.();
+    const drawerState = useSharedValue(BetterDrawerState.IDLE);
+    // between 0 and drawerWidth (drawer on the left) or -drawerWidth and 0 (drawer on the right)
+    const drawerOffset = useSharedValue(0);
+    // stores value of the offset at the start of the gesture
+    const drawerSavedOffset = useSharedValue(0);
+    // stores the translation that is supposed to be ignored (user tried to
+    // drag while animation was running)
+    const ignoredOffset = useSharedValue(0);
+    // stores the x coordinate of the drag starting point (to ignore dragging on the overlay)
+    const dragStartPosition = useSharedValue(0);
+    // between 0 and 1, 0 - closed, 1 - opened
+    const openingProgress = useDerivedValue(() => {
+      if (fromLeft) {
+        return drawerOffset.value / drawerWidth;
       } else {
-        props.onDrawerClose?.();
+        return -drawerOffset.value / drawerWidth;
+      }
+    }, [drawerOffset, containerWidth, drawerWidth, fromLeft]);
+
+    // we rely on row and row-reverse flex directions to position the drawer
+    // properly. Apparently for RTL these are flipped which requires us to use
+    // the opposite setting for the drawer to appear from left or right
+    // according to the drawerPosition prop
+    const reverseContentDirection = I18nManager.isRTL ? fromLeft : !fromLeft;
+
+    // set the drawer to closed position when the props change to prevent it from
+    // opening or moving on the screen
+    useEffect(() => {
+      drawerOffset.value = 0;
+      drawerSavedOffset.value = 0;
+
+      setDrawerVisible(false);
+    }, [drawerWidth, drawerPosition, drawerType]);
+
+    // measure the container
+    function handleContainerLayout({ nativeEvent }: LayoutChangeEvent) {
+      setContainerWidth(nativeEvent.layout.width);
+    }
+
+    function onDragStart() {
+      if (keyboardDismissMode === 'on-drag') {
+        Keyboard.dismiss();
+      }
+
+      // this is required in addition to the similar call below, because the gesture
+      // doesn't change `drawerVisible` state to prevent re-render during gesture
+      // so when dragging from closed it wouldn't hide the status bar
+      if (hideStatusBar) {
+        StatusBar.setHidden(true, statusBarAnimation ?? 'slide');
       }
     }
 
-    drawerState.value = newState;
-  }
+    function setState(newState: BetterDrawerState, willShow: boolean) {
+      if (hideStatusBar) {
+        StatusBar.setHidden(willShow, statusBarAnimation ?? 'slide');
+      }
 
-  function open() {
-    'worklet';
-    if (fromLeft && drawerOffset.value < drawerWidth) {
-      // drawer is on the left and is not fully opened
-      runOnJS(setState)(BetterDrawerState.SETTLING, true);
+      // dispach events
+      if (drawerState.value !== newState || drawerVisible !== willShow) {
+        // send state change event only when the state changed or the visibility of the
+        // drawer (for example when drawer is in SETTLING state after opening and the user
+        // taps on the overlay the state is still settling, but willShow is now false)
+        onDrawerStateChanged?.(newState, willShow);
+      }
 
-      drawerOffset.value = withSpring(
-        drawerWidth,
-        animationConfig,
-        (finished) => {
+      if (drawerVisible !== willShow) {
+        setDrawerVisible(willShow);
+      }
+
+      if (newState === BetterDrawerState.IDLE) {
+        if (willShow) {
+          onDrawerOpen?.();
+        } else {
+          onDrawerClose?.();
+        }
+      }
+
+      drawerState.value = newState;
+    }
+
+    function open() {
+      'worklet';
+      if (fromLeft && drawerOffset.value < drawerWidth) {
+        // drawer is on the left and is not fully opened
+        runOnJS(setState)(BetterDrawerState.SETTLING, true);
+
+        drawerOffset.value = withSpring(
+          drawerWidth,
+          animationConfig,
+          (finished) => {
+            drawerSavedOffset.value = drawerOffset.value;
+            if (finished) {
+              // animation cannot be interrupted by a drag, but can be by
+              // calling close or open (through tap or a controller)
+              runOnJS(setState)(BetterDrawerState.IDLE, true);
+            }
+          }
+        );
+      } else if (!fromLeft && drawerOffset.value > -drawerWidth) {
+        // drawer is on the right and is not fully opened
+        runOnJS(setState)(BetterDrawerState.SETTLING, true);
+
+        drawerOffset.value = withSpring(
+          -drawerWidth,
+          animationConfig,
+          (finished) => {
+            drawerSavedOffset.value = drawerOffset.value;
+            if (finished) {
+              // animation cannot be interrupted by a drag, but can be by
+              // calling close or open (through tap or a controller)
+              runOnJS(setState)(BetterDrawerState.IDLE, true);
+            }
+          }
+        );
+      } else {
+        // drawer is fully opened
+        runOnJS(setState)(BetterDrawerState.IDLE, true);
+      }
+    }
+
+    function close() {
+      'worklet';
+      if (fromLeft && drawerOffset.value > 0) {
+        // drawer is on the left and is not fully closed
+        runOnJS(setState)(BetterDrawerState.SETTLING, false);
+
+        drawerOffset.value = withSpring(0, animationConfig, (finished) => {
           drawerSavedOffset.value = drawerOffset.value;
           if (finished) {
             // animation cannot be interrupted by a drag, but can be by
             // calling close or open (through tap or a controller)
-            runOnJS(setState)(BetterDrawerState.IDLE, true);
+            runOnJS(setState)(BetterDrawerState.IDLE, false);
           }
-        }
-      );
-    } else if (!fromLeft && drawerOffset.value > -drawerWidth) {
-      // drawer is on the right and is not fully opened
-      runOnJS(setState)(BetterDrawerState.SETTLING, true);
+        });
+      } else if (!fromLeft && drawerOffset.value < 0) {
+        // drawer is on the right and is not fully closed
+        runOnJS(setState)(BetterDrawerState.SETTLING, false);
 
-      drawerOffset.value = withSpring(
-        -drawerWidth,
-        animationConfig,
-        (finished) => {
+        drawerOffset.value = withSpring(0, animationConfig, (finished) => {
           drawerSavedOffset.value = drawerOffset.value;
           if (finished) {
             // animation cannot be interrupted by a drag, but can be by
             // calling close or open (through tap or a controller)
-            runOnJS(setState)(BetterDrawerState.IDLE, true);
+            runOnJS(setState)(BetterDrawerState.IDLE, false);
+          }
+        });
+      } else {
+        // drawer is fully closed
+        runOnJS(setState)(BetterDrawerState.IDLE, false);
+      }
+    }
+
+    // gestureOrientation is 1 if the expected gesture is from left to right and
+    // -1 otherwise e.g. when drawer is on the left and is closed we expect left
+    // to right gesture, thus orientation will be 1.
+    const gestureOrientation = (fromLeft ? 1 : -1) * (drawerVisible ? -1 : 1);
+
+    // When drawer is closed we want the hitSlop to be horizontally shorter than
+    // the container size by the value of SLOP. This will make it only activate
+    // when gesture happens not further than SLOP away from the edge
+    const hitSlop = fromLeft
+      ? { left: 0, width: drawerVisible ? undefined : edgeWidth }
+      : { right: 0, width: drawerVisible ? undefined : edgeWidth };
+
+    // *** THIS IS THE LARGE COMMENT ABOVE ***
+    //
+    // While closing the drawer when user starts gesture outside of its area (in greyed
+    // out part of the window), we want the drawer to follow only once finger reaches the
+    // edge of the drawer.
+    // E.g. on the diagram below drawer is illustrate by X signs and the greyed out area by
+    // dots. The touch gesture starts at '*' and moves left, touch path is indicated by
+    // an arrow pointing left
+    // 1) +---------------+ 2) +---------------+ 3) +---------------+ 4) +---------------+
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    |XXXXXXXX|......|    |XXXXXXXX|.<-*..|    |XXXXXXXX|<--*..|    |XXXXX|<-----*..|
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
+    //    +---------------+    +---------------+    +---------------+    +---------------+
+    //
+    // For the above to work properly we define animated value that will keep
+    // start position of the gesture. Then we use that value to calculate how
+    // much we need to subtract from the dragX. If the gesture started on the
+    // greyed out area we take the distance from the edge of the drawer to the
+    // start position. Otherwise we don't subtract at all and the drawer be
+    // pulled back as soon as you start the pan.
+    //
+    // This is used only when drawerType is "front"
+    //
+
+    const pan = Gesture.Pan();
+    pan.failOffsetY([-15, 15]);
+    pan.hitSlop(hitSlop);
+    pan.activeOffsetX(gestureOrientation * minSwipeDistance);
+    pan.enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture);
+    pan.enabled(
+      drawerLockMode !== 'locked-closed' && drawerLockMode !== 'locked-open'
+    );
+    pan.onStart((event) => {
+      'worklet';
+      ignoredOffset.value = 0;
+      dragStartPosition.value = event.x;
+    });
+    pan.onUpdate((event) => {
+      'worklet';
+      if (drawerState.value === BetterDrawerState.IDLE) {
+        runOnJS(setState)(BetterDrawerState.DRAGGING, drawerVisible);
+        runOnJS(onDragStart)();
+      }
+
+      if (drawerState.value === BetterDrawerState.DRAGGING) {
+        let newOffset =
+          drawerSavedOffset.value + event.translationX - ignoredOffset.value;
+
+        if (fromLeft) {
+          // refer to the large comment above
+          if (
+            drawerType === 'front' &&
+            event.translationX < 0 &&
+            drawerOffset.value > 0
+          ) {
+            newOffset += dragStartPosition.value - drawerWidth;
+          }
+
+          // clamp the offset so the drawer does not move away from the edge
+          newOffset = Math.max(0, Math.min(drawerWidth, newOffset));
+        } else {
+          // refer to the large comment above
+          if (
+            drawerType === 'front' &&
+            event.translationX > 0 &&
+            drawerOffset.value < 0
+          ) {
+            newOffset +=
+              dragStartPosition.value - (containerWidth - drawerWidth);
+          }
+
+          // clamp the offset so the drawer does not move away from the edge
+          newOffset = Math.max(-drawerWidth, Math.min(0, newOffset));
+        }
+
+        drawerOffset.value = newOffset;
+
+        // send event if there is a listener
+        if (onDrawerSlide !== undefined) {
+          runOnJS(onDrawerSlide)(openingProgress.value);
+        }
+      } else {
+        // drawerState is SETTLING, save the translation to ignore it later
+        ignoredOffset.value = event.translationX;
+      }
+    });
+    pan.onEnd((_event) => {
+      'worklet';
+      if (drawerState.value === BetterDrawerState.DRAGGING) {
+        // update offsets and animations only when the drag was not ignored
+        drawerSavedOffset.value = drawerOffset.value;
+
+        // if the drawer was dragged more than half of its width open it,
+        // otherwise close it
+        if (fromLeft) {
+          if (drawerOffset.value > drawerWidth / 2) {
+            open();
+          } else {
+            close();
+          }
+        } else {
+          if (drawerOffset.value < -drawerWidth / 2) {
+            open();
+          } else {
+            close();
           }
         }
-      );
-    } else {
-      // drawer is fully opened
-      runOnJS(setState)(BetterDrawerState.IDLE, true);
-    }
-  }
-
-  function close() {
-    'worklet';
-    if (fromLeft && drawerOffset.value > 0) {
-      // drawer is on the left and is not fully closed
-      runOnJS(setState)(BetterDrawerState.SETTLING, false);
-
-      drawerOffset.value = withSpring(0, animationConfig, (finished) => {
-        drawerSavedOffset.value = drawerOffset.value;
-        if (finished) {
-          // animation cannot be interrupted by a drag, but can be by
-          // calling close or open (through tap or a controller)
-          runOnJS(setState)(BetterDrawerState.IDLE, false);
-        }
-      });
-    } else if (!fromLeft && drawerOffset.value < 0) {
-      // drawer is on the right and is not fully closed
-      runOnJS(setState)(BetterDrawerState.SETTLING, false);
-
-      drawerOffset.value = withSpring(0, animationConfig, (finished) => {
-        drawerSavedOffset.value = drawerOffset.value;
-        if (finished) {
-          // animation cannot be interrupted by a drag, but can be by
-          // calling close or open (through tap or a controller)
-          runOnJS(setState)(BetterDrawerState.IDLE, false);
-        }
-      });
-    } else {
-      // drawer is fully closed
-      runOnJS(setState)(BetterDrawerState.IDLE, false);
-    }
-  }
-
-  // gestureOrientation is 1 if the expected gesture is from left to right and
-  // -1 otherwise e.g. when drawer is on the left and is closed we expect left
-  // to right gesture, thus orientation will be 1.
-  const gestureOrientation = (fromLeft ? 1 : -1) * (drawerVisible ? -1 : 1);
-
-  // When drawer is closed we want the hitSlop to be horizontally shorter than
-  // the container size by the value of SLOP. This will make it only activate
-  // when gesture happens not further than SLOP away from the edge
-  const hitSlop = fromLeft
-    ? { left: 0, width: drawerVisible ? undefined : edgeWidth }
-    : { right: 0, width: drawerVisible ? undefined : edgeWidth };
-
-  // *** THIS IS THE LARGE COMMENT ABOVE ***
-  //
-  // While closing the drawer when user starts gesture outside of its area (in greyed
-  // out part of the window), we want the drawer to follow only once finger reaches the
-  // edge of the drawer.
-  // E.g. on the diagram below drawer is illustrate by X signs and the greyed out area by
-  // dots. The touch gesture starts at '*' and moves left, touch path is indicated by
-  // an arrow pointing left
-  // 1) +---------------+ 2) +---------------+ 3) +---------------+ 4) +---------------+
-  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-  //    |XXXXXXXX|......|    |XXXXXXXX|.<-*..|    |XXXXXXXX|<--*..|    |XXXXX|<-----*..|
-  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-  //    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXXXXX|......|    |XXXXX|.........|
-  //    +---------------+    +---------------+    +---------------+    +---------------+
-  //
-  // For the above to work properly we define animated value that will keep
-  // start position of the gesture. Then we use that value to calculate how
-  // much we need to subtract from the dragX. If the gesture started on the
-  // greyed out area we take the distance from the edge of the drawer to the
-  // start position. Otherwise we don't subtract at all and the drawer be
-  // pulled back as soon as you start the pan.
-  //
-  // This is used only when drawerType is "front"
-  //
-
-  const pan = Gesture.Pan();
-  pan.failOffsetY([-15, 15]);
-  pan.hitSlop(hitSlop);
-  pan.activeOffsetX(gestureOrientation * minSwipeDistance);
-  pan.enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture);
-  pan.enabled(
-    drawerLockMode !== 'locked-closed' && drawerLockMode !== 'locked-open'
-  );
-  pan.onStart((event) => {
-    'worklet';
-    ignoredOffset.value = 0;
-    dragStartPosition.value = event.x;
-  });
-  pan.onUpdate((event) => {
-    'worklet';
-    if (drawerState.value === BetterDrawerState.IDLE) {
-      runOnJS(setState)(BetterDrawerState.DRAGGING, drawerVisible);
-      runOnJS(onDragStart)();
-    }
-
-    if (drawerState.value === BetterDrawerState.DRAGGING) {
-      let newOffset =
-        drawerSavedOffset.value + event.translationX - ignoredOffset.value;
-
-      if (fromLeft) {
-        // refer to the large comment above
-        if (
-          drawerType === 'front' &&
-          event.translationX < 0 &&
-          drawerOffset.value > 0
-        ) {
-          newOffset += dragStartPosition.value - drawerWidth;
-        }
-
-        // clamp the offset so the drawer does not move away from the edge
-        newOffset = Math.max(0, Math.min(drawerWidth, newOffset));
-      } else {
-        // refer to the large comment above
-        if (
-          drawerType === 'front' &&
-          event.translationX > 0 &&
-          drawerOffset.value < 0
-        ) {
-          newOffset += dragStartPosition.value - (containerWidth - drawerWidth);
-        }
-
-        // clamp the offset so the drawer does not move away from the edge
-        newOffset = Math.max(-drawerWidth, Math.min(0, newOffset));
       }
+    });
 
-      drawerOffset.value = newOffset;
+    const dynamicDrawerStyles = {
+      backgroundColor: drawerBackgroundColor,
+      width: drawerWidth,
+    };
 
-      // send event if there is a listener
-      if (props.onDrawerSlide !== undefined) {
-        runOnJS(props.onDrawerSlide)(openingProgress.value);
-      }
-    } else {
-      // drawerState is SETTLING, save the translation to ignore it later
-      ignoredOffset.value = event.translationX;
-    }
-  });
-  pan.onEnd((_event) => {
-    'worklet';
-    if (drawerState.value === BetterDrawerState.DRAGGING) {
-      // update offsets and animations only when the drag was not ignored
-      drawerSavedOffset.value = drawerOffset.value;
+    const drawerStyle = useAnimatedStyle(() => {
+      let translateX = 0;
 
-      // if the drawer was dragged more than half of its width open it,
-      // otherwise close it
-      if (fromLeft) {
-        if (drawerOffset.value > drawerWidth / 2) {
-          open();
+      if (drawerSlide) {
+        // drawer is supposed to be moved with the gesture (in this case
+        // drawer is anchored to be off the screen when not opened)
+        if (fromLeft) {
+          translateX = -drawerWidth;
         } else {
-          close();
+          translateX = containerWidth;
         }
+        translateX += drawerOffset.value;
       } else {
-        if (drawerOffset.value < -drawerWidth / 2) {
-          open();
+        // drawer is stationary (in this case drawer is below the content
+        // so it's anchored left edge to left edge or right to right)
+        if (fromLeft) {
+          translateX = 0;
         } else {
-          close();
+          translateX = containerWidth - drawerWidth;
         }
       }
-    }
-  });
 
-  const dynamicDrawerStyles = {
-    backgroundColor: props.drawerBackgroundColor,
-    width: drawerWidth,
-  };
-
-  const drawerStyle = useAnimatedStyle(() => {
-    let translateX = 0;
-
-    if (drawerSlide) {
-      // drawer is supposed to be moved with the gesture (in this case
-      // drawer is anchored to be off the screen when not opened)
-      if (fromLeft) {
-        translateX = -drawerWidth;
-      } else {
-        translateX = containerWidth;
+      // if the drawer is not visible move it off the screen to prevent it
+      // from intercepting touch events on Android
+      if (drawerOffset.value === 0) {
+        translateX = 10000;
       }
-      translateX += drawerOffset.value;
-    } else {
-      // drawer is stationary (in this case drawer is below the content
-      // so it's anchored left edge to left edge or right to right)
-      if (fromLeft) {
-        translateX = 0;
+
+      return {
+        flexDirection: reverseContentDirection ? 'row-reverse' : 'row',
+        transform: [{ translateX }],
+      };
+    });
+
+    const containerStyle = useAnimatedStyle(() => {
+      let translateX = 0;
+
+      if (containerSlide) {
+        // the container should be moved with the gesture
+        translateX = drawerOffset.value;
+      }
+
+      return {
+        transform: [{ translateX }],
+      };
+    });
+
+    if (ref !== null) {
+      // ref is set, create a controller and pass it
+      const controller: DrawerLayoutController = {
+        open: () => {
+          open();
+        },
+        close: () => {
+          close();
+        },
+      };
+
+      if (typeof ref === 'function') {
+        ref(controller);
       } else {
-        translateX = containerWidth - drawerWidth;
+        ref.current = controller;
       }
     }
 
-    // if the drawer is not visible move it off the screen to prevent it
-    // from intercepting touch events on Android
-    if (drawerOffset.value === 0) {
-      translateX = 10000;
-    }
+    return (
+      <GestureDetector animatedGesture={pan}>
+        <Animated.View style={styles.main} onLayout={handleContainerLayout}>
+          <Animated.View
+            style={[
+              drawerType === 'front'
+                ? styles.containerOnBack
+                : styles.containerInFront,
+              contentContainerStyle,
+              containerStyle,
+            ]}>
+            {children}
+            <Overlay
+              drawerType={drawerType}
+              color={overlayColor}
+              progress={openingProgress}
+              lockMode={drawerLockMode}
+              close={close}
+            />
+          </Animated.View>
 
-    return {
-      flexDirection: reverseContentDirection ? 'row-reverse' : 'row',
-      transform: [{ translateX }],
-    };
-  });
-
-  const containerStyle = useAnimatedStyle(() => {
-    let translateX = 0;
-
-    if (containerSlide) {
-      // the container should be moved with the gesture
-      translateX = drawerOffset.value;
-    }
-
-    return {
-      transform: [{ translateX }],
-    };
-  });
-
-  if (ref !== null) {
-    // ref is set, create a controller and pass it
-    const controller: DrawerLayoutController = {
-      open: () => {
-        open();
-      },
-      close: () => {
-        close();
-      },
-    };
-
-    if (typeof ref === 'function') {
-      ref(controller);
-    } else {
-      ref.current = controller;
-    }
+          <Animated.View
+            style={[
+              styles.drawerContainer,
+              drawerContainerStyle,
+              dynamicDrawerStyles,
+              drawerStyle,
+            ]}>
+            {renderNavigationView(openingProgress)}
+          </Animated.View>
+        </Animated.View>
+      </GestureDetector>
+    );
   }
-
-  return (
-    <GestureDetector animatedGesture={pan}>
-      <Animated.View style={styles.main} onLayout={handleContainerLayout}>
-        <Animated.View
-          style={[
-            drawerType === 'front'
-              ? styles.containerOnBack
-              : styles.containerInFront,
-            props.contentContainerStyle,
-            containerStyle,
-          ]}>
-          {props.children}
-          <Overlay
-            drawerType={drawerType}
-            color={overlayColor}
-            progress={openingProgress}
-            lockMode={drawerLockMode}
-            close={close}
-          />
-        </Animated.View>
-
-        <Animated.View
-          style={[
-            styles.drawerContainer,
-            props.drawerContainerStyle,
-            dynamicDrawerStyles,
-            drawerStyle,
-          ]}>
-          {props.renderNavigationView(openingProgress)}
-        </Animated.View>
-      </Animated.View>
-    </GestureDetector>
-  );
-});
+);
 
 const styles = StyleSheet.create({
   drawerContainer: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -120,6 +120,10 @@ export type {
 } from './handlers/gestureHandlerTypesCompat';
 
 export { default as Swipeable } from './components/Swipeable';
+export {
+  DrawerLayout as BetterDrawerLayout,
+  DrawerLayoutController,
+} from './components/BetterDrawerLayout';
 export type {
   DrawerLayoutProps,
   DrawerPosition,


### PR DESCRIPTION
## Description

Create a new BetterDrawerLayout component built with the new API of the gesture handler and Reanimated 2. It is supposed to be an almost drop-in replacement for the previous DrawerLayout.

## Test plan

Added a new example in the Example app.
