### PR TITLE
Add collapsable prop to the child of the Wrap

### DIFF
--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -423,7 +423,19 @@ export const GestureDetector: React.FunctionComponent<GestureDetectorProps> = (
 
 class Wrap extends React.Component<{ onGestureHandlerEvent?: unknown }> {
   render() {
-    return this.props.children;
+    // I don't think that fighting with types over such a simple function is worth it
+    // The only thing it does is add 'collapsable: false' to the child component
+    // to make sure it is in the native view hierarchy so the detector can find
+    // correct viewTag to attach to.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const child: any = React.Children.only(this.props.children);
+
+    return React.cloneElement(
+      child,
+      { collapsable: false },
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      child.props.children
+    );
   }
 }
 


### PR DESCRIPTION
## Description

This pr modifies the `Wrap` component used by the `GestureDetector` to find the viewTag of the view it should attach to. By adding the `collapsable: false` prop it makes sure that the child view of the wrap ends up in the view hierarchy.
Note that there are still problems when there is a `View` used just to group components (no props) inside a functional component that is a child of a `GestureDetector`.

## Test plan

Tested on the Example app
