### PR TITLE
Composed gestures callbacks

### DIFF
--- a/example/src/new_api/transformations/index.tsx
+++ b/example/src/new_api/transformations/index.tsx
@@ -15,6 +15,7 @@ function Photo() {
   const scale = useSharedValue(1);
   const savedRotation = useSharedValue(0);
   const rotation = useSharedValue(0);
+  const isTransforming = useSharedValue(false);
 
   const style = useAnimatedStyle(() => {
     return {
@@ -24,6 +25,7 @@ function Photo() {
         { scale: scale.value },
         { rotateZ: `${rotation.value}rad` },
       ],
+      backgroundColor: isTransforming.value ? 'red' : 'green',
     };
   });
 
@@ -74,7 +76,15 @@ function Photo() {
     scaleGesture,
     panGesture,
     doubleTapGesture
-  );
+  )
+    .onStart(() => {
+      'worklet';
+      isTransforming.value = true;
+    })
+    .onEnd(() => {
+      'worklet';
+      isTransforming.value = false;
+    });
 
   return (
     <GestureDetector gesture={gesture}>

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -79,6 +79,13 @@ export abstract class Gesture {
    * updating the handler on the native side.
    */
   abstract prepare(): void;
+
+  // The only thing done with the argument is a check whether it has a __workletHash property
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  protected isWorklet(callback: Function) {
+    // @ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
+    return callback.__workletHash !== undefined;
+  }
 }
 
 export abstract class BaseGesture<
@@ -105,17 +112,6 @@ export abstract class BaseGesture<
   withRef(ref: React.MutableRefObject<GestureType>) {
     this.config.ref = ref;
     return this;
-  }
-
-  protected isWorklet(
-    callback:
-      | ((event: UnwrappedGestureHandlerEvent<EventPayloadT>) => void)
-      | ((
-          event: UnwrappedGestureHandlerStateChangeEvent<EventPayloadT>
-        ) => void)
-  ) {
-    //@ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
-    return callback.__workletHash !== undefined;
   }
 
   onBegan(

--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -18,7 +18,6 @@ function extendRelation(
 }
 
 export interface ComposedGestureCallbacks {
-  onBegan?: () => void;
   onStart?: () => void;
   onEnd?: () => void;
   isWorklet: boolean[];
@@ -40,12 +39,6 @@ export class ComposedGesture extends Gesture {
   constructor(...gestures: Gesture[]) {
     super();
     this.gestures = gestures;
-  }
-
-  onBegan(callback: () => void) {
-    this.callbacks.onBegan = callback;
-    this.callbacks.isWorklet[CALLBACK_TYPE.BEGAN] = this.isWorklet(callback);
-    return this;
   }
 
   onStart(callback: () => void) {

--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -1,4 +1,10 @@
-import { BaseGesture, Gesture, GestureRef, GestureType } from './gesture';
+import {
+  BaseGesture,
+  CALLBACK_TYPE,
+  Gesture,
+  GestureRef,
+  GestureType,
+} from './gesture';
 
 function extendRelation(
   currentRelation: GestureRef[] | undefined,
@@ -12,7 +18,10 @@ function extendRelation(
 }
 
 export interface ComposedGestureCallbacks {
+  onBegan?: () => void;
+  onStart?: () => void;
   onEnd?: () => void;
+  isWorklet: boolean[];
 }
 
 export interface ComposedGestureConfiguration {
@@ -24,11 +33,31 @@ export class ComposedGesture extends Gesture {
   public gestures: Gesture[] = [];
   protected simultaneousGestures: GestureType[] = [];
   protected requireGesturesToFail: GestureType[] = [];
-  public callbacks: ComposedGestureCallbacks = {};
+  public callbacks: ComposedGestureCallbacks = {
+    isWorklet: [false, false, false, false],
+  };
 
   constructor(...gestures: Gesture[]) {
     super();
     this.gestures = gestures;
+  }
+
+  onBegan(callback: () => void) {
+    this.callbacks.onBegan = callback;
+    this.callbacks.isWorklet[CALLBACK_TYPE.BEGAN] = this.isWorklet(callback);
+    return this;
+  }
+
+  onStart(callback: () => void) {
+    this.callbacks.onStart = callback;
+    this.callbacks.isWorklet[CALLBACK_TYPE.START] = this.isWorklet(callback);
+    return this;
+  }
+
+  onEnd(callback: () => void) {
+    this.callbacks.onEnd = callback;
+    this.callbacks.isWorklet[CALLBACK_TYPE.END] = this.isWorklet(callback);
+    return this;
   }
 
   protected prepareSingleGesture(

--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -11,10 +11,20 @@ function extendRelation(
   }
 }
 
+export interface ComposedGestureCallbacks {
+  onEnd?: () => void;
+}
+
+export interface ComposedGestureConfiguration {
+  callbacks: ComposedGestureCallbacks;
+  requiredHandlers: number[];
+}
+
 export class ComposedGesture extends Gesture {
-  protected gestures: Gesture[] = [];
+  public gestures: Gesture[] = [];
   protected simultaneousGestures: GestureType[] = [];
   protected requireGesturesToFail: GestureType[] = [];
+  public callbacks: ComposedGestureCallbacks = {};
 
   constructor(...gestures: Gesture[]) {
     super();

--- a/src/handlers/handlersRegistry.ts
+++ b/src/handlers/handlersRegistry.ts
@@ -1,7 +1,9 @@
 import { GestureType } from './gestures/gesture';
+import { ComposedGestureConfiguration } from './gestures/gestureComposition';
 
 export const handlerIDToTag: Record<string, number> = {};
 const handlers = new Map<number, GestureType>();
+const composedCallbacks: ComposedGestureConfiguration[] = [];
 
 let handlerTag = 1;
 
@@ -19,4 +21,62 @@ export function unregisterHandler(handlerTag: number) {
 
 export function findHandler(handlerTag: number) {
   return handlers.get(handlerTag);
+}
+
+export function setComposedGestureCallbacks(
+  configurations: ComposedGestureConfiguration[]
+) {
+  for (const config of configurations) {
+    const index = indexOfComposedGestureCallbacks(config);
+    if (index === -1) {
+      composedCallbacks.push(config);
+    } else {
+      composedCallbacks[index] = config;
+    }
+  }
+}
+
+export function dropComposedGestureCallbacks(
+  configurations: ComposedGestureConfiguration[]
+) {
+  for (const config of configurations) {
+    const index = indexOfComposedGestureCallbacks(config);
+    if (index !== -1) {
+      composedCallbacks.splice(index, 1);
+    }
+  }
+}
+
+export function getComposedCallbacksForHandler(tag: number) {
+  const result = [];
+
+  for (const config of composedCallbacks) {
+    if (config.requiredHandlers.includes(tag)) {
+      result.push(config);
+    }
+  }
+
+  return result;
+}
+
+function indexOfComposedGestureCallbacks(config: ComposedGestureConfiguration) {
+  for (let i = 0; i < composedCallbacks.length; i++) {
+    const other = composedCallbacks[i];
+
+    if (other.requiredHandlers.length === config.requiredHandlers.length) {
+      let isTheSame = true;
+      for (const tag of config.requiredHandlers) {
+        if (!other.requiredHandlers.includes(tag)) {
+          isTheSame = false;
+          break;
+        }
+      }
+
+      if (isTheSame) {
+        return i;
+      }
+    }
+  }
+
+  return -1;
 }


### PR DESCRIPTION
## Description

Added `onStart` and `onEnd` callbacks to composed gestures.
`onStart` is called whenever the first gesture provided to the composed gesture activates. (First in order of activation not the arguments passed.)
`onEnd` is called when the last of the gestures that have began or activated finishes. Note that `onEnd` may be called even if the `onStart` was not because gestures that have began may finish before activating.

## Test plan

Updated example and tested on the Example app
