### PR TITLE
Fix state flow for manual activation on iOS

### DIFF
--- a/ios/Handlers/RNManualHandler.m
+++ b/ios/Handlers/RNManualHandler.m
@@ -65,9 +65,32 @@
 {
     if ((self = [super initWithTag:tag])) {
         _recognizer = [[RNManualRecognizer alloc] initWithGestureHandler:self];
-
     }
     return self;
+}
+
+- (void)resetConfig
+{
+    [super resetConfig];
+    
+    // RNManualGestureHandler doesn't change its state by itself (with the exception
+    // of transitioning to the BEGAN state with the first active finger). This flag
+    // doesn't change how the handler itself behaves, but it is necessary to be
+    // consistent with checks for manual activation in other places.
+    self.manualActivation = YES;
+}
+
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+{
+  // UNDETERMINED -> BEGAN state change event is sent before this method is called,
+  // in RNGestureHandler it resets _lastSatate variable, making is seem like handler
+  // went from UNDETERMINED to BEGAN and then from UNDETERMINED to ACTIVE.
+  // This way we preserve _lastState between events and keep correct state flow.
+  RNGestureHandlerState savedState = _lastState;
+  BOOL shouldBegin = [super gestureRecognizerShouldBegin:gestureRecognizer];
+  _lastState = savedState;
+  
+  return shouldBegin;
 }
 
 @end

--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -59,6 +59,7 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 @property (nonatomic) BOOL shouldCancelWhenOutside;
 @property (nonatomic) BOOL needsPointerData;
 @property (nonatomic) BOOL manualActivation;
+@property (nonatomic) BOOL endedManually;
 
 - (void)bindToView:(nonnull UIView *)view;
 - (void)unbindFromView;

--- a/ios/RNGestureHandlerModule.mm
+++ b/ios/RNGestureHandlerModule.mm
@@ -188,6 +188,7 @@ RCT_EXPORT_METHOD(handleClearJSResponder)
       [handler stopActivationBlocker];
       handler.recognizer.state = UIGestureRecognizerStateBegan;
     } else if (state == 5) { // ENDED
+      handler.endedManually = YES;
       handler.recognizer.state = UIGestureRecognizerStateEnded;
     }
   }


### PR DESCRIPTION
## Description

On iOS when using `manualActivation`, the gesture would receive `ACTIVATE` event just before ending because the states were filled in `sendEventsInState:`. During testing, I also noticed that if you were to end the Pan gesture in its `onTouchesUp` callback, it would receive the state cycle twice, i.e: `UNDETERMINED` -> `BEGAN` -> `ACTIVE` -> `END` -> `BEGAN` -> `ACTIVE` -> `END`.
This PR addresses both of these problems:
- adds `endedManually` property to `GestureHandler` in order to make distinction between gestures ending by themselves and by `GestureStateManager`
- don't fill `ACTIVATE` state when `manualActivation` is enabled for the gesture
- overrides the new state to `FAILED` if the gesture with `manualActivation` enabled ends before user activates it (makes it consistent with Android)
- ignore state change events if the new state is `BEGAN` and the old state is different than `UNDETERMINED`, solving the cycles mentioned earlier

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1865.

## Test plan

Modified `GestureDetector` to log every state transition and checked on following snippets:
<details>
<summary>Pan, correct flow</summary>

```jsx
  const gesture = Gesture.Pan()
    .manualActivation(true)
    .onTouchesMove((e, s) => {
      s.activate();
    })
    .onTouchesUp((e, s) => {
      s.end();
    });
```
`UNDETERMINED -> BEGAN -> ACTIVE -> END`

</details>

<details>
<summary>Pan, end on move</summary>

```jsx
  const gesture = Gesture.Pan()
    .manualActivation(true)
    .onTouchesMove((e, s) => {
      s.end();
    });
```
`UNDETERMINED -> BEGAN -> END`

</details>

<details>
<summary>Pan, fail on move</summary>

```jsx
  const gesture = Gesture.Pan()
    .manualActivation(true)
    .onTouchesMove((e, s) => {
      s.fail();
    });
```
`UNDETERMINED -> BEGAN -> FAILED`

</details>

<details>
<summary>Pan, end on up</summary>

```jsx
  const gesture = Gesture.Pan()
    .manualActivation(true)
    .onTouchesUp((e, s) => {
      s.end();
    });
```
`UNDETERMINED -> BEGAN -> END`

</details>

<details>
<summary>Pan, no control</summary>

```jsx
  const gesture = Gesture.Pan()
    .manualActivation(true);
```
`UNDETERMINED -> BEGAN -> FAILED`

</details>

<details>
<summary>Manual, correct flow</summary>

```jsx
  const gesture = Gesture.Pan()
    .manualActivation(true)
    .onTouchesMove((e, s) => {
      s.fail();
    });
```
`UNDETERMINED -> BEGAN -> ACTIVE -> END`

</details>

<details>
<summary>Manual, end on move</summary>

```jsx
  const gesture = Gesture.Manual()
    .onTouchesMove((e, s) => {
      s.end();
    });
```
`UNDETERMINED -> BEGAN -> END`

</details>

<details>
<summary>Manual, fail on move</summary>

```jsx
  const gesture = Gesture.Manual()
    .onTouchesMove((e, s) => {
      s.fail();
    });
```
`UNDETERMINED -> BEGAN -> FAILED`

</details>

<details>
<summary>Pinch, correct flow</summary>

```jsx
  const gesture = Gesture.Pinch()
    .manualActivation(true)
    .onTouchesDown((e, s) => {
      s.begin();
    })
    .onTouchesMove((e, s) => {
      s.activate();
    })
    .onTouchesUp((e, s) => {
      s.end();
    });
```
`UNDETERMINED -> BEGAN -> ACTIVE -> END`

</details>

<details>
<summary>Pinch, end on move</summary>

```jsx
  const gesture = Gesture.Pinch()
    .manualActivation(true)
    .onTouchesDown((e, s) => {
      s.begin();
    })
    .onTouchesMove((e, s) => {
      s.end();
    });
```
`UNDETERMINED -> BEGAN -> END`

</details>

<details>
<summary>Pinch, fail on move</summary>

```jsx
  const gesture = Gesture.Pinch()
    .manualActivation(true)
    .onTouchesDown((e, s) => {
      s.begin();
    })
    .onTouchesMove((e, s) => {
      s.fail();
    });
```
`UNDETERMINED -> BEGAN -> FAILED`

</details>
