### PR TITLE
Revert "Disable checking links to unblock docs publish"

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -19,7 +19,6 @@ module.exports = {
   baseUrl,
   url: 'https://docs.swmansion.com',
   favicon: 'img/SWM_Fav_192x192.png',
-  onBrokenLinks: 'warn',
   presets: [
     [
       '@docusaurus/preset-classic',


### PR DESCRIPTION
This reverts commit f80cea4e817bca39123da729f1d34e9148b4384a.

The links have been fixed.
