### PR TITLE
Fix gestures not attaching to views on iOS when using Fabric

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -407,10 +407,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
   fun handleClearJSResponder() {
   }
 
-  @ReactMethod
-  fun flushQueuedHandlers() {
-  }
-
   override fun setGestureHandlerState(handlerTag: Int, newState: Int) {
     registry.getHandler(handlerTag)?.let { handler ->
       when (newState) {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -407,6 +407,10 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
   fun handleClearJSResponder() {
   }
 
+  @ReactMethod
+  fun flushQueuedHandlers() {
+  }
+
   override fun setGestureHandlerState(handlerTag: Int, newState: Int) {
     registry.getHandler(handlerTag)?.let { handler ->
       when (newState) {

--- a/ios/RNGestureHandlerModule.mm
+++ b/ios/RNGestureHandlerModule.mm
@@ -173,7 +173,7 @@ RCT_EXPORT_METHOD(handleClearJSResponder)
     }];
 }
 
-RCT_EXPORT_METHOD(flushQueuedHandlers)
+RCT_EXPORT_METHOD(flushOperations)
 {
     if (_operations.count == 0) {
         return;

--- a/ios/RNGestureHandlerModule.mm
+++ b/ios/RNGestureHandlerModule.mm
@@ -173,6 +173,22 @@ RCT_EXPORT_METHOD(handleClearJSResponder)
     }];
 }
 
+RCT_EXPORT_METHOD(flushQueuedHandlers)
+{
+    if (_operations.count == 0) {
+        return;
+    }
+
+    NSArray<GestureHandlerOperation> *operations = _operations;
+    _operations = [NSMutableArray new];
+
+    [self.bridge.uiManager addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+        for (GestureHandlerOperation operation in operations) {
+            operation(self->_manager);
+        }
+    }];
+}
+
 - (void)setGestureState:(int)state forHandler:(int)handlerTag
 {
   RNGestureHandler *handler = [_manager handlerWithTag:@(handlerTag)];

--- a/src/RNGestureHandlerModule.ts
+++ b/src/RNGestureHandlerModule.ts
@@ -16,8 +16,8 @@ if (RNGestureHandlerModule == null) {
   );
 }
 
-if (RNGestureHandlerModule.flushQueuedHandlers === undefined) {
-  RNGestureHandlerModule.flushQueuedHandlers = () => {
+if (RNGestureHandlerModule.flushOperations === undefined) {
+  RNGestureHandlerModule.flushOperations = () => {
     // NO-OP if not defined
   };
 }
@@ -41,7 +41,7 @@ export type RNGestureHandlerModuleProps = {
   ) => void;
   dropGestureHandler: (handlerTag: number) => void;
   install: () => void;
-  flushQueuedHandlers: () => void;
+  flushOperations: () => void;
 };
 
 export default RNGestureHandlerModule as RNGestureHandlerModuleProps;

--- a/src/RNGestureHandlerModule.ts
+++ b/src/RNGestureHandlerModule.ts
@@ -16,6 +16,12 @@ if (RNGestureHandlerModule == null) {
   );
 }
 
+if (RNGestureHandlerModule.flushQueuedHandlers === undefined) {
+  RNGestureHandlerModule.flushQueuedHandlers = () => {
+    // NO-OP if not defined
+  };
+}
+
 export type RNGestureHandlerModuleProps = {
   handleSetJSResponder: (tag: number, blockNativeResponder: boolean) => void;
   handleClearJSResponder: () => void;

--- a/src/RNGestureHandlerModule.ts
+++ b/src/RNGestureHandlerModule.ts
@@ -35,6 +35,7 @@ export type RNGestureHandlerModuleProps = {
   ) => void;
   dropGestureHandler: (handlerTag: number) => void;
   install: () => void;
+  flushQueuedHandlers: () => void;
 };
 
 export default RNGestureHandlerModule as RNGestureHandlerModuleProps;

--- a/src/RNGestureHandlerModule.web.ts
+++ b/src/RNGestureHandlerModule.web.ts
@@ -59,5 +59,6 @@ export default {
   dropGestureHandler(handlerTag: number) {
     NodeManager.dropGestureHandler(handlerTag);
   },
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
   flushQueuedHandlers() {},
 };

--- a/src/RNGestureHandlerModule.web.ts
+++ b/src/RNGestureHandlerModule.web.ts
@@ -60,5 +60,5 @@ export default {
     NodeManager.dropGestureHandler(handlerTag);
   },
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  flushQueuedHandlers() {},
+  flushOperations() {},
 };

