### PR TITLE
Fix `minDist` not working for `Pan` on web and improve the state flow of `Pan` gesture

### DIFF
--- a/src/web/PanGestureHandler.ts
+++ b/src/web/PanGestureHandler.ts
@@ -220,8 +220,8 @@ class PanGestureHandler extends DraggingGestureHandler {
       this.previousState !== State.BEGAN &&
       this.previousState !== State.ACTIVE
     ) {
-      // BEGAN gesture should have UNDETERMINED as the oldState event property
-      this.previousState = State.UNDETERMINED;
+      // reset gesture state
+      this.onStart(ev);
       this.sendEvent(ev);
     } else if (
       ev.eventType === Hammer.INPUT_END &&

--- a/src/web/PanGestureHandler.ts
+++ b/src/web/PanGestureHandler.ts
@@ -18,11 +18,15 @@ class PanGestureHandler extends DraggingGestureHandler {
     return Hammer.Pan;
   }
 
+  get minDist() {
+    return isnan(this.config.minDist) ? 10 : this.config.minDist;
+  }
+
   getHammerConfig() {
     return {
       ...super.getHammerConfig(),
       direction: this.getDirection(),
-      threshold: this.config.minDist,
+      threshold: this.minDist,
     };
   }
 

--- a/src/web/PanGestureHandler.ts
+++ b/src/web/PanGestureHandler.ts
@@ -23,6 +23,7 @@ class PanGestureHandler extends DraggingGestureHandler {
     return {
       ...super.getHammerConfig(),
       direction: this.getDirection(),
+      threshold: this.config.minDist,
     };
   }
 


### PR DESCRIPTION
## Description

This PR updates the `Pan` gesture on web:
- adds `threshold` to hammer config, mapping to `minDist` which was previously ignored
- removes `getState` which was overwriting state of the first `ACTIVE` event to `BEGAN`
- adds logic responsible for sending `BEGAN` event when the input starts
- adds logic responsible for sending `FAILED` event when the gesture finishes without activating

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2066.

## Test plan

Tested on the Example app.
