### PR TITLE
Fix StyleSheet import in `RNGestureHandlerButtonNativeComponent.js`

### DIFF
--- a/src/fabric/RNGestureHandlerButtonNativeComponent.js
+++ b/src/fabric/RNGestureHandlerButtonNativeComponent.js
@@ -5,7 +5,7 @@
 /* eslint-disable */
 import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNativeComponent';
 import type { HostComponent } from 'react-native';
-import type { ColorValue } from 'react-native/Libraries/StyleSheet';
+import type { ColorValue } from 'react-native/Libraries/StyleSheet/StyleSheet';
 import type { ViewProps } from 'react-native/Libraries/Components/View/ViewPropTypes';
 import type { Int32 } from 'react-native/Libraries/Types/CodegenTypes';
 


### PR DESCRIPTION
## Description

Fixes import of `StyleSheet` in `RNGestureHandlerButtonNativeComponent.js`.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1906. Thank you @djMax for solving it ❤️.