### PR TITLE
Reset progress of handler when it finishes waiting ends

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -67,14 +67,11 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   protected inline fun applySelf(block: ConcreteGestureHandlerT.() -> Unit): ConcreteGestureHandlerT =
     self().apply { block() }
 
-  // set and accessed only by the orchestrator
+  // properties set and accessed only by the orchestrator
   var activationIndex = 0
-
-  // set and accessed only by the orchestrator
   var isActive = false
-
-  // set and accessed only by the orchestrator
   var isAwaiting = false
+  var shouldResetProgress = false
 
   open fun dispatchStateChange(newState: Int, prevState: Int) {
     onTouchEventListener?.onStateChange(self(), newState, prevState)
@@ -616,6 +613,10 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
       moveToState(STATE_END)
     }
   }
+
+  // responsible for resetting the state of handler upon activation (may be called more than once
+  // if the handler is waiting for failure of other one)
+  open fun resetProgress() {}
 
   protected open fun onHandle(event: MotionEvent) {
     moveToState(STATE_FAILED)

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -208,8 +208,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       lastY = getLastPointerY(event, averageTouches)
     }
     if (state == STATE_UNDETERMINED && event.pointerCount >= minPointers) {
-      startX = lastX
-      startY = lastY
+      resetProgress()
       offsetX = 0f
       offsetY = 0f
       velocityX = 0f
@@ -253,8 +252,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
   override fun activate(force: Boolean) {
     // reset starting point if the handler has not yet activated
     if (state != STATE_ACTIVE) {
-      startX = lastX
-      startY = lastY
+      resetProgress()
     }
     super.activate(force)
   }
@@ -264,6 +262,11 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       it.recycle()
       velocityTracker = null
     }
+  }
+
+  override fun resetProgress() {
+    startX = lastX
+    startY = lastY
   }
 
   companion object {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -52,8 +52,7 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
   override fun onHandle(event: MotionEvent) {
     if (state == STATE_UNDETERMINED) {
       val context = view!!.context
-      velocity = 0.0
-      scale = 1.0
+      resetProgress()
       scaleGestureDetector = ScaleGestureDetector(context, gestureListener)
       val configuration = ViewConfiguration.get(context)
       spanSlop = configuration.scaledTouchSlop.toFloat()
@@ -74,14 +73,17 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
   override fun activate(force: Boolean) {
     // reset scale if the handler has not yet activated
     if (state != STATE_ACTIVE) {
-      velocity = 0.0
-      scale = 1.0
+      resetProgress()
     }
     super.activate(force)
   }
 
   override fun onReset() {
     scaleGestureDetector = null
+    resetProgress()
+  }
+
+  override fun resetProgress() {
     velocity = 0.0
     scale = 1.0
   }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
@@ -43,8 +43,7 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
 
   override fun onHandle(event: MotionEvent) {
     if (state == STATE_UNDETERMINED) {
-      velocity = 0.0
-      rotation = 0.0
+      resetProgress()
       rotationGestureDetector = RotationGestureDetector(gestureListener)
       begin()
     }
@@ -61,14 +60,17 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
   override fun activate(force: Boolean) {
     // reset rotation if the handler has not yet activated
     if (state != STATE_ACTIVE) {
-      rotation = 0.0
-      velocity = 0.0
+      resetProgress()
     }
     super.activate(force)
   }
 
   override fun onReset() {
     rotationGestureDetector = null
+    resetProgress()
+  }
+
+  override fun resetProgress() {
     velocity = 0.0
     rotation = 0.0
   }


### PR DESCRIPTION
## Description

On Android when a handler is waiting for failure of another it activates as without this restriction but is prevented from sending updates and receiving touch stream until the other handler fails. Because of this, there may be a large difference between the event that caused activation, and the event delivered after failure of other handler, which is visible in the events sent by the handler.

This PR adds logic responsible for resetting the progress of a handler after the "fake" activation when waiting ends, making the behavior consistent with iOS.

## Test Plan

Tested on the Example app