### PR TITLE
Add `onChange` callback to continuous gestures.

### DIFF
--- a/docs/docs/api/gestures/base-continous-gesture-callbacks.md
+++ b/docs/docs/api/gestures/base-continous-gesture-callbacks.md
@@ -3,3 +3,7 @@
 ### `onUpdate(callback)`
 
 Set the callback that is being called every time the gesture receives an update while it's active.
+
+### `onChange(callback)`
+
+Set the callback that is being called every time the gesture receives an update while it's active. This callback will receive information about change in value in relation to the last received event.

--- a/example/src/new_api/camera/index.tsx
+++ b/example/src/new_api/camera/index.tsx
@@ -17,7 +17,6 @@ export default function Home() {
   const filter = useSharedValue(0);
   const filterOffset = useSharedValue(0);
   const zoom = useSharedValue(1);
-  const [scale, setScale] = useState(1);
   const [selectedFilter, setSelectedFilter] = useState(0);
   const [isRecording, setIsRecording] = useState(false);
   const [remainingTimeMs, setRemainingTimeMs] = useState(MAX_VIDEO_DURATION_MS);
@@ -79,15 +78,10 @@ export default function Home() {
       }
     });
 
-  const previewPinchGesture = Gesture.Pinch()
-    .onStart(() => {
-      'worklet';
-      runOnJS(setScale)(zoom.value);
-    })
-    .onUpdate((e) => {
-      'worklet';
-      zoom.value = scale * e.scale;
-    });
+  const previewPinchGesture = Gesture.Pinch().onChange((e) => {
+    'worklet';
+    zoom.value *= e.scaleChange;
+  });
 
   const buttonGesture = Gesture.Simultaneous(
     buttonLongPressGesture,

--- a/example/src/new_api/reanimated/index.tsx
+++ b/example/src/new_api/reanimated/index.tsx
@@ -10,7 +10,6 @@ import Animated, {
 function Ball() {
   const isPressed = useSharedValue(false);
   const offset = useSharedValue({ x: 0, y: 0 });
-  const start = useSharedValue({ x: 0, y: 0 });
 
   const animatedStyles = useAnimatedStyle(() => {
     return {
@@ -28,18 +27,11 @@ function Ball() {
       'worklet';
       isPressed.value = true;
     })
-    .onUpdate((e) => {
+    .onChange((e) => {
       'worklet';
       offset.value = {
-        x: e.translationX + start.value.x,
-        y: e.translationY + start.value.y,
-      };
-    })
-    .onEnd(() => {
-      'worklet';
-      start.value = {
-        x: offset.value.x,
-        y: offset.value.y,
+        x: e.changeX + offset.value.x,
+        y: e.changeY + offset.value.y,
       };
     })
     .onFinalize(() => {

--- a/example/src/new_api/transformations/index.tsx
+++ b/example/src/new_api/transformations/index.tsx
@@ -7,13 +7,9 @@ import Animated, {
 import { GestureDetector, Gesture } from 'react-native-gesture-handler';
 
 function Photo() {
-  const offsetX = useSharedValue(0);
-  const offsetY = useSharedValue(0);
   const translationX = useSharedValue(0);
   const translationY = useSharedValue(0);
-  const savedScale = useSharedValue(1);
   const scale = useSharedValue(1);
-  const savedRotation = useSharedValue(0);
   const rotation = useSharedValue(0);
 
   const style = useAnimatedStyle(() => {
@@ -27,37 +23,22 @@ function Photo() {
     };
   });
 
-  const rotationGesture = Gesture.Rotation()
-    .onUpdate((e) => {
-      'worklet';
-      rotation.value = savedRotation.value + e.rotation;
-    })
-    .onEnd(() => {
-      'worklet';
-      savedRotation.value = rotation.value;
-    });
+  const rotationGesture = Gesture.Rotation().onChange((e) => {
+    'worklet';
+    rotation.value += e.rotationChange;
+  });
 
-  const scaleGesture = Gesture.Pinch()
-    .onUpdate((e) => {
-      'worklet';
-      scale.value = savedScale.value * e.scale;
-    })
-    .onEnd(() => {
-      'worklet';
-      savedScale.value = scale.value;
-    });
+  const scaleGesture = Gesture.Pinch().onChange((e) => {
+    'worklet';
+    scale.value *= e.scaleChange;
+  });
 
   const panGesture = Gesture.Pan()
     .averageTouches(true)
-    .onUpdate((e) => {
+    .onChange((e) => {
       'worklet';
-      translationX.value = offsetX.value + e.translationX;
-      translationY.value = offsetY.value + e.translationY;
-    })
-    .onEnd(() => {
-      'worklet';
-      offsetX.value = translationX.value;
-      offsetY.value = translationY.value;
+      translationX.value += e.changeX;
+      translationY.value += e.changeY;
     });
 
   const doubleTapGesture = Gesture.Tap()

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -256,6 +256,8 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
         return gesture.onStart;
       case CALLBACK_TYPE.UPDATE:
         return gesture.onUpdate;
+      case CALLBACK_TYPE.CHANGE:
+        return gesture.onChange;
       case CALLBACK_TYPE.END:
         return gesture.onEnd;
       case CALLBACK_TYPE.FINALIZE:
@@ -310,6 +312,11 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
     HandlerCallbacks<Record<string, unknown>>[] | null
   >(null);
 
+  // eslint-disable-next-line react-hooks/rules-of-hooks
+  const lastUpdateEvent = Reanimated.useSharedValue<
+    (GestureUpdateEvent | undefined)[]
+  >([]);
+
   // not every gesture needs a state controller, init them lazily
   const stateControllers: GestureStateManagerType[] = [];
 
@@ -339,6 +346,7 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
             event.state === State.ACTIVE
           ) {
             runWorklet(CALLBACK_TYPE.START, gesture, event);
+            lastUpdateEvent.value[gesture.handlerTag] = undefined;
           } else if (
             event.oldState !== event.state &&
             event.state === State.END
@@ -371,6 +379,19 @@ function useAnimatedGesture(preparedGesture: GestureConfigReference) {
           }
         } else {
           runWorklet(CALLBACK_TYPE.UPDATE, gesture, event);
+
+          if (gesture.onChange && gesture.changeEventCalculator) {
+            runWorklet(
+              CALLBACK_TYPE.CHANGE,
+              gesture,
+              gesture.changeEventCalculator?.(
+                event,
+                lastUpdateEvent.value[gesture.handlerTag]
+              )
+            );
+
+            lastUpdateEvent.value[gesture.handlerTag] = event;
+          }
         }
       }
     }

--- a/src/handlers/gestures/forceTouchGesture.ts
+++ b/src/handlers/gestures/forceTouchGesture.ts
@@ -3,8 +3,35 @@ import {
   ForceTouchGestureConfig,
   ForceTouchGestureHandlerEventPayload,
 } from '../ForceTouchGestureHandler';
+import { GestureUpdateEvent } from '../gestureHandlerCommon';
 
-export class ForceTouchGesture extends ContinousBaseGesture<ForceTouchGestureHandlerEventPayload> {
+type ForceTouchGestureChangeEventPayload = {
+  forceChange: number;
+};
+
+function changeEventCalculator(
+  current: GestureUpdateEvent<ForceTouchGestureHandlerEventPayload>,
+  previous?: GestureUpdateEvent<ForceTouchGestureHandlerEventPayload>
+) {
+  'worklet';
+  let changePayload: ForceTouchGestureChangeEventPayload;
+  if (previous === undefined) {
+    changePayload = {
+      forceChange: current.force,
+    };
+  } else {
+    changePayload = {
+      forceChange: current.force - previous.force,
+    };
+  }
+
+  return { ...current, ...changePayload };
+}
+
+export class ForceTouchGesture extends ContinousBaseGesture<
+  ForceTouchGestureHandlerEventPayload,
+  ForceTouchGestureChangeEventPayload
+> {
   public config: BaseGestureConfig & ForceTouchGestureConfig = {};
 
   constructor() {
@@ -26,6 +53,21 @@ export class ForceTouchGesture extends ContinousBaseGesture<ForceTouchGestureHan
   feedbackOnActivation(value: boolean) {
     this.config.feedbackOnActivation = value;
     return this;
+  }
+
+  onChange(
+    callback: (
+      event: GestureUpdateEvent<
+        GestureUpdateEvent<
+          ForceTouchGestureHandlerEventPayload &
+            ForceTouchGestureChangeEventPayload
+        >
+      >
+    ) => void
+  ) {
+    // @ts-ignore TS being overprotective, ForceTouchGestureHandlerEventPayload is Record
+    this.handlers.changeEventCalculator = changeEventCalculator;
+    return super.onChange(callback);
   }
 }
 

--- a/src/handlers/gestures/manualGesture.ts
+++ b/src/handlers/gestures/manualGesture.ts
@@ -1,10 +1,30 @@
+import { GestureUpdateEvent } from '../gestureHandlerCommon';
 import { ContinousBaseGesture } from './gesture';
 
-export class ManualGesture extends ContinousBaseGesture<Record<string, never>> {
+function changeEventCalculator(
+  current: GestureUpdateEvent<Record<string, never>>,
+  _previous?: GestureUpdateEvent<Record<string, never>>
+) {
+  'worklet';
+  return current;
+}
+
+export class ManualGesture extends ContinousBaseGesture<
+  Record<string, never>,
+  Record<string, never>
+> {
   constructor() {
     super();
 
     this.handlerName = 'ManualGestureHandler';
+  }
+
+  onChange(
+    callback: (event: GestureUpdateEvent<Record<string, never>>) => void
+  ) {
+    // @ts-ignore TS being overprotective, Record<string, never> is Record
+    this.handlers.changeEventCalculator = changeEventCalculator;
+    return super.onChange(callback);
   }
 }
 

--- a/src/handlers/gestures/pinchGesture.ts
+++ b/src/handlers/gestures/pinchGesture.ts
@@ -1,11 +1,50 @@
 import { ContinousBaseGesture } from './gesture';
 import { PinchGestureHandlerEventPayload } from '../PinchGestureHandler';
+import { GestureUpdateEvent } from '../gestureHandlerCommon';
 
-export class PinchGesture extends ContinousBaseGesture<PinchGestureHandlerEventPayload> {
+type PinchGestureChangeEventPayload = {
+  scaleChange: number;
+};
+
+function changeEventCalculator(
+  current: GestureUpdateEvent<PinchGestureHandlerEventPayload>,
+  previous?: GestureUpdateEvent<PinchGestureHandlerEventPayload>
+) {
+  'worklet';
+  let changePayload: PinchGestureChangeEventPayload;
+  if (previous === undefined) {
+    changePayload = {
+      scaleChange: current.scale,
+    };
+  } else {
+    changePayload = {
+      scaleChange: current.scale / previous.scale,
+    };
+  }
+
+  return { ...current, ...changePayload };
+}
+
+export class PinchGesture extends ContinousBaseGesture<
+  PinchGestureHandlerEventPayload,
+  PinchGestureChangeEventPayload
+> {
   constructor() {
     super();
 
     this.handlerName = 'PinchGestureHandler';
+  }
+
+  onChange(
+    callback: (
+      event: GestureUpdateEvent<
+        PinchGestureHandlerEventPayload & PinchGestureChangeEventPayload
+      >
+    ) => void
+  ) {
+    // @ts-ignore TS being overprotective, PinchGestureHandlerEventPayload is Record
+    this.handlers.changeEventCalculator = changeEventCalculator;
+    return super.onChange(callback);
   }
 }
 

--- a/src/handlers/gestures/rotationGesture.ts
+++ b/src/handlers/gestures/rotationGesture.ts
@@ -1,11 +1,50 @@
 import { ContinousBaseGesture } from './gesture';
 import { RotationGestureHandlerEventPayload } from '../RotationGestureHandler';
+import { GestureUpdateEvent } from '../gestureHandlerCommon';
 
-export class RotationGesture extends ContinousBaseGesture<RotationGestureHandlerEventPayload> {
+type RotationGestureChangeEventPayload = {
+  rotationChange: number;
+};
+
+function changeEventCalculator(
+  current: GestureUpdateEvent<RotationGestureHandlerEventPayload>,
+  previous?: GestureUpdateEvent<RotationGestureHandlerEventPayload>
+) {
+  'worklet';
+  let changePayload: RotationGestureChangeEventPayload;
+  if (previous === undefined) {
+    changePayload = {
+      rotationChange: current.rotation,
+    };
+  } else {
+    changePayload = {
+      rotationChange: current.rotation - previous.rotation,
+    };
+  }
+
+  return { ...current, ...changePayload };
+}
+
+export class RotationGesture extends ContinousBaseGesture<
+  RotationGestureHandlerEventPayload,
+  RotationGestureChangeEventPayload
+> {
   constructor() {
     super();
 
     this.handlerName = 'RotationGestureHandler';
+  }
+
+  onChange(
+    callback: (
+      event: GestureUpdateEvent<
+        RotationGestureHandlerEventPayload & RotationGestureChangeEventPayload
+      >
+    ) => void
+  ) {
+    // @ts-ignore TS being overprotective, RotationGestureHandlerEventPayload is Record
+    this.handlers.changeEventCalculator = changeEventCalculator;
+    return super.onChange(callback);
   }
 }
 


### PR DESCRIPTION
## Description

This PR adds `onChange` callback to continuous gestures. This callback is called just after `onUpdate` and carries additional information - change of value since the last event:
- For `PanGesture`: `changeX`, `changeY` - additive difference in translation
- For `PinchGesture`: `scaleChange` - multiplicative difference in scale
- For `RotationGesture`: `rotationChange` - additive difference in rotation
- For `ForceTouchGesture`: `forceChange` - additive difference in force

## Test plan

Updated examples and tested on the Example app.
