### PR TITLE
add compileOptions to build.gradle. Needed for Detox@19.5.7 to work

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -76,6 +76,11 @@ android {
         }
     }
 
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_1_8
+        targetCompatibility JavaVersion.VERSION_1_8
+    }
+
     if (isNewArchitectureEnabled()) {
         externalNativeBuild {
             ndkBuild {


### PR DESCRIPTION
## Description

<!--
Detox@19.5.7 build error in react-native project when the compileOptions  sourceCompatibility JavaVersion.VERSION_1_8 and targetCompatibility JavaVersion.VERSION_1_8 are not included in android/build.gradle of react-native-gesture-handler
-->

## Test plan

<!--
Describe how did you test this change here.
-->
