### PR TITLE
Remove unnecessary null check from RNGestureHandlerModule on Android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -367,11 +367,8 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) : ReactCont
 
   @ReactMethod
   fun handleSetJSResponder(viewTag: Int, blockNativeResponder: Boolean) {
-    // TODO: check if it can be null
-    if (registry != null) {
-      val rootView = findRootHelperForViewAncestor(viewTag)
-      rootView?.handleSetJSResponder(viewTag, blockNativeResponder)
-    }
+    val rootView = findRootHelperForViewAncestor(viewTag)
+    rootView?.handleSetJSResponder(viewTag, blockNativeResponder)
   }
 
   @ReactMethod


### PR DESCRIPTION
## Description

It cannot be null, I checked. The `registry` is a `val` initialized at declaration.

## Test plan

Tested on the Example app
