### PR TITLE
Rename PointerEvents

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -78,8 +78,8 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     onTouchEventListener?.onStateChange(self(), newState, prevState)
   }
 
-  open fun dispatchTouchEvent(event: MotionEvent) {
-    onTouchEventListener?.onTouchEvent(self(), event)
+  open fun dispatchHandlerUpdate(event: MotionEvent) {
+    onTouchEventListener?.onHandlerUpdate(self(), event)
   }
 
   open fun dispatchPointerEvent() {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -249,7 +249,7 @@ class GestureHandlerOrchestrator(
     if (!handler.isAwaiting || action != MotionEvent.ACTION_MOVE) {
       handler.handle(event)
       if (handler.isActive) {
-        handler.dispatchTouchEvent(event)
+        handler.dispatchHandlerUpdate(event)
       }
 
       // if event was of type UP or POINTER_UP we request handler to stop tracking now that

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.kt
@@ -85,9 +85,9 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
     super.dispatchStateChange(newState, prevState)
   }
 
-  override fun dispatchTouchEvent(event: MotionEvent) {
+  override fun dispatchHandlerUpdate(event: MotionEvent) {
     previousTime = SystemClock.uptimeMillis()
-    super.dispatchTouchEvent(event)
+    super.dispatchHandlerUpdate(event)
   }
 
   companion object {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/OnTouchEventListener.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/OnTouchEventListener.kt
@@ -5,5 +5,5 @@ import android.view.MotionEvent
 interface OnTouchEventListener {
   fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, event: MotionEvent)
   fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int)
-  fun <T : GestureHandler<T>> onPointerEvent(handler: T)
+  fun <T : GestureHandler<T>> onTouchEvent(handler: T)
 }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/OnTouchEventListener.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/OnTouchEventListener.kt
@@ -3,7 +3,7 @@ package com.swmansion.gesturehandler
 import android.view.MotionEvent
 
 interface OnTouchEventListener {
-  fun <T : GestureHandler<T>> onTouchEvent(handler: T, event: MotionEvent)
+  fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, event: MotionEvent)
   fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int)
   fun <T : GestureHandler<T>> onPointerEvent(handler: T)
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -309,8 +309,8 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
       this@RNGestureHandlerModule.onStateChange(handler, newState, oldState)
     }
 
-    override fun <T : GestureHandler<T>> onPointerEvent(handler: T) {
-      this@RNGestureHandlerModule.onPointerEvent(handler)
+    override fun <T : GestureHandler<T>> onTouchEvent(handler: T) {
+      this@RNGestureHandlerModule.onTouchEvent(handler)
     }
   }
   private val handlerFactories = arrayOf<HandlerFactory<*>>(
@@ -564,7 +564,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
     }
   }
 
