### PR TITLE
Update examples

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,6 +15,7 @@ import DoubleDraggable from './release_tests/doubleDraggable';
 import { ComboWithGHScroll } from './release_tests/combo';
 import { TouchablesIndex, TouchableExample } from './release_tests/touchables';
 import Rows from './release_tests/rows';
+import Fling from './release_tests/fling';
 import NestedTouchables from './release_tests/nestedTouchables';
 import NestedGestureHandlerRootViewWithModal from './release_tests/nestedGHRootViewWithModal';
 import { PinchableBox } from './recipes/scaleAndRotate';
@@ -22,7 +23,7 @@ import PanAndScroll from './recipes/panAndScroll';
 import { BottomSheet } from './showcase/bottomSheet';
 import Swipeables from './showcase/swipeable';
 import ChatHeads from './showcase/chatHeads';
-import { DraggableBox } from './basic/draggable';
+import Draggable from './basic/draggable';
 import MultiTap from './basic/multitap';
 import BouncingBox from './basic/bouncing';
 import PanResponder from './basic/panResponder';
@@ -43,7 +44,7 @@ const EXAMPLES: ExamplesSection[] = [
   {
     sectionTitle: 'Basic examples',
     data: [
-      { name: 'Draggable', component: DraggableBox },
+      { name: 'Draggable', component: Draggable },
       { name: 'Multitap', component: MultiTap },
       { name: 'Bouncing box', component: BouncingBox },
       { name: 'Pan responder', component: PanResponder },
@@ -85,6 +86,7 @@ const EXAMPLES: ExamplesSection[] = [
       { name: 'Double pinch & rotate', component: DoublePinchRotate },
       { name: 'Double draggable', component: DoubleDraggable },
       { name: 'Rows', component: Rows },
+      { name: 'Fling', component: Fling },
       { name: 'Combo', component: ComboWithGHScroll },
       { name: 'Touchables', component: TouchablesIndex as React.ComponentType },
     ],

--- a/example/src/basic/draggable/index.tsx
+++ b/example/src/basic/draggable/index.tsx
@@ -1,11 +1,12 @@
 import React, { Component } from 'react';
-import { Animated, StyleProp, StyleSheet, View, ViewStyle } from 'react-native';
+import { Animated, StyleProp, StyleSheet, ViewStyle } from 'react-native';
 
 import {
   PanGestureHandler,
   State,
   PanGestureHandlerStateChangeEvent,
   PanGestureHandlerGestureEvent,
+  ScrollView,
 } from 'react-native-gesture-handler';
 
 import { USE_NATIVE_DRIVER } from '../../config';
@@ -75,11 +76,11 @@ export class DraggableBox extends Component<DraggableBoxProps> {
 export default class Example extends Component {
   render() {
     return (
-      <View style={styles.scrollView}>
+      <ScrollView style={styles.scrollView}>
         <LoremIpsum words={40} />
         <DraggableBox />
         <LoremIpsum />
-      </View>
+      </ScrollView>
     );
   }
 }

--- a/example/src/release_tests/nestedGHRootViewWithModal/index.tsx
+++ b/example/src/release_tests/nestedGHRootViewWithModal/index.tsx
@@ -6,7 +6,7 @@ import {
   GestureHandlerRootView,
   TouchableOpacity,
 } from 'react-native-gesture-handler';
-import { DraggableBox } from '../basic/draggable';
+import { DraggableBox } from '../../basic/draggable';
 
 export default function App() {
   const [isModalVisible, setIsModalVisible] = useState(false);


### PR DESCRIPTION
## Description

Minor changes:
 - Fling example was not included on the list
 - Draggable was pointing to the draggable component instead of the example
 - Draggable example was wrapped in `View` instead of `ScrollView`
 - NestedGHRootWithModals example was not inside a directory like the rest of examples

## Test plan

Tested on the Example app.
