### PR TITLE
Make Gesture.Exclusive accept a variable number of arguments

### DIFF
--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -94,22 +94,21 @@ export class SimultaneousGesture extends ComposedGesture {
 }
 
 export class ExclusiveGesture extends ComposedGesture {
-  constructor(first: Gesture, second: Gesture) {
-    super(first, second);
-  }
-
   prepare() {
-    const leftSide = this.gestures[0].toGestureArray();
+    const gestureArrays = this.gestures.map((gesture) =>
+      gesture.toGestureArray()
+    );
 
-    this.prepareSingleGesture(
-      this.gestures[0],
-      this.simultaneousGestures,
-      this.requireGesturesToFail
-    );
-    this.prepareSingleGesture(
-      this.gestures[1],
-      this.simultaneousGestures,
-      this.requireGesturesToFail.concat(leftSide)
-    );
+    let requireToFail: GestureType[] = [];
+
+    for (let i = 0; i < this.gestures.length; i++) {
+      this.prepareSingleGesture(
+        this.gestures[i],
+        this.simultaneousGestures,
+        this.requireGesturesToFail.concat(requireToFail)
+      );
+
+      requireToFail = requireToFail.concat(gestureArrays[i]);
+    }
   }
 }

--- a/src/handlers/gestures/gestureObjects.ts
+++ b/src/handlers/gestures/gestureObjects.ts
@@ -62,14 +62,11 @@ export const GestureObjects = {
   /**
    * Builds a composed gesture where only one of the provided gestures can become active.
    * Priority is decided through the order of gestures: the first one has higher priority
-   * than the second one.
+   * than the second one, second one has higher priority than the third one, and so on.
    * For example, to make a gesture that recognizes both single and double tap you need
    * to call Exclusive(doubleTap, singleTap).
-   * @param first A gesture with higher priority
-   * @param second A gesture with lower priority
-   * @returns ComposedGesture consisting of the gestures provided as parameters.
    */
-  Exclusive(first: Gesture, second: Gesture) {
-    return new ExclusiveGesture(first, second);
+  Exclusive(...gestures: Gesture[]) {
+    return new ExclusiveGesture(...gestures);
   },
 };


### PR DESCRIPTION
## Description

While I don't think there are many use cases where deep nesting of `Gesture.Exclusive` would be required, with `Gesture.Simultaneous` and `Gesture.Race` both accepting a variable number of arguments I changed `Exclusive` to also accept more than two for the sake of consistency.

## Test plan

Tested on the Example app
