### PR TITLE
Default import `package.json` in `src/utils`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,6 @@
-import { version as rnVersion } from 'react-native/package.json';
+import pack from 'react-native/package.json';
+
+const rnVersion = pack.version;
 
 export function toArray<T>(object: T | T[]): T[] {
   if (!Array.isArray(object)) {


### PR DESCRIPTION
This change silences the following error from Webpack:

```sh
warn  - ../../node_modules/react-native-gesture-handler/lib/module/utils.js
Should not import the named export 'version'.'split' (imported as 'rnVersion') from default-exporting module (only default export is available soon)
```

## Description

Changes `import { version as rnVersion }` to `import pack`.

## Test plan

Patched it in my app.
