### PR TITLE
Remove leftover set prefix in ForceTouchGesture

### DIFF
--- a/src/handlers/gestures/forceTouchGesture.ts
+++ b/src/handlers/gestures/forceTouchGesture.ts
@@ -13,7 +13,7 @@ export class ForceTouchGesture extends ContinousBaseGesture<ForceTouchGestureHan
     this.handlerName = 'ForceTouchGestureHandler';
   }
 
-  setMinForce(force: number) {
+  minForce(force: number) {
     this.config.minForce = force;
     return this;
   }


### PR DESCRIPTION
## Description

Remove leftover `set` prefix from `setMinForce`.

## Test plan

Ran `npm pack`