### PR TITLE
Add `activateAfterLongPress` modifier to Pan gesture

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -1,6 +1,7 @@
 package com.swmansion.gesturehandler
 
 import android.content.Context
+import android.os.Handler
 import android.view.MotionEvent
 import android.view.VelocityTracker
 import android.view.ViewConfiguration
@@ -40,6 +41,9 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
   private var lastY = 0f
   private var velocityTracker: VelocityTracker? = null
   private var averageTouches = false
+  private var activateAfterLongPress = DEFAULT_ACTIVATE_AFTER_LONG_PRESS
+  private val activateDelayed = Runnable { activate() }
+  private var handler: Handler? = null
 
   /**
    * On Android when there are multiple pointers on the screen pan gestures most often just consider
@@ -76,6 +80,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
     minDistSq = defaultMinDistSq
     minPointers = DEFAULT_MIN_POINTERS
     maxPointers = DEFAULT_MAX_POINTERS
+    activateAfterLongPress = DEFAULT_ACTIVATE_AFTER_LONG_PRESS
     averageTouches = false
   }
 
@@ -125,6 +130,10 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
 
   fun setAverageTouches(averageTouches: Boolean) = apply {
     this.averageTouches = averageTouches
+  }
+
+  fun setActivateAfterLongPress(time: Long) = apply {
+    this.activateAfterLongPress = time
   }
 
   /**
@@ -177,13 +186,18 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
 
   private fun shouldFail(): Boolean {
     val dx = lastX - startX + offsetX
+    val dy = lastY - startY + offsetY
+
+    if (activateAfterLongPress > 0 && dx * dx + dy * dy > defaultMinDistSq) {
+      handler?.removeCallbacksAndMessages(null)
+      return true
+    }
     if (failOffsetXStart != MAX_VALUE_IGNORE && dx < failOffsetXStart) {
       return true
     }
     if (failOffsetXEnd != MIN_VALUE_IGNORE && dx > failOffsetXEnd) {
       return true
     }
-    val dy = lastY - startY + offsetY
     if (failOffsetYStart != MAX_VALUE_IGNORE && dy < failOffsetYStart) {
       return true
     }
@@ -216,6 +230,13 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       velocityTracker = VelocityTracker.obtain()
       addVelocityMovement(velocityTracker, event)
       begin()
+
+      if (activateAfterLongPress > 0) {
+        if (handler == null) {
+          handler = Handler()
+        }
+        handler!!.postDelayed(activateDelayed, activateAfterLongPress)
+      }
     } else if (velocityTracker != null) {
       addVelocityMovement(velocityTracker, event)
       velocityTracker!!.computeCurrentVelocity(1000)
@@ -257,7 +278,12 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
     super.activate(force)
   }
 
+  override fun onCancel() {
+    handler?.removeCallbacksAndMessages(null)
+  }
+
   override fun onReset() {
+    handler?.removeCallbacksAndMessages(null)
     velocityTracker?.let {
       it.recycle()
       velocityTracker = null
@@ -274,6 +300,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
     private const val MAX_VALUE_IGNORE = Float.MIN_VALUE
     private const val DEFAULT_MIN_POINTERS = 1
     private const val DEFAULT_MAX_POINTERS = 10
+    private const val DEFAULT_ACTIVATE_AFTER_LONG_PRESS = 0L
 
     /**
      * This method adds movement to {@class VelocityTracker} first resetting offset of the event so

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -219,6 +219,9 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
       if (config.hasKey(KEY_PAN_AVG_TOUCHES)) {
         handler.setAverageTouches(config.getBoolean(KEY_PAN_AVG_TOUCHES))
       }
+      if (config.hasKey(KEY_PAN_ACTIVATE_AFTER_LONG_PRESS)) {
+        handler.setActivateAfterLongPress(config.getInt(KEY_PAN_ACTIVATE_AFTER_LONG_PRESS).toLong())
+      }
     }
 
     override fun extractEventData(handler: PanGestureHandler, eventData: WritableMap) {
@@ -700,6 +703,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
     private const val KEY_PAN_MIN_POINTERS = "minPointers"
     private const val KEY_PAN_MAX_POINTERS = "maxPointers"
     private const val KEY_PAN_AVG_TOUCHES = "avgTouches"
+    private const val KEY_PAN_ACTIVATE_AFTER_LONG_PRESS = "activateAfterLongPress"
     private const val KEY_NUMBER_OF_POINTERS = "numberOfPointers"
     private const val KEY_DIRECTION = "direction"
 

--- a/docs/docs/api/gestures/pan-gesture.md
+++ b/docs/docs/api/gestures/pan-gesture.md
@@ -50,6 +50,10 @@ A number of fingers that is required to be placed before gesture can [activate](
 
 When the given number of fingers is placed on the screen and gesture hasn't yet [activated](../../under-the-hood/states-events.md#active) it will fail recognizing the gesture. Should be a higher or equal to 0 integer.
 
+### `activateAfterLongPress(duration: number)`
+
+Duration in milliseconds of the `LongPress` gesture before `Pan` is allowed to [activate](../../under-the-hood/states-events.md#active). If the finger is moved during that period, the gesture will [fail](../../under-the-hood/states-events.md#failed). Should be a higher or equal to 0 integer. Default value is 0, meaning no `LongPress` is required to [activate](../../under-the-hood/states-events.md#active) the `Pan`.
+
 ### `activeOffsetX(value: number | number[])`
 
 Range along X axis (in points) where fingers travels without activation of gesture. Moving outside of this range implies activation of gesture. Range can be given as an array or a single number.

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -24,6 +24,7 @@
 @property (nonatomic) CGFloat activeOffsetYEnd;
 @property (nonatomic) CGFloat failOffsetYStart;
 @property (nonatomic) CGFloat failOffsetYEnd;
+@property (nonatomic) CGFloat activateAfterLongPress;
 
 
 - (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
@@ -53,6 +54,7 @@
     _activeOffsetYEnd = NAN;
     _failOffsetYStart = NAN;
     _failOffsetYEnd = NAN;
+    _activateAfterLongPress = NAN;
     _hasCustomActivationCriteria = NO;
 #if !TARGET_OS_TV
     _realMinimumNumberOfTouches = self.minimumNumberOfTouches;
@@ -69,6 +71,13 @@
 - (void)setMinimumNumberOfTouches:(NSUInteger)minimumNumberOfTouches
 {
   _realMinimumNumberOfTouches = minimumNumberOfTouches;
+}
+
+- (void)activateAfterLongPress
+{
+  self.state = UIGestureRecognizerStateBegan;
+  // Send event in ACTIVE state because UIGestureRecognizerStateBegan is mapped to RNGestureHandlerStateBegan
+  [_gestureHandler handleGesture:self inState:RNGestureHandlerStateActive];
 }
 
 - (void)touchesBegan:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
@@ -89,6 +98,10 @@
   [super touchesBegan:touches withEvent:event];
   [self triggerAction];
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+    
+  if (!isnan(_activateAfterLongPress)) {
+    [self performSelector:@selector(activateAfterLongPress) withObject:nil afterDelay:_activateAfterLongPress];
+  }
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
@@ -140,6 +153,7 @@
 {
   [self triggerAction];
   [_gestureHandler.pointerTracker reset];
+  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(activateAfterLongPress) object:nil];
   self.enabled = YES;
   [super reset];
 }
@@ -155,6 +169,12 @@
 - (BOOL)shouldFailUnderCustomCriteria
 {
   CGPoint trans = [self translationInView:self.view.window];
+  // Apple docs say that 10 units is the default allowable movement for UILongPressGestureRecognizer
+  if (!isnan(_activateAfterLongPress) && trans.x * trans.x + trans.y * trans.y > 100) {
+    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(activateAfterLongPress) object:nil];
+    return YES;
+  }
+    
   if (!isnan(_failOffsetXStart) && trans.x < _failOffsetXStart) {
     return YES;
   }
@@ -242,6 +262,7 @@
 #endif
   recognizer.minDistSq = NAN;
   recognizer.minVelocitySq = NAN;
+  recognizer.activateAfterLongPress = NAN;
 }
 
 - (void)configure:(NSDictionary *)config
@@ -282,6 +303,12 @@
   if (prop != nil) {
     CGFloat velocity = [RCTConvert CGFloat:prop];
     recognizer.minVelocitySq = velocity * velocity;
+  }
+    
+  prop = config[@"activateAfterLongPress"];
+  if (prop != nil) {
+    recognizer.activateAfterLongPress = [RCTConvert CGFloat:prop] / 1000.0;
+    recognizer.minDistSq = MAX(100, recognizer.minDistSq);
   }
   [recognizer updateHasCustomActivationCriteria];
 }

--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -65,6 +65,7 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 - (void)resetConfig NS_REQUIRES_SUPER;
 - (void)configure:(nullable NSDictionary *)config NS_REQUIRES_SUPER;
 - (void)handleGesture:(nonnull id)recognizer;
+- (void)handleGesture:(nonnull id)recognizer inState:(RNGestureHandlerState)state;
 - (BOOL)containsPointInView;
 - (RNGestureHandlerState)state;
 - (nullable RNGestureHandlerEventExtraData *)eventExtraData:(nonnull id)recognizer;

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -190,6 +190,12 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 - (void)handleGesture:(UIGestureRecognizer *)recognizer
 {
     _state = [self recognizerState];
+    [self handleGesture:recognizer inState:_state];
+}
+
+- (void)handleGesture:(UIGestureRecognizer *)recognizer inState:(RNGestureHandlerState)state
+{
+    _state = state;
     RNGestureHandlerEventExtraData *eventData = [self eventExtraData:recognizer];
     [self sendEventsInState:self.state forViewWithTag:recognizer.view.reactTag withExtraData:eventData];
 }

--- a/src/handlers/PanGestureHandler.ts
+++ b/src/handlers/PanGestureHandler.ts
@@ -17,6 +17,7 @@ export const panGestureHandlerProps = [
   'maxPointers',
   'avgTouches',
   'enableTrackpadTwoFingerGesture',
+  'activateAfterLongPress',
 ] as const;
 
 export const panGestureHandlerCustomNativeProps = [
@@ -124,6 +125,7 @@ interface CommonPanProperties {
   minVelocity?: number;
   minVelocityX?: number;
   minVelocityY?: number;
+  activateAfterLongPress?: number;
 }
 
 export interface PanGestureConfig extends CommonPanProperties {

--- a/src/handlers/gestures/panGesture.ts
+++ b/src/handlers/gestures/panGesture.ts
@@ -131,6 +131,11 @@ export class PanGesture extends ContinousBaseGesture<
     return this;
   }
 
+  activateAfterLongPress(duration: number) {
+    this.config.activateAfterLongPress = duration;
+    return this;
+  }
+
   onChange(
     callback: (
       event: GestureUpdateEvent<


### PR DESCRIPTION
## Description

Since the release of Gesture Handler 2.0, it's been relatively easy to implement `LongPress` before `Pan` using `manualActivation` and touch events, however this approach adds a lot of unnecessary boilerplate code and may not seem obvious when tackling this problem.
This PR adds `activteAfterLongPress` modifier to `Pan` gesture, making it very easy to make `Pan` gesture activate only after `LongPress` of specified duration.

## Test plan

Tested on the Example app - added the modifier on existing examples utilizing `Pan` to see if they behave correctly.
