### PR TITLE
Add notice for old API users

### DIFF
--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -124,13 +124,11 @@ type InternalEventHandlers = {
 
 let showedRngh2Notice = false;
 function showRngh2NoticeIfNeeded() {
-  if (__DEV__) {
-    if (!showedRngh2Notice) {
-      console.warn(
-        "[react-native-gesture-handler] Seems like you're using an old API with gesture components, check out new Gestures system!"
-      );
-      showedRngh2Notice = true;
-    }
+  if (!showedRngh2Notice) {
+    console.warn(
+      "[react-native-gesture-handler] Seems like you're using an old API with gesture components, check out new Gestures system!"
+    );
+    showedRngh2Notice = true;
   }
 }
 
@@ -174,7 +172,9 @@ export default function createHandler<
         }
         handlerIDToTag[props.id] = this.handlerTag;
       }
-      showRngh2NoticeIfNeeded();
+      if (__DEV__) {
+        showRngh2NoticeIfNeeded();
+      }
     }
 
     componentDidMount() {

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -122,6 +122,18 @@ type InternalEventHandlers = {
   onGestureHandlerStateChange?: (event: any) => void;
 };
 
+let showedRngh2Notice = false;
+function showRngh2NoticeIfNeeded() {
+  if (__DEV__) {
+    if (!showedRngh2Notice) {
+      console.warn(
+        "[react-native-gesture-handler] Seems like you're using an old API with gesture components, check out new Gestures system!"
+      );
+      showedRngh2Notice = true;
+    }
+  }
+}
+
 // TODO(TS) - make sure that BaseGestureHandlerProps doesn't need other generic parameter to work with custom properties.
 export default function createHandler<
   T extends BaseGestureHandlerProps<U>,
@@ -162,6 +174,7 @@ export default function createHandler<
         }
         handlerIDToTag[props.id] = this.handlerTag;
       }
+      showRngh2NoticeIfNeeded();
     }
 
     componentDidMount() {


### PR DESCRIPTION
## Description

We want to improve the discoverability of the new API. To do that we add `console.info` when creating a gesture component such as `<PanGestureHandler />`. Unfortunately, we can't prevent false positives when components are used inside libraries. To disable this info, you can use this snippet:
```tsx
import { LogBox } from 'react-native';

LogBox.ignoreLogs([
  "[react-native-gesture-handler] Seems like you\'re using an old API with gesture components, check out new Gestures system!",
]);
```

## Test plan

- Checked if warning doesn't appear in RNGH2 component (`Example/src/new_api/reanimated/index.tsx`) and appears in RNGH1 component (`Example/src/basic/bouncing/index.tsx`)
- Checked if a warning doesn't appear with `LogBox.ignoreLogs`
