### PR TITLE
Support monorepos with new architecture

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,4 +1,5 @@
 import groovy.json.JsonSlurper
+import java.nio.file.Paths
 
 buildscript {
     def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNGH_kotlinVersion']
@@ -18,6 +19,20 @@ def isNewArchitectureEnabled() {
     // - Invoke gradle with `-newArchEnabled=true`
     // - Set an environment variable `ORG_GRADLE_PROJECT_newArchEnabled=true`
     return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
+}
+
+def findNodeModulePath(baseDir, packageName) {
+    def basePath = baseDir.toPath().normalize()
+    // Node's module resolution algorithm searches up to the root directory,
+    // after which the base path will be null
+    while (basePath) {
+        def candidatePath = Paths.get(basePath.toString(), "node_modules", packageName)
+        if (candidatePath.toFile().exists()) {
+            return candidatePath.toString()
+        }
+        basePath = basePath.getParent()
+    }
+    return null
 }
 
 if (isNewArchitectureEnabled()) {
@@ -66,8 +81,8 @@ android {
                             "NDK_TOOLCHAIN_VERSION=clang",
                             "GENERATED_SRC_DIR=${appProject.buildDir}/generated/source",
                             "PROJECT_BUILD_DIR=${appProject.buildDir}",
-                            "REACT_ANDROID_DIR=${appProject.rootDir}/../node_modules/react-native/ReactAndroid",
-                            "REACT_ANDROID_BUILD_DIR=${appProject.rootDir}/../node_modules/react-native/ReactAndroid/build"
+                            "REACT_ANDROID_DIR=${findNodeModulePath(appProject.rootDir, "react-native") ?: "../node_modules/react-native/"}/ReactAndroid",
+                            "REACT_ANDROID_BUILD_DIR=${findNodeModulePath(appProject.rootDir, "react-native") ?: "../node_modules/react-native/"}/ReactAndroid/build"
                     cFlags "-Wall", "-Werror", "-fexceptions", "-frtti", "-DWITH_INSPECTOR=1"
                     cppFlags "-std=c++17"
                     targets "rngesturehandler_modules"
@@ -148,9 +163,9 @@ dependencies {
 
 if (isNewArchitectureEnabled()) {
     react {
-        reactRoot = rootProject.file("../node_modules/react-native/")
+        reactNativeDir = rootProject.file(findNodeModulePath(rootProject.rootDir, "react-native") ?: "../node_modules/react-native/")
         jsRootDir = file("../src/fabric/")
-        codegenDir = rootProject.file("../node_modules/react-native-codegen/")
+        codegenDir = rootProject.file(findNodeModulePath(rootProject.rootDir, "react-native-codegen") ?: "../node_modules/react-native-codegen/")
         libraryName = "rngesturehandler"
         codegenJavaPackageName = "com.swmansion.gesturehandler"
     }


### PR DESCRIPTION
## Description

When enabling the new architecture in a monorepo/yarn workspace where the `react-native` package is hoisted `RNGH` fails due to incorrect paths to `react-native`/`react-native-codegen` packages. 

This PR vendors the `findNodeModulePath` from RN core and applies it to this project. 

## Test plan

Tested the changes in our project via `patch-package`. 