### PR TITLE
Fix links in docs

### DIFF
--- a/docs/docs/about-handlers.md
+++ b/docs/docs/about-handlers.md
@@ -72,9 +72,7 @@ class Multitap extends Component {
 
 ### Using native components
 
-<!-- TODO Add page for NativeViewGH -->
-
-Gesture handler library exposes a set of components normally available in React Native that are wrapped in [`NativeViewGestureHandler`](#).
+Gesture handler library exposes a set of components normally available in React Native that are wrapped in [`NativeViewGestureHandler`](api/gesture-handlers/nativeview-gh.md).
 Here is a list of exposed components:
 
 - `ScrollView`

--- a/docs/docs/api/components/swipeable.md
+++ b/docs/docs/api/components/swipeable.md
@@ -131,7 +131,7 @@ method that opens component on right side.
 
 ### Example:
 
-See the [swipeable example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/swipeable/index.tsx) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
+See the [swipeable example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/showcase/swipeable/index.tsx) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 import React, { Component } from 'react';

--- a/docs/docs/api/components/touchables.md
+++ b/docs/docs/api/components/touchables.md
@@ -45,4 +45,4 @@ import {
 } from 'react-native-gesture-handler';
 ```
 
-For a comparison of both touchable implementations see our [touchables example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/touchables/index.tsx)
+For a comparison of both touchable implementations see our [touchables example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/release_tests/touchables/index.tsx)

--- a/docs/docs/api/gesture-handlers/fling-gh.md
+++ b/docs/docs/api/gesture-handlers/fling-gh.md
@@ -54,7 +54,7 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ## Example
 
-See the [fling example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/fling/index.tsx) from [GestureHandler Example App](../../example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
+See the [fling example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/release_tests/fling/index.tsx) from [GestureHandler Example App](../../example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 const LongPressButton = () => (

--- a/docs/docs/api/gesture-handlers/force-gh.md
+++ b/docs/docs/api/gesture-handlers/force-gh.md
@@ -45,7 +45,7 @@ You may check if it's possible to use `ForceTouchGestureHandler` with `ForceTouc
 
 ## Example
 
-See the [force touch handler example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/forcetouch/index.tsx) from [GestureHandler Example App](../../example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
+See the [force touch handler example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/basic/forcetouch/index.tsx) from [GestureHandler Example App](../../example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 <ForceTouchGestureHandler

--- a/docs/docs/api/gesture-handlers/longpress-gh.md
+++ b/docs/docs/api/gesture-handlers/longpress-gh.md
@@ -8,7 +8,7 @@ A discrete gesture handler that activates when the corresponding view is pressed
 This handler's state will turn into [END](../../state.md#end) immediately after the finger is released.
 The handler will fail to recognize a touch event if the finger is lifted before the [minimum required time](#mindurationms) or if the finger is moved further than the [allowable distance](#maxdist).
 
-The handler is implemented using [UILongPressGestureRecognizer](https://developer.apple.com/documentation/uikit/uilongpressgesturerecognizer) on iOS and [LongPressGestureHandler](https://github.com/software-mansion/react-native-gesture-handler/blob/master/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.java) on Android.
+The handler is implemented using [UILongPressGestureRecognizer](https://developer.apple.com/documentation/uikit/uilongpressgesturerecognizer) on iOS and [LongPressGestureHandler](https://github.com/software-mansion/react-native-gesture-handler/blob/master/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.kt) on Android.
 
 ## Properties
 
@@ -45,9 +45,10 @@ Y coordinate, expressed in points, of the current position of the pointer (finge
 ### `duration`
 
 Duration of the long press (time since the start of the event), expressed in milliseconds.
+
 ## Example
 
-See the [multitap example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/multitap/index.tsx) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
+See the [multitap example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/basic/multitap/index.tsx) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 const LongPressButton = () => (

--- a/docs/docs/api/gesture-handlers/pan-gh.md
+++ b/docs/docs/api/gesture-handlers/pan-gh.md
@@ -12,7 +12,7 @@ Configurations such as a minimum initial distance, specific vertical or horizont
 
 Gesture callback can be used for continuous tracking of the pan gesture. It provides information about the gesture such as its XY translation from the starting point as well as its instantaneous velocity.
 
-The handler is implemented using [UIPanGestureRecognizer](https://developer.apple.com/documentation/uikit/uipangesturerecognizer) on iOS and [PanGestureHandler](https://github.com/software-mansion/react-native-gesture-handler/blob/master/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.java) on Android.
+The handler is implemented using [UIPanGestureRecognizer](https://developer.apple.com/documentation/uikit/uipangesturerecognizer) on iOS and [PanGestureHandler](https://github.com/software-mansion/react-native-gesture-handler/blob/master/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt) on Android.
 
 ## Custom activation criteria
 
@@ -159,7 +159,7 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ## Example
 
-See the [draggable example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/draggable/index.tsx) from [GestureHandler Example App](../../example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
+See the [draggable example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/basic/draggable/index.tsx) from [GestureHandler Example App](../../example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 const circleRadius = 30;

--- a/docs/docs/api/gesture-handlers/pinch-gh.md
+++ b/docs/docs/api/gesture-handlers/pinch-gh.md
@@ -41,7 +41,7 @@ Position expressed in points along Y axis of center anchor point of gesture
 
 ## Example
 
-See the [scale and rotation example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/scaleAndRotate/index.tsx) from [GestureHandler Example App](../../example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
+See the [scale and rotation example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/recipes/scaleAndRotate/index.tsx) from [GestureHandler Example App](../../example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 export class PinchableBox extends React.Component {

--- a/docs/docs/api/gesture-handlers/rotation-gh.md
+++ b/docs/docs/api/gesture-handlers/rotation-gh.md
@@ -38,7 +38,7 @@ Y coordinate, expressed in points, of the gesture's central focal point (anchor)
 
 ## Example
 
-See the [scale and rotation example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/scaleAndRotate/index.tsx) from [GestureHandler Example App](../../example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
+See the [scale and rotation example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/recipes/scaleAndRotate/index.tsx) from [GestureHandler Example App](../../example) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 class RotableBox extends React.Component {

--- a/docs/docs/api/gesture-handlers/tap-gh.md
+++ b/docs/docs/api/gesture-handlers/tap-gh.md
@@ -67,7 +67,7 @@ Y coordinate, expressed in points, of the current position of the pointer (finge
 
 ## Example
 
-See the [multitap example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/multitap/index.tsx) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
+See the [multitap example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/basic/multitap/index.tsx) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 export class PressBox extends Component {

--- a/docs/docs/example.md
+++ b/docs/docs/example.md
@@ -6,10 +6,10 @@ title: Running Example App
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import GifGallery from '@site/components/GifGallery'
 
-Example app code is located under [`Example/`](https://github.com/software-mansion/react-native-gesture-handler/tree/master/examples/Example) folder in the repo.
+Example app code is located under [`Example/`](https://github.com/software-mansion/react-native-gesture-handler/tree/master/example) folder in the repo.
 It showcases the majority of the Gesture Handler library features.
 The app consist of the list of single screen examples presenting the capabilities of the library.
-Each example is located under a separate folder under [`Example/`](https://github.com/software-mansion/react-native-gesture-handler/tree/master/examples/Example).
+Each example is located under a separate folder under [`Example/`](https://github.com/software-mansion/react-native-gesture-handler/tree/master/example).
 
 <GifGallery>
     <img src={useBaseUrl("gifs/sampleapp.gif")} width="180" height="320" />

--- a/docs/docs/interactions.md
+++ b/docs/docs/interactions.md
@@ -28,7 +28,7 @@ In this case we would use a [`PinchGestureHandler`](api/gesture-handlers/pinch-g
 
 ### Example
 
-See the ["Scale, rotate & tilt" example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/scaleAndRotate/index.tsx) from the [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
+See the ["Scale, rotate & tilt" example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/recipes/scaleAndRotate/index.tsx) from the [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 class PinchableBox extends React.Component {
@@ -76,7 +76,7 @@ Otherwise if we try to perform a double tap the single tap handler will fire jus
 
 ### Example
 
-See the ["Multitap" example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/examples/Example/src/multitap/index.tsx) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
+See the ["Multitap" example](https://github.com/software-mansion/react-native-gesture-handler/blob/master/example/src/basic/multitap/index.tsx) from [GestureHandler Example App](example.md) or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).
 
 ```js
 const doubleTap = React.createRef();


### PR DESCRIPTION
## Description

Removing Android native example and migration to Kotlin changed the project structure a bit and the docs haven't been updated to reflect that. This link updates links to github to point to the same places as before.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1703.

## Test plan

It compiled.
