### PR TITLE
Move `@types/react-native` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
   "homepage": "https://github.com/software-mansion/react-native-gesture-handler#readme",
   "dependencies": {
     "@egjs/hammerjs": "^2.0.17",
-    "@types/react-native": "^0.64.2",
     "hoist-non-react-statics": "^3.3.0",
     "invariant": "^2.2.4",
     "lodash": "^4.17.21",
@@ -79,6 +78,7 @@
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/jest": "^27.0.3",
     "@types/react": "^17.0.0",
+    "@types/react-native": "^0.64.2",
     "@types/react-test-renderer": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
@@ -105,6 +105,7 @@
     "typescript": "^4.5.5"
   },
   "peerDependencies": {
+    "@types/react-native": "*",
     "react": "*",
     "react-native": "*"
   },

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   "homepage": "https://github.com/software-mansion/react-native-gesture-handler#readme",
   "dependencies": {
     "@egjs/hammerjs": "^2.0.17",
+    "@types/react-native": "^0.64.2",
     "hoist-non-react-statics": "^3.3.0",
     "invariant": "^2.2.4",
     "lodash": "^4.17.21",
@@ -78,7 +79,6 @@
     "@types/hoist-non-react-statics": "^3.3.1",
     "@types/jest": "^27.0.3",
     "@types/react": "^17.0.0",
-    "@types/react-native": "^0.64.2",
     "@types/react-test-renderer": "^17.0.0",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",


### PR DESCRIPTION
## Description

Moves `@types/react-native` to dependencies from devDependencies.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1720.