### PR TITLE
Fix min distance on Pan with custom activation criteria

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -112,11 +112,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
   }
 
   fun setMinDist(minDist: Float) = apply {
-    minDistSq = if (minDist == MAX_VALUE_IGNORE) {
-      defaultMinDistSq
-    } else {
-      minDist * minDist
-    }
+    minDistSq = minDist * minDist
   }
 
   fun setMinPointers(minPointers: Int) = apply {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -62,7 +62,6 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
 
   override fun resetConfig() {
     super.resetConfig()
-    minDistSq = MAX_VALUE_IGNORE
     activeOffsetXStart = MIN_VALUE_IGNORE
     activeOffsetXEnd = MAX_VALUE_IGNORE
     failOffsetXStart = MAX_VALUE_IGNORE
@@ -113,7 +112,11 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
   }
 
   fun setMinDist(minDist: Float) = apply {
-    minDistSq = minDist * minDist
+    minDistSq = if (minDist == MAX_VALUE_IGNORE) {
+      defaultMinDistSq
+    } else {
+      minDist * minDist
+    }
   }
 
   fun setMinPointers(minPointers: Int) = apply {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -146,65 +146,51 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) : ReactCont
     override fun configure(handler: PanGestureHandler, config: ReadableMap) {
       super.configure(handler, config)
       var hasCustomActivationCriteria = false
-      var minDistFromActivationCriteria = 0f
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_START)) {
-        handler.setFailOffsetXStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_X_START)))
-        hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MIN_VALUE
-      }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_END)) {
-        handler.setFailOffsetXEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_X_END)))
-        hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MIN_VALUE
-      }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)) {
-        handler.setFailOffsetYStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)))
-        hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MIN_VALUE
-      }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)) {
-        handler.setFailOffsetYEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)))
-        hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MIN_VALUE
-      }
-
       if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_START)) {
         handler.setActiveOffsetXStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_X_START)))
         hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MAX_VALUE
       }
       if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_END)) {
         handler.setActiveOffsetXEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_X_END)))
         hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MAX_VALUE
+      }
+      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_START)) {
+        handler.setFailOffsetXStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_X_START)))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_END)) {
+        handler.setFailOffsetXEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_X_END)))
+        hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_START)) {
         handler.setActiveOffsetYStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_Y_START)))
         hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MAX_VALUE
       }
       if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_END)) {
         handler.setActiveOffsetYEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_Y_END)))
         hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MAX_VALUE
       }
-
+      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)) {
+        handler.setFailOffsetYStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)) {
+        handler.setFailOffsetYEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)))
+        hasCustomActivationCriteria = true
+      }
       if (config.hasKey(KEY_PAN_MIN_VELOCITY)) {
         // This value is actually in DPs/ms, but we can use the same function as for converting
         // from DPs to pixels as the unit we're converting is in the numerator
         handler.setMinVelocity(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY)))
         hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MAX_VALUE
       }
       if (config.hasKey(KEY_PAN_MIN_VELOCITY_X)) {
         handler.setMinVelocityX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY_X)))
         hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MAX_VALUE
       }
       if (config.hasKey(KEY_PAN_MIN_VELOCITY_Y)) {
         handler.setMinVelocityY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY_Y)))
         hasCustomActivationCriteria = true
-        minDistFromActivationCriteria = Float.MAX_VALUE
       }
 
       // PanGestureHandler sets minDist by default, if there are custom criteria specified we want
@@ -212,7 +198,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) : ReactCont
       if (config.hasKey(KEY_PAN_MIN_DIST)) {
         handler.setMinDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_DIST)))
       } else if (hasCustomActivationCriteria) {
-        handler.setMinDist(minDistFromActivationCriteria)
+        handler.setMinDist(Float.MAX_VALUE)
       }
       if (config.hasKey(KEY_PAN_MIN_POINTERS)) {
         handler.setMinPointers(config.getInt(KEY_PAN_MIN_POINTERS))

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -146,51 +146,65 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) : ReactCont
     override fun configure(handler: PanGestureHandler, config: ReadableMap) {
       super.configure(handler, config)
       var hasCustomActivationCriteria = false
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_START)) {
-        handler.setActiveOffsetXStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_X_START)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_END)) {
-        handler.setActiveOffsetXEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_X_END)))
-        hasCustomActivationCriteria = true
-      }
+      var minDistFromActivationCriteria = 0f
       if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_START)) {
         handler.setFailOffsetXStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_X_START)))
         hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MIN_VALUE
       }
       if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_END)) {
         handler.setFailOffsetXEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_X_END)))
         hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_START)) {
-        handler.setActiveOffsetYStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_Y_START)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_END)) {
-        handler.setActiveOffsetYEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_Y_END)))
-        hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MIN_VALUE
       }
       if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)) {
         handler.setFailOffsetYStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)))
         hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MIN_VALUE
       }
       if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)) {
         handler.setFailOffsetYEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)))
         hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MIN_VALUE
       }
