### PR TITLE
Drop all gesture handlers on invalidate

### DIFF
--- a/ios/RNGestureHandlerManager.h
+++ b/ios/RNGestureHandlerManager.h
@@ -24,6 +24,8 @@
 
 - (void)dropGestureHandler:(nonnull NSNumber *)handlerTag;
 
+- (void)dropAllGestureHandlers;
+
 - (void)handleSetJSResponder:(nonnull NSNumber *)viewTag
         blockNativeResponder:(nonnull NSNumber *)blockNativeResponder;
 

--- a/ios/RNGestureHandlerManager.mm
+++ b/ios/RNGestureHandlerManager.mm
@@ -139,6 +139,11 @@
     [_registry dropHandlerWithTag:handlerTag];
 }
 
+- (void)dropAllGestureHandlers
+{
+    [_registry dropAllHandlers];
+}
+
 - (void)handleSetJSResponder:(NSNumber *)viewTag blockNativeResponder:(NSNumber *)blockNativeResponder
 {
     if ([blockNativeResponder boolValue]) {

--- a/ios/RNGestureHandlerModule.mm
+++ b/ios/RNGestureHandlerModule.mm
@@ -60,6 +60,8 @@ RCT_EXPORT_MODULE()
 
 - (void)invalidate
 {
+    [_manager dropAllGestureHandlers];
+    
     _manager = nil;
     
 #ifdef RN_FABRIC_ENABLED

--- a/ios/RNGestureHandlerRegistry.h
+++ b/ios/RNGestureHandlerRegistry.h
@@ -14,5 +14,6 @@
 - (void)registerGestureHandler:(nonnull RNGestureHandler *)gestureHandler;
 - (void)attachHandlerWithTag:(nonnull NSNumber *)handlerTag toView:(nonnull UIView *)view withActionType:(RNGestureHandlerActionType)actionType;
 - (void)dropHandlerWithTag:(nonnull NSNumber *)handlerTag;
+- (void)dropAllHandlers;
 
 @end

--- a/ios/RNGestureHandlerRegistry.m
+++ b/ios/RNGestureHandlerRegistry.m
@@ -48,4 +48,14 @@
     [_handlers removeObjectForKey:handlerTag];
 }
 
+- (void)dropAllHandlers
+{
+    for (NSNumber* tag in _handlers) {
+        RNGestureHandler *handler = _handlers[tag];
+        [handler unbindFromView];
+    }
+    
+    [_handlers removeAllObjects];
+}
+
 @end


### PR DESCRIPTION
## Description

For some reason scheduled `dropGestureHandler` calls weren't executed on app refresh and all recognizers would stay attached to their respective views, alongside the newly created ones. This PR solves this problem by dropping all recognizers when the module is invalidated.

[Android already has a similar mechanism](https://github.com/software-mansion/react-native-gesture-handler/blob/8afdda06c532af957b1466760f11a28c973ce605/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt#L457).

## Test plan

Tested on FabricExample app.
