### PR TITLE
Fix major issues with `LongPress` gesture on web

### DIFF
--- a/src/web/DiscreteGestureHandler.ts
+++ b/src/web/DiscreteGestureHandler.ts
@@ -1,6 +1,6 @@
 /* eslint-disable eslint-comments/no-unlimited-disable */
 /* eslint-disable */
-import GestureHandler from './GestureHandler';
+import GestureHandler, { HammerInputExt } from './GestureHandler';
 import { TEST_MAX_IF_NOT_NAN } from './utils';
 
 abstract class DiscreteGestureHandler extends GestureHandler {
@@ -31,15 +31,15 @@ abstract class DiscreteGestureHandler extends GestureHandler {
     );
   }
 
-  transformNativeEvent({ center: { x, y } }: any) {
+  transformNativeEvent(event: HammerInputExt) {
     // @ts-ignore FIXME(TS)
     const rect = this.view!.getBoundingClientRect();
 
     return {
-      absoluteX: x,
-      absoluteY: y,
-      x: x - rect.left,
-      y: y - rect.top,
+      absoluteX: event.center.x,
+      absoluteY: event.center.y,
+      x: event.center.x - rect.left,
+      y: event.center.y - rect.top,
     };
   }
 

--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -171,6 +171,11 @@ abstract class GestureHandler {
     const hasStateChanged = state !== this.previousState;
 
     if (hasStateChanged) {
+      // gestures should transition to BEGAN state only from UNDETERMINED
+      if (state === State.BEGAN) {
+        this.previousState = State.UNDETERMINED;
+      }
+
       this.oldState = this.previousState;
       this.previousState = state;
     }
@@ -187,7 +192,8 @@ abstract class GestureHandler {
         // send oldState only when the state was changed, or is different than ACTIVE
         // GestureDetector relies on the presence of `oldState` to differentiate between
         // update events and state change events
-        oldState: hasStateChanged || state != 4 ? this.oldState : undefined,
+        oldState:
+          hasStateChanged || state != State.ACTIVE ? this.oldState : undefined,
       },
       timeStamp: Date.now(),
     };

--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -171,11 +171,6 @@ abstract class GestureHandler {
     const hasStateChanged = state !== this.previousState;
 
     if (hasStateChanged) {
-      // gestures should transition to BEGAN state only from UNDETERMINED
-      if (state === State.BEGAN) {
-        this.previousState = State.UNDETERMINED;
-      }
-
       this.oldState = this.previousState;
       this.previousState = state;
     }

--- a/src/web/LongPressGestureHandler.ts
+++ b/src/web/LongPressGestureHandler.ts
@@ -65,7 +65,10 @@ class LongPressGestureHandler extends PressGestureHandler {
       } else if (ev.isFinal && this.previousState === State.BEGAN) {
         this.sendEvent({ ...ev, eventType: Hammer.INPUT_CANCEL });
       }
-    } else if (ev.eventType === Hammer.INPUT_MOVE && ev.distance > this.maxDist) {
+    } else if (
+      ev.eventType === Hammer.INPUT_MOVE &&
+      ev.distance > this.maxDist
+    ) {
       this.sendEvent({ ...ev, eventType: Hammer.INPUT_CANCEL });
       this.onGestureEnded(ev);
     }

--- a/src/web/LongPressGestureHandler.ts
+++ b/src/web/LongPressGestureHandler.ts
@@ -11,12 +11,6 @@ import { HammerInputNames } from './constants';
 class LongPressGestureHandler extends PressGestureHandler {
   private gestureStartTimeStamp: number = 0;
 
-  constructor() {
-    super();
-
-    this.needsToSendMoveEvents = false;
-  }
-
   get minDurationMs(): number {
     // @ts-ignore FIXNE(TS)
     return isnan(this.config.minDurationMs) ? 251 : this.config.minDurationMs;
@@ -72,6 +66,19 @@ class LongPressGestureHandler extends PressGestureHandler {
       this.sendEvent({ ...ev, eventType: Hammer.INPUT_CANCEL });
       this.onGestureEnded(ev);
     }
+  }
+
+  onGestureStart(event: HammerInputExt) {
+    super.onGestureStart(event);
+
+    // send move events only in ACTIVE state
+    this.needsToSendMoveEvents = true;
+  }
+
+  onGestureEnded(event: HammerInputExt) {
+    super.onGestureEnded(event);
+
+    this.needsToSendMoveEvents = false;
   }
 
   transformNativeEvent(ev: HammerInputExt) {

--- a/src/web/LongPressGestureHandler.ts
+++ b/src/web/LongPressGestureHandler.ts
@@ -43,9 +43,21 @@ class LongPressGestureHandler extends PressGestureHandler {
     };
   }
 
+  onRawEvent(ev: HammerInput) {
+    super.onRawEvent(ev);
+
+    if (!this.isGestureRunning) {
+      if (ev.eventType === Hammer.INPUT_START) {
+        this.sendEvent(ev);
+      } else if (ev.isFinal && this.previousState === State.BEGAN) {
+        this.sendEvent({ ...ev, eventType: Hammer.INPUT_CANCEL });
+      }
+    }
+  }
+
   getState(type: keyof typeof HammerInputNames) {
     return {
-      [Hammer.INPUT_START]: State.ACTIVE,
+      [Hammer.INPUT_START]: State.BEGAN,
       [Hammer.INPUT_MOVE]: State.ACTIVE,
       [Hammer.INPUT_END]: State.END,
       [Hammer.INPUT_CANCEL]: State.FAILED,

--- a/src/web/LongPressGestureHandler.ts
+++ b/src/web/LongPressGestureHandler.ts
@@ -54,6 +54,7 @@ class LongPressGestureHandler extends PressGestureHandler {
 
     if (!this.isGestureRunning) {
       if (ev.eventType === Hammer.INPUT_START) {
+        this.onStart(ev);
         this.sendEvent(ev);
       } else if (ev.isFinal && this.previousState === State.BEGAN) {
         this.sendEvent({ ...ev, eventType: Hammer.INPUT_CANCEL });

--- a/src/web/LongPressGestureHandler.ts
+++ b/src/web/LongPressGestureHandler.ts
@@ -11,6 +11,12 @@ import { HammerInputNames } from './constants';
 class LongPressGestureHandler extends PressGestureHandler {
   private gestureStartTimeStamp: number = 0;
 
+  constructor() {
+    super();
+
+    this.needsToSendMoveEvents = false;
+  }
+
   get minDurationMs(): number {
     // @ts-ignore FIXNE(TS)
     return isnan(this.config.minDurationMs) ? 251 : this.config.minDurationMs;
@@ -18,7 +24,7 @@ class LongPressGestureHandler extends PressGestureHandler {
 
   get maxDist() {
     // @ts-ignore FIXNE(TS)
-    return isnan(this.config.maxDist) ? 9 : this.config.maxDist;
+    return isnan(this.config.maxDist) ? 9 : this.config.maxDist ?? 9;
   }
 
   updateHasCustomActivationCriteria({ maxDistSq }: Config) {
@@ -40,7 +46,7 @@ class LongPressGestureHandler extends PressGestureHandler {
   getHammerConfig() {
     return {
       ...super.getHammerConfig(),
-      // threshold: this.maxDist,
+      threshold: this.maxDist,
       time: this.minDurationMs,
     };
   }
@@ -59,6 +65,9 @@ class LongPressGestureHandler extends PressGestureHandler {
       } else if (ev.isFinal && this.previousState === State.BEGAN) {
         this.sendEvent({ ...ev, eventType: Hammer.INPUT_CANCEL });
       }
+    } else if (ev.eventType === Hammer.INPUT_MOVE && ev.distance > this.maxDist) {
+      this.sendEvent({ ...ev, eventType: Hammer.INPUT_CANCEL });
+      this.onGestureEnded(ev);
     }
   }
 

--- a/src/web/LongPressGestureHandler.ts
+++ b/src/web/LongPressGestureHandler.ts
@@ -65,7 +65,7 @@ class LongPressGestureHandler extends PressGestureHandler {
     return {
       ...super.transformNativeEvent(ev),
       duration: ev.timeStamp - this.gestureStartTimeStamp,
-    }
+    };
   }
 
   getState(type: keyof typeof HammerInputNames) {

--- a/src/web/PressGestureHandler.ts
+++ b/src/web/PressGestureHandler.ts
@@ -13,6 +13,7 @@ import { fireAfterInterval, isValidNumber, isnan } from './utils';
 class PressGestureHandler extends DiscreteGestureHandler {
   private visualFeedbackTimer: any;
   private initialEvent: HammerInputExt | null = null;
+  protected needsToSendMoveEvents = true;
   get name() {
     return 'press';
   }
@@ -132,7 +133,7 @@ class PressGestureHandler extends DiscreteGestureHandler {
           // @ts-ignore -- this should explicitly support undefined
           this.onGestureEnded();
         }, timeout);
-      } else {
+      } else if (this.needsToSendMoveEvents) {
         this.sendEvent({
           ...ev,
           eventType: Hammer.INPUT_MOVE,


### PR DESCRIPTION
## Description

This PR solves a few issues with `LongPress` gesture on web:
- adds a `duration` property to events send by the gesture
- fixes a bug where `onBegin` and `onStart` would not be called because of wrong `oldState` value in the events sent by the web implementation
- fixes a bug where no events would be called if the gesture failed, now it correctly calls `onBegin` and `onFinalize` if the press time is too short

(Mostly) fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2063

## Test plan

Tested on the Example app.
