### PR TITLE
Fix race condition between the orchestrator and the registry

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -344,11 +344,13 @@ class GestureHandlerOrchestrator(
         val parentViewGroup: ViewGroup = parent
 
         handlerRegistry.getHandlersForView(parent)?.let {
-          for (handler in it) {
-            if (handler.isEnabled && handler.isWithinBounds(view, coords[0], coords[1])) {
-              found = true
-              recordHandlerIfNotPresent(handler, parentViewGroup)
-              handler.startTrackingPointer(pointerId)
+          synchronized(it) {
+            for (handler in it) {
+              if (handler.isEnabled && handler.isWithinBounds(view, coords[0], coords[1])) {
+                found = true
+                recordHandlerIfNotPresent(handler, parentViewGroup)
+                handler.startTrackingPointer(pointerId)
+              }
             }
           }
         }
@@ -363,13 +365,13 @@ class GestureHandlerOrchestrator(
   private fun recordViewHandlersForPointer(view: View, coords: FloatArray, pointerId: Int): Boolean {
     var found = false
     handlerRegistry.getHandlersForView(view)?.let {
-      val size = it.size
-      for (i in 0 until size) {
-        val handler = it[i]
-        if (handler.isEnabled && handler.isWithinBounds(view, coords[0], coords[1])) {
-          recordHandlerIfNotPresent(handler, view)
-          handler.startTrackingPointer(pointerId)
-          found = true
+      synchronized(it) {
+        for (handler in it) {
+          if (handler.isEnabled && handler.isWithinBounds(view, coords[0], coords[1])) {
+            recordHandlerIfNotPresent(handler, view)
+            handler.startTrackingPointer(pointerId)
+            found = true
+          }
         }
       }
     }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
@@ -42,7 +42,9 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
       listToAdd.add(handler)
       handlersForView.put(viewTag, listToAdd)
     } else {
-      listToAdd.add(handler)
+      synchronized(listToAdd) {
+        listToAdd.add(handler)
+      }
     }
   }
 
@@ -53,7 +55,10 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
       attachedTo.remove(handler.tag)
       val attachedHandlers = handlersForView[attachedToView]
       if (attachedHandlers != null) {
-        attachedHandlers.remove(handler)
+        synchronized(attachedHandlers) {
+          attachedHandlers.remove(handler)
+        }
+
         if (attachedHandlers.size == 0) {
           handlersForView.remove(attachedToView)
         }


### PR DESCRIPTION
## Description

Should fix https://github.com/software-mansion/react-native-gesture-handler/issues/1639

The `IndexOutOfBoundsException` was thrown at line 387:
https://github.com/software-mansion/react-native-gesture-handler/blob/0343428d3d27e71c7996dc9c6c7130b26713cebf/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.java#L383-L388
So the `handlers` collection must have been modified in other place and the registry is the only class that modifies it. My guess is that the handler was dropped or removed from view and relevant method was called (asynchronously) 
causing the list to be modified while it was being iterated over. This PR locks the list while it's being modified or iterated over.

## Test plan

I couldn't reproduce the issue, but I tested the changes on the Example app and it works correctly.
