### PR TITLE
Don't update shared value containing the gesture config unless the config has changed

### DIFF
--- a/docs/docs/api/gestures/gesture.md
+++ b/docs/docs/api/gestures/gesture.md
@@ -6,6 +6,20 @@ sidebar_label: Gesture
 
 `Gesture` is the object that allows you to create and compose gestures.
 
+:::tip
+Consider wrapping your gesture configurations with `useMemo`, as it will reduce the amount of work Gesture Handler has to do under the hood when updating gestures. For example:
+```jsx
+const gesture = useMemo(
+  () =>
+    Gesture.Tap().onStart(() => {
+      console.log('Number of taps:', tapNumber + 1);
+      setTapNumber((value) => value + 1);
+    }),
+  [tapNumber, setTapNumber]
+);
+```
+:::
+
 ### Gesture.Tap()
 
 Creates a new instance of [`TapGesture`](./tap-gesture.md) with its default config and no callbacks.

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -53,6 +53,7 @@ type TouchEventHandlerType = (
 ) => void;
 
 export type HandlerCallbacks<EventPayloadT extends Record<string, unknown>> = {
+  gestureId: number;
   handlerTag: number;
   onBegin?: (event: GestureStateChangeEvent<EventPayloadT>) => void;
   onStart?: (event: GestureStateChangeEvent<EventPayloadT>) => void;
@@ -115,16 +116,31 @@ export abstract class Gesture {
   abstract prepare(): void;
 }
 
+let nextGestureId = 0;
 export abstract class BaseGesture<
   EventPayloadT extends Record<string, unknown>
 > extends Gesture {
+  private gestureId = -1;
   public handlerTag = -1;
   public handlerName = '';
   public config: BaseGestureConfig = {};
   public handlers: HandlerCallbacks<EventPayloadT> = {
+    gestureId: -1,
     handlerTag: -1,
     isWorklet: [],
   };
+
+  constructor() {
+    super();
+
+    // Used to check whether the gesture config has been updated when wrapping it
+    // with `useMemo`. Since every config will have a unique id, when the dependencies
+    // don't change, the config won't be recreated and the id will stay the same.
+    // If the id is different, it means that the config has changed and the gesture
+    // needs to be updated.
+    this.gestureId = nextGestureId++;
+    this.handlers.gestureId = this.gestureId;
+  }
 
   private addDependency(
     key: 'simultaneousWith' | 'requireToFail',


### PR DESCRIPTION
## Description

This PR slightly modifies how gesture callbacks are updated when using Reanimated. Instead of updating them every time, it will now be updated only when the gesture config has changed. In combination with `useMemo`, this will make optimizing performance-critical use cases easier.

It accomplishes this by adding `gestureId` property to every gesture instance, which then is checked before updating the shared value. The update happens only when the id is different (which will happen only when the gesture inside `useMemo` is recalculated, i.e. only when the dependencies change).

## Test plan

Tested on the Example app.
