### PR TITLE
Fix flushOperations is not a function

### DIFF
--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -21,6 +21,7 @@ const attachGestureHandler = NOOP;
 const createGestureHandler = NOOP;
 const dropGestureHandler = NOOP;
 const updateGestureHandler = NOOP;
+const flushOperations = NOOP;
 const NativeViewGestureHandler = View;
 const TapGestureHandler = View;
 const ForceTouchGestureHandler = View;
@@ -59,6 +60,7 @@ export default {
   createGestureHandler,
   dropGestureHandler,
   updateGestureHandler,
+  flushOperations,
   // probably can be removed
   Directions,
   State,


### PR DESCRIPTION
## Description

Error: 
```bash
    TypeError: _RNGestureHandlerModule.default.flushOperations is not a function

      at Timeout._onTimeout (node_modules/react-native-gesture-handler/lib/commonjs/handlers/gestureHandlerCommon.ts:194:30)
``` 
Error on execute test in components with imports from 'react-native-gesture-handler' on run any test what where your application use components from react-native-gesture-handler
 
## Test plan
import any component from react-native-gesture-handler and
run `yarn test` or `npm test` 
now no errors
