### PR TITLE
Remove `jestUtils` from the main `index.ts` and move it to separate `package.json`

### DIFF
--- a/docs/docs/api/test-api.md
+++ b/docs/docs/api/test-api.md
@@ -3,6 +3,10 @@ id: test-api
 title: Testing
 ---
 
+:::info
+If you want to use `fireGestureHandler` and `getByGestureTestId`, you need to import them from `react-native-gesture-handler/jest-utils` package.
+:::
+
 ## fireGestureHandler(gestureOrHandler, eventList)
 
 Simulates one event stream (i.e. event sequence starting with `BEGIN` state and ending

--- a/docs/versioned_docs/version-2.3.0/api/test-api.md
+++ b/docs/versioned_docs/version-2.3.0/api/test-api.md
@@ -3,6 +3,10 @@ id: test-api
 title: Testing
 ---
 
+:::info
+If you want to use `fireGestureHandler` and `getByGestureTestId`, you need to import them from `react-native-gesture-handler/jest-utils` package.
+:::
+
 ## fireGestureHandler(gestureOrHandler, eventList)
 
 Simulates one event stream (i.e. event sequence starting with `BEGIN` state and ending

--- a/docs/versioned_docs/version-2.3.0/api/test-api.md
+++ b/docs/versioned_docs/version-2.3.0/api/test-api.md
@@ -3,10 +3,6 @@ id: test-api
 title: Testing
 ---
 
-:::info
-If you want to use `fireGestureHandler` and `getByGestureTestId`, you need to import them from `react-native-gesture-handler/jest-utils` package.
-:::
-
 ## fireGestureHandler(gestureOrHandler, eventList)
 
 Simulates one event stream (i.e. event sequence starting with `BEGIN` state and ending

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -10,6 +10,9 @@
       ],
       "react-native-gesture-handler/DrawerLayout": [
         "../src/components/DrawerLayout.tsx"
+      ],
+      "react-native-gesture-handler/jest-utils": [
+        "../src/jestUtils/index.ts"
       ]
     }
   },

--- a/jest-utils/package.json
+++ b/jest-utils/package.json
@@ -1,0 +1,6 @@
+{
+  "main": "../lib/commonjs/jestUtils/index",
+  "module": "../lib/module/jestUtils/index",
+  "react-native": "../src/jestUtils/index",
+  "types": "../lib/typescript/jestUtils/index.d.ts"
+}

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "android/common/src/main/java/",
     "ios/",
     "Swipeable/",
+    "jest-utils/",
     "DrawerLayout/",
     "README.md",
     "jestSetup.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@ import { initialize } from './init';
 
 export { Directions } from './Directions';
 export { State } from './State';
-export { getByGestureTestId, fireGestureHandler } from './jestUtils';
 export { default as gestureHandlerRootHOC } from './gestureHandlerRootHOC';
 export { default as GestureHandlerRootView } from './GestureHandlerRootView';
 export type {

--- a/src/jestUtils/index.ts
+++ b/src/jestUtils/index.ts
@@ -1,0 +1,1 @@
+export { getByGestureTestId, fireGestureHandler } from './jestUtils';

--- a/src/jestUtils/jestUtils.ts
+++ b/src/jestUtils/jestUtils.ts
@@ -5,59 +5,59 @@ import {
   FlingGestureHandler,
   FlingGestureHandlerEventPayload,
   flingHandlerName,
-} from './handlers/FlingGestureHandler';
+} from '../handlers/FlingGestureHandler';
 import {
   ForceTouchGestureHandler,
   ForceTouchGestureHandlerEventPayload,
   forceTouchHandlerName,
-} from './handlers/ForceTouchGestureHandler';
+} from '../handlers/ForceTouchGestureHandler';
 import {
   BaseGestureHandlerProps,
   GestureEvent,
   HandlerStateChangeEvent,
-} from './handlers/gestureHandlerCommon';
-import { FlingGesture } from './handlers/gestures/flingGesture';
-import { ForceTouchGesture } from './handlers/gestures/forceTouchGesture';
-import { BaseGesture, GestureType } from './handlers/gestures/gesture';
-import { LongPressGesture } from './handlers/gestures/longPressGesture';
-import { NativeGesture } from './handlers/gestures/nativeGesture';
-import { PanGesture } from './handlers/gestures/panGesture';
-import { PinchGesture } from './handlers/gestures/pinchGesture';
-import { RotationGesture } from './handlers/gestures/rotationGesture';
-import { TapGesture } from './handlers/gestures/tapGesture';
-import { findHandlerByTestID } from './handlers/handlersRegistry';
+} from '../handlers/gestureHandlerCommon';
+import { FlingGesture } from '../handlers/gestures/flingGesture';
+import { ForceTouchGesture } from '../handlers/gestures/forceTouchGesture';
+import { BaseGesture, GestureType } from '../handlers/gestures/gesture';
+import { LongPressGesture } from '../handlers/gestures/longPressGesture';
+import { NativeGesture } from '../handlers/gestures/nativeGesture';
+import { PanGesture } from '../handlers/gestures/panGesture';
+import { PinchGesture } from '../handlers/gestures/pinchGesture';
+import { RotationGesture } from '../handlers/gestures/rotationGesture';
+import { TapGesture } from '../handlers/gestures/tapGesture';
+import { findHandlerByTestID } from '../handlers/handlersRegistry';
 import {
   LongPressGestureHandler,
   LongPressGestureHandlerEventPayload,
   longPressHandlerName,
-} from './handlers/LongPressGestureHandler';
+} from '../handlers/LongPressGestureHandler';
 import {
   NativeViewGestureHandler,
   NativeViewGestureHandlerPayload,
   nativeViewHandlerName,
-} from './handlers/NativeViewGestureHandler';
+} from '../handlers/NativeViewGestureHandler';
 import {
   PanGestureHandler,
   PanGestureHandlerEventPayload,
   panHandlerName,
-} from './handlers/PanGestureHandler';
+} from '../handlers/PanGestureHandler';
 import {
   PinchGestureHandler,
   PinchGestureHandlerEventPayload,
   pinchHandlerName,
-} from './handlers/PinchGestureHandler';
+} from '../handlers/PinchGestureHandler';
 import {
   RotationGestureHandler,
   RotationGestureHandlerEventPayload,
   rotationHandlerName,
-} from './handlers/RotationGestureHandler';
+} from '../handlers/RotationGestureHandler';
 import {
   TapGestureHandler,
   TapGestureHandlerEventPayload,
   tapHandlerName,
-} from './handlers/TapGestureHandler';
-import { State } from './State';
-import { hasProperty, withPrevAndCurrent } from './utils';
+} from '../handlers/TapGestureHandler';
+import { State } from '../State';
+import { hasProperty, withPrevAndCurrent } from '../utils';
 
 // load fireEvent conditionally, so RNGH may be used in setups without testing-library
 let fireEvent = (


### PR DESCRIPTION
## Description

Moves `jestUtils` to a separate package so it's not bundled when not actually used. This caused problems with `testing-library`, namely one of its dependencies - `ansi-styles`. It uses named capture groups in regex which is unsupported on Hermes.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1913.

## Test plan

Run a new app in release configuration with and without `testing-library` installed.
