### PR TITLE
Add native gesture

### DIFF
--- a/src/handlers/NativeViewGestureHandler.ts
+++ b/src/handlers/NativeViewGestureHandler.ts
@@ -8,8 +8,8 @@ export const nativeViewGestureHandlerProps = [
   'shouldActivateOnStart',
   'disallowInterruption',
 ] as const;
-export interface NativeViewGestureHandlerProps
-  extends BaseGestureHandlerProps<NativeViewGestureHandlerPayload> {
+
+export interface NativeViewGestureConfig {
   /**
    * Android only.
    *
@@ -24,6 +24,10 @@ export interface NativeViewGestureHandlerProps
    */
   disallowInterruption?: boolean;
 }
+
+export interface NativeViewGestureHandlerProps
+  extends BaseGestureHandlerProps<NativeViewGestureHandlerPayload>,
+    NativeViewGestureConfig {}
 
 export type NativeViewGestureHandlerPayload = {
   /**

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -12,6 +12,7 @@ import { PanGestureHandlerEventPayload } from '../PanGestureHandler';
 import { PinchGestureHandlerEventPayload } from '../PinchGestureHandler';
 import { RotationGestureHandlerEventPayload } from '../RotationGestureHandler';
 import { TapGestureHandlerEventPayload } from '../TapGestureHandler';
+import { NativeViewGestureHandlerPayload } from '../NativeViewGestureHandler';
 
 export type GestureType =
   | BaseGesture<Record<string, unknown>>
@@ -21,7 +22,8 @@ export type GestureType =
   | BaseGesture<RotationGestureHandlerEventPayload>
   | BaseGesture<PinchGestureHandlerEventPayload>
   | BaseGesture<FlingGestureHandlerEventPayload>
-  | BaseGesture<ForceTouchGestureHandlerEventPayload>;
+  | BaseGesture<ForceTouchGestureHandlerEventPayload>
+  | BaseGesture<NativeViewGestureHandlerPayload>;
 
 export type GestureRef = number | GestureType | React.RefObject<GestureType>;
 export interface BaseGestureConfig

--- a/src/handlers/gestures/gestureObjects.ts
+++ b/src/handlers/gestures/gestureObjects.ts
@@ -11,6 +11,7 @@ import { PanGesture } from './panGesture';
 import { PinchGesture } from './pinchGesture';
 import { RotationGesture } from './rotationGesture';
 import { TapGesture } from './tapGesture';
+import { NativeGesture } from './nativeGesture';
 
 export const GestureObjects = {
   Tap() {
@@ -39,6 +40,10 @@ export const GestureObjects = {
 
   ForceTouch() {
     return new ForceTouchGesture();
+  },
+
+  Native() {
+    return new NativeGesture();
   },
 
   /**

--- a/src/handlers/gestures/nativeGesture.ts
+++ b/src/handlers/gestures/nativeGesture.ts
@@ -1,0 +1,25 @@
+import { BaseGestureConfig, BaseGesture } from './gesture';
+import {
+  NativeViewGestureConfig,
+  NativeViewGestureHandlerPayload,
+} from '../NativeViewGestureHandler';
+
+export class NativeGesture extends BaseGesture<NativeViewGestureHandlerPayload> {
+  public config: BaseGestureConfig & NativeViewGestureConfig = {};
+
+  constructor() {
+    super();
+
+    this.handlerName = 'NativeViewGestureHandler';
+  }
+
+  shouldActivateOnStart(value: boolean) {
+    this.config.shouldActivateOnStart = value;
+    return this;
+  }
+
+  disallowInterruption(value: boolean) {
+    this.config.disallowInterruption = value;
+    return this;
+  }
+}


### PR DESCRIPTION
## Description

Adds a `NativeGesture` object alongside `Gesture.Native()` method to incorporate `NativeViewGestureHandler` to the new API.

## Test plan

Tested on the example app
