### PR TITLE
Make Gesture.Simultaneous accept variable number of arguments

### DIFF
--- a/docs/docs/api2/composing-gestures.md
+++ b/docs/docs/api2/composing-gestures.md
@@ -75,8 +75,8 @@ return (
 
 ## Simultaneous
 
-It accepts 2 arguments and both of the provided gestures can activate at the same time. Activation of one will not cancel the other.
-It is the equivalent to having two gesture handlers, each with `simultaneousHandlers` prop set to the other handler.
+It accepts variable number of arguments and all of the provided gestures can activate at the same time. Activation of one will not cancel the others.
+It is the equivalent to having some gesture handlers, each with `simultaneousHandlers` prop set to other handlers.
 
 For example, if you want to make a gallery app, you might want user to be able to zoom, rotate and pan around photos. You can do it with `Simultaneous`:
 
@@ -136,10 +136,7 @@ const rotateGesture = Gesture.Rotation()
     savedRotation.value = rotation.value;
   });
 
-const composed = Gesture.Simultaneous(
-  dragGesture,
-  Gesture.Simultaneous(zoomGesture, rotateGesture)
-);
+const composed = Gesture.Simultaneous(dragGesture, zoomGesture, rotateGesture);
 
 return (
   <Animated.View>

--- a/examples/Example/src/new_api/transformations/index.tsx
+++ b/examples/Example/src/new_api/transformations/index.tsx
@@ -71,10 +71,9 @@ function Photo() {
 
   const gesture = Gesture.Simultaneous(
     rotationGesture,
-    Gesture.Simultaneous(
-      scaleGesture,
-      Gesture.Simultaneous(panGesture, doubleTapGesture)
-    )
+    scaleGesture,
+    panGesture,
+    doubleTapGesture
   );
 
   return (

--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -74,8 +74,7 @@ export class ComposedGesture extends Gesture {
 export class SimultaneousGesture extends ComposedGesture {
   prepare() {
     const simultaneousArray = this.gestures
-      .map((gesture) => gesture.toGestureArray())
-      .flat()
+      .flatMap((gesture) => gesture.toGestureArray())
       .concat(this.simultaneousGestures);
 
     for (const gesture of this.gestures) {

--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -72,24 +72,19 @@ export class ComposedGesture extends Gesture {
 }
 
 export class SimultaneousGesture extends ComposedGesture {
-  constructor(first: Gesture, second: Gesture) {
-    super(first, second);
-  }
-
   prepare() {
-    const leftSide = this.gestures[0].toGestureArray();
-    const rightSide = this.gestures[1].toGestureArray();
+    const simultaneousArray = this.gestures
+      .map((gesture) => gesture.toGestureArray())
+      .flat()
+      .concat(this.simultaneousGestures);
 
-    this.prepareSingleGesture(
-      this.gestures[0],
-      this.simultaneousGestures.concat(rightSide),
-      this.requireGesturesToFail
-    );
-    this.prepareSingleGesture(
-      this.gestures[1],
-      this.simultaneousGestures.concat(leftSide),
-      this.requireGesturesToFail
-    );
+    for (const gesture of this.gestures) {
+      this.prepareSingleGesture(
+        gesture,
+        simultaneousArray,
+        this.requireGesturesToFail
+      );
+    }
   }
 }
 

--- a/src/handlers/gestures/gestureObjects.ts
+++ b/src/handlers/gestures/gestureObjects.ts
@@ -50,13 +50,10 @@ export const GestureObjects = {
   },
 
   /**
-   * Builds a composed gesture that allows its two base gestures to run simultaneously.
-   * @param first A gesture to run simultaneously with the second one
-   * @param second A gesture to run simultaneously with the first one
-   * @returns ComposedGesture consisting of the gestures provided as parameters.
+   * Builds a composed gesture that allows all base gestures to run simultaneously.
    */
-  Simultaneous(first: Gesture, second: Gesture) {
-    return new SimultaneousGesture(first, second);
+  Simultaneous(...gestures: Gesture[]) {
+    return new SimultaneousGesture(...gestures);
   },
 
   /**


### PR DESCRIPTION
## Description

Current implementation of nesting gestures in pairs may suggest that the ordering of the gestures in `Simultaneous` matters, and it is not really necessary to limit it in this way. This change allows `Gesture.Simultaneous` to accept multiple gestures at once.

## Test plan

Updated and tested on the Example app.
