### PR TITLE
Add bot for triaging issues

### DIFF
--- a/.github/workflows/close-when-stale.yml
+++ b/.github/workflows/close-when-stale.yml
@@ -1,0 +1,41 @@
+name: Check for stale issues
+on:
+  schedule:
+    - cron: '37 21 * * *' # at 21:37 every day
+  issues:
+    types: [edited]
+  issue_comment:
+    types: [created, edited]
+  workflow_dispatch:
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: 'software-mansion-labs/swmansion-bot'
+          ref: stable
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Use yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Actions
+        run: yarn install
+
+      - name: Close when stale
+        uses: ./close-when-stale
+        with:
+          close-when-stale-label: 'Abandoned'
+          days-to-close: 20

--- a/.github/workflows/needs-more-info.yml
+++ b/.github/workflows/needs-more-info.yml
@@ -1,0 +1,43 @@
+name: Check issue template
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: needs-more-info-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: 'software-mansion-labs/swmansion-bot'
+          ref: stable
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Use yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Actions
+        run: yarn install
+
+      - name: Needs More Info
+        uses: ./needs-more-info
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          needs-more-info-label: 'Missing info'
+          required-sections: 'Description;Platforms;Steps To Reproduce;Snack or minimal code example;Package versions'
+          needs-more-info-response: "Hey! 👋 \n\nIt looks like you've omitted a few important sections from the issue template."
+          # This action also appends something like: "Please complete X, Y and Z sections." to the response.
+          # Code responsible for this can be found here: https://github.com/software-mansion-labs/swmansion-bot/blob/main/needs-more-info/MissingSectionsFormatter.js

--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -1,0 +1,44 @@
+name: Check for reproduction
+on:
+  issues:
+    types: [opened, edited]
+  issue_comment:
+    types: [created, edited, deleted]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: needs-repro-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: 'software-mansion-labs/swmansion-bot'
+          ref: stable
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Use yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Actions
+        run: yarn install
+
+      - name: Needs Repro
+        uses: ./needs-repro
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          needs-repro-label: 'Missing repro'
+          needs-repro-response: "Hey! 👋 \n\nThe issue doesn't seem to contain a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example).\n\nCould you provide a snippet of code, a [snack](https://snack.expo.dev/) or a link to a GitHub repository that reproduces the problem?"
+          repro-provided-label: 'Repro provided'
+          check-issues-only-created-after: 2022-02-01

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -1,0 +1,39 @@
+name: Check for platforms
+on:
+  issues:
+    types: [opened, edited]
+
+jobs:
+  main:
+    runs-on: ubuntu-latest
+    concurrency:
+      group: platforms-${{ github.event.issue.number }}
+      cancel-in-progress: true
+    steps:
+      - name: Checkout Actions
+        uses: actions/checkout@v2
+        with:
+          repository: 'software-mansion-labs/swmansion-bot'
+          ref: stable
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - name: Use yarn cache
+        uses: actions/cache@v2
+        id: yarn-cache
+        with:
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Install Actions
+        run: yarn install
+
+      - name: Platforms
+        uses: ./platforms
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          platforms-with-labels: '{"Android": "Platform: Android", "iOS": "Platform: iOS", "Web": "Platform: Web"}'


### PR DESCRIPTION
## Description

This PR introduces a GitHub Actions bot used for triaging issues - checking an issue template, assigning labels, and checking for reproduction. Its purpose is to save time on reviewing and replying to incomplete issues.

GitHub Actions code responsible for these actions can be found here: https://github.com/software-mansion-labs/swmansion-bot

## Changes

- Added `needs-more-info.yml` - an action used for checking whether the issue template fields are filled
- Added `needs-repro.yml` - an action used for checking whether the issue has a snack, GitHub repo, or a snippet of JavaScript/TypeScript code
- Added `platforms.yml` - an action that assigns labels to user-selected platforms in the issue template
- Added `close-when-stale.yml` - an action that closes an issue after 20 days of inactivity if it has the `Abandoned` label

- Added `Missing info` & `Repro provided` label

`needs-repro` action is triggered both by issue creation/edition and by comments. To prevent bot responses to old issues optional prop `check-issues-only-created-after` is set to 1 February 2022. This will assure that this action will be triggered only by comments on issues created after 2022-02-01. 

## Screenshots

### Example bot response on an empty template ⬇️

![image](https://user-images.githubusercontent.com/39658211/151796323-9058b063-a646-4ee8-9a56-6911b165db50.png)

### The bot responds to the current state of the issue whenever a user edits the issue template ⬇️

![image](https://user-images.githubusercontent.com/39658211/148205953-15579eb1-b7bf-4dee-adb9-f1568129116d.png)

### And removes comment whenever problems with the template are resolved ⬇️

![image](https://user-images.githubusercontent.com/39658211/151797086-ac180c92-f62a-4aab-b78b-af4ca29fae4e.png)