### PR TITLE
Don't send `UNDETERMINED` to `CANCELLED` state change event

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -143,7 +143,11 @@ class GestureHandlerOrchestrator(
       if (handler.isActive) {
         handler.dispatchStateChange(newState, prevState)
       }
-    } else {
+    } else if (prevState != GestureHandler.STATE_UNDETERMINED || newState != GestureHandler.STATE_CANCELLED) {
+      // If handler is changing state from UNDETERMINED to CANCELLED, the state change event shouldn't
+      // be sent. Handler hasn't yet began so it may not be initialized which results in crashes.
+      // If it doesn't crash, there may be some weird behavior on JS side, as `onFinalize` will be
+      // called without calling `onBegin` first.
       handler.dispatchStateChange(newState, prevState)
     }
     handlingChangeSemaphore -= 1


### PR DESCRIPTION
## Description

This PR changes Orchestrator in a way that the `UNDETERMINED` -> `CANCELLED` state change event would not be sent. Before introduction of touch events such change couldn't occur, but now it's possible to activate the gesture at the moment the finger touches the screen. Events are delivered to handlers sequentially, so it may happen that handlers next in line would get cancelled before receiving the first event (thus before they can initialize). If this doesn't result in a crash, then the `UNDETERMINED` to `CANCELLED` state change event will be sent, triggering `onFinalize` callback without calling `onBegin` first.

## Test plan

Tested on the Example app