--- a/src/RNGestureHandlerModule.web.ts
+++ b/src/RNGestureHandlerModule.web.ts
@@ -59,4 +59,5 @@ export default {
   dropGestureHandler(handlerTag: number) {
     NodeManager.dropGestureHandler(handlerTag);
   },
+  flushQueuedHandlers() {},
 };

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -236,6 +236,9 @@ export default function createHandler<
     componentWillUnmount() {
       this.inspectorToggleListener?.remove();
       RNGestureHandlerModule.dropGestureHandler(this.handlerTag);
+      requestAnimationFrame(() => {
+        RNGestureHandlerModule.flushQueuedHandlers();
+      });
       if (this.updateEnqueued) {
         clearImmediate(this.updateEnqueued);
       }
@@ -346,6 +349,10 @@ export default function createHandler<
           actionType
         );
       }
+
+      requestAnimationFrame(() => {
+        RNGestureHandlerModule.flushQueuedHandlers();
+      });
     };
 
     private updateGestureHandler = (
@@ -354,6 +361,9 @@ export default function createHandler<
       this.config = newConfig;
 
       RNGestureHandlerModule.updateGestureHandler(this.handlerTag, newConfig);
+      requestAnimationFrame(() => {
+        RNGestureHandlerModule.flushQueuedHandlers();
+      });
     };
 
     private update() {

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -23,7 +23,7 @@ import {
   GestureEvent,
   HandlerStateChangeEvent,
   findNodeHandle,
-  scheduleHandlersQueueFlush,
+  scheduleFlushOperationsQueue,
 } from './gestureHandlerCommon';
 import { ValueOf } from '../typeUtils';
 import { isFabric, isJestEnv } from '../utils';
@@ -237,7 +237,7 @@ export default function createHandler<
     componentWillUnmount() {
       this.inspectorToggleListener?.remove();
       RNGestureHandlerModule.dropGestureHandler(this.handlerTag);
-      scheduleHandlersQueueFlush();
+      scheduleFlushOperationsQueue();
       if (this.updateEnqueued) {
         clearImmediate(this.updateEnqueued);
       }
@@ -349,7 +349,7 @@ export default function createHandler<
         );
       }
 
-      scheduleHandlersQueueFlush();
+      scheduleFlushOperationsQueue();
     };
 
     private updateGestureHandler = (
@@ -358,7 +358,7 @@ export default function createHandler<
       this.config = newConfig;
 
       RNGestureHandlerModule.updateGestureHandler(this.handlerTag, newConfig);
-      scheduleHandlersQueueFlush();
+      scheduleFlushOperationsQueue();
     };
 
     private update() {

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -23,7 +23,7 @@ import {
   GestureEvent,
   HandlerStateChangeEvent,
   findNodeHandle,
-  scheduleFlushOperationsQueue,
+  scheduleFlushOperations,
 } from './gestureHandlerCommon';
 import { ValueOf } from '../typeUtils';
 import { isFabric, isJestEnv } from '../utils';
@@ -237,7 +237,7 @@ export default function createHandler<
     componentWillUnmount() {
       this.inspectorToggleListener?.remove();
       RNGestureHandlerModule.dropGestureHandler(this.handlerTag);
-      scheduleFlushOperationsQueue();
+      scheduleFlushOperations();
       if (this.updateEnqueued) {
         clearImmediate(this.updateEnqueued);
       }
@@ -349,7 +349,7 @@ export default function createHandler<
         );
       }
 
