### PR TITLE
Add a workaround for `pointerCount must be at least 1`

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -316,7 +316,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     isEnabled: ${handler.isEnabled}
     isActive: ${handler.isActive}
     isAwaiting: ${handler.isAwaiting}
-    trackedPointersCount: ${handler.trackedPointersCount}
+    trackedPointersCount: ${handler.trackedPointersIDsCount}
     trackedPointers: ${handler.trackedPointerIDs.joinToString(separator = ", ")}
     while handling event: $event
   """.trimIndent(), e) {}

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -329,7 +329,19 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
       || trackedPointersIDsCount < 1) {
       return
     }
-    val event = adaptEvent(origEvent)
+
+    // a workaround for https://github.com/software-mansion/react-native-gesture-handler/issues/1188
+    val event = if (BuildConfig.DEBUG) {
+      adaptEvent(origEvent)
+    } else {
+      try {
+        adaptEvent(origEvent)
+      } catch (e: AdaptEventException) {
+        fail()
+        return
+      }
+    }
+
     x = event.x
     y = event.y
     numberOfPointers = event.pointerCount


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1188.

As @kmagiera suggested in https://github.com/software-mansion/react-native-gesture-handler/issues/1188#issuecomment-1084433802, I added a workaround for the issue only when the app is build in the `release` mode, which still gives us a possibility to get a repro in the future, while preventing crashes for now.

In order not to pass an unchanged event to the gesture, which may cause it to misbehave, the gesture will now fail when this exception is thrown.

## Test plan

Tested on the Example app on `debug` and `release` configurations with `adaptEvent` modified to always throw `AdaptEventException`.
