### PR TITLE
Don't cancel handler if enabled value didn't change

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -84,7 +84,10 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     applySelf { this.shouldCancelWhenOutside = shouldCancelWhenOutside }
 
   fun setEnabled(enabled: Boolean): ConcreteGestureHandlerT = applySelf {
-    if (view != null) {
+    // Don't cancel handler when not changing the value of the isEnabled, executing it always caused
+    // handlers to be cancelled on re-render because that's the moment when the config is updated.
+    // If the enabled prop "changed" from true to true the handler would get cancelled.
+    if (view != null && isEnabled != enabled) {
       // If view is set then handler is in "active" state. In that case we want to "cancel" handler
       // when it changes enabled state so that it gets cleared from the orchestrator
       UiThreadUtil.runOnUiThread { cancel() }


### PR DESCRIPTION
## Description

On every re-render the updated handler config is send to the native side. On Android, if the `enabled` prop was present in the config, this causes the handler to get cancelled even when `enabled` was "changed" from `true` to `true`. This PR changes it so that the handler gets cancelled only when the value actually changes.

## Test plan

Tested on the Example app.
