### PR TITLE
Expand example code for PanGestureHandler

### DIFF
--- a/docs/docs/gesture-handlers/api/pan-gh.md
+++ b/docs/docs/gesture-handlers/api/pan-gh.md
@@ -167,43 +167,61 @@ Y coordinate of the current position of the pointer (finger or a leading pointer
 See the [draggable example](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example/src/basic/draggable/index.tsx) from Gesture Handler Example App.
 
 ```js
+import React, { Component } from 'react';
+import { Animated, Dimensions } from 'react-native';
+import {
+  GestureHandlerRootView,
+  PanGestureHandler,
+} from 'react-native-gesture-handler';
+
+const { width } = Dimensions.get('screen');
 const circleRadius = 30;
+
 class Circle extends Component {
-  _touchX = new Animated.Value(windowWidth / 2 - circleRadius);
+  _touchX = new Animated.Value(width / 2 - circleRadius);
+
   _onPanGestureEvent = Animated.event([{ nativeEvent: { x: this._touchX } }], {
     useNativeDriver: true,
   });
+
   render() {
     return (
-      <PanGestureHandler onGestureEvent={this._onPanGestureEvent}>
-        <Animated.View
-          style={{
-            height: 150,
-            justifyContent: 'center',
-          }}>
+      <GestureHandlerRootView>
+        <PanGestureHandler onGestureEvent={this._onPanGestureEvent}>
           <Animated.View
-            style={[
-              {
-                backgroundColor: '#42a5f5',
-                borderRadius: circleRadius,
-                height: circleRadius * 2,
-                width: circleRadius * 2,
-              },
-              {
-                transform: [
-                  {
-                    translateX: Animated.add(
-                      this._touchX,
-                      new Animated.Value(-circleRadius)
-                    ),
-                  },
-                ],
-              },
-            ]}
-          />
-        </Animated.View>
-      </PanGestureHandler>
+            style={{
+              height: 150,
+              justifyContent: 'center',
+            }}
+          >
+            <Animated.View
+              style={[
+                {
+                  backgroundColor: '#42a5f5',
+                  borderRadius: circleRadius,
+                  height: circleRadius * 2,
+                  width: circleRadius * 2,
+                },
+                {
+                  transform: [
+                    {
+                      translateX: Animated.add(
+                        this._touchX,
+                        new Animated.Value(-circleRadius),
+                      ),
+                    },
+                  ],
+                },
+              ]}
+            />
+          </Animated.View>
+        </PanGestureHandler>
+      </GestureHandlerRootView>
     );
   }
+}
+
+export default function App() {
+  return <Circle />;
 }
 ```


### PR DESCRIPTION
## Description

I found it hard to get this example to work. It took me a while to figure out that I needed `GestureHandlerRootView` because it otherwise simply wouldn't do anything on android.

I also had to hunt down the needed imports.

Lastly, I made it a copy-paste solution that just works when dropped into App.tsx which is something I personally really like about example code.

## Test plan

<!--
Describe how did you test this change here.
-->
