### PR TITLE
Change absolute position to be relative to the window instead of the screen

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -106,8 +106,8 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
       with(eventData) {
         putDouble("x", PixelUtil.toDIPFromPixel(handler.lastRelativePositionX).toDouble())
         putDouble("y", PixelUtil.toDIPFromPixel(handler.lastRelativePositionY).toDouble())
-        putDouble("absoluteX", PixelUtil.toDIPFromPixel(handler.lastAbsolutePositionX).toDouble())
-        putDouble("absoluteY", PixelUtil.toDIPFromPixel(handler.lastAbsolutePositionY).toDouble())
+        putDouble("absoluteX", PixelUtil.toDIPFromPixel(handler.lastPositionInWindowX).toDouble())
+        putDouble("absoluteY", PixelUtil.toDIPFromPixel(handler.lastPositionInWindowY).toDouble())
       }
     }
   }
@@ -135,8 +135,8 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
       with(eventData) {
         putDouble("x", PixelUtil.toDIPFromPixel(handler.lastRelativePositionX).toDouble())
         putDouble("y", PixelUtil.toDIPFromPixel(handler.lastRelativePositionY).toDouble())
-        putDouble("absoluteX", PixelUtil.toDIPFromPixel(handler.lastAbsolutePositionX).toDouble())
-        putDouble("absoluteY", PixelUtil.toDIPFromPixel(handler.lastAbsolutePositionY).toDouble())
+        putDouble("absoluteX", PixelUtil.toDIPFromPixel(handler.lastPositionInWindowX).toDouble())
+        putDouble("absoluteY", PixelUtil.toDIPFromPixel(handler.lastPositionInWindowY).toDouble())
         putInt("duration", handler.duration)
       }
     }
@@ -223,8 +223,8 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
       with(eventData) {
         putDouble("x", PixelUtil.toDIPFromPixel(handler.lastRelativePositionX).toDouble())
         putDouble("y", PixelUtil.toDIPFromPixel(handler.lastRelativePositionY).toDouble())
-        putDouble("absoluteX", PixelUtil.toDIPFromPixel(handler.lastAbsolutePositionX).toDouble())
-        putDouble("absoluteY", PixelUtil.toDIPFromPixel(handler.lastAbsolutePositionY).toDouble())
+        putDouble("absoluteX", PixelUtil.toDIPFromPixel(handler.lastPositionInWindowX).toDouble())
+        putDouble("absoluteY", PixelUtil.toDIPFromPixel(handler.lastPositionInWindowY).toDouble())
         putDouble("translationX", PixelUtil.toDIPFromPixel(handler.translationX).toDouble())
         putDouble("translationY", PixelUtil.toDIPFromPixel(handler.translationY).toDouble())
         putDouble("velocityX", PixelUtil.toDIPFromPixel(handler.velocityX).toDouble())
@@ -275,8 +275,8 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
       with(eventData) {
         putDouble("x", PixelUtil.toDIPFromPixel(handler.lastRelativePositionX).toDouble())
         putDouble("y", PixelUtil.toDIPFromPixel(handler.lastRelativePositionY).toDouble())
-        putDouble("absoluteX", PixelUtil.toDIPFromPixel(handler.lastAbsolutePositionX).toDouble())
-        putDouble("absoluteY", PixelUtil.toDIPFromPixel(handler.lastAbsolutePositionY).toDouble())
+        putDouble("absoluteX", PixelUtil.toDIPFromPixel(handler.lastPositionInWindowX).toDouble())
+        putDouble("absoluteY", PixelUtil.toDIPFromPixel(handler.lastPositionInWindowY).toDouble())
       }
     }
   }

--- a/docs/docs/api/gestures/fling-gesture.md
+++ b/docs/docs/api/gestures/fling-gesture.md
@@ -55,11 +55,11 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ### `absoluteX`
 
-X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
+X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
 
 ### `absoluteY`
 
-Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
+Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
 
 <BaseEventData />
 

