### PR TITLE
Rename `RNTouchEventType` to `RNGHTouchEventType`

### DIFF
--- a/ios/RNGHTouchEventType.h
+++ b/ios/RNGHTouchEventType.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-typedef NS_ENUM(NSInteger, RNTouchEventType) {
+typedef NS_ENUM(NSInteger, RNGHTouchEventType) {
   RNTouchEventTypeUndetermined = 0,
   RNTouchEventTypePointerDown,
   RNTouchEventTypePointerMove,

--- a/ios/RNGHTouchEventType.h
+++ b/ios/RNGHTouchEventType.h
@@ -1,9 +1,9 @@
 #import <Foundation/Foundation.h>
 
 typedef NS_ENUM(NSInteger, RNGHTouchEventType) {
-  RNTouchEventTypeUndetermined = 0,
-  RNTouchEventTypePointerDown,
-  RNTouchEventTypePointerMove,
-  RNTouchEventTypePointerUp,
-  RNTouchEventTypeCancelled,
+  RNGHTouchEventTypeUndetermined = 0,
+  RNGHTouchEventTypePointerDown,
+  RNGHTouchEventTypePointerMove,
+  RNGHTouchEventTypePointerUp,
+  RNGHTouchEventTypeCancelled,
 };

--- a/ios/RNGestureHandlerEvents.h
+++ b/ios/RNGestureHandlerEvents.h
@@ -4,7 +4,7 @@
 #import <UIKit/UIKit.h>
 
 #import "RNGestureHandlerState.h"
-#import "RNTouchEventType.h"
+#import "RNGHTouchEventType.h"
 
 @interface RNGestureHandlerEventExtraData : NSObject
 
@@ -36,7 +36,7 @@
                                 withAnchorPoint:(CGPoint)anchorPoint
                                    withVelocity:(CGFloat)velocity
                             withNumberOfTouches:(NSUInteger)numberOfTouches;
-+ (RNGestureHandlerEventExtraData *)forEventType:(RNTouchEventType)eventType
++ (RNGestureHandlerEventExtraData *)forEventType:(RNGHTouchEventType)eventType
                              withChangedPointers:(NSArray<NSDictionary *> *)changedPointers
                                  withAllPointers:(NSArray<NSDictionary *> *)allPointers
                              withNumberOfTouches:(NSUInteger)numberOfTouches;

--- a/ios/RNGestureHandlerEvents.m
+++ b/ios/RNGestureHandlerEvents.m
@@ -111,7 +111,7 @@
     if (changedPointers == nil || allPointers == nil) {
         changedPointers = @[];
         allPointers = @[];
-        eventType = RNTouchEventTypeUndetermined;
+        eventType = RNGHTouchEventTypeUndetermined;
     }
   
     return [[RNGestureHandlerEventExtraData alloc]

--- a/ios/RNGestureHandlerEvents.m
+++ b/ios/RNGestureHandlerEvents.m
@@ -103,7 +103,7 @@
                            @"numberOfPointers": @(numberOfTouches)}];
 }
 
-+ (RNGestureHandlerEventExtraData *)forEventType:(RNTouchEventType)eventType
++ (RNGestureHandlerEventExtraData *)forEventType:(RNGHTouchEventType)eventType
                              withChangedPointers:(NSArray<NSDictionary *> *)changedPointers
                                  withAllPointers:(NSArray<NSDictionary *> *)allPointers
                              withNumberOfTouches:(NSUInteger)numberOfTouches

--- a/ios/RNGestureHandlerPointerTracker.h
+++ b/ios/RNGestureHandlerPointerTracker.h
@@ -1,6 +1,6 @@
 #import <Foundation/Foundation.h>
 
-#import "RNTouchEventType.h"
+#import "RNGHTouchEventType.h"
 
 #define MAX_POINTERS_COUNT 12
 
@@ -8,7 +8,7 @@
 
 @interface RNGestureHandlerPointerTracker : NSObject
 
-@property (nonatomic) RNTouchEventType eventType;
+@property (nonatomic) RNGHTouchEventType eventType;
 @property (nonatomic) NSArray<NSDictionary *> *changedPointersData;
 @property (nonatomic) NSArray<NSDictionary *> *allPointersData;
 @property (nonatomic) int trackedPointersCount;

--- a/ios/RNGestureHandlerPointerTracker.m
+++ b/ios/RNGestureHandlerPointerTracker.m
@@ -103,7 +103,7 @@
     return;
   }
   
-  _eventType = RNTouchEventTypePointerDown;
+  _eventType = RNGHTouchEventTypePointerDown;
   
   NSDictionary *data[touches.count];
   
@@ -129,7 +129,7 @@
     return;
   }
   
-  _eventType = RNTouchEventTypePointerMove;
+  _eventType = RNGHTouchEventTypePointerMove;
   
   NSDictionary *data[touches.count];
   
@@ -153,7 +153,7 @@
   // extract all touches first to include the ones that were just lifted
   [self extractAllTouches];
   
-  _eventType = RNTouchEventTypePointerUp;
+  _eventType = RNGHTouchEventTypePointerUp;
   
   NSDictionary *data[touches.count];
   
@@ -188,7 +188,7 @@
   
   if (_trackedPointersCount == 0) {
     // gesture has finished because all pointers were lifted, reset event type to send state change event
-    _eventType = RNTouchEventTypeUndetermined;
+    _eventType = RNGHTouchEventTypeUndetermined;
   } else {
     // turns out that the gesture may be made to fail without calling touchesCancelled in that case there
     // are still tracked pointers but the recognizer state is already set to UIGestureRecognizerStateFailed
@@ -218,7 +218,7 @@
       }
     }
     
-    _eventType = RNTouchEventTypeCancelled;
+    _eventType = RNGHTouchEventTypeCancelled;
     _changedPointersData = [[NSArray alloc] initWithObjects:data count:registeredTouches];
     [self sendEvent];
     _trackedPointersCount = 0;


### PR DESCRIPTION
## Description

Rename `RNTouchEventType` to `RNGHTouchEventType` to be more consistent with the rest of the package.
Full `RNGestureHandlerTouchEventType` might be too verbose, but I'm not sure.

## Test plan

Compiled Example app
