### PR TITLE
Remove onTouchesChange

### DIFF
--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -270,8 +270,6 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
         return gesture.onTouchesUp;
       case CALLBACK_TYPE.TOUCHES_CANCELLED:
         return gesture.onTouchesCancelled;
-      case CALLBACK_TYPE.TOUCHES_CHANGE:
-        return gesture.onTouchesChange;
     }
   }
 
@@ -366,13 +364,6 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
           }
 
           if (event.eventType !== EventType.UNDETERMINED) {
-            runWorklet(
-              CALLBACK_TYPE.TOUCHES_CHANGE,
-              gesture,
-              event,
-              stateControllers[i]
-            );
-
             runWorklet(
               touchEventTypeToCallbackType(event.eventType),
               gesture,

--- a/src/handlers/gestures/eventReceiver.ts
+++ b/src/handlers/gestures/eventReceiver.ts
@@ -87,8 +87,6 @@ function onGestureHandlerEvent(
         handler.handlers.onEnd?.(event, false);
       }
     } else if (isTouchEvent(event)) {
-      handler.handlers?.onTouchesChange?.(event, dummyStateManager);
-
       switch (event.eventType) {
         case EventType.TOUCHES_DOWN:
           handler.handlers?.onTouchesDown?.(event, dummyStateManager);

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -60,7 +60,6 @@ export type HandlerCallbacks<EventPayloadT extends Record<string, unknown>> = {
   onTouchesMove?: TouchEventHandlerType;
   onTouchesUp?: TouchEventHandlerType;
   onTouchesCancelled?: TouchEventHandlerType;
-  onTouchesChange?: TouchEventHandlerType;
   isWorklet: boolean[];
 };
 
@@ -74,7 +73,6 @@ export const CALLBACK_TYPE = {
   TOUCHES_MOVE: 6,
   TOUCHES_UP: 7,
   TOUCHES_CANCELLED: 8,
-  TOUCHES_CHANGE: 9,
 } as const;
 
 // Allow using CALLBACK_TYPE as object and type
@@ -205,16 +203,6 @@ export abstract class BaseGesture<
     this.config.needsPointerData = true;
     this.handlers.onTouchesCancelled = callback;
     this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_CANCELLED] = this.isWorklet(
-      callback
-    );
-
-    return this;
-  }
-
-  onTouchesChange(callback: TouchEventHandlerType) {
-    this.config.needsPointerData = true;
-    this.handlers.onTouchesChange = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_CHANGE] = this.isWorklet(
       callback
     );
 


### PR DESCRIPTION
## Description

Remove `onTouchesChange` callback due to lack of use cases.
