### PR TITLE
Send data about all touches in TouchEvents

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -421,7 +421,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
       changedTouchesPayload = Arguments.createArray()
     }
 
-    changedTouchesPayload?.pushMap(createPointerData(pointerData))
+    changedTouchesPayload!!.pushMap(createPointerData(pointerData))
   }
 
   private fun addPointerToAll(pointerData: PointerData) {
@@ -429,7 +429,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
       allTouchesPayload = Arguments.createArray()
     }
 
-    allTouchesPayload?.pushMap(createPointerData(pointerData))
+    allTouchesPayload!!.pushMap(createPointerData(pointerData))
   }
 
   private fun createPointerData(pointerData: PointerData) = Arguments.createMap().apply {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
@@ -50,15 +50,19 @@ class RNGestureHandlerTouchEvent private constructor() : Event<RNGestureHandlerT
     fun <T: GestureHandler<T>> createEventData(handler: T,): WritableMap = Arguments.createMap().apply {
       putInt("handlerTag", handler.tag)
       putInt("state", handler.state)
-      putInt("numberOfPointers", handler.trackedPointersCount)
+      putInt("numberOfTouches", handler.trackedPointersCount)
       putInt("eventType", handler.touchEventType)
 
-      handler.touchEventPayload?.let {
-        putArray("touches", it)
+      handler.consumeChangedTouchesPayload()?.let {
+        putArray("changedTouches", it)
+      }
 
-        if (handler.isAwaiting && handler.state == GestureHandler.STATE_ACTIVE) {
-          putInt("state", GestureHandler.STATE_BEGAN)
-        }
+      handler.consumeAllTouchesPayload()?.let {
+        putArray("allTouches", it)
+      }
+
+      if (handler.isAwaiting && handler.state == GestureHandler.STATE_ACTIVE) {
+        putInt("state", GestureHandler.STATE_BEGAN)
       }
     }
   }

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -247,7 +247,8 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
                  forViewWithTag:(NSNumber *)reactTag
 {
   id extraData = [RNGestureHandlerEventExtraData forEventType:_pointerTracker.eventType
-                                              withPointerData:_pointerTracker.pointerData
+                                          withChangedPointers:_pointerTracker.changedPointersData
+                                              withAllPointers:_pointerTracker.allPointersData
                                           withNumberOfTouches:_pointerTracker.trackedPointersCount];
   id event = [[RNGestureHandlerEvent alloc] initWithReactTag:reactTag handlerTag:_tag state:state extraData:extraData coalescingKey:[_tag intValue]];
   

--- a/ios/RNGestureHandlerEvents.h
+++ b/ios/RNGestureHandlerEvents.h
@@ -37,7 +37,8 @@
                                    withVelocity:(CGFloat)velocity
                             withNumberOfTouches:(NSUInteger)numberOfTouches;
 + (RNGestureHandlerEventExtraData *)forEventType:(RNTouchEventType)eventType
-                                 withPointerData:(NSArray<NSDictionary *> *)data
+                             withChangedPointers:(NSArray<NSDictionary *> *)changedPointers
+                                 withAllPointers:(NSArray<NSDictionary *> *)allPointers
                              withNumberOfTouches:(NSUInteger)numberOfTouches;
 + (RNGestureHandlerEventExtraData *)forPointerInside:(BOOL)pointerInside;
 @end

--- a/ios/RNGestureHandlerEvents.m
+++ b/ios/RNGestureHandlerEvents.m
@@ -104,20 +104,21 @@
 }
 
 + (RNGestureHandlerEventExtraData *)forEventType:(RNTouchEventType)eventType
-                                 withPointerData:(NSArray<NSDictionary *> *)data
+                             withChangedPointers:(NSArray<NSDictionary *> *)changedPointers
+                                 withAllPointers:(NSArray<NSDictionary *> *)allPointers
                              withNumberOfTouches:(NSUInteger)numberOfTouches
 {
-    if (data != nil) {
-      return [[RNGestureHandlerEventExtraData alloc]
-              initWithData:@{@"eventType": @(eventType),
-                             @"touches": data,
-                             @"numberOfPointers": @(numberOfTouches)}];
-    } else {
-      return [[RNGestureHandlerEventExtraData alloc]
-              initWithData:@{@"eventType": @(RNTouchEventTypeUndetermined),
-                             @"touches": @{},
-                             @"numberOfPointers": @(numberOfTouches)}];
+    if (changedPointers == nil || allPointers == nil) {
+        changedPointers = @[];
+        allPointers = @[];
+        eventType = RNTouchEventTypeUndetermined;
     }
+  
+    return [[RNGestureHandlerEventExtraData alloc]
+            initWithData:@{@"eventType": @(eventType),
+                         @"changedTouches": changedPointers,
+                         @"allTouches": allPointers,
+                         @"numberOfTouches": @(numberOfTouches)}];
 }
 
 + (RNGestureHandlerEventExtraData *)forPointerInside:(BOOL)pointerInside

--- a/ios/RNGestureHandlerPointerTracker.h
+++ b/ios/RNGestureHandlerPointerTracker.h
@@ -9,7 +9,8 @@
 @interface RNGestureHandlerPointerTracker : NSObject
 
 @property (nonatomic) RNTouchEventType eventType;
-@property (nonatomic) NSArray<NSDictionary *> *pointerData;
+@property (nonatomic) NSArray<NSDictionary *> *changedPointersData;
+@property (nonatomic) NSArray<NSDictionary *> *allPointersData;
 @property (nonatomic) int trackedPointersCount;
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;

--- a/ios/RNGestureHandlerPointerTracker.m
+++ b/ios/RNGestureHandlerPointerTracker.m
@@ -118,7 +118,7 @@
   }
   
   _changedPointersData = [[NSArray alloc] initWithObjects:data count:[touches count]];
-  // extract all touches lasr to include the ones that were just added
+  // extract all touches last to include the ones that were just added
   [self extractAllTouches];
   [self sendEvent];
 }

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -83,9 +83,13 @@ export type TouchData = {
   absoluteY: number;
 };
 
-export type GestureTouchEvent = GestureEventPayload & {
+export type GestureTouchEvent = {
+  handlerTag: number;
+  numberOfTouches: number;
+  state: ValueOf<typeof State>;
   eventType: EventType;
-  touches: TouchData[];
+  allTouches: TouchData[];
+  changedTouches: TouchData[];
 };
 
 export type UnwrappedGestureHandlerEvent<


### PR DESCRIPTION
## Description

Send data about all active touches alongside data about touches that have changed in the event.
Rename `numberOfPointers` to `numberOfTouches` in the `GestureTouchEvent`.