### PR TITLE
Fixed IllegalArgumentException pointerCount must be at least 1

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -255,6 +255,10 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
       throw IllegalStateException("pointerCoords.size=${pointerCoords.size}, pointerProps.size=${pointerProps.size}")
     }
 
+    if (count == 0) {
+      return event
+    }
+
     val result: MotionEvent
     try {
       result = MotionEvent.obtain(


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Inlude 'Fixes #<number>' if this is fixing some issue.
-->
Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1188

## Test plan

<!--
Describe how did you test this change here.
-->
It's a random crash, at the moment nobody know how to reproduce it.