--- a/docs/docs/api/gestures/long-press-gesture.md
+++ b/docs/docs/api/gestures/long-press-gesture.md
@@ -44,11 +44,11 @@ Y coordinate, expressed in points, of the current position of the pointer (finge
 
 ### `absoluteX`
 
-X coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. It is recommended to use `absoluteX` instead of [`x`](#x) in cases when the view attached to the [`GestureDetector`](./gesture-detector.md) can be transformed as an effect of the gesture.
+X coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. It is recommended to use `absoluteX` instead of [`x`](#x) in cases when the view attached to the [`GestureDetector`](./gesture-detector.md) can be transformed as an effect of the gesture.
 
 ### `absoluteY`
 
-Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. It is recommended to use `absoluteY` instead of [`y`](#y) in cases when the view attached to the [`GestureDetector`](./gesture-detector.md) can be transformed as an effect of the gesture.
+Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. It is recommended to use `absoluteY` instead of [`y`](#y) in cases when the view attached to the [`GestureDetector`](./gesture-detector.md) can be transformed as an effect of the gesture.
 
 ### `duration`
 

--- a/docs/docs/api/gestures/pan-gesture.md
+++ b/docs/docs/api/gestures/pan-gesture.md
@@ -118,11 +118,11 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ### `absoluteX`
 
-X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
+X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
 
 ### `absoluteY`
 
-Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
+Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
 
 <BaseEventData />
 

--- a/docs/docs/api/gestures/tap-gesture.md
+++ b/docs/docs/api/gestures/tap-gesture.md
@@ -69,11 +69,11 @@ Y coordinate, expressed in points, of the current position of the pointer (finge
 
 ### `absoluteX`
 
-X coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. It is recommended to use `absoluteX` instead of [`x`](#x) in cases when the view attached to the [`GestureDetector`](./gesture-detector.md) can be transformed as an effect of the gesture.
+X coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. It is recommended to use `absoluteX` instead of [`x`](#x) in cases when the view attached to the [`GestureDetector`](./gesture-detector.md) can be transformed as an effect of the gesture.
 
 ### `absoluteY`
 
-Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. It is recommended to use `absoluteY` instead of [`y`](#y) in cases when the view attached to the [`GestureDetector`](./gesture-detector.md) can be transformed as an effect of the gesture.
+Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. It is recommended to use `absoluteY` instead of [`y`](#y) in cases when the view attached to the [`GestureDetector`](./gesture-detector.md) can be transformed as an effect of the gesture.
 
 <BaseEventData />
 

--- a/docs/docs/api/gestures/touch-events.md
+++ b/docs/docs/api/gestures/touch-events.md
@@ -42,8 +42,8 @@ Y coordinate of the current position of the touch relative to the view attached 
 
 ### `absoluteX`
 
-X coordinate of the current position of the touch relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
+X coordinate of the current position of the touch relative to the window. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
 
 ### `absoluteY`
 
-Y coordinate of the current position of the touch relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
+Y coordinate of the current position of the touch relative to the window. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.

--- a/docs/docs/gesture-handlers/api/fling-gh.md
+++ b/docs/docs/gesture-handlers/api/fling-gh.md
@@ -46,11 +46,11 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ### `absoluteX`
 
-X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
+X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
 
 ### `absoluteY`
 
-Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
+Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
 
 ## Example
 

--- a/docs/docs/gesture-handlers/api/longpress-gh.md
+++ b/docs/docs/gesture-handlers/api/longpress-gh.md
@@ -36,11 +36,11 @@ Y coordinate, expressed in points, of the current position of the pointer (finge
 
 ### `absoluteX`
 
-X coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. It is recommended to use `absoluteX` instead of [`x`](#x) in cases when the view attached to the handler can be transformed as an effect of the gesture.
+X coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. It is recommended to use `absoluteX` instead of [`x`](#x) in cases when the view attached to the handler can be transformed as an effect of the gesture.
 
 ### `absoluteY`
 
-Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. It is recommended to use `absoluteY` instead of [`y`](#y) in cases when the view attached to the handler can be transformed as an effect of the gesture.
+Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. It is recommended to use `absoluteY` instead of [`y`](#y) in cases when the view attached to the handler can be transformed as an effect of the gesture.
 
 ### `duration`
 

--- a/docs/docs/gesture-handlers/api/pan-gh.md
+++ b/docs/docs/gesture-handlers/api/pan-gh.md
@@ -151,11 +151,11 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 
 ### `absoluteX`
 
-X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
+X coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. The value is expressed in point units. It is recommended to use it instead of [`x`](#x) in cases when the original view can be transformed as an effect of the gesture.
 
 ### `absoluteY`
 
-Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
+Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
 
 ## Example
 

--- a/docs/docs/gesture-handlers/api/tap-gh.md
+++ b/docs/docs/gesture-handlers/api/tap-gh.md
@@ -59,11 +59,11 @@ Y coordinate, expressed in points, of the current position of the pointer (finge
 
 ### `absoluteX`
 
-X coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. It is recommended to use `absoluteX` instead of [`x`](#x) in cases when the view attached to the handler can be transformed as an effect of the gesture.
+X coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. It is recommended to use `absoluteX` instead of [`x`](#x) in cases when the view attached to the handler can be transformed as an effect of the gesture.
 
 ### `absoluteY`
 
-Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the root view. It is recommended to use `absoluteY` instead of [`y`](#y) in cases when the view attached to the handler can be transformed as an effect of the gesture.
+Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. It is recommended to use `absoluteY` instead of [`y`](#y) in cases when the view attached to the handler can be transformed as an effect of the gesture.
 
 ## Example
 

--- a/src/handlers/LongPressGestureHandler.ts
+++ b/src/handlers/LongPressGestureHandler.ts
@@ -27,7 +27,7 @@ export type LongPressGestureHandlerEventPayload = {
   /**
    * X coordinate, expressed in points, of the current position of the pointer
    * (finger or a leading pointer when there are multiple fingers placed)
-   * relative to the root view. It is recommended to use `absoluteX` instead of
+   * relative to the window. It is recommended to use `absoluteX` instead of
    * `x` in cases when the view attached to the handler can be transformed as an
    * effect of the gesture.
    */
@@ -36,7 +36,7 @@ export type LongPressGestureHandlerEventPayload = {
   /**
    * Y coordinate, expressed in points, of the current position of the pointer
    * (finger or a leading pointer when there are multiple fingers placed)
-   * relative to the root view. It is recommended to use `absoluteY` instead of
+   * relative to the window. It is recommended to use `absoluteY` instead of
    * `y` in cases when the view attached to the handler can be transformed as an
    * effect of the gesture.
    */

--- a/src/handlers/PanGestureHandler.ts
+++ b/src/handlers/PanGestureHandler.ts
@@ -47,7 +47,7 @@ export type PanGestureHandlerEventPayload = {
 
   /**
    * X coordinate of the current position of the pointer (finger or a leading
-   * pointer when there are multiple fingers placed) relative to the root view.
+   * pointer when there are multiple fingers placed) relative to the window.
    * The value is expressed in point units. It is recommended to use it instead
    * of `x` in cases when the original view can be transformed as an effect of
    * the gesture.
@@ -56,7 +56,7 @@ export type PanGestureHandlerEventPayload = {
 
   /**
    * Y coordinate of the current position of the pointer (finger or a leading
-   * pointer when there are multiple fingers placed) relative to the root view.
+   * pointer when there are multiple fingers placed) relative to the window.
    * The value is expressed in point units. It is recommended to use it instead
    * of `y` in cases when the original view can be transformed as an
    * effect of the gesture.


### PR DESCRIPTION
## Description

This PR changes how absolute position of events is calculated to be relative to the window instead of the screen. This makes it consistent with iOS and takes status bar and split-screen mode into account when calculating it.

## Test plan

Tested on the Example app
