### PR TITLE
Propose Expo integration for RNGestureHandlerEnabledRootView

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,5 @@
 apply plugin: 'com.android.library'
+apply from: './expo/linking.gradle'
 
 def safeExtGet(prop, fallback) {
     rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback

--- a/android/expo/linking.gradle
+++ b/android/expo/linking.gradle
@@ -1,0 +1,20 @@
+def isExpoLinked = false
+rootProject.getSubprojects().forEach({ project ->
+    if (project.plugins.hasPlugin("com.android.application")) {
+        if (project.configurations.implementation.getDependencies().find { dep -> dep.name == "expo" }) {
+            isExpoLinked = true
+        }
+    }
+})
+
+if (isExpoLinked) {
+    android {
+        sourceSets {
+            main.java.srcDirs += 'expo/src/main/java'
+        }
+    }
+
+    dependencies {
+        implementation project(':expo-modules-core')
+    }
+}

--- a/android/expo/src/main/java/expo/modules/adapters/gesturehandler/EXGestureHandlerPackage.java
+++ b/android/expo/src/main/java/expo/modules/adapters/gesturehandler/EXGestureHandlerPackage.java
@@ -1,0 +1,28 @@
+package expo.modules.adapters.gesturehandler;
+
+import android.app.Activity;
+import android.content.Context;
+import android.os.Bundle;
+
+import com.facebook.react.ReactRootView;
+import com.swmansion.gesturehandler.react.RNGestureHandlerEnabledRootView;
+
+import java.util.Collections;
+import java.util.List;
+
+import expo.modules.core.interfaces.Package;
+import expo.modules.core.interfaces.ReactActivityHandler;
+
+public class EXGestureHandlerPackage implements Package {
+    @Override
+    public List<ReactActivityHandler> createReactActivityHandlers(Context activityContext) {
+        final ReactActivityHandler handler = new ReactActivityHandler() {
+            @Override
+            public ReactRootView createReactRootView(Activity activity) {
+                return new RNGestureHandlerEnabledRootView(activity);
+            }
+        };
+
+        return Collections.singletonList(handler);
+    }
+}

--- a/expo-module.config.json
+++ b/expo-module.config.json
@@ -1,0 +1,4 @@
+{
+  "name": "react-native-gesture-handler",
+  "platforms": ["android"]
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "DrawerLayout/",
     "README.md",
     "jestSetup.js",
-    "RNGestureHandler.podspec"
+    "RNGestureHandler.podspec",
+    "expo-module.config.json"
   ],
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Description

Previously, to support gesture-handler in Expo SDK, we had gesture-handler builtin in our template even user don't use it. In newer SDK, we plan to support native modules as opt-in without extra setup; we proposed https://github.com/expo/expo/pull/14883 and it is for gesture-handler integration.

I know `RNGestureHandlerEnabledRootView` is going to deprecate in 2.0. Do you have any timeline of when will be 2.0 available? Otherwise, please consider having change in 1.x release. This pr is actually branched from tag `1.10.3`

## Test plan

## Test Expo integration

[demo repo](https://github.com/Kudo/ExpoAndroidWrapper) which based on expo sdk43 bare template with additional changes:
1. adapts https://github.com/expo/expo/pull/14883 patch because it doesn't publish yet.
2. remove `RNGestureHandlerEnabledRootView` from MainActivity.java
3. add this pr's patch by patch-package.

## Test classic RN app without Expo
makes sure not to break existing functionalities

```sh
$ npx react-native init RN066 --version 0.66
$ yarn add react-native-gesture-handler
# patch this pr's change into node_modules/react-native-gesture-handler
$ ./gradlew :app:assembleDebug
```



