### PR TITLE
Make sure that react-native-macos is supported by using the web fallback

### DIFF
--- a/src/RNGestureHandlerModule.macos.ts
+++ b/src/RNGestureHandlerModule.macos.ts
@@ -1,0 +1,62 @@
+import { ActionType } from './ActionType';
+import { Direction } from './web/constants';
+import FlingGestureHandler from './web/FlingGestureHandler';
+import LongPressGestureHandler from './web/LongPressGestureHandler';
+import NativeViewGestureHandler from './web/NativeViewGestureHandler';
+import * as NodeManager from './web/NodeManager';
+import PanGestureHandler from './web/PanGestureHandler';
+import PinchGestureHandler from './web/PinchGestureHandler';
+import RotationGestureHandler from './web/RotationGestureHandler';
+import TapGestureHandler from './web/TapGestureHandler';
+
+export const Gestures = {
+  PanGestureHandler,
+  RotationGestureHandler,
+  PinchGestureHandler,
+  TapGestureHandler,
+  NativeViewGestureHandler,
+  LongPressGestureHandler,
+  FlingGestureHandler,
+  // ForceTouchGestureHandler,
+};
+
+export default {
+  Direction,
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  handleSetJSResponder() {},
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  handleClearJSResponder() {},
+  createGestureHandler<T>(
+    handlerName: keyof typeof Gestures,
+    handlerTag: number,
+    config: T
+  ) {
+    //TODO(TS) extends config
+    if (!(handlerName in Gestures))
+      throw new Error(
+        `react-native-gesture-handler: ${handlerName} is not supported on macos.`
+      );
+    const GestureClass = Gestures[handlerName];
+    NodeManager.createGestureHandler(handlerTag, new GestureClass());
+    this.updateGestureHandler(handlerTag, config);
+  },
+  attachGestureHandler(
+    handlerTag: number,
+    newView: number,
+    _actionType: ActionType,
+    propsRef: React.RefObject<unknown>
+  ) {
+    NodeManager.getHandler(handlerTag).setView(newView, propsRef);
+  },
+  updateGestureHandler(handlerTag: number, newConfig: any) {
+    NodeManager.getHandler(handlerTag).updateGestureConfig(newConfig);
+  },
+  getGestureHandlerNode(handlerTag: number) {
+    return NodeManager.getHandler(handlerTag);
+  },
+  dropGestureHandler(handlerTag: number) {
+    NodeManager.dropGestureHandler(handlerTag);
+  },
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  flushOperations() {},
+};


### PR DESCRIPTION
## Description

Hi, this adds "support" for react-native-macos by using the web fallback, I say support in quotes because it would be nicer if gestures actually could be used on macOS, nonetheless this PR makes sure that you can at least run react-native-macos apps using react-native-gesture-handler (crashes without this fix), real support could be added later on.
Fixes #1927. 