### PR TITLE
Prepare state management for pointer events

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/FlingGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/FlingGestureHandler.kt
@@ -46,12 +46,14 @@ class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
       event.rawY - startY > minAcceptableDelta)) {
     handler!!.removeCallbacksAndMessages(null)
     activate()
-    end()
     true
   } else {
     false
   }
 
+  override fun afterActivation() {
+    end()
+  }
 
   private fun endFling(event: MotionEvent) {
     if (!tryEndFling(event)) {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/FlingGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/FlingGestureHandler.kt
@@ -51,7 +51,8 @@ class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
     false
   }
 
-  override fun afterActivation() {
+  override fun activate() {
+    super.activate()
     end()
   }
 

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -388,7 +388,9 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
 
   fun activate() {
     if (state == STATE_UNDETERMINED || state == STATE_BEGAN) {
+      beforeActivation()
       moveToState(STATE_ACTIVE)
+      afterActivation()
     }
   }
 
@@ -411,6 +413,8 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   protected open fun onStateChange(newState: Int, previousState: Int) {}
   protected open fun onReset() {}
   protected open fun onCancel() {}
+  protected open fun beforeActivation() {}
+  protected open fun afterActivation() {}
   fun reset() {
     view = null
     orchestrator = null

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -386,11 +386,9 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     }
   }
 
-  fun activate() {
+  open fun activate() {
     if (state == STATE_UNDETERMINED || state == STATE_BEGAN) {
-      beforeActivation()
       moveToState(STATE_ACTIVE)
-      afterActivation()
     }
   }
 
@@ -413,8 +411,6 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   protected open fun onStateChange(newState: Int, previousState: Int) {}
   protected open fun onReset() {}
   protected open fun onCancel() {}
-  protected open fun beforeActivation() {}
-  protected open fun afterActivation() {}
   fun reset() {
     view = null
     orchestrator = null

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -34,6 +34,8 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   var lastAbsolutePositionY = 0f
     private set
 
+  private var manualActivation = false
+
   private var lastEventOffsetX = 0f
   private var lastEventOffsetY = 0f
   private var shouldCancelWhenOutside = false
@@ -67,6 +69,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   }
 
   open fun resetConfig() {
+    manualActivation = false
     shouldCancelWhenOutside = false
     isEnabled = true
     hitSlop = null
@@ -92,6 +95,9 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     }
     isEnabled = enabled
   }
+
+  fun setManualActivation(manualActivation: Boolean): ConcreteGestureHandlerT =
+      applySelf { this.manualActivation = manualActivation }
 
   fun setHitSlop(
     leftPad: Float, topPad: Float, rightPad: Float, bottomPad: Float,
@@ -389,6 +395,12 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   open fun activate() {
     if (state == STATE_UNDETERMINED || state == STATE_BEGAN) {
       moveToState(STATE_ACTIVE)
+    }
+  }
+
+  fun activateIfNotManual() {
+    if (!manualActivation) {
+      activate()
     }
   }
 

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -244,12 +244,15 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       if (shouldFail()) {
         fail()
       } else if (shouldActivate()) {
-        // reset starting point
-        startX = lastX
-        startY = lastY
         activate()
       }
     }
+  }
+
+  override fun beforeActivation() {
+    // reset starting point
+    startX = lastX
+    startY = lastY
   }
 
   override fun onReset() {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -244,7 +244,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       if (shouldFail()) {
         fail()
       } else if (shouldActivate()) {
-        activate()
+        activateIfNotManual()
       }
     }
   }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -249,10 +249,11 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
     }
   }
 
-  override fun beforeActivation() {
+  override fun activate() {
     // reset starting point
     startX = lastX
     startY = lastY
+    super.activate()
   }
 
   override fun onReset() {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -71,6 +71,11 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
     }
   }
 
+  override fun beforeActivation() {
+    velocity = 0.0
+    scale = 1.0
+  }
+
   override fun onReset() {
     scaleGestureDetector = null
     velocity = 0.0

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -29,7 +29,7 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       }
       if (abs(startingSpan - detector.currentSpan) >= spanSlop
         && state == STATE_BEGAN) {
-        activate()
+        activateIfNotManual()
       }
       return true
     }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -71,9 +71,10 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
     }
   }
 
-  override fun beforeActivation() {
+  override fun activate() {
     velocity = 0.0
     scale = 1.0
+    super.activate()
   }
 
   override fun onReset() {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
@@ -58,6 +58,11 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
     }
   }
 
+  override fun beforeActivation() {
+    rotation = 0.0
+    velocity = 0.0
+  }
+
   override fun onReset() {
     rotationGestureDetector = null
     velocity = 0.0

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
@@ -58,9 +58,10 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
     }
   }
 
-  override fun beforeActivation() {
+  override fun activate() {
     rotation = 0.0
     velocity = 0.0
+    super.activate()
   }
 
   override fun onReset() {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
@@ -29,7 +29,7 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
         velocity = (rotation - prevRotation) / delta
       }
       if (abs(rotation) >= ROTATION_RECOGNITION_THRESHOLD && state == STATE_BEGAN) {
-        activate()
+        activateIfNotManual()
       }
       return true
     }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.kt
