### PR TITLE
Unify tags in messages from Gesture Handler

### DIFF
--- a/src/RNGestureHandlerModule.ts
+++ b/src/RNGestureHandlerModule.ts
@@ -1,14 +1,17 @@
 import { NativeModules } from 'react-native';
+import { tagMessage } from './utils';
 const { RNGestureHandlerModule } = NativeModules;
 
 if (RNGestureHandlerModule == null) {
   console.error(
-    `react-native-gesture-handler module was not found. Make sure you're running your app on the native platform and your code is linked properly (cd ios && pod install && cd ..).
+    tagMessage(
+      `react-native-gesture-handler module was not found. Make sure you're running your app on the native platform and your code is linked properly (cd ios && pod install && cd ..).
 
-    For installation instructions, please refer to https://docs.swmansion.com/react-native-gesture-handler/docs/#installation`
-      .split('\n')
-      .map((line) => line.trim())
-      .join('\n')
+      For installation instructions, please refer to https://docs.swmansion.com/react-native-gesture-handler/docs/#installation`
+        .split('\n')
+        .map((line) => line.trim())
+        .join('\n')
+    )
   );
 }
 

--- a/src/handlers/ForceTouchGestureHandler.ts
+++ b/src/handlers/ForceTouchGestureHandler.ts
@@ -1,4 +1,5 @@
 import React from 'react';
