### PR TITLE
Fix buttons not grabbing responder in some cases

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -290,6 +290,15 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>() {
     }
 
     override fun setPressed(pressed: Boolean) {
+      // there is a possibility of this method being called before NativeViewGestureHandler has
+      // opportunity to call canStart, in that case we need to grab responder in case the gesture
+      // will activate
+      // when canStart is called eventually, tryGrabbingResponder will return true if the button
+      // already is a responder
+      if (pressed) {
+        tryGrabbingResponder()
+      }
+
       // button can be pressed alongside other button if both are non-exclusive and it doesn't have
       // any pressed children (to prevent pressing the parent when children is pressed).
       val canBePressedAlongsideOther = !exclusive && responder?.exclusive != true && !isChildTouched()


### PR DESCRIPTION
## Description

In https://github.com/software-mansion/react-native-gesture-handler/pull/1601 I have moved the logic of grabbing the button responder to the `canStart` method, which is called by the `NativeViewGestureHandler` before it transition to the `BEGAN` state. I missed the fact that `onTouchEvent` is called by the `onInterceptTouchEvent` which in turn is called by the `NativeViewGestureHandler` before `canStart`, thus making it possible for `setPressed` to be called before the button grabs the responder. This caused the button not calling `super.setPressed` and handler not changing state and not calling `onPress`.

This PR makes the button try to grab responder when `setPressed` is called with `pressed` set to `true`. If the try was successful, `super.setPressed` is called correctly. This doesn't break previous logic because `tryGrabbingResponder` returns `true` if the button already is the responder.

## Test plan

Tested on the Example app
