### PR TITLE
Fix ripple animation on touchables in some cases

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -126,7 +126,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>() {
           ColorStateList(states, colors)
         } else {
           // if rippleColor is null, reapply the default color
-          context.theme.resolveAttribute(R.attr.colorControlHighlight, resolveOutValue, true)
+          context.theme.resolveAttribute(android.R.attr.colorControlHighlight, resolveOutValue, true)
           val colors = intArrayOf(resolveOutValue.data)
           ColorStateList(states, colors)
         }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -119,10 +119,18 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>() {
 
     private fun applyRippleEffectWhenNeeded(selectable: Drawable): Drawable {
       val rippleColor = rippleColor
-      if (rippleColor != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && selectable is RippleDrawable) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && selectable is RippleDrawable) {
         val states = arrayOf(intArrayOf(android.R.attr.state_enabled))
-        val colors = intArrayOf(rippleColor)
-        val colorStateList = ColorStateList(states, colors)
+        val colorStateList = if (rippleColor != null) {
+          val colors = intArrayOf(rippleColor)
+          ColorStateList(states, colors)
+        } else {
+          // if rippleColor is null, reapply the default color
+          context.theme.resolveAttribute(R.attr.colorControlHighlight, resolveOutValue, true)
+          val colors = intArrayOf(resolveOutValue.data)
+          ColorStateList(states, colors)
+        }
+
         selectable.setColor(colorStateList)
       }
 


### PR DESCRIPTION
## Description

In cases where `TouchableOpacity` and `TouchableNativeFeedback` were used together, but `TouchableOpacity` was placed first, the color of ripple animation would also be set to `transparent` for `TouchableNativeFeedback`. This PR changes the behavior of GestureHandlerButton so that it will set the color of ripple animation to [`android.R.attr.colorControlHighlight`](https://developer.android.com/reference/android/R.attr#colorControlHighlight) when no color is set by the user.

## Test plan

Tested on this code:
```tsx
import {
    GestureHandlerRootView,
    TouchableNativeFeedback,
    TouchableOpacity,
  } from 'react-native-gesture-handler';
  import {LogBox, StyleSheet, Text, View} from 'react-native';
  
  import React from 'react';
  
  
  LogBox.ignoreLogs([
    "Seems like you're using an old API with gesture components",
  ]);
  
  export default function App() {
    return (
      <GestureHandlerRootView style={styles.container}>
        <Text>TouchableOpacity</Text>
        <TouchableOpacity>
          <View style={styles.box1} />
        </TouchableOpacity>
        
        <Text>TouchableNativeFeedback</Text>
        <TouchableNativeFeedback>
          <View style={styles.box2} />
        </TouchableNativeFeedback>
      </GestureHandlerRootView>
    );
  }
  
  const styles = StyleSheet.create({
    container: {
      flex: 1,
      alignItems: 'center',
      justifyContent: 'center',
    },
    box1: {
      width: 50,
      height: 50,
      backgroundColor: 'cyan',
    },
    box2: {
      width: 50,
      height: 50,
      backgroundColor: 'magenta',
    },
  });
  ```
