### PR TITLE
Add pointer events examples

### DIFF
--- a/examples/Example/src/App.tsx
+++ b/examples/Example/src/App.tsx
@@ -28,6 +28,9 @@ import HorizontalDrawer from './basic/horizontalDrawer';
 import PagerAndDrawer from './basic/pagerAndDrawer';
 import ForceTouch from './basic/forcetouch';
 
+import LongPressDrag from './new_api/longpress_drag';
+import PointerTracker from './new_api/pointer_tracker';
+import Square from './new_api/square';
 import ReanimatedSimple from './new_api/reanimated';
 import Camera from './new_api/camera';
 import Transformations from './new_api/transformations';
@@ -90,6 +93,9 @@ const EXAMPLES: ExamplesSection[] = [
   {
     sectionTitle: 'New api',
     data: [
+      { name: 'LongPress and drag', component: LongPressDrag },
+      { name: 'Pointer tracker', component: PointerTracker },
+      { name: 'Square', component: Square },
       {
         name: 'Simple interaction with Reanimated',
         component: ReanimatedSimple,

--- a/examples/Example/src/new_api/longpress_drag/index.tsx
+++ b/examples/Example/src/new_api/longpress_drag/index.tsx
@@ -1,0 +1,127 @@
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withSpring,
+  runOnJS,
+} from 'react-native-reanimated';
+
+function Ball() {
+  const isHighlighted = useSharedValue(false);
+  const isPressed = useSharedValue(false);
+  const downPosition = useSharedValue({ x: 0, y: 0 });
+  const offset = useSharedValue({ x: 0, y: 0 });
+  const startTime = useSharedValue(0);
+  const highlightTimeoutId = useSharedValue(0);
+
+  const animatedStyles = useAnimatedStyle(() => {
+    return {
+      transform: [
+        { translateX: offset.value.x },
+        { translateY: offset.value.y },
+        { scale: withSpring(isHighlighted.value && isPressed.value ? 1.2 : 1) },
+      ],
+      backgroundColor:
+        isHighlighted.value && isPressed.value ? 'yellow' : 'blue',
+    };
+  });
+
+  function startTimeout() {
+    highlightTimeoutId.value = setTimeout(() => {
+      isHighlighted.value = true;
+    }, 500);
+  }
+
+  function stopTimeout() {
+    clearTimeout(highlightTimeoutId.value);
+  }
+
+  const start = useSharedValue({ x: 0, y: 0 });
+  const gesture = Gesture.Pan()
+    .manualActivation(true)
+    .onPointerChange((e) => {
+      'worklet';
+      console.log(e);
+    })
+    .onPointerDown((e, state) => {
+      'worklet';
+      downPosition.value = { x: e.pointerData[0].x, y: e.pointerData[0].y };
+      state.begin();
+    })
+    .onPointerUp((_e, state) => {
+      'worklet';
+      state.end();
+    })
+    .onPointerCancelled((_e, state) => {
+      'worklet';
+      state.end();
+    })
+    .onPointerMove((e, state) => {
+      'worklet';
+      if (Date.now() - startTime.value > 500) {
+        state.activate();
+      } else if (
+        Math.abs(e.pointerData[0].x - downPosition.value.x) > 2 ||
+        Math.abs(e.pointerData[0].y - downPosition.value.y) > 2
+      ) {
+        console.log(e.pointerData[0]);
+        console.log(downPosition.value);
+        state.fail();
+      }
+    })
+    .onBegan(() => {
+      'worklet';
+      startTime.value = Date.now();
+      isPressed.value = true;
+      isHighlighted.value = false;
+      runOnJS(startTimeout)();
+      console.log('begin');
+    })
+    .onUpdate((e) => {
+      'worklet';
+      offset.value = {
+        x: e.translationX + start.value.x,
+        y: e.translationY + start.value.y,
+      };
+    })
+    .onEnd(() => {
+      'worklet';
+      start.value = {
+        x: offset.value.x,
+        y: offset.value.y,
+      };
+      isPressed.value = false;
+      isHighlighted.value = false;
+      runOnJS(stopTimeout)();
+      console.log('end');
+    });
+
+  return (
+    <GestureDetector animatedGesture={gesture}>
+      <Animated.View style={[styles.ball, animatedStyles]} />
+    </GestureDetector>
+  );
+}
+
+export default function Example() {
+  return (
+    <View style={styles.container}>
+      <Ball />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  ball: {
+    width: 100,
+    height: 100,
+    borderRadius: 100,
+    backgroundColor: 'blue',
+    alignSelf: 'center',
+  },
+});

--- a/examples/Example/src/new_api/longpress_drag/index.tsx
+++ b/examples/Example/src/new_api/longpress_drag/index.tsx
@@ -41,32 +41,28 @@ function Ball() {
   const start = useSharedValue({ x: 0, y: 0 });
   const gesture = Gesture.Pan()
     .manualActivation(true)
-    .onPointerChange((e) => {
+    .onTouchesDown((e, state) => {
       'worklet';
-      console.log(e);
-    })
-    .onPointerDown((e, state) => {
-      'worklet';
-      downPosition.value = { x: e.pointerData[0].x, y: e.pointerData[0].y };
+      downPosition.value = { x: e.touches[0].x, y: e.touches[0].y };
       state.begin();
     })
-    .onPointerUp((_e, state) => {
+    .onTouchesUp((_e, state) => {
       'worklet';
       state.end();
     })
-    .onPointerCancelled((_e, state) => {
+    .onTouchesCancelled((_e, state) => {
       'worklet';
       state.end();
     })
-    .onPointerMove((e, state) => {
+    .onTouchesMove((e, state) => {
       'worklet';
       if (Date.now() - startTime.value > 500) {
         state.activate();
       } else if (
-        Math.abs(e.pointerData[0].x - downPosition.value.x) > 2 ||
-        Math.abs(e.pointerData[0].y - downPosition.value.y) > 2
+        Math.abs(e.touches[0].x - downPosition.value.x) > 2 ||
+        Math.abs(e.touches[0].y - downPosition.value.y) > 2
       ) {
-        console.log(e.pointerData[0]);
+        console.log(e.touches[0]);
         console.log(downPosition.value);
         state.fail();
       }

--- a/examples/Example/src/new_api/pointer_tracker/index.tsx
+++ b/examples/Example/src/new_api/pointer_tracker/index.tsx
@@ -4,7 +4,7 @@ import {
   GestureDetector,
   Gesture,
   GestureStateManager,
-  GesturePointerEvent,
+  GestureTouchEvent,
 } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
@@ -50,13 +50,13 @@ export default function Example() {
     });
   }
 
-  const pointerEnd = (e: GesturePointerEvent, manager: GestureStateManager) => {
+  const touchEnd = (e: GestureTouchEvent, manager: GestureStateManager) => {
     'worklet';
-    for (const pointer of e.pointerData) {
-      trackedPointers[pointer.pointerId].value = {
+    for (const touch of e.touches) {
+      trackedPointers[touch.id].value = {
         visible: false,
-        x: pointer.x,
-        y: pointer.y,
+        x: touch.x,
+        y: touch.y,
       };
     }
 
@@ -66,13 +66,13 @@ export default function Example() {
   };
 
   const gesture = Gesture.Custom()
-    .onPointerDown((e, manager) => {
+    .onTouchesDown((e, manager) => {
       'worklet';
-      for (const pointer of e.pointerData) {
-        trackedPointers[pointer.pointerId].value = {
+      for (const touch of e.touches) {
+        trackedPointers[touch.id].value = {
           visible: true,
-          x: pointer.x,
-          y: pointer.y,
+          x: touch.x,
+          y: touch.y,
         };
       }
 
@@ -80,18 +80,18 @@ export default function Example() {
         manager.activate();
       }
     })
-    .onPointerMove((e, _manager) => {
+    .onTouchesMove((e, _manager) => {
       'worklet';
-      for (const pointer of e.pointerData) {
-        trackedPointers[pointer.pointerId].value = {
+      for (const touch of e.touches) {
+        trackedPointers[touch.id].value = {
           visible: true,
-          x: pointer.x,
-          y: pointer.y,
+          x: touch.x,
+          y: touch.y,
         };
       }
     })
-    .onPointerUp(pointerEnd)
-    .onPointerCancelled(pointerEnd)
+    .onTouchesUp(touchEnd)
+    .onTouchesCancelled(touchEnd)
     .onStart(() => {
       'worklet';
       active.value = true;

--- a/examples/Example/src/new_api/pointer_tracker/index.tsx
+++ b/examples/Example/src/new_api/pointer_tracker/index.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import {
+  GestureDetector,
+  Gesture,
+  GestureStateManager,
+  GesturePointerEvent,
+} from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+
+interface Pointer {
+  visible: boolean;
+  x: number;
+  y: number;
+}
+
+function PointerElement(props: {
+  pointer: Animated.SharedValue<Pointer>;
+  active: Animated.SharedValue<boolean>;
+}) {
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: props.pointer.value.x },
+      { translateY: props.pointer.value.y },
+      {
+        scale:
+          (props.pointer.value.visible ? 1 : 0) *
+          (props.active.value ? 1.3 : 1),
+      },
+    ],
+    backgroundColor: props.active.value ? 'red' : 'blue',
+  }));
+
+  return <Animated.View style={[styles.pointer, animatedStyle]} />;
+}
+
+export default function Example() {
+  const trackedPointers: Animated.SharedValue<Pointer>[] = [];
+  const active = useSharedValue(false);
+
+  for (let i = 0; i < 12; i++) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    trackedPointers[i] = useSharedValue<Pointer>({
+      visible: false,
+      x: 0,
+      y: 0,
+    });
+  }
+
+  const pointerEnd = (e: GesturePointerEvent, manager: GestureStateManager) => {
+    'worklet';
+    for (const pointer of e.pointerData) {
+      trackedPointers[pointer.pointerId].value = {
+        visible: false,
+        x: pointer.x,
+        y: pointer.y,
+      };
+    }
+
+    if (e.numberOfPointers === 0) {
+      manager.end();
+    }
+  };
+
+  const gesture = Gesture.Custom()
+    .onPointerDown((e, manager) => {
+      'worklet';
+      for (const pointer of e.pointerData) {
+        trackedPointers[pointer.pointerId].value = {
+          visible: true,
+          x: pointer.x,
+          y: pointer.y,
+        };
+      }
+
+      if (e.numberOfPointers >= 2) {
+        manager.activate();
+      }
+    })
+    .onPointerMove((e, _manager) => {
+      'worklet';
+      for (const pointer of e.pointerData) {
+        trackedPointers[pointer.pointerId].value = {
+          visible: true,
+          x: pointer.x,
+          y: pointer.y,
+        };
+      }
+    })
+    .onPointerUp(pointerEnd)
+    .onPointerCancelled(pointerEnd)
+    .onStart(() => {
+      'worklet';
+      active.value = true;
+    })
+    .onEnd(() => {
+      'worklet';
+      active.value = false;
+    });
+
+  return (
+    <GestureDetector animatedGesture={gesture}>
+      <Animated.View style={styles.container}>
+        {trackedPointers.map((pointer, index) => (
+          // eslint-disable-next-line react/no-array-index-key
+          <PointerElement pointer={pointer} active={active} key={index} />
+        ))}
+      </Animated.View>
+    </GestureDetector>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  pointer: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: 'red',
+    position: 'absolute',
+    marginStart: -30,
+    marginTop: -30,
+  },
+});

--- a/examples/Example/src/new_api/square/index.tsx
+++ b/examples/Example/src/new_api/square/index.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { StyleSheet } from 'react-native';
+import {
+  GestureDetector,
+  Gesture,
+  GesturePointerEvent,
+  GestureStateManager,
+} from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
+
+export default function Example() {
+  const state = useSharedValue(0);
+  const active = useSharedValue(false);
+
+  const pointerEnd = (e: GesturePointerEvent, manager: GestureStateManager) => {
+    'worklet';
+    if (e.pointerData.find((e) => e.pointerId === 0)) {
+      if (e.state === 4) {
+        manager.end();
+      } else {
+        manager.fail();
+      }
+    }
+  };
+
+  const gesture = Gesture.Custom()
+    .onPointerDown((e, manager) => {
+      'worklet';
+      if (e.pointerData.find((e) => e.pointerId === 0) !== undefined) {
+        state.value = 0;
+        manager.begin();
+      }
+    })
+    .onPointerChange((e) => {
+      'worklet';
+      console.log(e);
+    })
+    .onPointerUp(pointerEnd)
+    .onPointerCancelled(pointerEnd)
+    .onPointerMove((e, manager) => {
+      'worklet';
+      if (e.state === 4) {
+        return;
+      }
+      const pointer = e.pointerData.find((e) => e.pointerId === 0)!;
+      switch (state.value) {
+        case 0:
+          if (pointer?.x > 50 || pointer.y > 300) {
+            manager.fail();
+          } else if (pointer.y > 250) {
+            state.value++;
+          }
+          break;
+        case 1:
+          if (pointer.x > 300 || pointer.y > 300 || pointer.y < 250) {
+            manager.fail();
+          } else if (pointer.x > 250) {
+            state.value++;
+          }
+          break;
+        case 2:
+          if (pointer.x > 300 || pointer.x < 250 || pointer.y > 300) {
+            manager.fail();
+          } else {
+            if (pointer.y < 50) {
+              state.value++;
+            }
+          }
+          break;
+        case 3:
+          if (pointer.x > 300 || pointer.y > 50) {
+            manager.fail();
+          } else if (pointer.x < 50) {
+            manager.activate();
+          }
+          break;
+      }
+    })
+    .onBegan(() => {
+      'worklet';
+      console.log('begin');
+    })
+    .onStart(() => {
+      'worklet';
+      active.value = true;
+      console.log('active');
+    })
+    .onEnd(() => {
+      'worklet';
+      active.value = false;
+      console.log('end');
+    });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    backgroundColor: active.value ? 'red' : 'transparent',
+  }));
+
+  return (
+    <GestureDetector animatedGesture={gesture}>
+      <Animated.View style={[styles.container, animatedStyle]}>
+        <Animated.View style={styles.square} />
+      </Animated.View>
+    </GestureDetector>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+  square: {
+    margin: 50,
+    width: 200,
+    height: 200,
+    backgroundColor: 'rgba(255, 0, 0, 0.1)',
+  },
+});

--- a/examples/Example/src/new_api/square/index.tsx
+++ b/examples/Example/src/new_api/square/index.tsx
@@ -3,7 +3,7 @@ import { StyleSheet } from 'react-native';
 import {
   GestureDetector,
   Gesture,
-  GesturePointerEvent,
+  GestureTouchEvent,
   GestureStateManager,
 } from 'react-native-gesture-handler';
 import Animated, {
@@ -15,9 +15,9 @@ export default function Example() {
   const state = useSharedValue(0);
   const active = useSharedValue(false);
 
-  const pointerEnd = (e: GesturePointerEvent, manager: GestureStateManager) => {
+  const touchEnd = (e: GestureTouchEvent, manager: GestureStateManager) => {
     'worklet';
-    if (e.pointerData.find((e) => e.pointerId === 0)) {
+    if (e.touches.find((e) => e.id === 0)) {
       if (e.state === 4) {
         manager.end();
       } else {
@@ -27,25 +27,21 @@ export default function Example() {
   };
 
   const gesture = Gesture.Custom()
-    .onPointerDown((e, manager) => {
+    .onTouchesDown((e, manager) => {
       'worklet';
-      if (e.pointerData.find((e) => e.pointerId === 0) !== undefined) {
+      if (e.touches.find((e) => e.id === 0) !== undefined) {
         state.value = 0;
         manager.begin();
       }
     })
-    .onPointerChange((e) => {
-      'worklet';
-      console.log(e);
-    })
-    .onPointerUp(pointerEnd)
-    .onPointerCancelled(pointerEnd)
-    .onPointerMove((e, manager) => {
+    .onTouchesUp(touchEnd)
+    .onTouchesCancelled(touchEnd)
+    .onTouchesMove((e, manager) => {
       'worklet';
       if (e.state === 4) {
         return;
       }
-      const pointer = e.pointerData.find((e) => e.pointerId === 0)!;
+      const pointer = e.touches.find((e) => e.id === 0)!;
       switch (state.value) {
         case 0:
           if (pointer?.x > 50 || pointer.y > 300) {


### PR DESCRIPTION
## Description

This PR adds examples making use of the new pointer events and manual activation:
- LongPress and drag - I think the name is self-explanatory
- Pointer tracker - Displays position of the pointers on the screen. The custom gesture activates when there are at least two pointers on the screen, changing the color of indicators.
- Square - Simple gesture that detects when a square is drawn (there is a helper component displayed on the screen, just move the pointer around it starting from the upper-left corner.

## Test plan

Needs to be tested when all the parts are merged together.
