### PR TITLE
Schedule calling `dropAllGestureHandlers` on main queue

### DIFF
--- a/ios/RNGestureHandlerModule.mm
+++ b/ios/RNGestureHandlerModule.mm
@@ -60,7 +60,10 @@ RCT_EXPORT_MODULE()
 
 - (void)invalidate
 {
-    [_manager dropAllGestureHandlers];
+    RNGestureHandlerManager *handlerManager = _manager;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        [handlerManager dropAllGestureHandlers];
+    });
     
     _manager = nil;
     


### PR DESCRIPTION
## Description

Instead of directly calling `dropAllGestureHandlers` in the `invalidate`, dispatch it to be called on the main queue.
Why not `[bridge.uiManager addUIBlock ...]` you may ask. Well, it appears to be cleared on the invalidation as well 😞 .

## Test plan

Check if the warning appears.
