### PR TITLE
Rename `EventType` to `TouchEventType` to clear up the naming

### DIFF
--- a/src/TouchEventType.ts
+++ b/src/TouchEventType.ts
@@ -1,4 +1,4 @@
-export const EventType = {
+export const TouchEventType = {
   UNDETERMINED: 0,
   TOUCHES_DOWN: 1,
   TOUCHES_MOVE: 2,
@@ -7,4 +7,4 @@ export const EventType = {
 } as const;
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value
-export type EventType = typeof EventType[keyof typeof EventType];
+export type TouchEventType = typeof TouchEventType[keyof typeof TouchEventType];

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -6,7 +6,7 @@ import * as React from 'react';
 import { Platform, findNodeHandle as findNodeHandleRN } from 'react-native';
 
 import { State } from '../State';
-import { EventType } from '../EventType';
+import { TouchEventType } from '../TouchEventType';
 import { ValueOf } from '../typeUtils';
 import { handlerIDToTag } from './handlersRegistry';
 import { toArray } from '../utils';
@@ -83,7 +83,7 @@ export type GestureTouchEvent = {
   handlerTag: number;
   numberOfTouches: number;
   state: ValueOf<typeof State>;
-  eventType: EventType;
+  eventType: TouchEventType;
   allTouches: TouchData[];
   changedTouches: TouchData[];
 };

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -30,7 +30,7 @@ import {
 } from '../PanGestureHandler';
 import { tapGestureHandlerProps } from '../TapGestureHandler';
 import { State } from '../../State';
-import { EventType } from '../../EventType';
+import { TouchEventType } from '../../TouchEventType';
 import { ComposedGesture } from './gestureComposition';
 import { ActionType } from '../../ActionType';
 import { isFabric, tagMessage } from '../../utils';
@@ -322,16 +322,18 @@ function useAnimatedGesture(
     }
   }
 
-  function touchEventTypeToCallbackType(eventType: EventType): CALLBACK_TYPE {
+  function touchEventTypeToCallbackType(
+    eventType: TouchEventType
+  ): CALLBACK_TYPE {
     'worklet';
     switch (eventType) {
-      case EventType.TOUCHES_DOWN:
+      case TouchEventType.TOUCHES_DOWN:
         return CALLBACK_TYPE.TOUCHES_DOWN;
-      case EventType.TOUCHES_MOVE:
+      case TouchEventType.TOUCHES_MOVE:
         return CALLBACK_TYPE.TOUCHES_MOVE;
-      case EventType.TOUCHES_UP:
+      case TouchEventType.TOUCHES_UP:
         return CALLBACK_TYPE.TOUCHES_UP;
-      case EventType.TOUCHES_CANCELLED:
+      case TouchEventType.TOUCHES_CANCELLED:
         return CALLBACK_TYPE.TOUCHES_CANCELLED;
     }
     return CALLBACK_TYPE.UNDEFINED;
@@ -418,7 +420,7 @@ function useAnimatedGesture(
             stateControllers[i] = GestureStateManager.create(event.handlerTag);
           }
 
-          if (event.eventType !== EventType.UNDETERMINED) {
+          if (event.eventType !== TouchEventType.UNDETERMINED) {
             runWorklet(
               touchEventTypeToCallbackType(event.eventType),
               gesture,

--- a/src/handlers/gestures/eventReceiver.ts
+++ b/src/handlers/gestures/eventReceiver.ts
@@ -1,6 +1,6 @@
 import { DeviceEventEmitter, EmitterSubscription } from 'react-native';
 import { State } from '../../State';
-import { EventType } from '../../EventType';
+import { TouchEventType } from '../../TouchEventType';
 import {
   GestureTouchEvent,
   GestureUpdateEvent,
@@ -87,16 +87,16 @@ function onGestureHandlerEvent(
       }
     } else if (isTouchEvent(event)) {
       switch (event.eventType) {
-        case EventType.TOUCHES_DOWN:
+        case TouchEventType.TOUCHES_DOWN:
           handler.handlers?.onTouchesDown?.(event, dummyStateManager);
           break;
-        case EventType.TOUCHES_MOVE:
+        case TouchEventType.TOUCHES_MOVE:
           handler.handlers?.onTouchesMove?.(event, dummyStateManager);
           break;
-        case EventType.TOUCHES_UP:
+        case TouchEventType.TOUCHES_UP:
           handler.handlers?.onTouchesUp?.(event, dummyStateManager);
           break;
-        case EventType.TOUCHES_CANCELLED:
+        case TouchEventType.TOUCHES_CANCELLED:
           handler.handlers?.onTouchesCancelled?.(event, dummyStateManager);
           break;
       }


### PR DESCRIPTION
## Description

Rename `EventType.ts` file to `TouchEventType.ts` and `EventType` to `TouchEventType` in code.

## Test plan

Ran `tsc`
