### PR TITLE
Updated Tap Gesture Handler Documentation

### DIFF
--- a/docs/docs/api/gestures/tap-gesture.md
+++ b/docs/docs/api/gestures/tap-gesture.md
@@ -15,7 +15,7 @@ The fingers involved in these gestures must not move significantly from their in
 The required number of taps and allowed distance from initial position may be configured.
 For example, you might configure tap gesture recognizers to detect single taps, double taps, or triple taps.
 
-In order for a gesture to [activate](../../under-the-hood/states-events.md#active), specified gesture requirements such as minPointers, numberOfTaps, maxDist, maxDurationMs, and maxDelayMs (explained below) must be met. Immediately after the gesture [activates](../../under-the-hood/states-events.md#active), it will [end](../../under-the-hood/states-events.md#end).
+In order for a gesture to [activate](../../under-the-hood/states-events.md#active), specified gesture requirements such as minPointers, numberOfTaps, maxDist, maxDuration, and maxDelayMs (explained below) must be met. Immediately after the gesture [activates](../../under-the-hood/states-events.md#active), it will [end](../../under-the-hood/states-events.md#end).
 
 ## Config
 
@@ -81,13 +81,13 @@ Y coordinate, expressed in points, of the current position of the pointer (finge
 
 ```jsx
 const singleTap = Gesture.Tap()
-  .maxDurationMs(250)
+  .maxDuration(250)
   .onStart(() => {
     Alert.alert('Single tap!');
   });
 
 const doubleTap = Gesture.Tap()
-  .maxDurationMs(250)
+  .maxDuration(250)
   .onStart(() => {
     Alert.alert('Double tap!');
   });


### PR DESCRIPTION
## Description

Since `maxDurationMs` function is undefined I have updated it to `maxDuration` in the gesture handler documentation description and example.

## Test plan
I just changed the documentation and checked the markdown preview.
