### PR TITLE
Update types

### DIFF
--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -70,11 +70,11 @@ export interface HandlerStateChangeEvent<
   nativeEvent: Readonly<HandlerStateChangeEventPayload & ExtraEventPayloadT>;
 }
 
-export type UnwrappedGestureHandlerEvent<
+export type GestureUpdateEvent<
   GestureEventPayloadT = Record<string, unknown>
 > = GestureEventPayload & GestureEventPayloadT;
 
-export type UnwrappedGestureHandlerStateChangeEvent<
+export type GestureStateChangeEvent<
   GestureStateChangeEventPayloadT = Record<string, unknown>
 > = HandlerStateChangeEventPayload & GestureStateChangeEventPayloadT;
 

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -53,6 +53,8 @@ function convertToHandlerTag(ref: GestureRef): number {
   } else if (ref instanceof BaseGesture) {
     return ref.handlerTag;
   } else {
+    // @ts-ignore in this case it should be a ref either to gesture object or
+    // a gesture handler component, in both cases handlerTag property exists
     return ref.current?.handlerTag ?? -1;
   }
 }

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -13,8 +13,8 @@ import {
   baseGestureHandlerWithMonitorProps,
   filterConfig,
   findNodeHandle,
-  UnwrappedGestureHandlerEvent,
-  UnwrappedGestureHandlerStateChangeEvent,
+  GestureUpdateEvent,
+  GestureStateChangeEvent,
 } from '../gestureHandlerCommon';
 import { flingGestureHandlerProps } from '../FlingGestureHandler';
 import { forceTouchGestureHandlerProps } from '../ForceTouchGestureHandler';
@@ -222,10 +222,8 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
   }
 
   function isStateChangeEvent(
-    event:
-      | UnwrappedGestureHandlerEvent
-      | UnwrappedGestureHandlerStateChangeEvent
-  ): event is UnwrappedGestureHandlerStateChangeEvent {
+    event: GestureUpdateEvent | GestureStateChangeEvent
+  ): event is GestureStateChangeEvent {
     'worklet';
     return event.oldState != null;
   }
