### PR TITLE
Rename `sendStateChangeEvent` to `sendEvent`

### DIFF
--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -26,7 +26,7 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 
 @protocol RNGestureHandlerEventEmitter
 
-- (void)sendStateChangeEvent:(nonnull RNGestureHandlerStateChange *)event withActionType:(RNGestureHandlerActionType)actionType;
+- (void)sendEvent:(nonnull RNGestureHandlerStateChange *)event withActionType:(RNGestureHandlerActionType)actionType;
 
 @end
 
@@ -74,7 +74,7 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 - (void)sendEventsInState:(RNGestureHandlerState)state
            forViewWithTag:(nonnull NSNumber *)reactTag
             withExtraData:(nonnull RNGestureHandlerEventExtraData *)extraData;
-- (void)sendStateChangeEvent:(nonnull RNGestureHandlerStateChange *)event;
+- (void)sendEvent:(nonnull RNGestureHandlerStateChange *)event;
 - (void)sendTouchEventInState:(RNGestureHandlerState)state
                  forViewWithTag:(nonnull NSNumber *)reactTag;
 

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -212,7 +212,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
                                                                        state:RNGestureHandlerStateActive
                                                                    prevState:_lastState
                                                                    extraData:extraData];
-            [self sendStateChangeEvent:event];
+            [self sendEvent:event];
             _lastState = RNGestureHandlerStateActive;
         }
         id stateEvent = [[RNGestureHandlerStateChange alloc] initWithReactTag:reactTag
@@ -220,7 +220,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
                                                                         state:state
                                                                     prevState:_lastState
                                                                     extraData:extraData];
-        [self sendStateChangeEvent:stateEvent];
+        [self sendEvent:stateEvent];
         _lastState = state;
     }
 
@@ -230,13 +230,13 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
                                                                   state:state
                                                               extraData:extraData
                                                           coalescingKey:self->_eventCoalescingKey];
-        [self sendStateChangeEvent:touchEvent];
+        [self sendEvent:touchEvent];
     }
 }
 
-- (void)sendStateChangeEvent:(RNGestureHandlerStateChange *)event
+- (void)sendEvent:(RNGestureHandlerStateChange *)event
 {
-    [self.emitter sendStateChangeEvent:event withActionType:self.actionType];
+    [self.emitter sendEvent:event withActionType:self.actionType];
 }
 
 - (void)sendTouchEventInState:(RNGestureHandlerState)state
@@ -248,7 +248,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
                                           withNumberOfTouches:_pointerTracker.trackedPointersCount];
   id event = [[RNGestureHandlerEvent alloc] initWithReactTag:reactTag handlerTag:_tag state:state extraData:extraData coalescingKey:[_tag intValue]];
   
-  [self.emitter sendStateChangeEvent:event withActionType:self.actionType];
+  [self.emitter sendEvent:event withActionType:self.actionType];
 }
 
 - (RNGestureHandlerState)recognizerState

--- a/ios/RNGestureHandlerManager.mm
+++ b/ios/RNGestureHandlerManager.mm
@@ -210,35 +210,35 @@
 
 #pragma mark Events
 
-- (void)sendStateChangeEvent:(RNGestureHandlerStateChange *)event withActionType:(RNGestureHandlerActionType)actionType
+- (void)sendEvent:(RNGestureHandlerStateChange *)event withActionType:(RNGestureHandlerActionType)actionType
 {
     switch (actionType) {
         case RNGestureHandlerActionTypeReanimatedWorklet:
-            [self sendStateChangeEventForReanimated:event];
+            [self sendEventForReanimated:event];
             break;
             
         case RNGestureHandlerActionTypeNativeAnimatedEvent:
             if ([event.eventName isEqualToString:@"onGestureHandlerEvent"]) {
-                [self sendStateChangeEventForNativeAnimatedEvent:event];
+                [self sendEventForNativeAnimatedEvent:event];
             } else {
                 // Although onGestureEvent prop is an Animated.event with useNativeDriver: true,
                 // onHandlerStateChange prop is still a regular JS function.
                 // Also, Animated.event is only supported with old API.
-                [self sendStateChangeEventForJSFunctionOldAPI:event];
+                [self sendEventForJSFunctionOldAPI:event];
             }
             break;
 
         case RNGestureHandlerActionTypeJSFunctionOldAPI:
-            [self sendStateChangeEventForJSFunctionOldAPI:event];
+            [self sendEventForJSFunctionOldAPI:event];
             break;
             
         case RNGestureHandlerActionTypeJSFunctionNewAPI:
-            [self sendStateChangeEventForJSFunctionNewAPI:event];
+            [self sendEventForJSFunctionNewAPI:event];
             break;
     }
 }
 