+
+      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_START)) {
+        handler.setActiveOffsetXStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_X_START)))
+        hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MAX_VALUE
+      }
+      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_END)) {
+        handler.setActiveOffsetXEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_X_END)))
+        hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MAX_VALUE
+      }
+      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_START)) {
+        handler.setActiveOffsetYStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_Y_START)))
+        hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MAX_VALUE
+      }
+      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_END)) {
+        handler.setActiveOffsetYEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_Y_END)))
+        hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MAX_VALUE
+      }
+
       if (config.hasKey(KEY_PAN_MIN_VELOCITY)) {
         // This value is actually in DPs/ms, but we can use the same function as for converting
         // from DPs to pixels as the unit we're converting is in the numerator
         handler.setMinVelocity(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY)))
         hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MAX_VALUE
       }
       if (config.hasKey(KEY_PAN_MIN_VELOCITY_X)) {
         handler.setMinVelocityX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY_X)))
         hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MAX_VALUE
       }
       if (config.hasKey(KEY_PAN_MIN_VELOCITY_Y)) {
         handler.setMinVelocityY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY_Y)))
         hasCustomActivationCriteria = true
+        minDistFromActivationCriteria = Float.MAX_VALUE
       }
 
       // PanGestureHandler sets minDist by default, if there are custom criteria specified we want
@@ -198,7 +212,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) : ReactCont
       if (config.hasKey(KEY_PAN_MIN_DIST)) {
         handler.setMinDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_DIST)))
       } else if (hasCustomActivationCriteria) {
-        handler.setMinDist(Float.MIN_VALUE)
+        handler.setMinDist(minDistFromActivationCriteria)
       }
       if (config.hasKey(KEY_PAN_MIN_POINTERS)) {
         handler.setMinPointers(config.getInt(KEY_PAN_MIN_POINTERS))

--- a/src/handlers/PanGestureHandler.ts
+++ b/src/handlers/PanGestureHandler.ts
@@ -305,6 +305,18 @@ function validatePanGestureHandlerProps(props: PanGestureHandlerProps) {
       `First element of failOffsetY should be negative, a the second one should be positive`
     );
   }
+
+  if (props.minDist && (props.failOffsetX || props.failOffsetY)) {
+    throw new Error(
+      `It is not supported to use minDist with failOffsetX or failOffsetY, use activeOffsetX and activeOffsetY instead`
+    );
+  }
+
+  if (props.minDist && (props.activeOffsetX || props.activeOffsetY)) {
+    throw new Error(
+      `It is not supported to use minDist with activeOffsetX or activeOffsetY`
+    );
+  }
 }
 
 function transformPanGestureHandlerProps(props: PanGestureHandlerProps) {


### PR DESCRIPTION
## Description

In https://github.com/software-mansion/react-native-gesture-handler/pull/1594 I have changed the default value of `minDist` with custom activation criteria from `Float.MAX_VALUE` to `Float.MIN_VALUE`. This fixed problems with `failOffset` set without `activeOffset` but broke `activeOffset` itself - in the `shouldActivate` method in PanGestureHandler the `minDist` prop is checked right after `activeOffset` and since the `minDist` was effectively 0 the handler would activate.

The simple fix would be to revert that PR, but I believe that setting only `failOffset` has some use cases (you could use it in tandem with `waitFor`) I changed the way props are parsed so that if only `failOffset` is set, the `minDist` will default to `Float.MIN_VALUE`, but if `activeOffset` or `minVelocity` is set the `minDist` will default to `Float.MAX_VALUE`.

In addition, I added a check in `setMinDist` in PanGestureHandler that sets the `minDistSq` to the default value if the method is called because of `failOffset`.

## Test plan

Tested on the Example app.
