### PR TITLE
Change log level from warn to info on new API notice

### DIFF
--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -125,7 +125,7 @@ type InternalEventHandlers = {
 let showedRngh2Notice = false;
 function showRngh2NoticeIfNeeded() {
   if (!showedRngh2Notice) {
-    console.warn(
+    console.info(
       "[react-native-gesture-handler] Seems like you're using an old API with gesture components, check out new Gestures system!"
     );
     showedRngh2Notice = true;


### PR DESCRIPTION
## Description

This updates the notice about the new Gestures system API to use `console.info` instead of `console.warn` to match the expectation initially expressed in [PR #1817](https://github.com/software-mansion/react-native-gesture-handler/pull/1817). Mentioned also in #1831.

## Test plan

No specific plan other than verifying that the notice is logged as info and not warning.
