### PR TITLE
fix missing testID when createHandler props do not have one assigned

### DIFF
--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -494,7 +494,7 @@ export default function createHandler<
                 handlerTag: this.handlerTag,
               }
             : {}),
-          ...(this.props.testID ? { testID: this.props.testID } : {}),
+          testID: this.props.testID ?? child.props.testID,
           ...events,
         },
         grandChildren

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -494,7 +494,7 @@ export default function createHandler<
                 handlerTag: this.handlerTag,
               }
             : {}),
-          testID: this.props.testID,
+          ...(this.props.testID ? { testID: this.props.testID } : {}),
           ...events,
         },
         grandChildren


### PR DESCRIPTION
## Description

Fix related to my comment [here](https://github.com/software-mansion/react-native-gesture-handler/pull/1844#issuecomment-1057400208) about `RNGestureHandlerButton` with `handlerType="NativeViewGestureHandler"` having missing testIDs when they were previously provided and assigned. I believe the testID on the `child` being cloned within `createHandler` was being removed by the testID being set within the render function when one was not even passed in. Now it will only assign a testID as a prop on the cloned element if a testID was provided to the handler