### PR TITLE
🔧🇫🇮 Fix TypeScript typing issues with `setTimeout` by removing NodeJS types

### DIFF
--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -36,9 +36,9 @@ import { ActionType } from '../../ActionType';
 import { isFabric, tagMessage } from '../../utils';
 import { getShadowNodeFromRef } from '../../getShadowNodeFromRef';
 
-declare global {
-  function isFormsStackingContext(node: unknown): boolean | null; // JSI function
-}
+declare const global: {
+  isFormsStackingContext: (node: unknown) => boolean | null; // JSI function
+};
 
 const ALLOWED_PROPS = [
   ...baseGestureHandlerWithMonitorProps,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,7 +32,7 @@ export function hasProperty(object: object, key: string) {
 }
 
 export function isJestEnv(): boolean {
-  // @ts-ignore Do not use `@types/node` because it will break setTimeout function types in React Native projects
+  // @ts-ignore Do not use `@types/node` because it will prioritise Node types over RN types which breaks the types (ex. setTimeout) in React Native projects.
   return hasProperty(global, 'process') && !!process.env.JEST_WORKER_ID;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -32,6 +32,7 @@ export function hasProperty(object: object, key: string) {
 }
 
 export function isJestEnv(): boolean {
+  // @ts-ignore Do not use `@types/node` because it will break setTimeout function types in React Native projects
   return hasProperty(global, 'process') && !!process.env.JEST_WORKER_ID;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,7 @@
     "esModuleInterop": true,
     "jsx": "react-native",
     "lib": ["esnext"],
-    "types": ["node", "jest"],
+    "types": ["jest"],
     "module": "esnext",
     "moduleResolution": "node",
     "resolveJsonModule": true,


### PR DESCRIPTION
## Description

This PR https://github.com/software-mansion/react-native-gesture-handler/pull/1844/files#diff-b55cdbef4907b7045f32cc5360d48d262cca5f94062e353089f189f4460039e0 added `node` to the `types` array of `tsconfig`. This causes all of the React Native projects with `gesture-handler` as dependency to get Node typings to their project and node has conflicting types with Dom on `setTimeout`.

This PR gets rid of the `node` typing and adds a new file which adds missing types to gesture handler project.

Long story short:
🔴  We were requiring the whole NodeJS types just because we wanted to use `process.env.JEST_WORKER_ID `
✅  Fixed by not requiring NodeJS types and just typed out the `process.env.JEST_WORKER_ID`

Fixes #1958 

<!--
Description and motivation for this PR.

Inlude 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

Run `yarn ts-check` and see that not TSC errors are produced.
<!--
Describe how did you test this change here.
-->
