### PR TITLE
Fix broken link to Gesture Responder System

### DIFF
--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -5,7 +5,7 @@ sidebar_label: Getting Started
 slug: /
 ---
 
-Gesture Handler aims to replace React Native's built in touch system called [Gesture Responder System](http://facebook.github.io/react-native/docs/gesture-responder-system.html).
+Gesture Handler aims to replace React Native's built in touch system called [Gesture Responder System](http://facebook.github.io/react-native/docs/gesture-responder-system).
 
 The motivation for building this library was to address the performance limitations of React Native's Gesture Responder System and to provide more control over the built-in native components that can handle gestures.
 We recommend [this talk](https://www.youtube.com/watch?v=V8maYc4R2G0) by [Krzysztof Magiera](https://twitter.com/kzzzf) in which he explains issues with the responder system.


### PR DESCRIPTION
Gesture Responder System link is currently broken. The `.html` in the URL causes a Page Not Found error. Removing it fixed the issue.

