### PR TITLE
Fix broken link to the Example app section in the docs

### DIFF
--- a/docs/docs/introduction.md
+++ b/docs/docs/introduction.md
@@ -38,7 +38,7 @@ This should allow you to migrate your codebase from the gesture handlers to gest
 
 ### Apps
 
-[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/Example) – official gesture handler "showcase" app.
+[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example) – official gesture handler "showcase" app.
 
 [Gesture Handler Example on Expo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo) – the official app you can install and play with using [Expo](https://expo.io).
 

--- a/docs/src/pages/index.js
+++ b/docs/src/pages/index.js
@@ -199,8 +199,8 @@ function Home() {
                   <a href="https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo">
                     get it here using Expo
                   </a>
-                  . Or just{' '}
-                  <Link to={useBaseUrl('docs/example/')}>go to this page</Link>{' '}
+                  . Or {' '}
+                  <Link to={useBaseUrl('docs/#learning-resources')}>check out the learning resources</Link>{' '}
                   to see how you can run it locally with React Native on both
                   Android and iOS.
                 </p>

--- a/docs/versioned_docs/version-1.10.3/resources.md
+++ b/docs/versioned_docs/version-1.10.3/resources.md
@@ -5,7 +5,7 @@ title: Learning Resources
 
 ## Apps
 
-[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/Example) – official gesture handler "showcase" app.
+[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example) – official gesture handler "showcase" app.
 
 [Gesture Handler Example on Expo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo) – the official app you can install and play with using [Expo](https://expo.io).
 

--- a/docs/versioned_docs/version-2.0.0/resources.md
+++ b/docs/versioned_docs/version-2.0.0/resources.md
@@ -5,7 +5,7 @@ title: Learning Resources
 
 ## Apps
 
-[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/Example) – official gesture handler "showcase" app.
+[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example) – official gesture handler "showcase" app.
 
 [Gesture Handler Example on Expo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo) – the official app you can install and play with using [Expo](https://expo.io).
 

--- a/docs/versioned_docs/version-2.1.1/resources.md
+++ b/docs/versioned_docs/version-2.1.1/resources.md
@@ -5,7 +5,7 @@ title: Learning Resources
 
 ## Apps
 
-[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/Example) – official gesture handler "showcase" app.
+[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example) – official gesture handler "showcase" app.
 
 [Gesture Handler Example on Expo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo) – the official app you can install and play with using [Expo](https://expo.io).
 

--- a/docs/versioned_docs/version-2.3.0/introduction.md
+++ b/docs/versioned_docs/version-2.3.0/introduction.md
@@ -38,7 +38,7 @@ This should allow you to migrate your codebase from the gesture handlers to gest
 
 ### Apps
 
-[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/Example) – official gesture handler "showcase" app.
+[Gesture Handler Example App](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example) – official gesture handler "showcase" app.
 
 [Gesture Handler Example on Expo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo) – the official app you can install and play with using [Expo](https://expo.io).
 


### PR DESCRIPTION
## Description

- Fix link to the Example app section that was removed in https://github.com/software-mansion/react-native-gesture-handler/commit/f36babf0f7ff0fa4ab0fec627227fb48ffbdf34c
- Fix broken links to the Example app on GitHub
