### PR TITLE
Use `subscription.remove()` instead of `EventEmitter.removeSubscription()` in EventReceiver

### DIFF
--- a/src/handlers/gestures/eventReceiver.ts
+++ b/src/handlers/gestures/eventReceiver.ts
@@ -136,16 +136,12 @@ export function startListening() {
 
 export function stopListening() {
   if (gestureHandlerEventSubscription) {
-    DeviceEventEmitter.removeSubscription(gestureHandlerEventSubscription);
-
+    gestureHandlerEventSubscription.remove();
     gestureHandlerEventSubscription = null;
   }
 
   if (gestureHandlerStateChangeEventSubscription) {
-    DeviceEventEmitter.removeSubscription(
-      gestureHandlerStateChangeEventSubscription
-    );
-
+    gestureHandlerStateChangeEventSubscription.remove();
     gestureHandlerStateChangeEventSubscription = null;
   }
 }


### PR DESCRIPTION
## Description

Change how device event subscriptions are removed to use `.remove()` on subscription itself instead of `DeviceEventEmitter.removeSubscription(...)`.
