### PR TITLE
Add prop for setting `handlerTag` in Jest environment

### DIFF
--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -154,9 +154,7 @@ export default function createHandler<
     constructor(props: T & InternalEventHandlers) {
       super(props);
       this.handlerTag =
-        isJest() && props.testHandlerTag
-          ? props.testHandlerTag
-          : getNextHandlerTag();
+        isJest() && props.testId ? props.testId : getNextHandlerTag();
       this.config = {};
       this.propsRef = React.createRef();
       this.state = { allowTouches };

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -11,7 +11,12 @@ import deepEqual from 'lodash/isEqual';
 import RNGestureHandlerModule from '../RNGestureHandlerModule';
 import type RNGestureHandlerModuleWeb from '../RNGestureHandlerModule.web';
 import { State } from '../State';
-import { handlerIDToTag, getNextHandlerTag } from './handlersRegistry';
+import {
+  handlerIDToTag,
+  getNextHandlerTag,
+  unregisterJestHandler,
+  registerJestHandler,
+} from './handlersRegistry';
 
 import {
   BaseGestureHandlerProps,
@@ -222,6 +227,10 @@ export default function createHandler<
         // eslint-disable-next-line @typescript-eslint/no-dynamic-delete
         delete handlerIDToTag[handlerID];
       }
+
+      if (isJest()) {
+        unregisterJestHandler(this.handlerTag);
+      }
     }
 
     private onGestureHandlerEvent = (event: GestureEvent<U>) => {
@@ -295,6 +304,10 @@ export default function createHandler<
           false
         );
       }
