### PR TITLE
Remove animatedGesture prop, use animated gesture automatically

### DIFF
--- a/examples/Example/src/new_api/calculator/index.tsx
+++ b/examples/Example/src/new_api/calculator/index.tsx
@@ -126,7 +126,7 @@ function Output({ offset, expression, history }: OutputProps) {
   scrollView.current?.scrollToEnd({ animated: true });
 
   return (
-    <GestureDetector animatedGesture={dragGesture}>
+    <GestureDetector gesture={dragGesture}>
       <Animated.View
         style={[styles.output, translationStyle]}
         onLayout={measure}>
@@ -298,7 +298,7 @@ function Operations() {
   }
 
   return (
-    <GestureDetector animatedGesture={dragGesture}>
+    <GestureDetector gesture={dragGesture}>
       <Animated.View
         style={[styles.operations, translationStyle]}
         onLayout={measure}
@@ -336,7 +336,7 @@ function Button({ text, append }: ButtonProps) {
     });
 
   return (
-    <GestureDetector animatedGesture={tapHandler}>
+    <GestureDetector gesture={tapHandler}>
       <Animated.View style={styles.button}>
         <Animated.View style={[styles.buttonTextContainer, backgroundStyles]}>
           <Text style={styles.buttonText}>{text}</Text>

--- a/examples/Example/src/new_api/camera/index.tsx
+++ b/examples/Example/src/new_api/camera/index.tsx
@@ -145,17 +145,17 @@ export default function Home() {
 
   return (
     <Animated.View style={styles.container}>
-      <GestureDetector animatedGesture={previewPinchGesture}>
+      <GestureDetector gesture={previewPinchGesture}>
         <Animated.View
           style={[styles.home, { backgroundColor: filters[selectedFilter] }]}>
           <Animated.View style={[styles.box, zoomStyle]} />
         </Animated.View>
       </GestureDetector>
 
-      <GestureDetector animatedGesture={filtersPanGesture}>
+      <GestureDetector gesture={filtersPanGesture}>
         <Animated.View style={styles.buttonContainer}>
           <FilterCarousel filters={filters} selected={filter} />
-          <GestureDetector animatedGesture={buttonGesture}>
+          <GestureDetector gesture={buttonGesture}>
             <CaptureButton
               progress={1 - remainingTimeMs / MAX_VIDEO_DURATION_MS}
               onTimerFinished={() => {

--- a/examples/Example/src/new_api/reanimated/index.tsx
+++ b/examples/Example/src/new_api/reanimated/index.tsx
@@ -45,7 +45,7 @@ function Ball() {
     });
 
   return (
-    <GestureDetector animatedGesture={gesture}>
+    <GestureDetector gesture={gesture}>
       <Animated.View style={[styles.ball, animatedStyles]} />
     </GestureDetector>
   );

--- a/examples/Example/src/new_api/transformations/index.tsx
+++ b/examples/Example/src/new_api/transformations/index.tsx
@@ -77,7 +77,7 @@ function Photo() {
   );
 
   return (
-    <GestureDetector animatedGesture={gesture}>
+    <GestureDetector gesture={gesture}>
       <Animated.View style={[styles.button, style]} />
     </GestureDetector>
   );

--- a/src/components/BetterDrawerLayout.tsx
+++ b/src/components/BetterDrawerLayout.tsx
@@ -166,7 +166,7 @@ function Overlay(props: OverlayProps) {
   });
 
   return (
-    <GestureDetector animatedGesture={tap}>
+    <GestureDetector gesture={tap}>
       <Animated.View style={[styles.overlay, overlayStyle]} />
     </GestureDetector>
   );
@@ -566,7 +566,7 @@ export const DrawerLayout = React.forwardRef<
     }
 
     return (
-      <GestureDetector animatedGesture={pan}>
+      <GestureDetector gesture={pan}>
         <Animated.View style={styles.main} onLayout={handleContainerLayout}>
           <Animated.View
             style={[

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -335,14 +335,16 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
 
 interface GestureDetectorProps {
   gesture?: ComposedGesture | GestureType;
-  animatedGesture?: ComposedGesture | GestureType;
 }
 export const GestureDetector: React.FunctionComponent<GestureDetectorProps> = (
   props
 ) => {
-  const useAnimated = props.animatedGesture != null;
-  const gestureConfig = props.animatedGesture ?? props.gesture;
+  const gestureConfig = props.gesture;
   const gesture = gestureConfig?.toGestureArray?.() ?? [];
+  const useAnimated =
+    gesture.find((gesture) =>
+      gesture.handlers.isWorklet.reduce((prev, current) => prev || current)
+    ) != null;
   const viewRef = useRef(null);
   const firstRenderRef = useRef(true);
 
@@ -408,7 +410,7 @@ export const GestureDetector: React.FunctionComponent<GestureDetectorProps> = (
     }
   }, [props]);
 
-  if (props.animatedGesture) {
+  if (useAnimated) {
     return (
       <AnimatedWrap
         ref={viewRef}


### PR DESCRIPTION
## Description

This PR removes `animatedGesture` prop from `GestureDetector` component and adds automatic check whether the gesture callbacks are worklets. If any one of them is a worklet, gesture will be initialized the same way it would be via `animatedGesture`. If no callback is a worklet, then the gesture will be initialized without using `Reanimated`.

## Test plan

Updated examples and tested on the Example app