### PR TITLE
Change invocation order of methods when resetting gesture recognizers

### DIFF
--- a/ios/Handlers/RNFlingHandler.m
+++ b/ios/Handlers/RNFlingHandler.m
@@ -51,8 +51,8 @@
 
 - (void)reset
 {
-  [_gestureHandler.pointerTracker reset];
   [self triggerAction];
+  [_gestureHandler.pointerTracker reset];
   [super reset];
 }
 

--- a/ios/Handlers/RNLongPressHandler.m
+++ b/ios/Handlers/RNLongPressHandler.m
@@ -93,11 +93,11 @@
 
 - (void)reset
 {
-  [_gestureHandler.pointerTracker reset];
-
   if (self.state == UIGestureRecognizerStateFailed) {
     [self triggerAction];
   }
+  
+  [_gestureHandler.pointerTracker reset];
   
   [super reset];
 }

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -138,8 +138,8 @@
 
 - (void)reset
 {
-  [_gestureHandler.pointerTracker reset];
   [self triggerAction];
+  [_gestureHandler.pointerTracker reset];
   self.enabled = YES;
   [super reset];
 }

--- a/ios/Handlers/RNTapHandler.m
+++ b/ios/Handlers/RNTapHandler.m
@@ -171,11 +171,11 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 
 - (void)reset
 {
-  [_gestureHandler.pointerTracker reset];
-  
   if (self.state == UIGestureRecognizerStateFailed) {
     [self triggerAction];
   }
+  [_gestureHandler.pointerTracker reset];
+
   [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
   _tapsSoFar = 0;
   _maxNumberOfTouches = 0;


### PR DESCRIPTION
## Description

Changed order of method invocations in `reset` method of gesture recognizers. `triggerAction` should be called before resetting the `pointerTracker`, as it in turn may reset the GestureHandler they are associated with. This causes GestureHandler to set its cached `lastState` to `UNDETERMINED` which was breaking the state flow when using `touchEvents`.

## Test plan

Tested on the Example app