-      scheduleFlushOperationsQueue();
+      scheduleFlushOperations();
     };
 
     private updateGestureHandler = (
@@ -358,7 +358,7 @@ export default function createHandler<
       this.config = newConfig;
 
       RNGestureHandlerModule.updateGestureHandler(this.handlerTag, newConfig);
-      scheduleFlushOperationsQueue();
+      scheduleFlushOperations();
     };
 
     private update() {

--- a/src/handlers/createHandler.ts
+++ b/src/handlers/createHandler.ts
@@ -23,6 +23,7 @@ import {
   GestureEvent,
   HandlerStateChangeEvent,
   findNodeHandle,
+  scheduleHandlersQueueFlush,
 } from './gestureHandlerCommon';
 import { ValueOf } from '../typeUtils';
 import { isFabric, isJestEnv } from '../utils';
@@ -236,9 +237,7 @@ export default function createHandler<
     componentWillUnmount() {
       this.inspectorToggleListener?.remove();
       RNGestureHandlerModule.dropGestureHandler(this.handlerTag);
-      requestAnimationFrame(() => {
-        RNGestureHandlerModule.flushQueuedHandlers();
-      });
+      scheduleHandlersQueueFlush();
       if (this.updateEnqueued) {
         clearImmediate(this.updateEnqueued);
       }
@@ -350,9 +349,7 @@ export default function createHandler<
         );
       }
 
