### PR TITLE
Remove `onTouchesChange` from documentation

### DIFF
--- a/docs/docs/api/gestures/base-gesture-callbacks.md
+++ b/docs/docs/api/gestures/base-gesture-callbacks.md
@@ -16,22 +16,18 @@ Set the callback that is being called when the gesture that was recognized by th
 
 Set the callback that is being called when the handler finalizes handling gesture - the gesture was recognized and has finished or it failed to recognize.
 
-### `onTouchesDown(event, stateManager)`
+### `onTouchesDown(callback)`
 
 Set the `onTouchesDown` callback which is called every time a finger is placed on the screen.
 
-### `onTouchesMove(event, stateManager)`
+### `onTouchesMove(callback)`
 
 Set the `onTouchesMove` callback which is called every time a finger is moved on the screen.
 
-### `onTouchesUp(event, stateManager)`
+### `onTouchesUp(callback)`
 
 Set the `onTouchesUp` callback which is called every time a finger is lifted from the screen.
 
-### `onTouchesCancelled(event, stateManager)`
+### `onTouchesCancelled(callback)`
 
 Set the `onTouchesCancelled` callback which is called every time a finger stops being tracked, for example when the gesture finishes.
-
-### `onTouchesChange(event, stateManager)`
-
-Set the `onTouchesChange` callback which is called for every touch event.

--- a/docs/versioned_docs/version-2.0.0/api/gestures/base-gesture-callbacks.md
+++ b/docs/versioned_docs/version-2.0.0/api/gestures/base-gesture-callbacks.md
@@ -16,22 +16,18 @@ Set the callback that is being called when the gesture that was recognized by th
 
 Set the callback that is being called when the handler finalizes handling gesture - the gesture was recognized and has finished or it failed to recognize.
 
-### `onTouchesDown(event, stateManager)`
+### `onTouchesDown(callback)`
 
 Set the `onTouchesDown` callback which is called every time a finger is placed on the screen.
 
-### `onTouchesMove(event, stateManager)`
+### `onTouchesMove(callback)`
 
 Set the `onTouchesMove` callback which is called every time a finger is moved on the screen.
 
-### `onTouchesUp(event, stateManager)`
+### `onTouchesUp(callback)`
 
 Set the `onTouchesUp` callback which is called every time a finger is lifted from the screen.
 
-### `onTouchesCancelled(event, stateManager)`
+### `onTouchesCancelled(callback)`
 
 Set the `onTouchesCancelled` callback which is called every time a finger stops being tracked, for example when the gesture finishes.
-
-### `onTouchesChange(event, stateManager)`
-
-Set the `onTouchesChange` callback which is called for every touch event.


### PR DESCRIPTION
## Description

Remove `onTouchesChange` callback from documentation.
Update arguments for touch events callbacks.
