### PR TITLE
Update pan gesture to use the same set of properties as PanGestureHandler

### DIFF
--- a/src/handlers/PanGestureHandler.ts
+++ b/src/handlers/PanGestureHandler.ts
@@ -10,7 +10,6 @@ export const panGestureHandlerProps = [
   'failOffsetY',
   'failOffsetX',
   'minDist',
-  'minPointers',
   'minVelocity',
   'minVelocityX',
   'minVelocityY',
@@ -114,6 +113,17 @@ interface CommonPanProperties {
    * activate. Should be a higher or equal to 0 integer.
    */
   minPointers?: number;
+
+  /**
+   * When the given number of fingers is placed on the screen and handler hasn't
+   * yet activated it will fail recognizing the gesture. Should be a higher or
+   * equal to 0 integer.
+   */
+  maxPointers?: number;
+
+  minVelocity?: number;
+  minVelocityX?: number;
+  minVelocityY?: number;
 }
 
 export interface PanGestureConfig extends CommonPanProperties {
@@ -235,22 +245,6 @@ export interface PanGestureHandlerProps
    * if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
    */
   failOffsetX?: number | number[];
-  minVelocity?: number;
-  minVelocityX?: number;
-  minVelocityY?: number;
-
-  /**
-   * A number of fingers that is required to be placed before handler can
-   * activate. Should be a higher or equal to 0 integer.
-   */
-  minPointers?: number;
-
-  /**
-   * When the given number of fingers is placed on the screen and handler hasn't
-   * yet activated it will fail recognizing the gesture. Should be a higher or
-   * equal to 0 integer.
-   */
-  maxPointers?: number;
 }
 
 export type PanGestureHandler = typeof PanGestureHandler;

--- a/src/handlers/gestures/panGesture.ts
+++ b/src/handlers/gestures/panGesture.ts
@@ -66,8 +66,28 @@ export class PanGesture extends ContinousBaseGesture<PanGestureHandlerEventPaylo
     return this;
   }
 
+  maxPointers(maxPointers: number) {
+    this.config.maxPointers = maxPointers;
+    return this;
+  }
+
   minDistance(distance: number) {
     this.config.minDist = distance;
+    return this;
+  }
+
+  minVelocity(velocity: number) {
+    this.config.minVelocity = velocity;
+    return this;
+  }
+
+  minVelocityX(velocity: number) {
+    this.config.minVelocityX = velocity;
+    return this;
+  }
+
+  minVelocityY(velocity: number) {
+    this.config.minVelocityY = velocity;
     return this;
   }
 


### PR DESCRIPTION
## Description

Move all shared properties of PanGesture and PanGestureHandler to the CommonPanProperties interface. This allows PanGesture to utlize all (non-deprecated) properties available to the PanGestureHandler.
Added PanGesture config methods corresponding to the moved props.

## Test plan

Tested on the Example app