### PR TITLE
chore: bump react-native-screens to 3.13.1 in FabricExample

### DIFF
--- a/FabricExample/index.js
+++ b/FabricExample/index.js
@@ -12,5 +12,4 @@ AppRegistry.registerComponent(appName, () => App);
 LogBox.ignoreLogs([
   "Seems like you're using an old API with gesture components", // react-native-gesture-handler
   'GestureDetector has received a child that may get view-flattened.', // react-native-gesture-handler
-  'Function components cannot be given refs.', // react-native-screens
 ]);

--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -717,7 +717,7 @@ PODS:
     - React-jsi (= 0.68.0-rc.2)
     - React-logger (= 0.68.0-rc.2)
     - React-perflogger (= 0.68.0-rc.2)
-  - RNGestureHandler (2.2.0):
+  - RNGestureHandler (2.3.0):
     - RCT-Folly (= 2021.06.28.00-v2)
     - RCTRequired
     - RCTTypeSafety
@@ -725,7 +725,7 @@ PODS:
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-  - RNScreens (3.13.0):
+  - RNScreens (3.13.1):
     - RCT-Folly (= 2021.06.28.00-v2)
     - RCTRequired
     - RCTTypeSafety
@@ -733,8 +733,8 @@ PODS:
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.13.0)
-  - RNScreens/common (3.13.0):
+    - RNScreens/common (= 3.13.1)
+  - RNScreens/common (3.13.1):
     - RCT-Folly (= 2021.06.28.00-v2)
     - RCTRequired
     - RCTTypeSafety
@@ -966,8 +966,8 @@ SPEC CHECKSUMS:
   React-rncore: f9e4ffbbe4bc01bb34869b73320da97d98227a04
   React-runtimeexecutor: 37e5fa0b81067a8e487391e2816bae8813b226a5
   ReactCommon: 4c7431a20d472996669b2230f34df0115bf5dc8d
-  RNGestureHandler: 6bd20312c171013db4d94a1b1315a2051e4d4769
-  RNScreens: 58e91b8ed1d247912440d3632dcdbf7d2e6991a5
+  RNGestureHandler: 0ccc67ba16a3833b6edae55eb92d9769838a81fd
+  RNScreens: 9c1dfa815b0e70f24453f6acd1fb26090ddd38cb
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: d7b12009fb66b91a161cddf00c349d42a0015de2
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -17,7 +17,7 @@
     "react-native": "0.68.0-rc.2",
     "react-native-gesture-handler": "link:../",
     "react-native-safe-area-context": "^4.0.1",
-    "react-native-screens": "^3.13.0"
+    "react-native-screens": "^3.13.1"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -5547,10 +5547,10 @@ react-native-safe-area-context@^4.0.1:
   resolved "https://registry.yarnpkg.com/react-native-safe-area-context/-/react-native-safe-area-context-4.0.1.tgz#b8413ad703088d8c36d2e56202a28b17aa0df79b"
   integrity sha512-N8xvlDrcdQ8FBtS/jIvsxm7Wwb5ZRnYjQpoQR2CfFTN1AwIHG80ZACteeLFQ8ErGBRTPBgXNBPoFCppCDHbnyg==
 
-react-native-screens@^3.13.0:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.13.0.tgz#011ed3b27d358aeab664f88d1b9eb8edc5c5f6fb"
-  integrity sha512-cAreMaFPW+qikOc0YFFvfue0tJ9CQaHwzRNg0IPd8/VILbqM7U8TJrCK+K0OUY6o+9B0KYbFfDrkj1wmqidHpw==
+react-native-screens@^3.13.1:
+  version "3.13.1"
+  resolved "https://registry.yarnpkg.com/react-native-screens/-/react-native-screens-3.13.1.tgz#b3b1c5788dca25a71668909f66d87fb35c5c5241"
+  integrity sha512-xcrnuUs0qUrGpc2gOTDY4VgHHADQwp80mwR1prU/Q0JqbZN5W3koLhuOsT6FkSRKjR5t40l+4LcjhHdpqRB2HA==
   dependencies:
     react-freeze "^1.0.0"
     warn-once "^0.1.0"


### PR DESCRIPTION
## Description

This PR bumps `react-native-screens` in FabricExample to v3.13.1.

Release notes: https://github.com/software-mansion/react-native-screens/releases/tag/3.13.1


## Test plan

FarbicExample/ app runs without 'Function components cannot be given refs.' warning 
