### PR TITLE
Add manual gestures example & Fix Draggable example

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -48,6 +48,7 @@ import BottomSheetNewApi from './new_api/bottom_sheet';
 import ChatHeadsNewApi from './new_api/chat_heads';
 import DragNDrop from './new_api/drag_n_drop';
 import BetterHorizontalDrawer from './new_api/betterHorizontalDrawer';
+import ManualGestures from './new_api/manualGestures/index';
 
 LogBox.ignoreLogs([
   "[react-native-gesture-handler] Seems like you're using an old API with gesture components, check out new Gestures system!",
@@ -131,6 +132,10 @@ const EXAMPLES: ExamplesSection[] = [
       {
         name: 'Horizontal Drawer (Reanimated 2 & RNGH 2)',
         component: BetterHorizontalDrawer,
+      },
+      {
+        name: 'Manual gestures',
+        component: ManualGestures,
       },
     ],
   },

--- a/example/src/new_api/drag_n_drop/Draggable.tsx
+++ b/example/src/new_api/drag_n_drop/Draggable.tsx
@@ -7,7 +7,7 @@ import {
   PanGesture,
   TapGesture,
 } from 'react-native-gesture-handler';
-import Animated, { useAnimatedStyle } from 'react-native-reanimated';
+import Animated, { runOnJS, useAnimatedStyle } from 'react-native-reanimated';
 
 type AnimatedPostion = {
   x: Animated.SharedValue<number>;
@@ -43,7 +43,7 @@ const Draggable: FunctionComponent<DraggableProps> = ({
 }) => {
   const tapGesture = Gesture.LongPress()
     .minDuration(300)
-    .onStart(() => onLongPress(id))
+    .onStart(() => runOnJS(onLongPress)(id))
     .simultaneousWithExternalGesture(dragGesture)
     .simultaneousWithExternalGesture(tapEndGesture);
 

--- a/example/src/new_api/manualGestures/index.tsx
+++ b/example/src/new_api/manualGestures/index.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import Animated, {
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
+
+interface Pointer {
+  visible: boolean;
+  x: number;
+  y: number;
+}
+
+function PointerElement(props: {
+  pointer: Animated.SharedValue<Pointer>;
+  active: Animated.SharedValue<boolean>;
+}) {
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [
+      { translateX: props.pointer.value.x },
+      { translateY: props.pointer.value.y },
+      {
+        scale:
+          (props.pointer.value.visible ? 1 : 0) *
+          (props.active.value ? 1.3 : 1),
+      },
+    ],
+    backgroundColor: props.active.value ? 'red' : 'blue',
+  }));
+
+  return <Animated.View style={[styles.pointer, animatedStyle]} />;
+}
+
+export default function Example() {
+  const trackedPointers: Animated.SharedValue<Pointer>[] = [];
+  const active = useSharedValue(false);
+
+  for (let i = 0; i < 12; i++) {
+    // eslint-disable-next-line react-hooks/rules-of-hooks
+    trackedPointers[i] = useSharedValue<Pointer>({
+      visible: false,
+      x: 0,
+      y: 0,
+    });
+  }
+
+  const gesture = Gesture.Manual()
+    .onTouchesDown((e, manager) => {
+      for (const touch of e.changedTouches) {
+        trackedPointers[touch.id].value = {
+          visible: true,
+          x: touch.x,
+          y: touch.y,
+        };
+      }
+
+      if (e.numberOfTouches >= 2) {
+        manager.activate();
+      }
+    })
+    .onTouchesMove((e, _manager) => {
+      for (const touch of e.changedTouches) {
+        trackedPointers[touch.id].value = {
+          visible: true,
+          x: touch.x,
+          y: touch.y,
+        };
+      }
+    })
+    .onTouchesUp((e, manager) => {
+      for (const touch of e.changedTouches) {
+        trackedPointers[touch.id].value = {
+          visible: false,
+          x: touch.x,
+          y: touch.y,
+        };
+      }
+
+      if (e.numberOfTouches === 0) {
+        manager.end();
+      }
+    })
+    .onStart(() => {
+      active.value = true;
+    })
+    .onEnd(() => {
+      active.value = false;
+    });
+  return (
+    <View style={styles.home}>
+      <Text style={styles.title}>
+        A simple one that tracks all pointers on the screen, Trigger method:{' '}
+      </Text>
+      <Text style={styles.desc}>- Emulator: option + tap</Text>
+      <Text style={styles.desc}>- Device: multiple finger taps</Text>
+      <GestureDetector gesture={gesture}>
+        <Animated.View style={{ flex: 1 }}>
+          {trackedPointers.map((pointer, index) => (
+            // eslint-disable-next-line react/no-array-index-key
+            <PointerElement pointer={pointer} active={active} key={index} />
+          ))}
+        </Animated.View>
+      </GestureDetector>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  home: {
+    width: '100%',
+    height: '100%',
+    alignSelf: 'center',
+  },
+  pointer: {
+    width: 60,
+    height: 60,
+    borderRadius: 30,
+    backgroundColor: 'red',
+    position: 'absolute',
+    marginStart: -30,
+    marginTop: -30,
+  },
+
+  title: {
+    fontWeight: 'bold',
+    fontSize: 20,
+    marginVertical: 20,
+    paddingHorizontal: 10,
+  },
+  desc: {
+    marginVertical: 3,
+    marginHorizontal: 10,
+    fontSize: 16,
+  },
+});

--- a/example/src/new_api/manualGestures/index.tsx
+++ b/example/src/new_api/manualGestures/index.tsx
@@ -92,7 +92,9 @@ export default function Example() {
       <Text style={styles.title}>
         A simple one that tracks all pointers on the screen, Trigger method:{' '}
       </Text>
-      <Text style={styles.desc}>- Emulator: option + tap</Text>
+      <Text style={styles.desc}>
+        - Emulator: option + tap (iOS) or command + tap (Android)
+      </Text>
       <Text style={styles.desc}>- Device: multiple finger taps</Text>
       <GestureDetector gesture={gesture}>
         <Animated.View style={{ flex: 1 }}>

--- a/example/src/new_api/manualGestures/index.tsx
+++ b/example/src/new_api/manualGestures/index.tsx
@@ -90,7 +90,7 @@ export default function Example() {
   return (
     <View style={styles.home}>
       <Text style={styles.title}>
-        A simple one that tracks all pointers on the screen, Trigger method:{' '}
+        A simple one that tracks all pointers on the screen, Trigger method:
       </Text>
       <Text style={styles.desc}>
         - Emulator: option + tap (iOS) or command + tap (Android)


### PR DESCRIPTION
## Description
**Hi, maintainers, thank you so much for doing a great project for React Native, I like this project very much!**
**I'm happy to do somethings for this project!**

### This PR is innocuous for this lib, just fix bug and add example. 
- Add manual gestures example, I looked at your documentation, but found this [Manual gestures](https://docs.swmansion.com/react-native-gesture-handler/docs/manual-gestures/manual-gestures) without an example, So I added.


- Fix Draggable example, <Draggable />  had bug, onLongPress callback method should run on JSThread that can execute the `setState`.

<!--
Description and motivation for this PR.

Inlude 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

<!--
Describe how did you test this change here.
-->
![image](https://user-images.githubusercontent.com/37520667/158007648-b9dacd59-692f-40fe-9f25-711595e54b37.png)

This is the error thrown, After I fixed it: 

![image](https://user-images.githubusercontent.com/37520667/158007705-6f7160ae-7e02-4dc9-8203-11512f3076e5.png)