+import { tagMessage } from '../utils';
 import PlatformConstants from '../PlatformConstants';
 import createHandler from './createHandler';
 import {
@@ -16,7 +17,9 @@ class ForceTouchFallback extends React.Component {
   static forceTouchAvailable = false;
   componentDidMount() {
     console.warn(
-      'ForceTouchGestureHandler is not available on this platform. Please use ForceTouchGestureHandler.forceTouchAvailable to conditionally render other components that would provide a fallback behavior specific to your usecase'
+      tagMessage(
+        'ForceTouchGestureHandler is not available on this platform. Please use ForceTouchGestureHandler.forceTouchAvailable to conditionally render other components that would provide a fallback behavior specific to your usecase'
+      )
     );
   }
   render() {

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -21,7 +21,7 @@ import {
   findNodeHandle,
 } from './gestureHandlerCommon';
 import { ValueOf } from '../typeUtils';
-import { isJestEnv } from '../utils';
+import { isJestEnv, tagMessage } from '../utils';
 
 const UIManagerAny = UIManager as any;
 
@@ -127,7 +127,9 @@ let showedRngh2Notice = false;
 function showRngh2NoticeIfNeeded() {
   if (!showedRngh2Notice) {
     console.warn(
-      "[react-native-gesture-handler] Seems like you're using an old API with gesture components, check out new Gestures system!"
+      tagMessage(
+        "Seems like you're using an old API with gesture components, check out new Gestures system!"
+      )
     );
     showedRngh2Notice = true;
   }

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -32,6 +32,7 @@ import { tapGestureHandlerProps } from '../TapGestureHandler';
 import { State } from '../../State';
 import { EventType } from '../../EventType';
 import { ComposedGesture } from './gestureComposition';
+import { tagMessage } from '../../utils';
 
 const ALLOWED_PROPS = [
   ...baseGestureHandlerWithMonitorProps,
@@ -337,9 +338,7 @@ function useAnimatedGesture(
       // correct handler.
       handler?.(event, ...args);
     } else if (handler) {
-      console.warn(
-        '[RNGestureHandler] Animated gesture callback must be a worklet'
-      );
+      console.warn(tagMessage('Animated gesture callback must be a worklet'));
     }
   }
 

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -94,7 +94,9 @@ function checkGestureCallbacksForWorklets(gesture: GestureType) {
   // explicitly marked with `.runOnJS(true)` show an error
   if (areSomeNotWorklets && areSomeWorklets) {
     console.error(
-      `[react-native-gesture-handler] Some of the callbacks in the gesture are worklets and some are not. Either make sure that all calbacks are marked as 'worklet' if you wish to run them on the UI thread or use '.runOnJS(true)' modifier on the gesture explicitly to run all callbacks on the JS thread.`
+      tagMessage(
+        `Some of the callbacks in the gesture are worklets and some are not. Either make sure that all calbacks are marked as 'worklet' if you wish to run them on the UI thread or use '.runOnJS(true)' modifier on the gesture explicitly to run all callbacks on the JS thread.`
+      )
     );
   }
 }

--- a/src/handlers/gestures/eventReceiver.ts
+++ b/src/handlers/gestures/eventReceiver.ts
@@ -9,30 +9,27 @@ import {
 import { GestureStateManagerType } from './gestureStateManager';
 import { findHandler } from '../handlersRegistry';
 import { BaseGesture } from './gesture';
+import { tagMessage } from '../../utils';
 
 let gestureHandlerEventSubscription: EmitterSubscription | null = null;
 let gestureHandlerStateChangeEventSubscription: EmitterSubscription | null = null;
 
+const warningMessage = tagMessage(
+  'You have to use react-native-reanimated in order to control the state of the gesture.'
+);
+
 const dummyStateManager: GestureStateManagerType = {
   begin: () => {
-    console.warn(
-      'You have to use react-native-reanimated in order to control the state of the gesture.'
-    );
+    console.warn(warningMessage);
   },
   activate: () => {
-    console.warn(
-      'You have to use react-native-reanimated in order to control the state of the gesture.'
-    );
+    console.warn(warningMessage);
   },
   end: () => {
-    console.warn(
-      'You have to use react-native-reanimated in order to control the state of the gesture.'
-    );
+    console.warn(warningMessage);
   },
   fail: () => {
-    console.warn(
-      'You have to use react-native-reanimated in order to control the state of the gesture.'
-    );
+    console.warn(warningMessage);
   },
 };
 

--- a/src/handlers/gestures/gestureStateManager.ts
+++ b/src/handlers/gestures/gestureStateManager.ts
@@ -1,5 +1,6 @@
 import { Reanimated } from './reanimatedWrapper';
 import { State } from '../../State';
+import { tagMessage } from '../../utils';
 
 export interface GestureStateManagerType {
   begin: () => void;
@@ -7,6 +8,10 @@ export interface GestureStateManagerType {
   fail: () => void;
   end: () => void;
 }
+
+const warningMessage = tagMessage(
+  'react-native-reanimated is required in order to use synchronous state management'
+);
 
 export const GestureStateManager = {
   create(handlerTag: number): GestureStateManagerType {
@@ -17,9 +22,7 @@ export const GestureStateManager = {
         if (Reanimated) {
           Reanimated.setGestureState(handlerTag, State.BEGAN);
         } else {
-          console.warn(
-            'react-native-reanimated is required in order to use synchronous state management'
-          );
+          console.warn(warningMessage);
         }
       },
 
@@ -28,9 +31,7 @@ export const GestureStateManager = {
         if (Reanimated) {
           Reanimated.setGestureState(handlerTag, State.ACTIVE);
         } else {
-          console.warn(
-            'react-native-reanimated is required in order to use synchronous state management'
-          );
+          console.warn(warningMessage);
         }
       },
 
@@ -39,9 +40,7 @@ export const GestureStateManager = {
         if (Reanimated) {
           Reanimated.setGestureState(handlerTag, State.FAILED);
         } else {
-          console.warn(
-            'react-native-reanimated is required in order to use synchronous state management'
-          );
+          console.warn(warningMessage);
         }
       },
 
@@ -50,9 +49,7 @@ export const GestureStateManager = {
         if (Reanimated) {
           Reanimated.setGestureState(handlerTag, State.END);
         } else {
-          console.warn(
-            'react-native-reanimated is required in order to use synchronous state management'
-          );
+          console.warn(warningMessage);
         }
       },
     };

--- a/src/handlers/gestures/reanimatedWrapper.ts
+++ b/src/handlers/gestures/reanimatedWrapper.ts
@@ -3,6 +3,7 @@ import {
   GestureUpdateEvent,
   GestureStateChangeEvent,
 } from '../gestureHandlerCommon';
+import { tagMessage } from '../../utils';
 
 export interface SharedValue<T> {
   value: T;
@@ -33,7 +34,9 @@ try {
     Reanimated.setGestureState = () => {
       'worklet';
       console.warn(
-        'Please use newer version of react-native-reanimated in order to control state of the gestures.'
+        tagMessage(
+          'Please use newer version of react-native-reanimated in order to control state of the gestures.'
+        )
       );
     };
   }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -33,3 +33,7 @@ export function hasProperty(object: Record<string, unknown>, key: string) {
 export function isJestEnv(): boolean {
   return !!process.env.JEST_WORKER_ID;
 }
+
+export function tagMessage(msg: string) {
+  return `[react-native-gesture-handler] ${msg}`;
+}


### PR DESCRIPTION
## Description

Add `tagMessage` function in `utils` that adds a standard tag to the message.
Update existing `console.warn` and `console.error` invocations to make use of the new method.

## Test plan

Checked warnings on the Example app.
