### PR TITLE
Add ndkVersion to Android project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -51,6 +51,15 @@ repositories {
 android {
     compileSdkVersion safeExtGet("compileSdkVersion", 28)
 
+    // Used to override the NDK path/version on internal CI or by allowing
+    // users to customize the NDK path/version from their root project (e.g. for M1 support)
+    if (rootProject.hasProperty("ndkPath")) {
+        ndkPath rootProject.ext.ndkPath
+    }
+    if (rootProject.hasProperty("ndkVersion")) {
+        ndkVersion rootProject.ext.ndkVersion
+    }
+
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 16)
         targetSdkVersion safeExtGet('targetSdkVersion', 28)


### PR DESCRIPTION
## Description

When I build Android app (react native 0.68.1) using arm based MacBook Pro M1, I receive 'Unknown host CPU architecture: arm64' error. This happens because library uses default ndkVersion, but not custom ndkVersion from 'ext'. I propose include this line in the build.gradle file to use globally specified ndkVersion if exists.
