### PR TITLE
Fix `Gesture.Exclusive` and `onStart` not being called on web

### DIFF
--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -511,9 +511,13 @@ function ensureConfig(config: Config): Required<Config> {
   }
   if ('waitFor' in config) {
     props.waitFor = asArray(config.waitFor)
-      .map(({ handlerTag }: { handlerTag: number }) =>
-        NodeManager.getHandler(handlerTag)
-      )
+      .map((handler: number | GestureHandler) => {
+        if (typeof handler === 'number') {
+          NodeManager.getHandler(handler)
+        } else {
+          return NodeManager.getHandler(handler.handlerTag);
+        }
+      })
       .filter((v) => v);
   } else {
     props.waitFor = null;

--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -169,7 +169,7 @@ abstract class GestureHandler {
     // TODO(TS) Remove cast after https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50966 is merged.
     const state = this.getState(eventType as 1 | 2 | 4 | 8);
     const hasStateChanged = state !== this.previousState;
-    
+
     if (hasStateChanged) {
       this.oldState = this.previousState;
       this.previousState = state;
@@ -187,10 +187,7 @@ abstract class GestureHandler {
         // send oldState only when the state was changed, or is different than ACTIVE
         // GestureDetector relies on the presence of `oldState` to differentiate between
         // update events and state change events
-        oldState:
-          hasStateChanged || state != 4
-            ? this.oldState
-            : undefined,
+        oldState: hasStateChanged || state != 4 ? this.oldState : undefined,
       },
       timeStamp: Date.now(),
     };
@@ -515,7 +512,7 @@ function ensureConfig(config: Config): Required<Config> {
     props.waitFor = asArray(config.waitFor)
       .map((handler: number | GestureHandler) => {
         if (typeof handler === 'number') {
-          NodeManager.getHandler(handler)
+          NodeManager.getHandler(handler);
         } else {
           return NodeManager.getHandler(handler.handlerTag);
         }

--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -512,7 +512,7 @@ function ensureConfig(config: Config): Required<Config> {
     props.waitFor = asArray(config.waitFor)
       .map((handler: number | GestureHandler) => {
         if (typeof handler === 'number') {
-          NodeManager.getHandler(handler);
+          return NodeManager.getHandler(handler);
         } else {
           return NodeManager.getHandler(handler.handlerTag);
         }

--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -168,7 +168,9 @@ abstract class GestureHandler {
 
     // TODO(TS) Remove cast after https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50966 is merged.
     const state = this.getState(eventType as 1 | 2 | 4 | 8);
-    if (state !== this.previousState) {
+    const hasStateChanged = state !== this.previousState;
+    
+    if (hasStateChanged) {
       this.oldState = this.previousState;
       this.previousState = state;
     }
@@ -186,7 +188,7 @@ abstract class GestureHandler {
         // GestureDetector relies on the presence of `oldState` to differentiate between
         // update events and state change events
         oldState:
-          state !== this.previousState || state != 4
+          hasStateChanged || state != 4
             ? this.oldState
             : undefined,
       },


### PR DESCRIPTION
## Description

- moves checking if the state has changed to happen before `previousState` gets overwritten, which makes GestureHandler correctly add `oldState` prop to events
- updates `waitFor` check so that it handles getting only `handlerTag`, which is the case with the new API

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2056 and https://github.com/software-mansion/react-native-gesture-handler/issues/2057.

## Test plan

Tested on the Example app.
