### PR TITLE
Remove warning about the old API

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -1,12 +1,5 @@
 import React from 'react';
-import {
-  Text,
-  View,
-  StyleSheet,
-  SectionList,
-  Platform,
-  LogBox,
-} from 'react-native';
+import { Text, View, StyleSheet, SectionList, Platform } from 'react-native';
 import {
   createStackNavigator,
   StackScreenProps,
@@ -49,10 +42,6 @@ import ChatHeadsNewApi from './new_api/chat_heads';
 import DragNDrop from './new_api/drag_n_drop';
 import BetterHorizontalDrawer from './new_api/betterHorizontalDrawer';
 import ManualGestures from './new_api/manualGestures/index';
-
-LogBox.ignoreLogs([
-  "[react-native-gesture-handler] Seems like you're using an old API with gesture components, check out new Gestures system!",
-]);
 
 interface Example {
   name: string;

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -147,18 +147,6 @@ type InternalEventHandlers = {
   onGestureHandlerStateChange?: (event: any) => void;
 };
 
-let showedRngh2Notice = false;
-function showRngh2NoticeIfNeeded() {
-  if (!showedRngh2Notice) {
-    console.warn(
-      tagMessage(
-        "Seems like you're using an old API with gesture components, check out new Gestures system!"
-      )
-    );
-    showedRngh2Notice = true;
-  }
-}
-
 // TODO(TS) - make sure that BaseGestureHandlerProps doesn't need other generic parameter to work with custom properties.
 export default function createHandler<
   T extends BaseGestureHandlerProps<U>,
@@ -198,9 +186,6 @@ export default function createHandler<
           throw new Error(`Handler with ID "${props.id}" already registered`);
         }
         handlerIDToTag[props.id] = this.handlerTag;
-      }
-      if (__DEV__ && !isJestEnv()) {
-        showRngh2NoticeIfNeeded();
       }
     }
 


### PR DESCRIPTION
## Description

Reverts https://github.com/software-mansion/react-native-gesture-handler/pull/1817 and https://github.com/software-mansion/react-native-gesture-handler/pull/1822, removing the warning when using the old API.

Closes https://github.com/software-mansion/react-native-gesture-handler/issues/1831.

## Test plan

Checked Example app.