@@ -85,7 +85,6 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
     }
     if (++tapsSoFar == numberOfTaps && currentMaxNumberOfPointers >= minNumberOfPointers) {
       activate()
-      end()
     } else {
       handler!!.postDelayed(failDelayed, maxDelayMs)
     }
@@ -141,6 +140,10 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
         startTap()
       }
     }
+  }
+
+  override fun afterActivation() {
+    end()
   }
 
   override fun onCancel() {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.kt
@@ -142,7 +142,8 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
     }
   }
 
-  override fun afterActivation() {
+  override fun activate() {
+    super.activate()
     end()
   }
 

--- a/android/src/main/java/com/swmansion/common/GestureHandlerStateManager.kt
+++ b/android/src/main/java/com/swmansion/common/GestureHandlerStateManager.kt
@@ -1,0 +1,5 @@
+package com.swmansion.common
+
+interface GestureHandlerStateManager {
+  fun setGestureHandlerState(handlerTag: Int, newState: Int)
+}

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -30,6 +30,9 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
       if (config.hasKey(KEY_HIT_SLOP)) {
         handleHitSlopProperty(handler, config)
       }
+      if (config.hasKey(KEY_MANUAL_ACTIVATION)) {
+        handler.setManualActivation(config.getBoolean(KEY_MANUAL_ACTIVATION))
+      }
     }
 
     override fun extractEventData(handler: T, eventData: WritableMap) {
@@ -558,6 +561,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
     const val MODULE_NAME = "RNGestureHandlerModule"
     private const val KEY_SHOULD_CANCEL_WHEN_OUTSIDE = "shouldCancelWhenOutside"
     private const val KEY_ENABLED = "enabled"
+    private const val KEY_MANUAL_ACTIVATION = "manualActivation"
     private const val KEY_HIT_SLOP = "hitSlop"
     private const val KEY_HIT_SLOP_LEFT = "left"
     private const val KEY_HIT_SLOP_TOP = "top"

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -382,7 +382,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
   }
 
   override fun setGestureHandlerState(handlerTag: Int, newState: Int) {
-    Log.w("A", "state $newState for handler $handlerTag")
     registry.getHandler(handlerTag)?.let { handler ->
       when (newState) {
         GestureHandler.STATE_ACTIVE -> handler.activate()

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -1,7 +1,6 @@
 package com.swmansion.gesturehandler.react
 
 import android.content.Context
-import android.util.Log
 import android.view.MotionEvent
 import android.view.ViewGroup
 import com.facebook.react.ReactRootView

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -1,6 +1,7 @@
 package com.swmansion.gesturehandler.react
 
 import android.content.Context
+import android.util.Log
 import android.view.MotionEvent
 import android.view.ViewGroup
 import com.facebook.react.ReactRootView
@@ -8,11 +9,13 @@ import com.facebook.react.bridge.*
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.UIBlock
+import com.swmansion.common.GestureHandlerStateManager
 import com.swmansion.gesturehandler.*
 import java.util.*
 
 @ReactModule(name = RNGestureHandlerModule.MODULE_NAME)
-class RNGestureHandlerModule(reactContext: ReactApplicationContext?) : ReactContextBaseJavaModule(reactContext) {
+class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
+  : ReactContextBaseJavaModule(reactContext), GestureHandlerStateManager {
   private abstract class HandlerFactory<T : GestureHandler<T>> : RNGestureHandlerEventDataExtractor<T> {
     abstract val type: Class<T>
     abstract val name: String
@@ -376,6 +379,19 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) : ReactCont
 
   @ReactMethod
   fun handleClearJSResponder() {
+  }
+
+  override fun setGestureHandlerState(handlerTag: Int, newState: Int) {
+    Log.w("A", "state $newState for handler $handlerTag")
+    registry.getHandler(handlerTag)?.let { handler ->
+      when (newState) {
+        GestureHandler.STATE_ACTIVE -> handler.activate()
+        GestureHandler.STATE_BEGAN -> handler.begin()
+        GestureHandler.STATE_END -> handler.end()
+        GestureHandler.STATE_FAILED -> handler.fail()
+        GestureHandler.STATE_CANCELLED -> handler.cancel()
+      }
+    }
   }
 
   override fun getConstants(): Map<String, Any> {

--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -59,7 +59,8 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 @property (nonatomic, readonly, nullable) UIGestureRecognizer *recognizer;
 @property (nonatomic) BOOL enabled;
 @property (nonatomic) BOOL usesDeviceEvents;
-@property(nonatomic) BOOL shouldCancelWhenOutside;
+@property (nonatomic) BOOL shouldCancelWhenOutside;
+@property (nonatomic) BOOL manualActivation;
 
 - (void)bindToView:(nonnull UIView *)view;
 - (void)unbindFromView;
@@ -70,6 +71,8 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 - (RNGestureHandlerState)state;
 - (nullable RNGestureHandlerEventExtraData *)eventExtraData:(nonnull id)recognizer;
 
+- (void)stopActivationBlocker;
+- (void)resetManualActivation;
 - (void)reset;
 - (void)sendEventsInState:(RNGestureHandlerState)state
            forViewWithTag:(nonnull NSNumber *)reactTag

--- a/ios/RNGestureHandlerManager.h
+++ b/ios/RNGestureHandlerManager.h
@@ -2,6 +2,8 @@
 
 #import <React/RCTBridgeModule.h>
 
+#import "RNGestureHandler.h"
+
 @class RCTUIManager;
 @class RCTEventDispatcher;
 
@@ -28,5 +30,7 @@
         blockNativeResponder:(nonnull NSNumber *)blockNativeResponder;
 
 - (void)handleClearJSResponder;
+
+- (nullable RNGestureHandler *)handlerWithTag:(nonnull NSNumber *)handlerTag;
 
 @end

--- a/ios/RNGestureHandlerManager.m
+++ b/ios/RNGestureHandlerManager.m
@@ -137,6 +137,12 @@
     // ignore...
 }
 
+- (id)handlerWithTag:(NSNumber *)handlerTag
+{
+  return [_registry handlerWithTag:handlerTag];
+}
+
+
 #pragma mark Root Views Management
 
 - (void)registerViewWithGestureRecognizerAttachedIfNeeded:(UIView *)childView

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -154,11 +154,19 @@ RCT_EXPORT_METHOD(handleClearJSResponder)
     } else if (state == 3) { // CANCELLED
       handler.recognizer.state = UIGestureRecognizerStateCancelled;
     } else if (state == 4) { // ACTIVE
+      [handler stopActivationBlocker];
       handler.recognizer.state = UIGestureRecognizerStateBegan;
     } else if (state == 5) { // ENDED
       handler.recognizer.state = UIGestureRecognizerStateEnded;
     }
   }
+  
+  // the code needs to be uncommented after merging relevant PRs, I left it
+  // here not to forget about it later
+  // if the gesture was set to finish, cancel all pointers it was tracking
+//  if (state == 1 || state == 3 || state == 5) {
+//    [handler.pointerTracker cancelPointers];
+//  }
   
   // do not send state change event when activating because it bypasses
   // shouldRequireFailureOfGestureRecognizer

--- a/ios/RNGestureHandlerStateManager.h
+++ b/ios/RNGestureHandlerStateManager.h
@@ -1,0 +1,5 @@
+@protocol RNGestureHandlerStateManager
+
+-(void) setGestureState:(int)state forHandler:(int)handlerTag;
+
+@end

--- a/ios/RNManualActivationRecognizer.h
+++ b/ios/RNManualActivationRecognizer.h
@@ -1,0 +1,10 @@
+#import <UIKit/UIGestureRecognizerSubclass.h>
+
+@class RNGestureHandler;
+
+@interface RNManualActivationRecognizer : UIGestureRecognizer <UIGestureRecognizerDelegate>
+
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
+- (void)fail;
+
+@end

--- a/ios/RNManualActivationRecognizer.m
+++ b/ios/RNManualActivationRecognizer.m
@@ -1,0 +1,80 @@
+#import "RNManualActivationRecognizer.h"
+#import "RNGestureHandler.h"
+
+@implementation RNManualActivationRecognizer {
+  RNGestureHandler *_handler;
+  int _activePointers;
+}
+
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler
+{
+  if ((self = [super initWithTarget:self action:nil])) {
+    _handler = gestureHandler;
+    self.delegate = self;
+    _activePointers = 0;
+  }
+  return self;
+}
+
+- (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesBegan:touches withEvent:event];
+
+  _activePointers += touches.count;
+}
+
+- (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesMoved:touches withEvent:event];
+}
+
+- (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesEnded:touches withEvent:event];
+  
+  _activePointers -= touches.count;
+  
+  if (_activePointers == 0) {
+    [self fail];
+    [self reset];
+  }
+}
+
+- (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
+{
+  [super touchesCancelled:touches withEvent:event];
+  
+  _activePointers = 0;
+  [self reset];
+}
+
+- (void)reset
+{
+  self.enabled = YES;
+  [super reset];
+}
+
+- (void)fail
+{
+  self.enabled = NO;
+}
+
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
+shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  return YES;
+}
+
+- (BOOL)shouldBeRequiredToFailByGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
+{
+  RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
+  if (handler != nil) {
+    if (handler.tag == _handler.tag) {
+      return YES;
+    }
+  }
+  
+  return NO;
+}
+
+@end


### PR DESCRIPTION
## Description

- Add common interface and protocol that will be shared between Gesture Handler and Reanimated.
- Add `setGestureState` method to allow managing state of the gesture handlers. This method will be used by `react-native-reanimated` to allow for synchronous state management inside worklets.
- Extracted pre- and post-activation logic to separate functions on Android. This allows for it to be executed just by calling `activate`.
- Reset `Pinch` and `Rotation` state on activation to prevent unexpected behavior with manual activation.

## Test plan

It compiles, needs to be tested when all the changes are merged together.
