### PR TITLE
Use native driver by default for `TouchableOpacity` animations

### DIFF
--- a/docs/docs/api/components/touchables.md
+++ b/docs/docs/api/components/touchables.md
@@ -23,6 +23,10 @@ follows native apps' behavior.
 Our intention was to make switch for these touchables as simple as possible. In order to use RNGH's touchables the only thing you need to do is to change library from which you import touchable components.
 need only to change imports of touchables.
 
+:::info
+Gesture Handler's TouchableOpacity uses native driver for animations by default. If this causes problems for you, you can set `useNativeAnimations` prop to false.
+:::
+
 ### Example:
 
 ```javascript

--- a/src/components/touchables/TouchableOpacity.tsx
+++ b/src/components/touchables/TouchableOpacity.tsx
@@ -12,11 +12,15 @@ import GenericTouchable, {
 import * as React from 'react';
 import { Component } from 'react';
 
+interface GHTouchableOpacityProps {
+  useNativeAnimations?: boolean;
+}
+
 /**
  * TouchableOpacity bases on timing animation which has been used in RN's core
  */
 export default class TouchableOpacity extends Component<
-  TouchableOpacityProps & GenericTouchableProps
+  TouchableOpacityProps & GenericTouchableProps & GHTouchableOpacityProps
 > {
   static defaultProps = {
     ...GenericTouchable.defaultProps,
@@ -36,7 +40,7 @@ export default class TouchableOpacity extends Component<
       toValue: value,
       duration: duration,
       easing: Easing.inOut(Easing.quad),
-      useNativeDriver: false,
+      useNativeDriver: this.props.useNativeAnimations ?? true,
     }).start();
   };
 


### PR DESCRIPTION
## Description

- makes Gesture Handler's `TouchableOpacity` use native driver for animations by default
- adds prop that allows to disable it

## Test plan

Tested on the Example app
