### PR TITLE
Use device events when remote debugging is enabled

### DIFF
--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -15,6 +15,7 @@ import { PinchGestureHandlerEventPayload } from '../PinchGestureHandler';
 import { RotationGestureHandlerEventPayload } from '../RotationGestureHandler';
 import { TapGestureHandlerEventPayload } from '../TapGestureHandler';
 import { NativeViewGestureHandlerPayload } from '../NativeViewGestureHandler';
+import { isRemoteDebuggingEnabled } from '../../utils';
 
 export type GestureType =
   | BaseGesture<Record<string, unknown>>
@@ -278,9 +279,13 @@ export abstract class BaseGesture<
   prepare() {}
 
   get shouldUseReanimated(): boolean {
-    // use Reanimated when runOnJS isn't set explicitly and all defined callbacks are worklets
+    // use Reanimated when runOnJS isn't set explicitly,
+    // and all defined callbacks are worklets,
+    // and remote debugging is disabled
     return (
-      this.config.runOnJS !== true && !this.handlers.isWorklet.includes(false)
+      this.config.runOnJS !== true &&
+      !this.handlers.isWorklet.includes(false) &&
+      !isRemoteDebuggingEnabled()
     );
   }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -46,5 +46,6 @@ export function isFabric(): boolean {
 
 export function isRemoteDebuggingEnabled(): boolean {
   // react-native-reanimated checks if in remote debugging in the same way
+  // @ts-ignore global is available but node types are not included
   return !(global as any).nativeCallSyncHook || (global as any).__REMOTEDEV__;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,5 +45,6 @@ export function isFabric(): boolean {
 }
 
 export function isRemoteDebuggingEnabled(): boolean {
+  // react-native-reanimated checks if in remote debugging in the same way
   return !(global as any).nativeCallSyncHook || (global as any).__REMOTEDEV__;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,3 +43,14 @@ export function isFabric(): boolean {
   // @ts-expect-error nativeFabricUIManager is not yet included in the RN types
   return !!global?.nativeFabricUIManager;
 }
+
+export function isRemoteDebuggingEnabled(): boolean {
+  return (
+    // @ts-ignore WorkerGlobalScope available only when remote debugging
+    'undefined' !== typeof WorkerGlobalScope &&
+    // @ts-ignore importScripts available only when remote debugging
+    'function' === typeof importScripts &&
+    // @ts-ignore WorkerNavigator available only when remote debugging
+    navigator instanceof WorkerNavigator
+  );
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -45,12 +45,5 @@ export function isFabric(): boolean {
 }
 
 export function isRemoteDebuggingEnabled(): boolean {
-  return (
-    // @ts-ignore WorkerGlobalScope available only when remote debugging
-    'undefined' !== typeof WorkerGlobalScope &&
-    // @ts-ignore importScripts available only when remote debugging
-    'function' === typeof importScripts &&
-    // @ts-ignore WorkerNavigator available only when remote debugging
-    navigator instanceof WorkerNavigator
-  );
+  return !(global as any).nativeCallSyncHook || (global as any).__REMOTEDEV__;
 }


### PR DESCRIPTION
## Description

Don't rely on Reanimated for receiving events when using remote debugging, as it's not supported by Reanimated 2.

Should fix https://github.com/software-mansion/react-native-gesture-handler/issues/1797.

## Test plan

Run an app with Chrome remote debugging enabled and disabled.
