### PR TITLE
Export gesture types

### DIFF
--- a/src/handlers/gestures/flingGesture.ts
+++ b/src/handlers/gestures/flingGesture.ts
@@ -23,3 +23,5 @@ export class FlingGesture extends BaseGesture<FlingGestureHandlerEventPayload> {
     return this;
   }
 }
+
+export type FlingGestureType = InstanceType<typeof FlingGesture>;

--- a/src/handlers/gestures/forceTouchGesture.ts
+++ b/src/handlers/gestures/forceTouchGesture.ts
@@ -28,3 +28,5 @@ export class ForceTouchGesture extends ContinousBaseGesture<ForceTouchGestureHan
     return this;
   }
 }
+
+export type ForceTouchGestureType = InstanceType<typeof ForceTouchGesture>;

--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -102,3 +102,8 @@ export class ExclusiveGesture extends ComposedGesture {
     }
   }
 }
+
+export type ComposedGestureType = InstanceType<typeof ComposedGesture>;
+export type RaceGestureType = ComposedGestureType;
+export type SimultaneousGestureType = InstanceType<typeof SimultaneousGesture>;
+export type ExclusiveGestureType = InstanceType<typeof ExclusiveGesture>;

--- a/src/handlers/gestures/longPressGesture.ts
+++ b/src/handlers/gestures/longPressGesture.ts
@@ -23,3 +23,5 @@ export class LongPressGesture extends BaseGesture<LongPressGestureHandlerEventPa
     return this;
   }
 }
+
+export type LongPressGestureType = InstanceType<typeof LongPressGesture>;

--- a/src/handlers/gestures/nativeGesture.ts
+++ b/src/handlers/gestures/nativeGesture.ts
@@ -23,3 +23,5 @@ export class NativeGesture extends BaseGesture<NativeViewGestureHandlerPayload> 
     return this;
   }
 }
+
+export type NativeGestureType = InstanceType<typeof NativeGesture>;

--- a/src/handlers/gestures/panGesture.ts
+++ b/src/handlers/gestures/panGesture.ts
@@ -81,3 +81,5 @@ export class PanGesture extends ContinousBaseGesture<PanGestureHandlerEventPaylo
     return this;
   }
 }
+
+export type PanGestureType = InstanceType<typeof PanGesture>;

--- a/src/handlers/gestures/pinchGesture.ts
+++ b/src/handlers/gestures/pinchGesture.ts
@@ -8,3 +8,5 @@ export class PinchGesture extends ContinousBaseGesture<PinchGestureHandlerEventP
     this.handlerName = 'PinchGestureHandler';
   }
 }
+
+export type PinchGestureType = InstanceType<typeof PinchGesture>;

--- a/src/handlers/gestures/rotationGesture.ts
+++ b/src/handlers/gestures/rotationGesture.ts
@@ -8,3 +8,5 @@ export class RotationGesture extends ContinousBaseGesture<RotationGestureHandler
     this.handlerName = 'RotationGestureHandler';
   }
 }
+
+export type RotationGestureType = InstanceType<typeof RotationGesture>;

--- a/src/handlers/gestures/tapGesture.ts
+++ b/src/handlers/gestures/tapGesture.ts
@@ -48,3 +48,5 @@ export class TapGesture extends BaseGesture<TapGestureHandlerEventPayload> {
     return this;
   }
 }
+
+export type TapGestureType = InstanceType<typeof TapGesture>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,18 +54,19 @@ export type {
 } from './handlers/NativeViewGestureHandler';
 export { GestureDetector } from './handlers/gestures/GestureDetector';
 export { GestureObjects as Gesture } from './handlers/gestures/gestureObjects';
-export { TapGesture } from './handlers/gestures/tapGesture';
-export { PanGesture } from './handlers/gestures/panGesture';
-export { FlingGesture } from './handlers/gestures/flingGesture';
-export { LongPressGesture } from './handlers/gestures/longPressGesture';
-export { PinchGesture } from './handlers/gestures/pinchGesture';
-export { RotationGesture } from './handlers/gestures/rotationGesture';
-export { ForceTouchGesture } from './handlers/gestures/forceTouchGesture';
-export { NativeGesture } from './handlers/gestures/nativeGesture';
+export { TapGestureType as TapGesture } from './handlers/gestures/tapGesture';
+export { PanGestureType as PanGesture } from './handlers/gestures/panGesture';
+export { FlingGestureType as FlingGesture } from './handlers/gestures/flingGesture';
+export { LongPressGestureType as LongPressGesture } from './handlers/gestures/longPressGesture';
+export { PinchGestureType as PinchGesture } from './handlers/gestures/pinchGesture';
+export { RotationGestureType as RotationGesture } from './handlers/gestures/rotationGesture';
+export { ForceTouchGestureType as ForceTouchGesture } from './handlers/gestures/forceTouchGesture';
+export { NativeGestureType as NativeGesture } from './handlers/gestures/nativeGesture';
 export {
-  ComposedGesture,
-  SimultaneousGesture,
-  ExclusiveGesture,
+  ComposedGestureType as ComposedGesture,
+  RaceGestureType as RaceGesture,
+  SimultaneousGestureType as SimultaneousGesture,
+  ExclusiveGestureType as ExclusiveGesture,
 } from './handlers/gestures/gestureComposition';
 export { NativeViewGestureHandler } from './handlers/NativeViewGestureHandler';
 export type {

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,19 @@ export type {
 } from './handlers/NativeViewGestureHandler';
 export { GestureDetector } from './handlers/gestures/GestureDetector';
 export { GestureObjects as Gesture } from './handlers/gestures/gestureObjects';
+export { TapGesture } from './handlers/gestures/tapGesture';
+export { PanGesture } from './handlers/gestures/panGesture';
+export { FlingGesture } from './handlers/gestures/flingGesture';
+export { LongPressGesture } from './handlers/gestures/longPressGesture';
+export { PinchGesture } from './handlers/gestures/pinchGesture';
+export { RotationGesture } from './handlers/gestures/rotationGesture';
+export { ForceTouchGesture } from './handlers/gestures/forceTouchGesture';
+export { NativeGesture } from './handlers/gestures/nativeGesture';
+export {
+  ComposedGesture,
+  SimultaneousGesture,
+  ExclusiveGesture,
+} from './handlers/gestures/gestureComposition';
 export { NativeViewGestureHandler } from './handlers/NativeViewGestureHandler';
 export type {
   RawButtonProps,


### PR DESCRIPTION
## Description

Objects representing gestures were not exported, this PR changes that.

## Test plan

Ran `tsc`.
