### PR TITLE
Fix nested buttons with outer one disabled on iOS

### DIFF
--- a/ios/RNGestureHandlerButton.h
+++ b/ios/RNGestureHandlerButton.h
@@ -14,5 +14,6 @@
  *  Insets used when hit testing inside this view.
  */
 @property (nonatomic, assign) UIEdgeInsets hitTestEdgeInsets;
+@property (nonatomic) BOOL userEnabled;
 
 @end

--- a/ios/RNGestureHandlerButton.m
+++ b/ios/RNGestureHandlerButton.m
@@ -68,8 +68,7 @@
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     UIView *inner = [super hitTest:point withEvent:event];
-    while (inner && ![self shouldHandleTouch:inner])
-    {
+    while (inner && ![self shouldHandleTouch:inner]) {
         inner = inner.superview;
     }
     return inner;

--- a/ios/RNGestureHandlerButton.m
+++ b/ios/RNGestureHandlerButton.m
@@ -38,6 +38,7 @@
   self = [super init];
   if (self) {
     _hitTestEdgeInsets = UIEdgeInsetsZero;
+    _userEnabled = YES;
 #if !TARGET_OS_TV
     [self setExclusiveTouch:YES];
 #endif
@@ -47,6 +48,11 @@
 
 - (BOOL)shouldHandleTouch:(UIView *)view
 {
+    if ([view isKindOfClass:[RNGestureHandlerButton class]]) {
+        RNGestureHandlerButton *button = (RNGestureHandlerButton *)view;
+        return button.userEnabled;
+    }
+    
     return [view isKindOfClass:[UIControl class]] || [view.gestureRecognizers count] > 0;
 }
 
@@ -62,7 +68,10 @@
 - (UIView *)hitTest:(CGPoint)point withEvent:(UIEvent *)event
 {
     UIView *inner = [super hitTest:point withEvent:event];
-    while (inner && ![self shouldHandleTouch:inner]) inner = inner.superview;
+    while (inner && ![self shouldHandleTouch:inner])
+    {
+        inner = inner.superview;
+    }
     return inner;
 }
 

--- a/ios/RNGestureHandlerButtonManager.m
+++ b/ios/RNGestureHandlerButtonManager.m
@@ -5,7 +5,10 @@
 
 RCT_EXPORT_MODULE(RNGestureHandlerButton)
 
-RCT_EXPORT_VIEW_PROPERTY(enabled, BOOL)
+RCT_CUSTOM_VIEW_PROPERTY(enabled, BOOL, RNGestureHandlerButton)
+{
+    view.userEnabled = json == nil ? YES : [RCTConvert BOOL: json];
+}
 #if !TARGET_OS_TV
 RCT_CUSTOM_VIEW_PROPERTY(exclusive, BOOL, RNGestureHandlerButton)
 {


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/294.

When the outer button had `enabled` property set to `false` it was mapped to the `enabled` property of `UIControl` with the same name. In that case the view would ignore all touches on its surface. This PR changes that by:
- mapping the `enabled` prop to the new `userEnabled` property of `RNGestureHandlerButton`
- changing the logic of hit-testing to check for the `userEnabled` prop and handle it correctly
Now the `hitTest` method finds a deepest view that was under the pointer, and searches the view tree upwards until a view that can handle the event is found.

This change makes it consistent with Android.

## Test plan

Tested on the Example app.
