### PR TITLE
Send first `onTouchesDown` after gesture begins

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -242,14 +242,28 @@ class GestureHandlerOrchestrator(
     // approach when we want to use pointer coordinates to calculate velocity or distance
     // for pinch so I don't know yet if we should transform or not...
     event.setLocation(coords[0], coords[1])
-    if (handler.needsPointerData) {
+    
+    // Touch events are sent before the handler itself has a chance to process them,
+    // mainly because `onTouchesUp` shoul be send befor gesture finishes. This means that
+    // the first `onTouchesDown` event is sent before a gesture begins, activation in 
+    // callback for this event causes problems because the handler doesn't have a chance
+    // to initialize itself with starting values of pointer (in pan this causes translation
+    // to be equal to the coordinates of the pointer). The simplest solution is to send
+    // the first `onTouchesDown` event after the handler processes it and changes state
+    // to `BEGAN`.
+    if (handler.needsPointerData && handler.state != 0) {
       handler.updatePointerData(event)
     }
 
     if (!handler.isAwaiting || action != MotionEvent.ACTION_MOVE) {
+      val isFirstEvent = handler.state == 0
       handler.handle(event)
       if (handler.isActive) {
         handler.dispatchHandlerUpdate(event)
+      }
+
+      if (handler.needsPointerData && isFirstEvent) {
+        handler.updatePointerData(event)
       }
 
       // if event was of type UP or POINTER_UP we request handler to stop tracking now that


### PR DESCRIPTION
## Description

On Android touch events are sent before other events. This causes problems when the gesture is activated in the `onTouchesDown` callback. The gesture then goes from `UNDETERMINED` state to `ACTIVE` before it has a change to process the first event. For example, if done with `PanGesture`, the translation would start with values equal to the coordinates of the pointer.

This PR adds a workaround that sends the first touch event (which would be `TOUCH_DOWN`) only after the handler has processed the event (making sure the handler is initialized correctly, and `UNDETERMINED` -> `BEGAN` state change event is sent).

## Test plan

Tested on the Example app
