### PR TITLE
Always extract ancestor handlers on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -366,7 +366,8 @@ class GestureHandlerOrchestrator(
     // been extracted (pointer might be in a child, but may be outside parent)
     // the other case is when one of the ancestors has a handler attached to it and has pointer-events
     // prop set to box-none, in which case its children can become target of the touch
-    if (extractAncestorHandlers(view, coords, pointerId)) {
+    if (coords[0] in 0f..view.width.toFloat() && coords[1] in 0f..view.height.toFloat() &&
+      extractAncestorHandlers(view, coords, pointerId)) {
         found = true
     }
 

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -366,8 +366,8 @@ class GestureHandlerOrchestrator(
     // been extracted (pointer might be in a child, but may be outside parent)
     // the other case is when one of the ancestors has a handler attached to it and has pointer-events
     // prop set to box-none, in which case its children can become target of the touch
-    if (coords[0] in 0f..view.width.toFloat() && coords[1] in 0f..view.height.toFloat() &&
-      extractAncestorHandlers(view, coords, pointerId)) {
+    if (coords[0] in 0f..view.width.toFloat() && coords[1] in 0f..view.height.toFloat()
+      && extractAncestorHandlers(view, coords, pointerId)) {
         found = true
     }
 


### PR DESCRIPTION
## Description

Currently handlers attached to the ancestors of a view are extracted only if the view overflows its parent as described in https://github.com/software-mansion/react-native-gesture-handler/pull/1618. There is at least one more use-case where that would be a desirable behavior: if the view has `pointer-events` prop set to `box-none` then the view itself cannot become the target of touch events but its children can, however currently any gesture handler attached to that view would not be extracted when its child captures a touch event.
An example of this can be found in this issue: https://github.com/software-mansion/react-native-gesture-handler/issues/1000 (note that this PR does not fully resolve this issue as there are more things to be addressed there).

## Test plan

Tested on the Example app and on slightly modified code from the linked issue (imported touchables and flatlist from `react-native-gesture-handler` instead of `react-native`).
