### PR TITLE
Send state change event when awaiting handler finishes

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -142,6 +142,10 @@ class GestureHandlerOrchestrator(
     } else if (prevState == GestureHandler.STATE_ACTIVE || prevState == GestureHandler.STATE_END) {
       if (handler.isActive) {
         handler.dispatchStateChange(newState, prevState)
+      } else if (prevState == GestureHandler.STATE_ACTIVE) {
+        // handle edge case where handler awaiting for another one tries to activate but finishes
+        // before the other would not send state change event upon ending
+        handler.dispatchStateChange(newState, GestureHandler.STATE_BEGAN)
       }
     } else {
       handler.dispatchStateChange(newState, prevState)


### PR DESCRIPTION
## Description

On Android when a handler awaiting another one tries to activate its state is changed to `ACTIVE` but event with that change is delayed until the other finishes. If the awaiting handler were to fail before that happens, state change event with information about its failure would not be sent.

This PR adds a workaround that sends state change event when the handler is active internally but still awaiting another one.

## Test plan

Tested on the Example app.