-      requestAnimationFrame(() => {
-        RNGestureHandlerModule.flushQueuedHandlers();
-      });
+      scheduleHandlersQueueFlush();
     };
 
     private updateGestureHandler = (
@@ -361,9 +358,7 @@ export default function createHandler<
       this.config = newConfig;
 
       RNGestureHandlerModule.updateGestureHandler(this.handlerTag, newConfig);
-      requestAnimationFrame(() => {
-        RNGestureHandlerModule.flushQueuedHandlers();
-      });
+      scheduleHandlersQueueFlush();
     };
 
     private update() {

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -182,16 +182,16 @@ export function findNodeHandle(
   return findNodeHandleRN(node);
 }
 
-let scheduledHandlersQueueFlush:
+let scheduledFlushOperationsId:
   | ReturnType<typeof requestAnimationFrame>
   | undefined = undefined;
 
-export function scheduleHandlersQueueFlush() {
-  if (scheduledHandlersQueueFlush === undefined) {
-    scheduledHandlersQueueFlush = requestAnimationFrame(() => {
-      RNGestureHandlerModule.flushQueuedHandlers();
+export function scheduleFlushOperationsQueue() {
+  if (scheduledFlushOperationsId === undefined) {
+    scheduledFlushOperationsId = requestAnimationFrame(() => {
+      RNGestureHandlerModule.flushOperations();
 
-      scheduledHandlersQueueFlush = undefined;
+      scheduledFlushOperationsId = undefined;
     });
   }
 }

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -10,6 +10,7 @@ import { TouchEventType } from '../TouchEventType';
 import { ValueOf } from '../typeUtils';
 import { handlerIDToTag } from './handlersRegistry';
 import { toArray } from '../utils';
+import RNGestureHandlerModule from '../RNGestureHandlerModule';
 
 const commonProps = [
   'id',
@@ -179,4 +180,18 @@ export function findNodeHandle(
 ): null | number | React.Component<any, any> | React.ComponentClass<any> {
   if (Platform.OS === 'web') return node;
   return findNodeHandleRN(node);
+}
+
+let scheduledHandlersQueueFlush:
+  | ReturnType<typeof requestAnimationFrame>
+  | undefined = undefined;
+
+export function scheduleHandlersQueueFlush() {
+  if (scheduledHandlersQueueFlush === undefined) {
+    scheduledHandlersQueueFlush = requestAnimationFrame(() => {
+      RNGestureHandlerModule.flushQueuedHandlers();
+
+      scheduledHandlersQueueFlush = undefined;
+    });
+  }
 }

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -182,16 +182,16 @@ export function findNodeHandle(
   return findNodeHandleRN(node);
 }
 
-let scheduledFlushOperationsId:
-  | ReturnType<typeof requestAnimationFrame>
-  | undefined = undefined;
+let scheduledFlushOperationsId: ReturnType<
+  typeof requestAnimationFrame
+> | null = null;
 
 export function scheduleFlushOperationsQueue() {
-  if (scheduledFlushOperationsId === undefined) {
+  if (scheduledFlushOperationsId === null) {
     scheduledFlushOperationsId = requestAnimationFrame(() => {
       RNGestureHandlerModule.flushOperations();
 
-      scheduledFlushOperationsId = undefined;
+      scheduledFlushOperationsId = null;
     });
   }
 }

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -186,7 +186,7 @@ let scheduledFlushOperationsId: ReturnType<
   typeof requestAnimationFrame
 > | null = null;
 
-export function scheduleFlushOperationsQueue() {
+export function scheduleFlushOperations() {
   if (scheduledFlushOperationsId === null) {
     scheduledFlushOperationsId = requestAnimationFrame(() => {
       RNGestureHandlerModule.flushOperations();

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -17,6 +17,7 @@ import {
   GestureUpdateEvent,
   GestureStateChangeEvent,
   HandlerStateChangeEvent,
+  scheduleHandlersQueueFlush,
 } from '../gestureHandlerCommon';
 import {
   GestureStateManager,
@@ -89,9 +90,7 @@ function dropHandlers(preparedGesture: GestureConfigReference) {
     unregisterHandler(handler.handlerTag, handler.config.testId);
   }
 
-  requestAnimationFrame(() => {
-    RNGestureHandlerModule.flushQueuedHandlers();
-  });
+  scheduleHandlersQueueFlush();
 }
 
 function checkGestureCallbacksForWorklets(gesture: GestureType) {
@@ -183,9 +182,7 @@ function attachHandlers({
       );
     }
 
-    requestAnimationFrame(() => {
-      RNGestureHandlerModule.flushQueuedHandlers();
-    });
+    scheduleHandlersQueueFlush();
   });
 
   preparedGesture.config = gesture;
@@ -278,9 +275,7 @@ function updateHandlers(
       >[];
     }
 
-    requestAnimationFrame(() => {
-      RNGestureHandlerModule.flushQueuedHandlers();
-    });
+    scheduleHandlersQueueFlush();
   });
 }
 

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -17,7 +17,7 @@ import {
   GestureUpdateEvent,
   GestureStateChangeEvent,
   HandlerStateChangeEvent,
-  scheduleFlushOperationsQueue,
+  scheduleFlushOperations,
 } from '../gestureHandlerCommon';
 import {
   GestureStateManager,
@@ -90,7 +90,7 @@ function dropHandlers(preparedGesture: GestureConfigReference) {
     unregisterHandler(handler.handlerTag, handler.config.testId);
   }
 
-  scheduleFlushOperationsQueue();
+  scheduleFlushOperations();
 }
 
 function checkGestureCallbacksForWorklets(gesture: GestureType) {
@@ -182,7 +182,7 @@ function attachHandlers({
       );
     }
 
-    scheduleFlushOperationsQueue();
+    scheduleFlushOperations();
   });
 
   preparedGesture.config = gesture;
@@ -275,7 +275,7 @@ function updateHandlers(
       >[];
     }
 
-    scheduleFlushOperationsQueue();
+    scheduleFlushOperations();
   });
 }
 

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -17,7 +17,7 @@ import {
   GestureUpdateEvent,
   GestureStateChangeEvent,
   HandlerStateChangeEvent,
-  scheduleHandlersQueueFlush,
+  scheduleFlushOperationsQueue,
 } from '../gestureHandlerCommon';
 import {
   GestureStateManager,
@@ -90,7 +90,7 @@ function dropHandlers(preparedGesture: GestureConfigReference) {
     unregisterHandler(handler.handlerTag, handler.config.testId);
   }
 
-  scheduleHandlersQueueFlush();
+  scheduleFlushOperationsQueue();
 }
 
 function checkGestureCallbacksForWorklets(gesture: GestureType) {
@@ -182,7 +182,7 @@ function attachHandlers({
       );
     }
 
-    scheduleHandlersQueueFlush();
+    scheduleFlushOperationsQueue();
   });
 
   preparedGesture.config = gesture;
@@ -275,7 +275,7 @@ function updateHandlers(
       >[];
     }
 
-    scheduleHandlersQueueFlush();
+    scheduleFlushOperationsQueue();
   });
 }
 


### PR DESCRIPTION
## Description

when gestures are created and attached to views, on iOS the operations are batched and executed on the UI thread. The method we are using currently is run too early - the batched queue is flushed before the gestures are created on the JS side, effectively making the app unresponsive.

This PR adds a method that allows flushing the queue from the JS side, after all the operations are scheduled.

## Test plan

Tested on Example and FabricExample apps