+
+      if (isJest()) {
+        registerJestHandler(this.handlerTag, this);
+      }
     };
 
     private updateGestureHandler = (
@@ -303,6 +316,10 @@ export default function createHandler<
       this.config = newConfig;
 
       RNGestureHandlerModule.updateGestureHandler(this.handlerTag, newConfig);
+
+      if (isJest()) {
+        registerJestHandler(this.handlerTag, this);
+      }
     };
 
     private update() {

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -21,6 +21,7 @@ import {
   findNodeHandle,
 } from './gestureHandlerCommon';
 import { ValueOf } from '../typeUtils';
+import { isJest } from '../utils';
 
 const UIManagerAny = UIManager as any;
 
@@ -152,7 +153,10 @@ export default function createHandler<
 
     constructor(props: T & InternalEventHandlers) {
       super(props);
-      this.handlerTag = getNextHandlerTag();
+      this.handlerTag =
+        isJest() && props.testHandlerTag
+          ? props.testHandlerTag
+          : getNextHandlerTag();
       this.config = {};
       this.propsRef = React.createRef();
       this.state = { allowTouches };

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -114,6 +114,7 @@ export type BaseGestureHandlerProps<
   id?: string;
   waitFor?: React.Ref<unknown> | React.Ref<unknown>[];
   simultaneousHandlers?: React.Ref<unknown> | React.Ref<unknown>[];
+  testHandlerTag?: number;
   // TODO(TS) - fix event types
   onBegan?: (event: HandlerStateChangeEvent) => void;
   onFailed?: (event: HandlerStateChangeEvent) => void;

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -114,7 +114,7 @@ export type BaseGestureHandlerProps<
   id?: string;
   waitFor?: React.Ref<unknown> | React.Ref<unknown>[];
   simultaneousHandlers?: React.Ref<unknown> | React.Ref<unknown>[];
-  testHandlerTag?: number;
+  testId?: number;
   // TODO(TS) - fix event types
   onBegan?: (event: HandlerStateChangeEvent) => void;
   onFailed?: (event: HandlerStateChangeEvent) => void;

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -7,7 +7,12 @@ import {
   CALLBACK_TYPE,
 } from './gesture';
 import { Reanimated, SharedValue } from './reanimatedWrapper';
-import { registerHandler, unregisterHandler } from '../handlersRegistry';
+import {
+  registerHandler,
+  registerJestHandler,
+  unregisterHandler,
+  unregisterJestHandler,
+} from '../handlersRegistry';
 import RNGestureHandlerModule from '../../RNGestureHandlerModule';
 import {
   baseGestureHandlerWithMonitorProps,
@@ -32,6 +37,7 @@ import { tapGestureHandlerProps } from '../TapGestureHandler';
 import { State } from '../../State';
 import { EventType } from '../../EventType';
 import { ComposedGesture } from './gestureComposition';
+import { isJest } from '../../utils';
 
 const ALLOWED_PROPS = [
   ...baseGestureHandlerWithMonitorProps,
@@ -76,6 +82,10 @@ function dropHandlers(preparedGesture: GestureConfigReference) {
     RNGestureHandlerModule.dropGestureHandler(handler.handlerTag);
 
     unregisterHandler(handler.handlerTag);
+
+    if (isJest()) {
+      unregisterJestHandler(handler.handlerTag);
+    }
   }
 }
 
@@ -147,6 +157,10 @@ function attachHandlers({
       viewTag,
       !useAnimated // send direct events when using animatedGesture, device events otherwise
     );
+
+    if (isJest()) {
+      registerJestHandler(gesture.handlerTag, gesture);
+    }
   }
 
   if (preparedGesture.animatedHandlers) {
@@ -198,6 +212,10 @@ function updateHandlers(
       );
 
       registerHandler(handler.handlerTag, handler);
+
+      if (isJest()) {
+        registerJestHandler(handler.handlerTag, handler);
+      }
     }
 
     if (preparedGesture.animatedHandlers) {

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -15,6 +15,7 @@ import { PinchGestureHandlerEventPayload } from '../PinchGestureHandler';
 import { RotationGestureHandlerEventPayload } from '../RotationGestureHandler';
 import { TapGestureHandlerEventPayload } from '../TapGestureHandler';
 import { NativeViewGestureHandlerPayload } from '../NativeViewGestureHandler';
+import { isJest } from '../../utils';
 
 export type GestureType =
   | BaseGesture<Record<string, unknown>>
@@ -41,6 +42,7 @@ export interface BaseGestureConfig
   simultaneousWith?: GestureRef[];
   needsPointerData?: boolean;
   manualActivation?: boolean;
+  testHandlerTag?: number;
 }
 
 type TouchEventHandlerType = (
@@ -246,8 +248,17 @@ export abstract class BaseGesture<
     return this;
   }
 
+  withTestTag(tag: number) {
+    this.config.testHandlerTag = tag;
+    return this;
+  }
+
   initialize() {
-    this.handlerTag = getNextHandlerTag();
+    this.handlerTag =
+      isJest() && this.config.testHandlerTag
+        ? this.config.testHandlerTag
+        : getNextHandlerTag();
+
     this.handlers = { ...this.handlers, handlerTag: this.handlerTag };
 
     if (this.config.ref) {

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -42,7 +42,7 @@ export interface BaseGestureConfig
   simultaneousWith?: GestureRef[];
   needsPointerData?: boolean;
   manualActivation?: boolean;
-  testHandlerTag?: number;
+  testId?: number;
 }
 
 type TouchEventHandlerType = (
@@ -248,16 +248,14 @@ export abstract class BaseGesture<
     return this;
   }
 
-  withTestTag(tag: number) {
-    this.config.testHandlerTag = tag;
+  withTestId(id: number) {
+    this.config.testId = id;
     return this;
   }
 
   initialize() {
     this.handlerTag =
-      isJest() && this.config.testHandlerTag
-        ? this.config.testHandlerTag
-        : getNextHandlerTag();
+      isJest() && this.config.testId ? this.config.testId : getNextHandlerTag();
 
     this.handlers = { ...this.handlers, handlerTag: this.handlerTag };
 

--- a/src/handlers/handlersRegistry.ts
+++ b/src/handlers/handlersRegistry.ts
@@ -20,3 +20,18 @@ export function unregisterHandler(handlerTag: number) {
 export function findHandler(handlerTag: number) {
   return handlers.get(handlerTag);
 }
+
+// store all gestures and handlers for Jest
+const jestHandlers = new Map<number, any>();
+
+export function registerJestHandler(handlerTag: number, handler: any) {
+  jestHandlers.set(handlerTag, handler);
+}
+
+export function unregisterJestHandler(handlerTag: number) {
+  jestHandlers.delete(handlerTag);
+}
+
+export function findJestHandler(handlerTag: number) {
+  return jestHandlers.get(handlerTag);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,7 @@
 import { initialize } from './init';
 
+export { findJestHandler } from './handlers/handlersRegistry';
+
 export { Directions } from './Directions';
 export { State } from './State';
 export { default as gestureHandlerRootHOC } from './gestureHandlerRootHOC';

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,6 +7,5 @@ export function toArray<T>(object: T | T[]): T[] {
 }
 
 export function isJest(): boolean {
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   return !!process.env.JEST_WORKER_ID;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,3 +5,7 @@ export function toArray<T>(object: T | T[]): T[] {
 
   return object;
 }
+
+export function isJest(): boolean {
+  return !!process.env.JEST_WORKER_ID;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -7,5 +7,6 @@ export function toArray<T>(object: T | T[]): T[] {
 }
 
 export function isJest(): boolean {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   return !!process.env.JEST_WORKER_ID;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "jsx": "react-native",
     "lib": ["esnext"],
-    "types": [],
+    "types": ["node"],
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Description

Add prop `testId` which allows to set `handlerTag` property of gesture handlers in Jest environments.
Add `withTestId` method to gesture config objects which behaves in the same way.

Add handler registry for Jest environment which allows to find every gesture configuration and gesture handler in tests using `handlerTag`.

This change simplifies creating tests for Gesture Handler as each gesture can have its tag set explicitly and `handlerTag` is necessary to deliver events to relevant handler.

## Test plan

Tested on a separate app
