### PR TITLE
Add missing mock for flushOperations

### DIFF
--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -21,6 +21,7 @@ const attachGestureHandler = NOOP;
 const createGestureHandler = NOOP;
 const dropGestureHandler = NOOP;
 const updateGestureHandler = NOOP;
+const flushOperations = NOOP;
 const NativeViewGestureHandler = View;
 const TapGestureHandler = View;
 const ForceTouchGestureHandler = View;
@@ -59,6 +60,7 @@ export default {
   createGestureHandler,
   dropGestureHandler,
   updateGestureHandler,
+  flushOperations,
   // probably can be removed
   Directions,
   State,


### PR DESCRIPTION
## Description

This pull request fixes missing mock for `flushOperations` which caused jest tests to fail:

```
    TypeError: _RNGestureHandlerModule.default.flushOperations is not a function

      at Timeout._onTimeout (node_modules/react-native-gesture-handler/lib/commonjs/handlers/gestureHandlerCommon.ts:194:30)
```