@@ -250,9 +248,7 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
   function runWorklet(
     type: CALLBACK_TYPE,
     gesture: HandlerCallbacks<Record<string, unknown>>,
-    event:
-      | UnwrappedGestureHandlerStateChangeEvent
-      | UnwrappedGestureHandlerEvent,
+    event: GestureStateChangeEvent | GestureUpdateEvent,
     success?: boolean
   ) {
     'worklet';
@@ -273,11 +269,7 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
     HandlerCallbacks<Record<string, unknown>>[] | null
   >(null);
 
-  const callback = (
-    event:
-      | UnwrappedGestureHandlerStateChangeEvent
-      | UnwrappedGestureHandlerEvent
-  ) => {
+  const callback = (event: GestureStateChangeEvent | GestureUpdateEvent) => {
     'worklet';
 
     const currentCallback = sharedHandlersCallbacks.value;

--- a/src/handlers/gestures/eventReceiver.ts
+++ b/src/handlers/gestures/eventReceiver.ts
@@ -1,8 +1,8 @@
 import { DeviceEventEmitter, EmitterSubscription } from 'react-native';
 import { State } from '../../State';
 import {
-  UnwrappedGestureHandlerEvent,
-  UnwrappedGestureHandlerStateChangeEvent,
+  GestureUpdateEvent,
+  GestureStateChangeEvent,
 } from '../gestureHandlerCommon';
 import { findHandler } from '../handlersRegistry';
 import { BaseGesture } from './gesture';
@@ -11,13 +11,13 @@ let gestureHandlerEventSubscription: EmitterSubscription | null = null;
 let gestureHandlerStateChangeEventSubscription: EmitterSubscription | null = null;
 
 function isStateChangeEvent(
-  event: UnwrappedGestureHandlerEvent | UnwrappedGestureHandlerStateChangeEvent
-): event is UnwrappedGestureHandlerStateChangeEvent {
+  event: GestureUpdateEvent | GestureStateChangeEvent
+): event is GestureStateChangeEvent {
   return event.oldState != null;
 }
 
 function onGestureHandlerEvent(
-  event: UnwrappedGestureHandlerEvent | UnwrappedGestureHandlerStateChangeEvent
+  event: GestureUpdateEvent | GestureStateChangeEvent
 ) {
   const handler = findHandler(event.handlerTag) as BaseGesture<
     Record<string, unknown>

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -3,8 +3,8 @@ import { ForceTouchGestureHandlerEventPayload } from '../ForceTouchGestureHandle
 import {
   HitSlop,
   CommonGestureConfig,
-  UnwrappedGestureHandlerStateChangeEvent,
-  UnwrappedGestureHandlerEvent,
+  GestureStateChangeEvent,
+  GestureUpdateEvent,
 } from '../gestureHandlerCommon';
 import { getNextHandlerTag } from '../handlersRegistry';
 import { LongPressGestureHandlerEventPayload } from '../LongPressGestureHandler';
@@ -25,28 +25,28 @@ export type GestureType =
   | BaseGesture<ForceTouchGestureHandlerEventPayload>
   | BaseGesture<NativeViewGestureHandlerPayload>;
 
-export type GestureRef = number | GestureType | React.RefObject<GestureType>;
+export type GestureRef =
+  | number
+  | GestureType
+  | React.RefObject<GestureType | undefined>
+  | React.RefObject<any>; // allow adding a ref to a gesture handler
 export interface BaseGestureConfig
   extends CommonGestureConfig,
     Record<string, unknown> {
-  ref?: React.MutableRefObject<GestureType>;
+  ref?: React.MutableRefObject<GestureType | undefined>;
   requireToFail?: GestureRef[];
   simultaneousWith?: GestureRef[];
 }
 
 export type HandlerCallbacks<EventPayloadT extends Record<string, unknown>> = {
   handlerTag: number;
-  onBegin?: (
-    event: UnwrappedGestureHandlerStateChangeEvent<EventPayloadT>
-  ) => void;
-  onStart?: (
-    event: UnwrappedGestureHandlerStateChangeEvent<EventPayloadT>
-  ) => void;
+  onBegin?: (event: GestureStateChangeEvent<EventPayloadT>) => void;
+  onStart?: (event: GestureStateChangeEvent<EventPayloadT>) => void;
   onEnd?: (
-    event: UnwrappedGestureHandlerStateChangeEvent<EventPayloadT>,
+    event: GestureStateChangeEvent<EventPayloadT>,
     success: boolean
   ) => void;
-  onUpdate?: (event: UnwrappedGestureHandlerEvent<EventPayloadT>) => void;
+  onUpdate?: (event: GestureUpdateEvent<EventPayloadT>) => void;
   isWorklet: boolean[];
 };
 
@@ -102,37 +102,27 @@ export abstract class BaseGesture<
       : [gesture];
   }
 
-  withRef(ref: React.MutableRefObject<GestureType>) {
+  withRef(ref: React.MutableRefObject<GestureType | undefined>) {
     this.config.ref = ref;
     return this;
   }
 
   protected isWorklet(
     callback:
-      | ((event: UnwrappedGestureHandlerEvent<EventPayloadT>) => void)
-      | ((
-          event: UnwrappedGestureHandlerStateChangeEvent<EventPayloadT>
-        ) => void)
+      | ((event: GestureUpdateEvent<EventPayloadT>) => void)
+      | ((event: GestureStateChangeEvent<EventPayloadT>) => void)
   ) {
     //@ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
     return callback.__workletHash !== undefined;
   }
 
-  onBegin(
-    callback: (
-      event: UnwrappedGestureHandlerStateChangeEvent<EventPayloadT>
-    ) => void
-  ) {
+  onBegin(callback: (event: GestureStateChangeEvent<EventPayloadT>) => void) {
     this.handlers.onBegin = callback;
     this.handlers.isWorklet[CALLBACK_TYPE.BEGAN] = this.isWorklet(callback);
     return this;
   }
 
-  onStart(
-    callback: (
-      event: UnwrappedGestureHandlerStateChangeEvent<EventPayloadT>
-    ) => void
-  ) {
+  onStart(callback: (event: GestureStateChangeEvent<EventPayloadT>) => void) {
     this.handlers.onStart = callback;
     this.handlers.isWorklet[CALLBACK_TYPE.START] = this.isWorklet(callback);
     return this;
@@ -140,7 +130,7 @@ export abstract class BaseGesture<
 
   onEnd(
     callback: (
-      event: UnwrappedGestureHandlerStateChangeEvent<EventPayloadT>,
+      event: GestureStateChangeEvent<EventPayloadT>,
       success: boolean
     ) => void
   ) {
@@ -199,9 +189,7 @@ export abstract class BaseGesture<
 export abstract class ContinousBaseGesture<
   EventPayloadT extends Record<string, unknown>
 > extends BaseGesture<EventPayloadT> {
-  onUpdate(
-    callback: (event: UnwrappedGestureHandlerEvent<EventPayloadT>) => void
-  ) {
+  onUpdate(callback: (event: GestureUpdateEvent<EventPayloadT>) => void) {
     this.handlers.onUpdate = callback;
     this.handlers.isWorklet[CALLBACK_TYPE.UPDATE] = this.isWorklet(callback);
     return this;

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -29,7 +29,7 @@ export type GestureRef =
   | number
   | GestureType
   | React.RefObject<GestureType | undefined>
-  | React.RefObject<any>; // allow adding a ref to a gesture handler
+  | React.RefObject<React.ComponentType | undefined>; // allow adding a ref to a gesture handler
 export interface BaseGestureConfig
   extends CommonGestureConfig,
     Record<string, unknown> {

--- a/src/handlers/gestures/reanimatedWrapper.ts
+++ b/src/handlers/gestures/reanimatedWrapper.ts
@@ -1,7 +1,7 @@
 import { ComponentClass } from 'react';
 import {
-  UnwrappedGestureHandlerEvent,
-  UnwrappedGestureHandlerStateChangeEvent,
+  GestureUpdateEvent,
+  GestureStateChangeEvent,
 } from '../gestureHandlerCommon';
 
 export interface SharedValue<T> {
@@ -18,11 +18,7 @@ let Reanimated: {
     ): ComponentClass<P>;
   };
   useEvent: (
-    callback: (
-      event:
-        | UnwrappedGestureHandlerEvent
-        | UnwrappedGestureHandlerStateChangeEvent
-    ) => void,
+    callback: (event: GestureUpdateEvent | GestureStateChangeEvent) => void,
     events: string[],
     rebuild: boolean
   ) => unknown;

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,7 +11,11 @@ export type {
   // event payloads types
   GestureEventPayload,
   HandlerStateChangeEventPayload,
+  // new api event types
+  GestureUpdateEvent,
+  GestureStateChangeEvent,
 } from './handlers/gestureHandlerCommon';
+export type { GestureType } from './handlers/gestures/gesture';
 export type {
   TapGestureHandlerEventPayload,
   TapGestureHandlerProps,


### PR DESCRIPTION
## Description

Changes regarding types:
 - Rename `UnwrappedGestureHandlerEvent` to `GestureUpdateEvent` and export it
 - Rename `UnwrappedGestureHandlerStateChangeEvent` to `GestureStateChangeEvent` and export it
 - export `GestureType`
 - change gesture refs type to `React.RefObject<GestureType | undefined>`
 - add `React.RefObject<React.ComponentType | undefined>` to `GestureRef` not to show error when adding a gesture handler

## Test plan

Ran `tsc`
