### PR TITLE
Don't unpack props in GestureHandlerRootView

### DIFF
--- a/src/GestureHandlerRootView.tsx
+++ b/src/GestureHandlerRootView.tsx
@@ -5,8 +5,8 @@ import { View, ViewProps } from 'react-native';
 export interface GestureHandlerRootViewProps
   extends PropsWithChildren<ViewProps> {}
 
-export default function GestureHandlerRootView({
-  ...rest
-}: GestureHandlerRootViewProps) {
-  return <View {...rest} />;
+export default function GestureHandlerRootView(
+  props: GestureHandlerRootViewProps
+) {
+  return <View {...props} />;
 }


### PR DESCRIPTION
## Description

There's no need to unpack props in `GestureHandlerRootView` component.

This PR is just a minor improvement and a rename.

Additionally, it appears as `GestureHandlerRootView.tsx` can be improved further to leave only the following:
```tsx
import { View } from 'react-native';

export default View;
```
However, I'm not sure about TypeScript and also the readability of potential error messages in component stack.

edit: The current version of this file is analogous to `GestureHandlerRootView.android.tsx` so I won't mind if this doesn't get merged 😄 

<!--
Description and motivation for this PR.

Inlude 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

<!--
Describe how did you test this change here.
-->
