### PR TITLE
Rename pointerEvents to touchEvents

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -242,8 +242,8 @@ class GestureHandlerOrchestrator(
     // approach when we want to use pointer coordinates to calculate velocity or distance
     // for pinch so I don't know yet if we should transform or not...
     event.setLocation(coords[0], coords[1])
-    if (handler.needsPointerData) {
-      handler.updatePointerData(event)
+    if (handler.needsTouchData) {
+      handler.updateTouchData(event)
     }
 
     if (!handler.isAwaiting || action != MotionEvent.ACTION_MOVE) {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/OnTouchEventListener.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/OnTouchEventListener.kt
@@ -3,7 +3,7 @@ package com.swmansion.gesturehandler
 import android.view.MotionEvent
 
 interface OnTouchEventListener {
-  fun <T : GestureHandler<T>> onTouchEvent(handler: T, event: MotionEvent)
+  fun <T : GestureHandler<T>> onHandlerEvent(handler: T, event: MotionEvent)
   fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int)
-  fun <T : GestureHandler<T>> onPointerEvent(handler: T)
+  fun <T : GestureHandler<T>> onTouchEvent(handler: T)
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -30,8 +30,8 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
       if (config.hasKey(KEY_HIT_SLOP)) {
         handleHitSlopProperty(handler, config)
       }
-      if (config.hasKey(KEY_NEEDS_POINTER_DATA)) {
-        handler.needsPointerData = config.getBoolean(KEY_NEEDS_POINTER_DATA)
+      if (config.hasKey(KEY_NEEDS_TOUCH_DATA)) {
+        handler.needsTouchData = config.getBoolean(KEY_NEEDS_TOUCH_DATA)
       }
       if (config.hasKey(KEY_MANUAL_ACTIVATION)) {
         handler.setManualActivation(config.getBoolean(KEY_MANUAL_ACTIVATION))
@@ -301,7 +301,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
   }
 
   private val eventListener = object : OnTouchEventListener {
-    override fun <T : GestureHandler<T>> onTouchEvent(handler: T, event: MotionEvent) {
+    override fun <T : GestureHandler<T>> onHandlerEvent(handler: T, event: MotionEvent) {
       this@RNGestureHandlerModule.onTouchEvent(handler, event)
     }
 
@@ -309,7 +309,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
       this@RNGestureHandlerModule.onStateChange(handler, newState, oldState)
     }
 
-    override fun <T : GestureHandler<T>> onPointerEvent(handler: T) {
+    override fun <T : GestureHandler<T>> onTouchEvent(handler: T) {
       this@RNGestureHandlerModule.onPointerEvent(handler)
     }
   }
@@ -572,16 +572,16 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
     if (handler.state == GestureHandler.STATE_BEGAN || handler.state == GestureHandler.STATE_ACTIVE
         || handler.state == GestureHandler.STATE_UNDETERMINED || handler.view != null) {
       if (handler.usesDeviceEvents) {
-        val data = RNGestureHandlerPointerEvent.createEventData(handler)
+        val data = RNGestureHandlerTouchEvent.createEventData(handler)
 
         reactApplicationContext
             .deviceEventEmitter
-            .emit(RNGestureHandlerPointerEvent.EVENT_NAME, data)
+            .emit(RNGestureHandlerTouchEvent.EVENT_NAME, data)
       } else {
         reactApplicationContext
             .UIManager
             .eventDispatcher.let {
-              val event = RNGestureHandlerPointerEvent.obtain(handler)
+              val event = RNGestureHandlerTouchEvent.obtain(handler)
               it.dispatchEvent(event)
             }
       }
@@ -592,7 +592,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
     const val MODULE_NAME = "RNGestureHandlerModule"
     private const val KEY_SHOULD_CANCEL_WHEN_OUTSIDE = "shouldCancelWhenOutside"
     private const val KEY_ENABLED = "enabled"
-    private const val KEY_NEEDS_POINTER_DATA = "needsPointerData"
+    private const val KEY_NEEDS_TOUCH_DATA = "needsTouchData"
     private const val KEY_MANUAL_ACTIVATION = "manualActivation"
     private const val KEY_HIT_SLOP = "hitSlop"
     private const val KEY_HIT_SLOP_LEFT = "left"

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
@@ -7,7 +7,7 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 import com.swmansion.gesturehandler.GestureHandler
 
-class RNGestureHandlerPointerEvent private constructor() : Event<RNGestureHandlerPointerEvent>() {
+class RNGestureHandlerTouchEvent private constructor() : Event<RNGestureHandlerTouchEvent>() {
   private var extraData: WritableMap? = null
   private var coalescingKey: Short = 0
   private fun <T : GestureHandler<T>> init(handler: T) {
@@ -33,28 +33,28 @@ class RNGestureHandlerPointerEvent private constructor() : Event<RNGestureHandle
 
   companion object {
     const val EVENT_UNDETERMINED = 0
-    const val EVENT_POINTER_DOWN = 1
-    const val EVENT_POINTER_MOVE = 2
-    const val EVENT_POINTER_UP = 3
-    const val EVENT_POINTER_CANCELLED = 4
+    const val EVENT_TOUCHES_DOWN = 1
+    const val EVENT_TOUCHES_MOVE = 2
+    const val EVENT_TOUCHES_UP = 3
+    const val EVENT_TOUCHES_CANCELLED = 4
 
     const val EVENT_NAME = "onGestureHandlerEvent"
     private const val TOUCH_EVENTS_POOL_SIZE = 7 // magic
-    private val EVENTS_POOL = Pools.SynchronizedPool<RNGestureHandlerPointerEvent>(TOUCH_EVENTS_POOL_SIZE)
+    private val EVENTS_POOL = Pools.SynchronizedPool<RNGestureHandlerTouchEvent>(TOUCH_EVENTS_POOL_SIZE)
 
-    fun <T : GestureHandler<T>> obtain(handler: T): RNGestureHandlerPointerEvent =
-        (EVENTS_POOL.acquire() ?: RNGestureHandlerPointerEvent()).apply {
+    fun <T : GestureHandler<T>> obtain(handler: T): RNGestureHandlerTouchEvent =
+        (EVENTS_POOL.acquire() ?: RNGestureHandlerTouchEvent()).apply {
           init(handler)
         }
 
     fun <T: GestureHandler<T>> createEventData(handler: T,): WritableMap = Arguments.createMap().apply {
       putInt("handlerTag", handler.tag)
       putInt("state", handler.state)
-      putInt("numberOfPointers", handler.trackedPointersCount)
-      putInt("eventType", handler.pointerEventType)
+      putInt("numberOfPointers", handler.trackedTouchesCount)
+      putInt("eventType", handler.touchEventType)
 
-      handler.pointerEventPayload?.let {
-        putArray("pointerData", it)
+      handler.touchEventPayload?.let {
+        putArray("touchesData", it)
 
         if (handler.isAwaiting && handler.state == GestureHandler.STATE_ACTIVE) {
           putInt("state", GestureHandler.STATE_BEGAN)

--- a/ios/Handlers/RNFlingHandler.m
+++ b/ios/Handlers/RNFlingHandler.m
@@ -21,30 +21,30 @@
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesBegan:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesMoved:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesEnded:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesEnded:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesCancelled:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesCancelled:touches withEvent:event];
 }
 
 - (void)reset
 {
-  [_gestureHandler.pointerTracker reset];
+  [_gestureHandler.touchTracker reset];
   [super reset];
 }
 

--- a/ios/Handlers/RNForceTouchHandler.m
+++ b/ios/Handlers/RNForceTouchHandler.m
@@ -44,7 +44,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
     return;
   }
   [super touchesBegan:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesBegan:touches withEvent:event];
   
   _firstTouch = [touches anyObject];
   [self handleForceWithTouches:touches];
@@ -58,7 +58,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
     return;
   }
   [super touchesMoved:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesMoved:touches withEvent:event];
   
   [self handleForceWithTouches:touches];
   
@@ -99,7 +99,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
     return;
   }
   [super touchesEnded:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesEnded:touches withEvent:event];
   if (self.state == UIGestureRecognizerStateBegan || self.state == UIGestureRecognizerStateChanged) {
     self.state = UIGestureRecognizerStateEnded;
   } else {
@@ -110,7 +110,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesCancelled:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesCancelled:touches withEvent:event];
 }
 
 - (void)handleForceWithTouches:(NSSet<UITouch *> *)touches {
@@ -118,7 +118,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
 }
 
 - (void)reset {
-  [_gestureHandler.pointerTracker reset];
+  [_gestureHandler.touchTracker reset];
   [super reset];
   _force = 0;
   _firstTouch = NULL;

--- a/ios/Handlers/RNLongPressHandler.m
+++ b/ios/Handlers/RNLongPressHandler.m
@@ -50,13 +50,13 @@
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesBegan:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesMoved:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesMoved:touches withEvent:event];
   
   if (_gestureHandler.shouldCancelWhenOutside && ![_gestureHandler containsPointInView]) {
     self.enabled = NO;
@@ -67,18 +67,18 @@
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesEnded:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesEnded:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesCancelled:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesCancelled:touches withEvent:event];
 }
 
 - (void)reset
 {
-  [_gestureHandler.pointerTracker reset];
+  [_gestureHandler.touchTracker reset];
   [super reset];
 }
 

--- a/ios/Handlers/RNNativeViewHandler.m
+++ b/ios/Handlers/RNNativeViewHandler.m
@@ -30,31 +30,31 @@
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+    [_gestureHandler.touchTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
+    [_gestureHandler.touchTracker touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+    [_gestureHandler.touchTracker touchesEnded:touches withEvent:event];
     self.state = UIGestureRecognizerStateFailed;
     [self reset];
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
-    [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+    [_gestureHandler.touchTracker touchesCancelled:touches withEvent:event];
     self.state = UIGestureRecognizerStateCancelled;
     [self reset];
 }
 
 -(void)reset
 {
-  [_gestureHandler.pointerTracker reset];
+  [_gestureHandler.touchTracker reset];
   [super reset];
 }
 

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -79,13 +79,13 @@
   }
 #endif
   [super touchesBegan:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesMoved:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesMoved:touches withEvent:event];
   
   if (self.state == UIGestureRecognizerStatePossible && [self shouldFailUnderCustomCriteria]) {
     self.state = UIGestureRecognizerStateFailed;
@@ -118,18 +118,18 @@
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesEnded:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesEnded:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesCancelled:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesCancelled:touches withEvent:event];
 }
 
 - (void)reset
 {
-  [_gestureHandler.pointerTracker reset];
+  [_gestureHandler.touchTracker reset];
   self.enabled = YES;
   [super reset];
 }

--- a/ios/Handlers/RNPinchHandler.m
+++ b/ios/Handlers/RNPinchHandler.m
@@ -39,30 +39,30 @@
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesBegan:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesMoved:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesEnded:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesEnded:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesCancelled:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesCancelled:touches withEvent:event];
 }
 
 - (void)reset
 {
-  [_gestureHandler.pointerTracker reset];
+  [_gestureHandler.touchTracker reset];
   [super reset];
 }
 

--- a/ios/Handlers/RNRotationHandler.m
+++ b/ios/Handlers/RNRotationHandler.m
@@ -38,30 +38,30 @@
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesBegan:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesMoved:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesEnded:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesEnded:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesCancelled:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesCancelled:touches withEvent:event];
 }
 
 - (void)reset
 {
-  [_gestureHandler.pointerTracker reset];
+  [_gestureHandler.touchTracker reset];
   [super reset];
 }
 

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -72,7 +72,7 @@ static const NSTimeInterval defaultMaxDuration = NAN;
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesBegan:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesBegan:touches withEvent:event];
   
   if (_tapsSoFar == 0) {
     _initPosition = [self locationInView:self.view];
@@ -95,7 +95,7 @@ static const NSTimeInterval defaultMaxDuration = NAN;
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesMoved:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesMoved:touches withEvent:event];
   
   NSInteger numberOfTouches = [touches count];
   if (numberOfTouches > _maxNumberOfTouches) {
@@ -146,7 +146,7 @@ static const NSTimeInterval defaultMaxDuration = NAN;
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesEnded:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesEnded:touches withEvent:event];
   
   if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
     self.state = UIGestureRecognizerStateEnded;
@@ -159,7 +159,7 @@ static const NSTimeInterval defaultMaxDuration = NAN;
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesCancelled:touches withEvent:event];
-  [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [_gestureHandler.touchTracker touchesCancelled:touches withEvent:event];
   
   self.state = UIGestureRecognizerStateCancelled;
   [self reset];
@@ -167,7 +167,7 @@ static const NSTimeInterval defaultMaxDuration = NAN;
 
 - (void)reset
 {
-  [_gestureHandler.pointerTracker reset];
+  [_gestureHandler.touchTracker reset];
   
   if (self.state == UIGestureRecognizerStateFailed) {
     [self triggerAction];

--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -1,7 +1,7 @@
 #import "RNGestureHandlerState.h"
 #import "RNGestureHandlerDirection.h"
 #import "RNGestureHandlerEvents.h"
-#import "RNGestureHandlerPointerTracker.h"
+#import "RNGestureHandlerTouchTracker.h"
 
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
@@ -58,11 +58,11 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 @property (nonatomic, readonly, nonnull) NSNumber *tag;
 @property (nonatomic, weak, nullable) id<RNGestureHandlerEventEmitter> emitter;
 @property (nonatomic, readonly, nullable) UIGestureRecognizer *recognizer;
-@property (nonatomic, readonly, nullable) RNGestureHandlerPointerTracker *pointerTracker;
+@property (nonatomic, readonly, nullable) RNGestureHandlerTouchTracker *touchTracker;
 @property (nonatomic) BOOL enabled;
 @property (nonatomic) BOOL usesDeviceEvents;
 @property (nonatomic) BOOL shouldCancelWhenOutside;
-@property (nonatomic) BOOL needsPointerData;
+@property (nonatomic) BOOL needsTouchData;
 @property (nonatomic) BOOL manualActivation;
 
 - (void)bindToView:(nonnull UIView *)view;
@@ -80,7 +80,7 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
            forViewWithTag:(nonnull NSNumber *)reactTag
             withExtraData:(nonnull RNGestureHandlerEventExtraData *)extraData;
 - (void)sendStateChangeEvent:(nonnull RNGestureHandlerStateChange *)event;
-- (void)sendPointerEventInState:(RNGestureHandlerState)state
+- (void)sendTouchEventInState:(RNGestureHandlerState)state
                  forViewWithTag:(nonnull NSNumber *)reactTag;
 
 @end

--- a/ios/RNGestureHandlerEvents.h
+++ b/ios/RNGestureHandlerEvents.h
@@ -4,7 +4,7 @@
 #import <UIKit/UIKit.h>
 
 #import "RNGestureHandlerState.h"
-#import "RNPointerEventType.h"
+#import "RNTouchEventType.h"
 
 @interface RNGestureHandlerEventExtraData : NSObject
 
@@ -36,8 +36,8 @@
                                 withAnchorPoint:(CGPoint)anchorPoint
                                    withVelocity:(CGFloat)velocity
                             withNumberOfTouches:(NSUInteger)numberOfTouches;
-+ (RNGestureHandlerEventExtraData *)forEventType:(RNPointerEventType)eventType
-                                 withPointerData:(NSArray<NSDictionary *> *)data
++ (RNGestureHandlerEventExtraData *)forEventType:(RNTouchEventType)eventType
+                                 withTouchData:(NSArray<NSDictionary *> *)data
                              withNumberOfTouches:(NSUInteger)numberOfTouches;
 + (RNGestureHandlerEventExtraData *)forPointerInside:(BOOL)pointerInside;
 @end

--- a/ios/RNGestureHandlerEvents.m
+++ b/ios/RNGestureHandlerEvents.m
@@ -103,19 +103,19 @@
                            @"numberOfPointers": @(numberOfTouches)}];
 }
 
-+ (RNGestureHandlerEventExtraData *)forEventType:(RNPointerEventType)eventType
-                                 withPointerData:(NSArray<NSDictionary *> *)data
++ (RNGestureHandlerEventExtraData *)forEventType:(RNTouchEventType)eventType
+                                 withTouchData:(NSArray<NSDictionary *> *)data
                              withNumberOfTouches:(NSUInteger)numberOfTouches
 {
     if (data != nil) {
       return [[RNGestureHandlerEventExtraData alloc]
               initWithData:@{@"eventType": @(eventType),
-                             @"pointerData": data,
+                             @"touchesData": data,
                              @"numberOfPointers": @(numberOfTouches)}];
     } else {
       return [[RNGestureHandlerEventExtraData alloc]
-              initWithData:@{@"eventType": @(RNPointerEventTypeUndetermined),
-                             @"pointerData": @{},
+              initWithData:@{@"eventType": @(RNTouchEventTypeUndetermined),
+                             @"touchesData": @{},
                              @"numberOfPointers": @(numberOfTouches)}];
     }
 }

--- a/ios/RNGestureHandlerModule.m
+++ b/ios/RNGestureHandlerModule.m
@@ -163,7 +163,7 @@ RCT_EXPORT_METHOD(handleClearJSResponder)
   
   // if the gesture was set to finish, cancel all pointers it was tracking
   if (state == 1 || state == 3 || state == 5) {
-    [handler.pointerTracker cancelPointers];
+    [handler.touchTracker cancelTouches];
   }
   
   // do not send state change event when activating because it bypasses

--- a/ios/RNGestureHandlerTouchTracker.h
+++ b/ios/RNGestureHandlerTouchTracker.h
@@ -1,16 +1,16 @@
 #import <Foundation/Foundation.h>
 
-#import "RNPointerEventType.h"
+#import "RNTouchEventType.h"
 
-#define MAX_POINTERS_COUNT 12
+#define MAX_TOUCHES_COUNT 12
 
 @class RNGestureHandler;
 
-@interface RNGestureHandlerPointerTracker : NSObject
+@interface RNGestureHandlerTouchTracker : NSObject
 
-@property (nonatomic) RNPointerEventType eventType;
-@property (nonatomic) NSArray<NSDictionary *> *pointerData;
-@property (nonatomic) int trackedPointersCount;
+@property (nonatomic) RNTouchEventType eventType;
+@property (nonatomic) NSArray<NSDictionary *> *touchesData;
+@property (nonatomic) int trackedTouchesCount;
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
 
@@ -19,6 +19,6 @@
 - (void)touchesEnded:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
 - (void)touchesCancelled:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event;
 - (void)reset;
-- (void)cancelPointers;
+- (void)cancelTouches;
 
 @end

--- a/ios/RNPointerEventType.h
+++ b/ios/RNPointerEventType.h
@@ -1,9 +1,0 @@
-#import <Foundation/Foundation.h>
-
-typedef NS_ENUM(NSInteger, RNPointerEventType) {
-  RNPointerEventTypeUndetermined = 0,
-  RNPointerEventTypePointerDown,
-  RNPointerEventTypePointerMove,
-  RNPointerEventTypePointerUp,
-  RNPointerEventTypeCancelled,
-};

--- a/ios/RNTouchEventType.h
+++ b/ios/RNTouchEventType.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, RNTouchEventType) {
+  RNTouchEventTypeUndetermined = 0,
+  RNTouchEventTypeTouchesDown,
+  RNTouchEventTypeTouchesMove,
+  RNTouchEventTypeTouchesUp,
+  RNTouchEventTypeCancelled,
+};

--- a/src/EventType.ts
+++ b/src/EventType.ts
@@ -1,9 +1,9 @@
 export const EventType = {
   UNDETERMINED: 0,
-  POINTER_DOWN: 1,
-  POINTER_MOVE: 2,
-  POINTER_UP: 3,
-  POINTER_CANCELLED: 4,
+  TOUCHES_DOWN: 1,
+  TOUCHES_MOVE: 2,
+  TOUCHES_UP: 3,
+  TOUCHES_CANCELLED: 4,
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -34,7 +34,7 @@ export const baseGestureHandlerProps = [
 
 export const baseGestureHandlerWithMonitorProps = [
   ...commonProps,
-  'needsPointerData',
+  'needsTouchData',
   'manualActivation',
 ];
 
@@ -75,17 +75,17 @@ export interface HandlerStateChangeEvent<
   nativeEvent: Readonly<HandlerStateChangeEventPayload & ExtraEventPayloadT>;
 }
 
-export type PointerData = {
-  pointerId: number;
+export type TouchData = {
+  touchId: number;
   x: number;
   y: number;
   absoluteX: number;
   absoluteY: number;
 };
 
-export type GesturePointerEvent = GestureEventPayload & {
+export type GestureTouchEvent = GestureEventPayload & {
   eventType: EventType;
-  pointerData: PointerData[];
+  touchesData: TouchData[];
 };
 
 export type UnwrappedGestureHandlerEvent<

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -15,7 +15,7 @@ import {
   findNodeHandle,
   UnwrappedGestureHandlerEvent,
   UnwrappedGestureHandlerStateChangeEvent,
-  GesturePointerEvent,
+  GestureTouchEvent,
 } from '../gestureHandlerCommon';
 import {
   GestureStateManager,
@@ -231,20 +231,20 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
     event:
       | UnwrappedGestureHandlerEvent
       | UnwrappedGestureHandlerStateChangeEvent
-      | GesturePointerEvent
+      | GestureTouchEvent
   ): event is UnwrappedGestureHandlerStateChangeEvent {
     'worklet';
-    // @ts-ignore Yes, the oldState prop is missing on UnwrappedGestureHandlerPointerEvent,
+    // @ts-ignore Yes, the oldState prop is missing on GestureTouchEvent,
     // that's the point
     return event.oldState != null;
   }
 
-  function isPointerEvent(
+  function isTouchEvent(
     event:
       | UnwrappedGestureHandlerEvent
       | UnwrappedGestureHandlerStateChangeEvent
-      | GesturePointerEvent
-  ): event is GesturePointerEvent {
+      | GestureTouchEvent
+  ): event is GestureTouchEvent {
     'worklet';
     return event.eventType != null;
   }
@@ -263,30 +263,30 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
         return gesture.onUpdate;
       case CALLBACK_TYPE.END:
         return gesture.onEnd;
-      case CALLBACK_TYPE.POINTER_DOWN:
-        return gesture.onPointerDown;
-      case CALLBACK_TYPE.POINTER_MOVE:
-        return gesture.onPointerMove;
-      case CALLBACK_TYPE.POINTER_UP:
-        return gesture.onPointerUp;
-      case CALLBACK_TYPE.POINTER_CANCELLED:
-        return gesture.onPointerCancelled;
-      case CALLBACK_TYPE.POINTER_CHANGE:
-        return gesture.onPointerChange;
+      case CALLBACK_TYPE.TOUCHES_DOWN:
+        return gesture.onTouchesDown;
+      case CALLBACK_TYPE.TOUCHES_MOVE:
+        return gesture.onTouchesMove;
+      case CALLBACK_TYPE.TOUCHES_UP:
+        return gesture.onTouchesUp;
+      case CALLBACK_TYPE.TOUCHES_CANCELLED:
+        return gesture.onTouchesCancelled;
+      case CALLBACK_TYPE.TOUCHES_CHANGE:
+        return gesture.onTouchesChange;
     }
   }
 
-  function pointerEventTypeToCallbackType(eventType: EventType): CALLBACK_TYPE {
+  function touchEventTypeToCallbackType(eventType: EventType): CALLBACK_TYPE {
     'worklet';
     switch (eventType) {
-      case EventType.POINTER_DOWN:
-        return CALLBACK_TYPE.POINTER_DOWN;
-      case EventType.POINTER_MOVE:
-        return CALLBACK_TYPE.POINTER_MOVE;
-      case EventType.POINTER_UP:
-        return CALLBACK_TYPE.POINTER_UP;
-      case EventType.POINTER_CANCELLED:
-        return CALLBACK_TYPE.POINTER_CANCELLED;
+      case EventType.TOUCHES_DOWN:
+        return CALLBACK_TYPE.TOUCHES_DOWN;
+      case EventType.TOUCHES_MOVE:
+        return CALLBACK_TYPE.TOUCHES_MOVE;
+      case EventType.TOUCHES_UP:
+        return CALLBACK_TYPE.TOUCHES_UP;
+      case EventType.TOUCHES_CANCELLED:
+        return CALLBACK_TYPE.TOUCHES_CANCELLED;
     }
     return CALLBACK_TYPE.UNDEFINED;
   }
@@ -297,7 +297,7 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
     event:
       | UnwrappedGestureHandlerStateChangeEvent
       | UnwrappedGestureHandlerEvent
-      | GesturePointerEvent,
+      | GestureTouchEvent,
     ...args: any[]
   ) {
     'worklet';
@@ -325,7 +325,7 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
     event:
       | UnwrappedGestureHandlerStateChangeEvent
       | UnwrappedGestureHandlerEvent
-      | GesturePointerEvent
+      | GestureTouchEvent
   ) => {
     'worklet';
 
@@ -361,21 +361,21 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
           ) {
             runWorklet(CALLBACK_TYPE.END, gesture, event, false);
           }
-        } else if (isPointerEvent(event)) {
+        } else if (isTouchEvent(event)) {
           if (!stateControllers[i]) {
             stateControllers[i] = GestureStateManager.create(event.handlerTag);
           }
 
           if (event.eventType !== EventType.UNDETERMINED) {
             runWorklet(
-              CALLBACK_TYPE.POINTER_CHANGE,
+              CALLBACK_TYPE.TOUCHES_CHANGE,
               gesture,
               event,
               stateControllers[i]
             );
 
             runWorklet(
-              pointerEventTypeToCallbackType(event.eventType),
+              touchEventTypeToCallbackType(event.eventType),
               gesture,
               event,
               stateControllers[i]

--- a/src/handlers/gestures/eventReceiver.ts
+++ b/src/handlers/gestures/eventReceiver.ts
@@ -4,7 +4,7 @@ import { EventType } from '../../EventType';
 import {
   UnwrappedGestureHandlerEvent,
   UnwrappedGestureHandlerStateChangeEvent,
-  GesturePointerEvent,
+  GestureTouchEvent,
 } from '../gestureHandlerCommon';
 import { GestureStateManagerType } from './gestureStateManager';
 import { findHandler } from '../handlersRegistry';
@@ -40,18 +40,18 @@ function isStateChangeEvent(
   event:
     | UnwrappedGestureHandlerEvent
     | UnwrappedGestureHandlerStateChangeEvent
-    | GesturePointerEvent
+    | GestureTouchEvent
 ): event is UnwrappedGestureHandlerStateChangeEvent {
-  // @ts-ignore oldState doesn't exist on UnwrappedGestureHandlerPointerEvent and that's the point
+  // @ts-ignore oldState doesn't exist on GestureTouchEvent and that's the point
   return event.oldState != null;
 }
 
-function isPointerEvent(
+function isTouchEvent(
   event:
     | UnwrappedGestureHandlerEvent
     | UnwrappedGestureHandlerStateChangeEvent
-    | GesturePointerEvent
-): event is GesturePointerEvent {
+    | GestureTouchEvent
+): event is GestureTouchEvent {
   return event.eventType != null;
 }
 
@@ -59,7 +59,7 @@ function onGestureHandlerEvent(
   event:
     | UnwrappedGestureHandlerEvent
     | UnwrappedGestureHandlerStateChangeEvent
-    | GesturePointerEvent
+    | GestureTouchEvent
 ) {
   const handler = findHandler(event.handlerTag) as BaseGesture<
     Record<string, unknown>
@@ -86,21 +86,21 @@ function onGestureHandlerEvent(
       ) {
         handler.handlers.onEnd?.(event, false);
       }
-    } else if (isPointerEvent(event)) {
-      handler.handlers?.onPointerChange?.(event, dummyStateManager);
+    } else if (isTouchEvent(event)) {
+      handler.handlers?.onTouchesChange?.(event, dummyStateManager);
 
       switch (event.eventType) {
-        case EventType.POINTER_DOWN:
-          handler.handlers?.onPointerDown?.(event, dummyStateManager);
+        case EventType.TOUCHES_DOWN:
+          handler.handlers?.onTouchesDown?.(event, dummyStateManager);
           break;
-        case EventType.POINTER_MOVE:
-          handler.handlers?.onPointerMove?.(event, dummyStateManager);
+        case EventType.TOUCHES_MOVE:
+          handler.handlers?.onTouchesMove?.(event, dummyStateManager);
           break;
-        case EventType.POINTER_UP:
-          handler.handlers?.onPointerUp?.(event, dummyStateManager);
+        case EventType.TOUCHES_UP:
+          handler.handlers?.onTouchesUp?.(event, dummyStateManager);
           break;
-        case EventType.POINTER_CANCELLED:
-          handler.handlers?.onPointerCancelled?.(event, dummyStateManager);
+        case EventType.TOUCHES_CANCELLED:
+          handler.handlers?.onTouchesCancelled?.(event, dummyStateManager);
           break;
       }
     } else {

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -5,7 +5,7 @@ import {
   CommonGestureConfig,
   UnwrappedGestureHandlerStateChangeEvent,
   UnwrappedGestureHandlerEvent,
-  GesturePointerEvent,
+  GestureTouchEvent,
 } from '../gestureHandlerCommon';
 import { getNextHandlerTag } from '../handlersRegistry';
 import { GestureStateManagerType } from './gestureStateManager';
@@ -34,12 +34,12 @@ export interface BaseGestureConfig
   ref?: React.MutableRefObject<GestureType>;
   requireToFail?: GestureRef[];
   simultaneousWith?: GestureRef[];
-  needsPointerData?: boolean;
+  needsTouchData?: boolean;
   manualActivation?: boolean;
 }
 
-type PointerEventHandlerType = (
-  event: GesturePointerEvent,
+type TouchEventHandlerType = (
+  event: GestureTouchEvent,
   stateManager: GestureStateManagerType
 ) => void;
 
@@ -56,11 +56,11 @@ export type HandlerCallbacks<EventPayloadT extends Record<string, unknown>> = {
     success: boolean
   ) => void;
   onUpdate?: (event: UnwrappedGestureHandlerEvent<EventPayloadT>) => void;
-  onPointerDown?: PointerEventHandlerType;
-  onPointerMove?: PointerEventHandlerType;
-  onPointerUp?: PointerEventHandlerType;
-  onPointerCancelled?: PointerEventHandlerType;
-  onPointerChange?: PointerEventHandlerType;
+  onTouchesDown?: TouchEventHandlerType;
+  onTouchesMove?: TouchEventHandlerType;
+  onTouchesUp?: TouchEventHandlerType;
+  onTouchesCancelled?: TouchEventHandlerType;
+  onTouchesChange?: TouchEventHandlerType;
   isWorklet: boolean[];
 };
 
@@ -70,11 +70,11 @@ export const CALLBACK_TYPE = {
   START: 2,
   UPDATE: 3,
   END: 4,
-  POINTER_DOWN: 5,
-  POINTER_MOVE: 6,
-  POINTER_UP: 7,
-  POINTER_CANCELLED: 8,
-  POINTER_CHANGE: 9,
+  TOUCHES_DOWN: 5,
+  TOUCHES_MOVE: 6,
+  TOUCHES_UP: 7,
+  TOUCHES_CANCELLED: 8,
+  TOUCHES_CHANGE: 9,
 } as const;
 
 // Allow using CALLBACK_TYPE as object and type
@@ -129,7 +129,7 @@ export abstract class BaseGesture<
 
   protected isWorklet(
     callback:
-      | PointerEventHandlerType
+      | TouchEventHandlerType
       | ((event: UnwrappedGestureHandlerEvent<EventPayloadT>) => void)
       | ((
           event: UnwrappedGestureHandlerStateChangeEvent<EventPayloadT>
@@ -171,50 +171,50 @@ export abstract class BaseGesture<
     return this;
   }
 
-  onPointerDown(callback: PointerEventHandlerType) {
-    this.config.needsPointerData = true;
-    this.handlers.onPointerDown = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.POINTER_DOWN] = this.isWorklet(
+  onTouchesDown(callback: TouchEventHandlerType) {
+    this.config.needsTouchData = true;
+    this.handlers.onTouchesDown = callback;
+    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_DOWN] = this.isWorklet(
       callback
     );
 
     return this;
   }
 
-  onPointerMove(callback: PointerEventHandlerType) {
-    this.config.needsPointerData = true;
-    this.handlers.onPointerMove = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.POINTER_MOVE] = this.isWorklet(
+  onTouchesMove(callback: TouchEventHandlerType) {
+    this.config.needsTouchData = true;
+    this.handlers.onTouchesMove = callback;
+    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_MOVE] = this.isWorklet(
       callback
     );
 
     return this;
   }
 
-  onPointerUp(callback: PointerEventHandlerType) {
-    this.config.needsPointerData = true;
-    this.handlers.onPointerUp = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.POINTER_UP] = this.isWorklet(
+  onTouchesUp(callback: TouchEventHandlerType) {
+    this.config.needsTouchData = true;
+    this.handlers.onTouchesUp = callback;
+    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_UP] = this.isWorklet(
       callback
     );
 
     return this;
   }
 
-  onPointerCancelled(callback: PointerEventHandlerType) {
-    this.config.needsPointerData = true;
-    this.handlers.onPointerCancelled = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.POINTER_CANCELLED] = this.isWorklet(
+  onTouchesCancelled(callback: TouchEventHandlerType) {
+    this.config.needsTouchData = true;
+    this.handlers.onTouchesCancelled = callback;
+    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_CANCELLED] = this.isWorklet(
       callback
     );
 
     return this;
   }
 
-  onPointerChange(callback: PointerEventHandlerType) {
-    this.config.needsPointerData = true;
-    this.handlers.onPointerChange = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.POINTER_CHANGE] = this.isWorklet(
+  onTouchesChange(callback: TouchEventHandlerType) {
+    this.config.needsTouchData = true;
+    this.handlers.onTouchesChange = callback;
+    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_CHANGE] = this.isWorklet(
       callback
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,9 +11,9 @@ export type {
   // event payloads types
   GestureEventPayload,
   HandlerStateChangeEventPayload,
-  // pointer events
-  GesturePointerEvent,
-  PointerData,
+  // touch events
+  GestureTouchEvent,
+  TouchData,
 } from './handlers/gestureHandlerCommon';
 export type {
   TapGestureHandlerEventPayload,


### PR DESCRIPTION
## Description

Rename `pointerEvents` to `touchEvents`. Due to this change I also renamed a bunch of methods and constants to replace `pointer` with `touch` in them. This is because of the name conflict mentioned in https://github.com/software-mansion/react-native-gesture-handler/pull/1672#pullrequestreview-802404440.