### PR TITLE
Don't send events on iOS when target is `nil`

### DIFF
--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -189,6 +189,13 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 - (void)handleGesture:(UIGestureRecognizer *)recognizer
 {
+    // it may happen that the gesture recognizer is reset after it's been unbound from the view,
+    // it that recognizer tried to send event, the app would crash because the target of the event
+    // would be nil.
+    if (recognizer.view.reactTag == nil) {
+      return;
+    }
+    
     _state = [self recognizerState];
     RNGestureHandlerEventExtraData *eventData = [self eventExtraData:recognizer];
     [self sendEventsInState:self.state forViewWithTag:recognizer.view.reactTag withExtraData:eventData];

--- a/ios/RNGestureHandlerPointerTracker.m
+++ b/ios/RNGestureHandlerPointerTracker.m
@@ -227,7 +227,10 @@
 
 - (void)sendEvent
 {
-  if (!_gestureHandler.needsPointerData) {
+  // it may happen that the gesture recognizer is reset after it's been unbound from the view,
+  // it that recognizer tried to send event, the app would crash because the target of the event
+  // would be nil.
+  if (!_gestureHandler.needsPointerData || _gestureHandler.recognizer.view.reactTag == nil) {
     return;
   }
   


### PR DESCRIPTION
## Description

Should fix https://github.com/software-mansion/react-native-gesture-handler/issues/1883.

I managed to (kind of and by accident) reproduce the crash mentioned in the issue when I was working on https://github.com/software-mansion/react-native-gesture-handler/pull/1912. After commenting out [those lines](https://github.com/software-mansion/react-native-gesture-handler/pull/1912/files#diff-0c167f367b6ea1c2605e4c3ec7d9ea7edd077697285273e4e5e5721c9248591cR22-R23), I tapped the view that had a `Pan` gesture attached with `manualActivation` set to true. After that going to a different screen caused the crash.

The issue comes from the fact that some gestures try to send events in their `reset` method to properly close the state flow, however this method is also called when the view is unmounted and all gesture recognizers get unbound from the view. This PR adds a simple check to see if the `reactTag` property is `nil` or not before sending the event. Events are send only when their target is not `nil` which prevents the crash.

## Test plan

Tested on the Example app, modified as explained above.
