### PR TITLE
Use C++17 for Fabric on iOS

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -717,7 +717,7 @@ PODS:
     - React-jsi (= 0.68.0-rc.2)
     - React-logger (= 0.68.0-rc.2)
     - React-perflogger (= 0.68.0-rc.2)
-  - RNGestureHandler (2.3.0):
+  - RNGestureHandler (2.3.2):
     - RCT-Folly (= 2021.06.28.00-v2)
     - RCTRequired
     - RCTTypeSafety
@@ -725,7 +725,7 @@ PODS:
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-  - RNScreens (3.13.1):
+  - RNScreens (3.13.0):
     - RCT-Folly (= 2021.06.28.00-v2)
     - RCTRequired
     - RCTTypeSafety
@@ -733,8 +733,8 @@ PODS:
     - React-Codegen
     - React-RCTFabric
     - ReactCommon/turbomodule/core
-    - RNScreens/common (= 3.13.1)
-  - RNScreens/common (3.13.1):
+    - RNScreens/common (= 3.13.0)
+  - RNScreens/common (3.13.0):
     - RCT-Folly (= 2021.06.28.00-v2)
     - RCTRequired
     - RCTTypeSafety
@@ -966,8 +966,8 @@ SPEC CHECKSUMS:
   React-rncore: f9e4ffbbe4bc01bb34869b73320da97d98227a04
   React-runtimeexecutor: 37e5fa0b81067a8e487391e2816bae8813b226a5
   ReactCommon: 4c7431a20d472996669b2230f34df0115bf5dc8d
-  RNGestureHandler: 0ccc67ba16a3833b6edae55eb92d9769838a81fd
-  RNScreens: 9c1dfa815b0e70f24453f6acd1fb26090ddd38cb
+  RNGestureHandler: 7fc15a5a001ce68432434f3a351771b28104cdba
+  RNScreens: 58e91b8ed1d247912440d3632dcdbf7d2e6991a5
   SocketRocket: fccef3f9c5cedea1353a9ef6ada904fde10d6608
   Yoga: d7b12009fb66b91a161cddf00c349d42a0015de2
   YogaKit: f782866e155069a2cca2517aafea43200b01fd5a

--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -23,7 +23,8 @@ Pod::Spec.new do |s|
     folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
 
     s.pod_target_xcconfig = {
-      'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native" "$(PODS_ROOT)/RCT-Folly"'
+      'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native" "$(PODS_ROOT)/RCT-Folly"',
+      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
     }
     s.platforms       = { ios: '11.0', tvos: '11.0' }
     s.compiler_flags  = folly_compiler_flags + ' -DRN_FABRIC_ENABLED'


### PR DESCRIPTION
## Description

Use C++17 for Fabric on iOS.

## Test plan

Build the Example app.