-  private fun <T : GestureHandler<T>> onPointerEvent(handler: T) {
+  private fun <T : GestureHandler<T>> onTouchEvent(handler: T) {
     if (handler.tag < 0) {
       // root containers use negative tags, we don't need to dispatch events for them to the JS
       return
@@ -572,16 +572,16 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
     if (handler.state == GestureHandler.STATE_BEGAN || handler.state == GestureHandler.STATE_ACTIVE
         || handler.state == GestureHandler.STATE_UNDETERMINED || handler.view != null) {
       if (handler.usesDeviceEvents) {
-        val data = RNGestureHandlerPointerEvent.createEventData(handler)
+        val data = RNGestureHandlerTouchEvent.createEventData(handler)
 
         reactApplicationContext
             .deviceEventEmitter
-            .emit(RNGestureHandlerPointerEvent.EVENT_NAME, data)
+            .emit(RNGestureHandlerTouchEvent.EVENT_NAME, data)
       } else {
         reactApplicationContext
             .UIManager
             .eventDispatcher.let {
-              val event = RNGestureHandlerPointerEvent.obtain(handler)
+              val event = RNGestureHandlerTouchEvent.obtain(handler)
               it.dispatchEvent(event)
             }
       }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -301,8 +301,8 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
   }
 
   private val eventListener = object : OnTouchEventListener {
-    override fun <T : GestureHandler<T>> onTouchEvent(handler: T, event: MotionEvent) {
-      this@RNGestureHandlerModule.onTouchEvent(handler, event)
+    override fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, event: MotionEvent) {
+      this@RNGestureHandlerModule.onHandlerUpdate(handler, event)
     }
 
     override fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int) {
@@ -510,7 +510,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
   private fun <T : GestureHandler<T>> findFactoryForHandler(handler: GestureHandler<T>): HandlerFactory<T>? =
     handlerFactories.firstOrNull { it.type == handler.javaClass } as HandlerFactory<T>?
 
-  private fun <T : GestureHandler<T>> onTouchEvent(handler: T, motionEvent: MotionEvent) {
+  private fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, motionEvent: MotionEvent) {
     if (handler.tag < 0) {
       // root containers use negative tags, we don't need to dispatch events for them to the JS
       return

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
@@ -7,7 +7,7 @@ import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.RCTEventEmitter
 import com.swmansion.gesturehandler.GestureHandler
 
-class RNGestureHandlerPointerEvent private constructor() : Event<RNGestureHandlerPointerEvent>() {
+class RNGestureHandlerTouchEvent private constructor() : Event<RNGestureHandlerTouchEvent>() {
   private var extraData: WritableMap? = null
   private var coalescingKey: Short = 0
   private fun <T : GestureHandler<T>> init(handler: T) {
@@ -33,17 +33,17 @@ class RNGestureHandlerPointerEvent private constructor() : Event<RNGestureHandle
 
   companion object {
     const val EVENT_UNDETERMINED = 0
-    const val EVENT_POINTER_DOWN = 1
-    const val EVENT_POINTER_MOVE = 2
-    const val EVENT_POINTER_UP = 3
-    const val EVENT_POINTER_CANCELLED = 4
+    const val EVENT_TOUCH_DOWN = 1
+    const val EVENT_TOUCH_MOVE = 2
+    const val EVENT_TOUCH_UP = 3
+    const val EVENT_TOUCH_CANCELLED = 4
 
     const val EVENT_NAME = "onGestureHandlerEvent"
     private const val TOUCH_EVENTS_POOL_SIZE = 7 // magic
-    private val EVENTS_POOL = Pools.SynchronizedPool<RNGestureHandlerPointerEvent>(TOUCH_EVENTS_POOL_SIZE)
+    private val EVENTS_POOL = Pools.SynchronizedPool<RNGestureHandlerTouchEvent>(TOUCH_EVENTS_POOL_SIZE)
 
-    fun <T : GestureHandler<T>> obtain(handler: T): RNGestureHandlerPointerEvent =
-        (EVENTS_POOL.acquire() ?: RNGestureHandlerPointerEvent()).apply {
+    fun <T : GestureHandler<T>> obtain(handler: T): RNGestureHandlerTouchEvent =
+        (EVENTS_POOL.acquire() ?: RNGestureHandlerTouchEvent()).apply {
           init(handler)
         }
 
@@ -51,10 +51,10 @@ class RNGestureHandlerPointerEvent private constructor() : Event<RNGestureHandle
       putInt("handlerTag", handler.tag)
       putInt("state", handler.state)
       putInt("numberOfPointers", handler.trackedPointersCount)
-      putInt("eventType", handler.pointerEventType)
+      putInt("eventType", handler.touchEventType)
 
-      handler.pointerEventPayload?.let {
-        putArray("pointerData", it)
+      handler.touchEventPayload?.let {
+        putArray("touches", it)
 
         if (handler.isAwaiting && handler.state == GestureHandler.STATE_ACTIVE) {
           putInt("state", GestureHandler.STATE_BEGAN)

--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -80,7 +80,7 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
            forViewWithTag:(nonnull NSNumber *)reactTag
             withExtraData:(nonnull RNGestureHandlerEventExtraData *)extraData;
 - (void)sendStateChangeEvent:(nonnull RNGestureHandlerStateChange *)event;
-- (void)sendPointerEventInState:(RNGestureHandlerState)state
+- (void)sendTouchEventInState:(RNGestureHandlerState)state
                  forViewWithTag:(nonnull NSNumber *)reactTag;
 
 @end

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -243,7 +243,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     }
 }
 
-- (void)sendPointerEventInState:(RNGestureHandlerState)state
+- (void)sendTouchEventInState:(RNGestureHandlerState)state
                  forViewWithTag:(NSNumber *)reactTag
 {
   id extraData = [RNGestureHandlerEventExtraData forEventType:_pointerTracker.eventType

--- a/ios/RNGestureHandlerEvents.h
+++ b/ios/RNGestureHandlerEvents.h
@@ -4,7 +4,7 @@
 #import <UIKit/UIKit.h>
 
 #import "RNGestureHandlerState.h"
-#import "RNPointerEventType.h"
+#import "RNTouchEventType.h"
 
 @interface RNGestureHandlerEventExtraData : NSObject
 
@@ -36,7 +36,7 @@
                                 withAnchorPoint:(CGPoint)anchorPoint
                                    withVelocity:(CGFloat)velocity
                             withNumberOfTouches:(NSUInteger)numberOfTouches;
-+ (RNGestureHandlerEventExtraData *)forEventType:(RNPointerEventType)eventType
++ (RNGestureHandlerEventExtraData *)forEventType:(RNTouchEventType)eventType
                                  withPointerData:(NSArray<NSDictionary *> *)data
                              withNumberOfTouches:(NSUInteger)numberOfTouches;
 + (RNGestureHandlerEventExtraData *)forPointerInside:(BOOL)pointerInside;

--- a/ios/RNGestureHandlerEvents.m
+++ b/ios/RNGestureHandlerEvents.m
@@ -103,19 +103,19 @@
                            @"numberOfPointers": @(numberOfTouches)}];
 }
 
-+ (RNGestureHandlerEventExtraData *)forEventType:(RNPointerEventType)eventType
++ (RNGestureHandlerEventExtraData *)forEventType:(RNTouchEventType)eventType
                                  withPointerData:(NSArray<NSDictionary *> *)data
                              withNumberOfTouches:(NSUInteger)numberOfTouches
 {
     if (data != nil) {
       return [[RNGestureHandlerEventExtraData alloc]
               initWithData:@{@"eventType": @(eventType),
-                             @"pointerData": data,
+                             @"touches": data,
                              @"numberOfPointers": @(numberOfTouches)}];
     } else {
       return [[RNGestureHandlerEventExtraData alloc]
-              initWithData:@{@"eventType": @(RNPointerEventTypeUndetermined),
-                             @"pointerData": @{},
+              initWithData:@{@"eventType": @(RNTouchEventTypeUndetermined),
+                             @"touches": @{},
                              @"numberOfPointers": @(numberOfTouches)}];
     }
 }

--- a/ios/RNGestureHandlerPointerTracker.h
+++ b/ios/RNGestureHandlerPointerTracker.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-#import "RNPointerEventType.h"
+#import "RNTouchEventType.h"
 
 #define MAX_POINTERS_COUNT 12
 
@@ -8,7 +8,7 @@
 
 @interface RNGestureHandlerPointerTracker : NSObject
 
-@property (nonatomic) RNPointerEventType eventType;
+@property (nonatomic) RNTouchEventType eventType;
 @property (nonatomic) NSArray<NSDictionary *> *pointerData;
 @property (nonatomic) int trackedPointersCount;
 

--- a/ios/RNGestureHandlerPointerTracker.m
+++ b/ios/RNGestureHandlerPointerTracker.m
@@ -73,7 +73,7 @@
   CGPoint relativePos = [touch locationInView:_gestureHandler.recognizer.view];
   CGPoint absolutePos = [touch locationInView:_gestureHandler.recognizer.view.window];
   
-  return @{@"pointerId": @(index),
+  return @{@"id": @(index),
               @"x": @(relativePos.x),
               @"y": @(relativePos.y),
               @"absoluteX": @(absolutePos.x),
@@ -86,7 +86,7 @@
     return;
   }
   
-  _eventType = RNPointerEventTypePointerDown;
+  _eventType = RNTouchEventTypePointerDown;
   
   NSDictionary *data[touches.count];
   
@@ -110,7 +110,7 @@
     return;
   }
   
-  _eventType = RNPointerEventTypePointerMove;
+  _eventType = RNTouchEventTypePointerMove;
   
   NSDictionary *data[touches.count];
   
@@ -130,7 +130,7 @@
     return;
   }
   
-  _eventType = RNPointerEventTypePointerUp;
+  _eventType = RNTouchEventTypePointerUp;
   
   NSDictionary *data[touches.count];
   
@@ -165,7 +165,7 @@
   
   if (_trackedPointersCount == 0) {
     // gesture has finished because all pointers were lifted, reset event type to send state change event
-    _eventType = RNPointerEventTypeUndetermined;
+    _eventType = RNTouchEventTypeUndetermined;
   } else {
     // turns out that the gesture may be made to fail without calling touchesCancelled in that case there
     // are still tracked pointers but the recognizer state is already set to UIGestureRecognizerStateFailed
@@ -192,7 +192,7 @@
       }
     }
     
-    _eventType = RNPointerEventTypeCancelled;
+    _eventType = RNTouchEventTypeCancelled;
     _pointerData = [[NSArray alloc] initWithObjects:data count:registeredTouches];
     [self sendEvent];
     _trackedPointersCount = 0;
@@ -205,7 +205,7 @@
     return;
   }
   
-  [_gestureHandler sendPointerEventInState:[_gestureHandler state] forViewWithTag:_gestureHandler.recognizer.view.reactTag];
+  [_gestureHandler sendTouchEventInState:[_gestureHandler state] forViewWithTag:_gestureHandler.recognizer.view.reactTag];
 }
 
 @end

--- a/ios/RNPointerEventType.h
+++ b/ios/RNPointerEventType.h
@@ -1,9 +1,0 @@
-#import <Foundation/Foundation.h>
-
-typedef NS_ENUM(NSInteger, RNPointerEventType) {
-  RNPointerEventTypeUndetermined = 0,
-  RNPointerEventTypePointerDown,
-  RNPointerEventTypePointerMove,
-  RNPointerEventTypePointerUp,
-  RNPointerEventTypeCancelled,
-};

--- a/ios/RNTouchEventType.h
+++ b/ios/RNTouchEventType.h
@@ -1,0 +1,9 @@
+#import <Foundation/Foundation.h>
+
+typedef NS_ENUM(NSInteger, RNTouchEventType) {
+  RNTouchEventTypeUndetermined = 0,
+  RNTouchEventTypePointerDown,
+  RNTouchEventTypePointerMove,
+  RNTouchEventTypePointerUp,
+  RNTouchEventTypeCancelled,
+};

--- a/src/EventType.ts
+++ b/src/EventType.ts
@@ -1,9 +1,9 @@
 export const EventType = {
   UNDETERMINED: 0,
-  POINTER_DOWN: 1,
-  POINTER_MOVE: 2,
-  POINTER_UP: 3,
-  POINTER_CANCELLED: 4,
+  TOUCHES_DOWN: 1,
+  TOUCHES_MOVE: 2,
+  TOUCHES_UP: 3,
+  TOUCHES_CANCELLED: 4,
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -75,17 +75,17 @@ export interface HandlerStateChangeEvent<
   nativeEvent: Readonly<HandlerStateChangeEventPayload & ExtraEventPayloadT>;
 }
 
-export type PointerData = {
-  pointerId: number;
+export type TouchData = {
+  id: number;
   x: number;
   y: number;
   absoluteX: number;
   absoluteY: number;
 };
 
-export type GesturePointerEvent = GestureEventPayload & {
+export type GestureTouchEvent = GestureEventPayload & {
   eventType: EventType;
-  pointerData: PointerData[];
+  touches: TouchData[];
 };
 
 export type UnwrappedGestureHandlerEvent<

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -15,7 +15,7 @@ import {
   findNodeHandle,
   UnwrappedGestureHandlerEvent,
   UnwrappedGestureHandlerStateChangeEvent,
-  GesturePointerEvent,
+  GestureTouchEvent,
 } from '../gestureHandlerCommon';
 import {
   GestureStateManager,
@@ -231,20 +231,19 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
     event:
       | UnwrappedGestureHandlerEvent
       | UnwrappedGestureHandlerStateChangeEvent
-      | GesturePointerEvent
+      | GestureTouchEvent
   ): event is UnwrappedGestureHandlerStateChangeEvent {
     'worklet';
-    // @ts-ignore Yes, the oldState prop is missing on UnwrappedGestureHandlerPointerEvent,
-    // that's the point
+    // @ts-ignore Yes, the oldState prop is missing on GestureTouchEvent, that's the point
     return event.oldState != null;
   }
 
-  function isPointerEvent(
+  function isTouchEvent(
     event:
       | UnwrappedGestureHandlerEvent
       | UnwrappedGestureHandlerStateChangeEvent
-      | GesturePointerEvent
-  ): event is GesturePointerEvent {
+      | GestureTouchEvent
+  ): event is GestureTouchEvent {
     'worklet';
     return event.eventType != null;
   }
@@ -263,30 +262,30 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
         return gesture.onUpdate;
       case CALLBACK_TYPE.END:
         return gesture.onEnd;
-      case CALLBACK_TYPE.POINTER_DOWN:
-        return gesture.onPointerDown;
-      case CALLBACK_TYPE.POINTER_MOVE:
-        return gesture.onPointerMove;
-      case CALLBACK_TYPE.POINTER_UP:
-        return gesture.onPointerUp;
-      case CALLBACK_TYPE.POINTER_CANCELLED:
-        return gesture.onPointerCancelled;
-      case CALLBACK_TYPE.POINTER_CHANGE:
-        return gesture.onPointerChange;
+      case CALLBACK_TYPE.TOUCHES_DOWN:
+        return gesture.onTouchesDown;
+      case CALLBACK_TYPE.TOUCHES_MOVE:
+        return gesture.onTouchesMove;
+      case CALLBACK_TYPE.TOUCHES_UP:
+        return gesture.onTouchesUp;
+      case CALLBACK_TYPE.TOUCHES_CANCELLED:
+        return gesture.onTouchesCancelled;
+      case CALLBACK_TYPE.TOUCHES_CHANGE:
+        return gesture.onTouchesChange;
     }
   }
 
-  function pointerEventTypeToCallbackType(eventType: EventType): CALLBACK_TYPE {
+  function touchEventTypeToCallbackType(eventType: EventType): CALLBACK_TYPE {
     'worklet';
     switch (eventType) {
-      case EventType.POINTER_DOWN:
-        return CALLBACK_TYPE.POINTER_DOWN;
-      case EventType.POINTER_MOVE:
-        return CALLBACK_TYPE.POINTER_MOVE;
-      case EventType.POINTER_UP:
-        return CALLBACK_TYPE.POINTER_UP;
-      case EventType.POINTER_CANCELLED:
-        return CALLBACK_TYPE.POINTER_CANCELLED;
+      case EventType.TOUCHES_DOWN:
+        return CALLBACK_TYPE.TOUCHES_DOWN;
+      case EventType.TOUCHES_MOVE:
+        return CALLBACK_TYPE.TOUCHES_MOVE;
+      case EventType.TOUCHES_UP:
+        return CALLBACK_TYPE.TOUCHES_UP;
+      case EventType.TOUCHES_CANCELLED:
+        return CALLBACK_TYPE.TOUCHES_CANCELLED;
     }
     return CALLBACK_TYPE.UNDEFINED;
   }
@@ -297,7 +296,7 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
     event:
       | UnwrappedGestureHandlerStateChangeEvent
       | UnwrappedGestureHandlerEvent
-      | GesturePointerEvent,
+      | GestureTouchEvent,
     ...args: any[]
   ) {
     'worklet';
@@ -325,7 +324,7 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
     event:
       | UnwrappedGestureHandlerStateChangeEvent
       | UnwrappedGestureHandlerEvent
-      | GesturePointerEvent
+      | GestureTouchEvent
   ) => {
     'worklet';
 
@@ -361,21 +360,21 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
           ) {
             runWorklet(CALLBACK_TYPE.END, gesture, event, false);
           }
-        } else if (isPointerEvent(event)) {
+        } else if (isTouchEvent(event)) {
           if (!stateControllers[i]) {
             stateControllers[i] = GestureStateManager.create(event.handlerTag);
           }
 
           if (event.eventType !== EventType.UNDETERMINED) {
             runWorklet(
-              CALLBACK_TYPE.POINTER_CHANGE,
+              CALLBACK_TYPE.TOUCHES_CHANGE,
               gesture,
               event,
               stateControllers[i]
             );
 
             runWorklet(
-              pointerEventTypeToCallbackType(event.eventType),
+              touchEventTypeToCallbackType(event.eventType),
               gesture,
               event,
               stateControllers[i]

--- a/src/handlers/gestures/eventReceiver.ts
+++ b/src/handlers/gestures/eventReceiver.ts
@@ -4,7 +4,7 @@ import { EventType } from '../../EventType';
 import {
   UnwrappedGestureHandlerEvent,
   UnwrappedGestureHandlerStateChangeEvent,
-  GesturePointerEvent,
+  GestureTouchEvent,
 } from '../gestureHandlerCommon';
 import { GestureStateManagerType } from './gestureStateManager';
 import { findHandler } from '../handlersRegistry';
@@ -40,18 +40,18 @@ function isStateChangeEvent(
   event:
     | UnwrappedGestureHandlerEvent
     | UnwrappedGestureHandlerStateChangeEvent
-    | GesturePointerEvent
+    | GestureTouchEvent
 ): event is UnwrappedGestureHandlerStateChangeEvent {
-  // @ts-ignore oldState doesn't exist on UnwrappedGestureHandlerPointerEvent and that's the point
+  // @ts-ignore oldState doesn't exist on GestureTouchEvent and that's the point
   return event.oldState != null;
 }
 
-function isPointerEvent(
+function isTouchEvent(
   event:
     | UnwrappedGestureHandlerEvent
     | UnwrappedGestureHandlerStateChangeEvent
-    | GesturePointerEvent
-): event is GesturePointerEvent {
+    | GestureTouchEvent
+): event is GestureTouchEvent {
   return event.eventType != null;
 }
 
@@ -59,7 +59,7 @@ function onGestureHandlerEvent(
   event:
     | UnwrappedGestureHandlerEvent
     | UnwrappedGestureHandlerStateChangeEvent
-    | GesturePointerEvent
+    | GestureTouchEvent
 ) {
   const handler = findHandler(event.handlerTag) as BaseGesture<
     Record<string, unknown>
@@ -86,21 +86,21 @@ function onGestureHandlerEvent(
       ) {
         handler.handlers.onEnd?.(event, false);
       }
-    } else if (isPointerEvent(event)) {
-      handler.handlers?.onPointerChange?.(event, dummyStateManager);
+    } else if (isTouchEvent(event)) {
+      handler.handlers?.onTouchesChange?.(event, dummyStateManager);
 
       switch (event.eventType) {
-        case EventType.POINTER_DOWN:
-          handler.handlers?.onPointerDown?.(event, dummyStateManager);
+        case EventType.TOUCHES_DOWN:
+          handler.handlers?.onTouchesDown?.(event, dummyStateManager);
           break;
-        case EventType.POINTER_MOVE:
-          handler.handlers?.onPointerMove?.(event, dummyStateManager);
+        case EventType.TOUCHES_MOVE:
+          handler.handlers?.onTouchesMove?.(event, dummyStateManager);
           break;
-        case EventType.POINTER_UP:
-          handler.handlers?.onPointerUp?.(event, dummyStateManager);
+        case EventType.TOUCHES_UP:
+          handler.handlers?.onTouchesUp?.(event, dummyStateManager);
           break;
-        case EventType.POINTER_CANCELLED:
-          handler.handlers?.onPointerCancelled?.(event, dummyStateManager);
+        case EventType.TOUCHES_CANCELLED:
+          handler.handlers?.onTouchesCancelled?.(event, dummyStateManager);
           break;
       }
     } else {

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -5,7 +5,7 @@ import {
   CommonGestureConfig,
   UnwrappedGestureHandlerStateChangeEvent,
   UnwrappedGestureHandlerEvent,
-  GesturePointerEvent,
+  GestureTouchEvent,
 } from '../gestureHandlerCommon';
 import { getNextHandlerTag } from '../handlersRegistry';
 import { GestureStateManagerType } from './gestureStateManager';
@@ -38,8 +38,8 @@ export interface BaseGestureConfig
   manualActivation?: boolean;
 }
 
-type PointerEventHandlerType = (
-  event: GesturePointerEvent,
+type TouchEventHandlerType = (
+  event: GestureTouchEvent,
   stateManager: GestureStateManagerType
 ) => void;
 
@@ -56,11 +56,11 @@ export type HandlerCallbacks<EventPayloadT extends Record<string, unknown>> = {
     success: boolean
   ) => void;
   onUpdate?: (event: UnwrappedGestureHandlerEvent<EventPayloadT>) => void;
-  onPointerDown?: PointerEventHandlerType;
-  onPointerMove?: PointerEventHandlerType;
-  onPointerUp?: PointerEventHandlerType;
-  onPointerCancelled?: PointerEventHandlerType;
-  onPointerChange?: PointerEventHandlerType;
+  onTouchesDown?: TouchEventHandlerType;
+  onTouchesMove?: TouchEventHandlerType;
+  onTouchesUp?: TouchEventHandlerType;
+  onTouchesCancelled?: TouchEventHandlerType;
+  onTouchesChange?: TouchEventHandlerType;
   isWorklet: boolean[];
 };
 
@@ -70,11 +70,11 @@ export const CALLBACK_TYPE = {
   START: 2,
   UPDATE: 3,
   END: 4,
-  POINTER_DOWN: 5,
-  POINTER_MOVE: 6,
-  POINTER_UP: 7,
-  POINTER_CANCELLED: 8,
-  POINTER_CHANGE: 9,
+  TOUCHES_DOWN: 5,
+  TOUCHES_MOVE: 6,
+  TOUCHES_UP: 7,
+  TOUCHES_CANCELLED: 8,
+  TOUCHES_CHANGE: 9,
 } as const;
 
 // Allow using CALLBACK_TYPE as object and type
@@ -129,7 +129,7 @@ export abstract class BaseGesture<
 
   protected isWorklet(
     callback:
-      | PointerEventHandlerType
+      | TouchEventHandlerType
       | ((event: UnwrappedGestureHandlerEvent<EventPayloadT>) => void)
       | ((
           event: UnwrappedGestureHandlerStateChangeEvent<EventPayloadT>
@@ -171,50 +171,50 @@ export abstract class BaseGesture<
     return this;
   }
 
-  onPointerDown(callback: PointerEventHandlerType) {
+  onTouchesDown(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
-    this.handlers.onPointerDown = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.POINTER_DOWN] = this.isWorklet(
+    this.handlers.onTouchesDown = callback;
+    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_DOWN] = this.isWorklet(
       callback
     );
 
     return this;
   }
 
-  onPointerMove(callback: PointerEventHandlerType) {
+  onTouchesMove(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
-    this.handlers.onPointerMove = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.POINTER_MOVE] = this.isWorklet(
+    this.handlers.onTouchesMove = callback;
+    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_MOVE] = this.isWorklet(
       callback
     );
 
     return this;
   }
 
-  onPointerUp(callback: PointerEventHandlerType) {
+  onTouchesUp(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
-    this.handlers.onPointerUp = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.POINTER_UP] = this.isWorklet(
+    this.handlers.onTouchesUp = callback;
+    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_UP] = this.isWorklet(
       callback
     );
 
     return this;
   }
 
-  onPointerCancelled(callback: PointerEventHandlerType) {
+  onTouchesCancelled(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
-    this.handlers.onPointerCancelled = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.POINTER_CANCELLED] = this.isWorklet(
+    this.handlers.onTouchesCancelled = callback;
+    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_CANCELLED] = this.isWorklet(
       callback
     );
 
     return this;
   }
 
-  onPointerChange(callback: PointerEventHandlerType) {
+  onTouchesChange(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
-    this.handlers.onPointerChange = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.POINTER_CHANGE] = this.isWorklet(
+    this.handlers.onTouchesChange = callback;
+    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_CHANGE] = this.isWorklet(
       callback
     );
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,8 +12,8 @@ export type {
   GestureEventPayload,
   HandlerStateChangeEventPayload,
   // pointer events
-  GesturePointerEvent,
-  PointerData,
+  GestureTouchEvent,
+  TouchData,
 } from './handlers/gestureHandlerCommon';
 export type {
   TapGestureHandlerEventPayload,


### PR DESCRIPTION
## Description

Replace occurrences of PointerEvents with TouchEvents in the API and in places where it could be confusing due to naming conflict mentioned in https://github.com/software-mansion/react-native-gesture-handler/pull/1672#pullrequestreview-802404440.
