### PR TITLE
Fix compatibility with `@types/react^18.0.0`

### DIFF
--- a/example/src/basic/bouncing/index.tsx
+++ b/example/src/basic/bouncing/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropsWithChildren } from 'react';
 import { Animated, StyleSheet, View } from 'react-native';
 
 import {
@@ -13,7 +13,7 @@ import {
 
 import { USE_NATIVE_DRIVER } from '../../config';
 
-class Snappable extends Component<Record<string, unknown>> {
+class Snappable extends Component<PropsWithChildren<Record<string, unknown>>> {
   private onGestureEvent?: (event: PanGestureHandlerGestureEvent) => void;
   private transX: Animated.AnimatedInterpolation;
   private dragX: Animated.Value;
@@ -59,7 +59,7 @@ class Snappable extends Component<Record<string, unknown>> {
   }
 }
 
-class Twistable extends Component {
+class Twistable extends Component<PropsWithChildren<unknown>> {
   private gesture: Animated.Value;
   private onGestureEvent?: (event: RotationGestureHandlerGestureEvent) => void;
   private rot: Animated.AnimatedInterpolation;

--- a/example/src/new_api/drag_n_drop/Draggable.tsx
+++ b/example/src/new_api/drag_n_drop/Draggable.tsx
@@ -1,4 +1,4 @@
-import React, { FunctionComponent } from 'react';
+import React from 'react';
 import { StyleSheet } from 'react-native';
 import {
   PanGestureHandlerEventPayload,
@@ -27,9 +27,10 @@ interface DraggableProps {
   tileSize: number;
   rowGap: number;
   columnGap: number;
+  children?: React.ReactNode;
 }
 
-const Draggable: FunctionComponent<DraggableProps> = ({
+const Draggable = ({
   id,
   children,
   onLongPress,
@@ -40,7 +41,7 @@ const Draggable: FunctionComponent<DraggableProps> = ({
   columnGap,
   rowGap,
   position,
-}) => {
+}: DraggableProps) => {
   const tapGesture = Gesture.LongPress()
     .minDuration(300)
     .onStart(() => runOnJS(onLongPress)(id))

--- a/example/src/release_tests/rows/index.tsx
+++ b/example/src/release_tests/rows/index.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropsWithChildren } from 'react';
 import {
   Animated,
   StyleSheet,
@@ -29,7 +29,7 @@ type Props = {
   enableTrackpadTwoFingerGesture: boolean;
 };
 
-export class Swipeable extends Component<Props> {
+export class Swipeable extends Component<PropsWithChildren<Props>> {
   private width: number;
   private dragX: Animated.Value;
   private transX: Animated.AnimatedInterpolation;

--- a/example/src/showcase/swipeable/AppleStyleSwipeableRow.tsx
+++ b/example/src/showcase/swipeable/AppleStyleSwipeableRow.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropsWithChildren } from 'react';
 import {
   Animated,
   StyleSheet,
@@ -12,7 +12,9 @@ import { RectButton } from 'react-native-gesture-handler';
 
 import Swipeable from 'react-native-gesture-handler/Swipeable';
 
-export default class AppleStyleSwipeableRow extends Component {
+export default class AppleStyleSwipeableRow extends Component<
+  PropsWithChildren<unknown>
+> {
   private renderLeftActions = (
     _progress: Animated.AnimatedInterpolation,
     dragX: Animated.AnimatedInterpolation

--- a/example/src/showcase/swipeable/GmailStyleSwipeableRow.tsx
+++ b/example/src/showcase/swipeable/GmailStyleSwipeableRow.tsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, PropsWithChildren } from 'react';
 import { Animated, StyleSheet, I18nManager, View } from 'react-native';
 
 import { RectButton } from 'react-native-gesture-handler';
@@ -7,7 +7,9 @@ import Swipeable from 'react-native-gesture-handler/Swipeable';
 
 const AnimatedView = Animated.createAnimatedComponent(View);
 
-export default class GmailStyleSwipeableRow extends Component {
+export default class GmailStyleSwipeableRow extends Component<
+  PropsWithChildren<unknown>
+> {
   private renderLeftActions = (
     _progress: Animated.AnimatedInterpolation,
     dragX: Animated.AnimatedInterpolation

--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -148,6 +148,11 @@ export interface DrawerLayoutProps {
   onDrawerSlide?: (position: number) => void;
 
   onGestureRef?: (ref: PanGestureHandler) => void;
+
+  // implicit `children` prop has been removed in @types/react^18.0.0
+  children?:
+    | React.ReactNode
+    | ((openValue?: Animated.AnimatedInterpolation) => React.ReactNode);
 }
 
 export type DrawerLayoutState = {

--- a/src/handlers/ForceTouchGestureHandler.ts
+++ b/src/handlers/ForceTouchGestureHandler.ts
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { PropsWithChildren } from 'react';
 import { tagMessage } from '../utils';
 import PlatformConstants from '../PlatformConstants';
 import createHandler from './createHandler';
@@ -13,7 +13,8 @@ export const forceTouchGestureHandlerProps = [
   'feedbackOnActivation',
 ] as const;
 
-class ForceTouchFallback extends React.Component {
+// implicit `children` prop has been removed in @types/react^18.0.0
+class ForceTouchFallback extends React.Component<PropsWithChildren<unknown>> {
   static forceTouchAvailable = false;
   componentDidMount() {
     console.warn(

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -126,6 +126,8 @@ export type BaseGestureHandlerProps<
   onHandlerStateChange?: (
     event: HandlerStateChangeEvent<ExtraEventPayloadT>
   ) => void;
+  // implicit `children` prop has been removed in @types/react^18.0.0
+  children?: React.ReactNode;
 };
 
 function isConfigParam(param: unknown, name: string) {

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -490,10 +490,9 @@ function useAnimatedGesture(
 
 interface GestureDetectorProps {
   gesture?: ComposedGesture | GestureType;
+  children?: React.ReactNode;
 }
-export const GestureDetector: React.FunctionComponent<GestureDetectorProps> = (
-  props
-) => {
+export const GestureDetector = (props: GestureDetectorProps) => {
   const gestureConfig = props.gesture;
   const gesture = gestureConfig?.toGestureArray?.() ?? [];
   const useReanimatedHook = gesture.some((g) => g.shouldUseReanimated);

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -604,7 +604,11 @@ export const GestureDetector = (props: GestureDetectorProps) => {
   }
 };
 
-class Wrap extends React.Component<{ onGestureHandlerEvent?: unknown }> {
+class Wrap extends React.Component<{
+  onGestureHandlerEvent?: unknown;
+  // implicit `children` prop has been removed in @types/react^18.0.0
+  children?: React.ReactNode;
+}> {
   render() {
     // I don't think that fighting with types over such a simple function is worth it
     // The only thing it does is add 'collapsable: false' to the child component

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -20,5 +20,5 @@ export function fireAfterInterval(
     method();
     return null;
   }
-  return setTimeout(() => method(), interval);
+  return setTimeout(() => method(), interval as number);
 }


### PR DESCRIPTION
## Description

Fix compatibility with `@types/react^18.0.0`:
- Remove `React.FunctionComponent` type from `GestureDetector`
- Add explicit `children` props to components as suggested in https://github.com/DefinitelyTyped/DefinitelyTyped/pull/56210
- Update types in the Example app

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2029.
