### PR TITLE
Fix `simultaneousHandlers` prop on `NativeViewGestureHandler` on iOS

### DIFF
--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -77,6 +77,7 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 - (void)sendEvent:(nonnull RNGestureHandlerStateChange *)event;
 - (void)sendTouchEventInState:(RNGestureHandlerState)state
                  forViewWithTag:(nonnull NSNumber *)reactTag;
+- (NSArray<NSNumber *> *)getSimultaneousHandlers;
 
 @end
 

--- a/ios/RNGestureHandler.h
+++ b/ios/RNGestureHandler.h
@@ -77,7 +77,6 @@ if (value != nil) { recognizer.prop = [RCTConvert type:value]; }\
 - (void)sendEvent:(nonnull RNGestureHandlerStateChange *)event;
 - (void)sendTouchEventInState:(RNGestureHandlerState)state
                  forViewWithTag:(nonnull NSNumber *)reactTag;
-- (NSArray<NSNumber *> *)getSimultaneousHandlers;
 
 @end
 

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -289,11 +289,6 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     return _state;
 }
 
-- (NSArray<NSNumber *> *)getSimultaneousHandlers
-{
-    return _simultaneousHandlers;
-}
-
 #pragma mark Manual activation
 
 - (void)stopActivationBlocker
@@ -404,8 +399,8 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
                     return YES;
                 }
             }
-        } else if ([handler getSimultaneousHandlers]) {
-            for (NSNumber *handlerTag in [handler getSimultaneousHandlers]) {
+        } else if (handler->_simultaneousHandlers) {
+            for (NSNumber *handlerTag in handler->_simultaneousHandlers) {
                 if ([self.tag isEqual:handlerTag]) {
                     return YES;
                 }

--- a/ios/RNGestureHandler.m
+++ b/ios/RNGestureHandler.m
@@ -289,6 +289,11 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     return _state;
 }
 
+- (NSArray<NSNumber *> *)getSimultaneousHandlers
+{
+    return _simultaneousHandlers;
+}
+
 #pragma mark Manual activation
 
 - (void)stopActivationBlocker
@@ -390,11 +395,18 @@ shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherG
     if (_recognizer.state == UIGestureRecognizerStateBegan && _recognizer.state == UIGestureRecognizerStatePossible) {
         return YES;
     }
-    if ([_simultaneousHandlers count]) {
-        RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
-        if (handler != nil) {
+    
+    RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
+    if (handler != nil) {
+        if ([_simultaneousHandlers count]) {
             for (NSNumber *handlerTag in _simultaneousHandlers) {
                 if ([handler.tag isEqual:handlerTag]) {
+                    return YES;
+                }
+            }
+        } else if ([handler getSimultaneousHandlers]) {
+            for (NSNumber *handlerTag in [handler getSimultaneousHandlers]) {
+                if ([self.tag isEqual:handlerTag]) {
                     return YES;
                 }
             }


### PR DESCRIPTION
## Description

It seems like to make two `UIGestureRecognizers` work simultaneously, both calls of `shouldRecognizeSimultaneouslyWithGestureRecognizer` should return `YES` (should `A` be recognized alongside `B` and vice versa). This isn't much of a problem in case of all gestures but `NativeViewGestureHandler`, which most often is used implicitly via components exported by Gesture Handler. In this case one can access `simultaneousHandlers` prop on the wrapped component, but cannot obtain the ref to the `NativeViewGestureHandler` (only to the view).

This PR makes `shouldRecognizeSimultaneouslyWithGestureRecognizer` symmetric, so only one gesture needs to be marked as simultaneous with the other

## Test plan

Tested on the Example app
