### PR TITLE
Make `Tap` respect `maxDuration` on web

### DIFF
--- a/src/web/TapGestureHandler.ts
+++ b/src/web/TapGestureHandler.ts
@@ -7,7 +7,7 @@ import { isnan } from './utils';
 class TapGestureHandler extends DiscreteGestureHandler {
   private _shouldFireEndEvent: HammerInputExt | null = null;
   private _timer: any;
-  private _multiTapTimer: any; // TODO unused?
+  private _multiTapTimer: any;
   get name() {
     return 'tap';
   }


### PR DESCRIPTION
## Description

This PR changes the logic of `TapGestureHandler` on web so that it sends `CANCELLED` event when the view is pressed too long by utilizing both timers defined in `TapGestureHandler`.

(Mostly) fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2062

## Test plan

Tested on the Example app
