### PR TITLE
Add option to enable manual activation

### DIFF
--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -31,7 +31,10 @@ export const baseGestureHandlerProps = [
   'onHandlerStateChange',
 ] as const;
 
-export const baseGestureHandlerWithMonitorProps = commonProps;
+export const baseGestureHandlerWithMonitorProps = [
+  ...commonProps,
+  'manualActivation',
+];
 
 export interface GestureEventPayload {
   handlerTag: number;

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -32,6 +32,7 @@ export interface BaseGestureConfig
   ref?: React.MutableRefObject<GestureType>;
   requireToFail?: GestureRef[];
   simultaneousWith?: GestureRef[];
+  manualActivation?: boolean;
 }
 
 export type HandlerCallbacks<EventPayloadT extends Record<string, unknown>> = {
@@ -204,6 +205,11 @@ export abstract class ContinousBaseGesture<
   ) {
     this.handlers.onUpdate = callback;
     this.handlers.isWorklet[CALLBACK_TYPE.UPDATE] = this.isWorklet(callback);
+    return this;
+  }
+
+  manualActivation(manualActivation: boolean) {
+    this.config.manualActivation = manualActivation;
     return this;
   }
 }


### PR DESCRIPTION
## Description

Add `manualActivation` method to continuous gestures. When set to `true` the gesture will not activate by itself only by calling relevant method.

## Test plan

Needs to be tested when all parts are merged together.
