### PR TITLE
Fix crash when using version of Reanimated without setGestureState function

### DIFF
--- a/src/handlers/gestures/reanimatedWrapper.ts
+++ b/src/handlers/gestures/reanimatedWrapper.ts
@@ -34,10 +34,12 @@ try {
   Reanimated = require('react-native-reanimated');
 
   if (!Reanimated.setGestureState) {
-    Reanimated.setGestureState = () =>
+    Reanimated.setGestureState = () => {
+      'worklet';
       console.warn(
         'Please use newer version of react-native-reanimated in order to control state of the gestures.'
       );
+    };
   }
   // When 'react-native-reanimated' is not available we want to
   // quietly continue


### PR DESCRIPTION
## Description

Fix crash of the app when used version of Reanimated doesn't have `setGestureState` implemented by making a fallback function a worklet.