-- (void)sendStateChangeEventForReanimated:(RNGestureHandlerStateChange *)event
+- (void)sendEventForReanimated:(RNGestureHandlerStateChange *)event
 {
     // Delivers the event to Reanimated.
 #ifdef RN_FABRIC_ENABLED
@@ -248,42 +248,42 @@
 #else
     // In the old architecture, Reanimated overwrites RCTEventDispatcher
     // with REAEventDispatcher and intercepts all direct events.
-    [self sendStateChangeEventForDirectEvent:event];
+    [self sendEventForDirectEvent:event];
 #endif // RN_FABRIC_ENABLED
 }
 
-- (void)sendStateChangeEventForNativeAnimatedEvent:(RNGestureHandlerStateChange *)event
+- (void)sendEventForNativeAnimatedEvent:(RNGestureHandlerStateChange *)event
 {
     // Delivers the event to NativeAnimatedModule.
     // Currently, NativeAnimated[Turbo]Module is RCTEventDispatcherObserver so we can
     // simply send a direct event which is handled by the observer but ignored on JS side.
     // TODO: send event directly to NativeAnimated[Turbo]Module
-    [self sendStateChangeEventForDirectEvent:event];
+    [self sendEventForDirectEvent:event];
 }
 
-- (void)sendStateChangeEventForJSFunctionOldAPI:(RNGestureHandlerStateChange *)event
+- (void)sendEventForJSFunctionOldAPI:(RNGestureHandlerStateChange *)event
 {
     // Delivers the event to JS (old RNGH API).
 #ifdef RN_FABRIC_ENABLED
-    [self sendStateChangeEventForDeviceEvent:event];
+    [self sendEventForDeviceEvent:event];
 #else
-    [self sendStateChangeEventForDirectEvent:event];
+    [self sendEventForDirectEvent:event];
 #endif // RN_FABRIC_ENABLED
 }
 
-- (void)sendStateChangeEventForJSFunctionNewAPI:(RNGestureHandlerStateChange *)event
+- (void)sendEventForJSFunctionNewAPI:(RNGestureHandlerStateChange *)event
 {
     // Delivers the event to JS (new RNGH API).
-    [self sendStateChangeEventForDeviceEvent:event];
+    [self sendEventForDeviceEvent:event];
 }
 
-- (void)sendStateChangeEventForDirectEvent:(RNGestureHandlerStateChange *)event
+- (void)sendEventForDirectEvent:(RNGestureHandlerStateChange *)event
 {
     // Delivers the event to JS as a direct event.
     [_eventDispatcher sendEvent:event];
 }
 
-- (void)sendStateChangeEventForDeviceEvent:(RNGestureHandlerStateChange *)event
+- (void)sendEventForDeviceEvent:(RNGestureHandlerStateChange *)event
 {
     // Delivers the event to JS as a device event.
     NSMutableDictionary *body = [[event arguments] objectAtIndex:2];


### PR DESCRIPTION
## Description

Before https://github.com/software-mansion/react-native-gesture-handler/commit/0d1a917a3de5281656276e05bcbff1d832d8d624 there was a method responsible for sending each type of event, however `sendStateChangeEvent` was used to send all of them. In https://github.com/software-mansion/react-native-gesture-handler/commit/0d1a917a3de5281656276e05bcbff1d832d8d624 the redundant methods were removed, but the name remained.
This PR changes the name of `sendStateChangeEvent` to `sendEvent` on iOS with hope that it will be (slightly) less confusing.

## Test plan

Compiled Example app.
