### PR TITLE
Add `onLongPress` callback to Gesture Handler buttons

### DIFF
--- a/docs/docs/api/components/buttons.mdx
+++ b/docs/docs/api/components/buttons.mdx
@@ -59,7 +59,7 @@ function that gets triggered when the button gets pressed (analogous to `onPress
 
 ### `onLongPress`
 
-function that gets triggered when the putton gets pressed for at least `delayLongPress` milliseconds.
+function that gets triggered when the button gets pressed for at least `delayLongPress` milliseconds.
 
 ### `rippleColor` (**Android only**)
 

--- a/docs/docs/api/components/buttons.mdx
+++ b/docs/docs/api/components/buttons.mdx
@@ -57,6 +57,10 @@ function that gets triggered when button changes from inactive to active and vic
 
 function that gets triggered when the button gets pressed (analogous to `onPress` in `TouchableHighlight` from RN core).
 
+### `onLongPress`
+
+function that gets triggered when the putton gets pressed for at least `delayLongPress` milliseconds.
+
 ### `rippleColor` (**Android only**)
 
 defines color of native [ripple](https://developer.android.com/reference/android/graphics/drawable/RippleDrawable) animation used since API level 21.
@@ -64,6 +68,10 @@ defines color of native [ripple](https://developer.android.com/reference/android
 ### `exclusive`
 
 defines if more than one button could be pressed simultaneously. By default set `true`.
+
+### `delayLongPress`
+
+defines the delay, in milliseconds, after which the `onLongPress` callback gets called. By default set to 600.
 
 ## `RectButton`
 

--- a/src/components/GestureButtons.tsx
+++ b/src/components/GestureButtons.tsx
@@ -66,6 +66,12 @@ export interface BaseButtonProps extends RawButtonProps {
   onPress?: (pointerInside: boolean) => void;
 
   /**
+   * Called when the button gets pressed and is held for `delayLongPress`
+   * milliseconds.
+   */
+  onLongPress?: () => void;
+
+  /**
    * Called when button changes from inactive to active and vice versa. It
    * passes active state as a boolean variable as a first parameter for that
    * method.
@@ -73,6 +79,12 @@ export interface BaseButtonProps extends RawButtonProps {
   onActiveStateChange?: (active: boolean) => void;
   style?: StyleProp<ViewStyle>;
   testID?: string;
+
+  /**
+   * Delay, in milliseconds, after which the `onLongPress` callback gets called.
+   * Defaults to 600.
+   */
+  delayLongPress?: number;
 }
 
 export interface RectButtonProps extends BaseButtonProps {
@@ -104,11 +116,18 @@ export const RawButton = createNativeWrapper(GestureHandlerButton, {
 });
 
 export class BaseButton extends React.Component<BaseButtonProps> {
+  static defaultProps = {
+    delayLongPress: 600,
+  };
+
   private lastActive: boolean;
+  private longPressTimeout: ReturnType<typeof setTimeout> | undefined;
+  private longPressDetected: boolean;
 
   constructor(props: BaseButtonProps) {
     super(props);
     this.lastActive = false;
+    this.longPressDetected = false;
   }
 
   private handleEvent = ({
@@ -122,6 +141,7 @@ export class BaseButton extends React.Component<BaseButtonProps> {
     }
 
     if (
+      !this.longPressDetected &&
       oldState === State.ACTIVE &&
       state !== State.CANCELLED &&
       this.lastActive &&
@@ -130,7 +150,44 @@ export class BaseButton extends React.Component<BaseButtonProps> {
       this.props.onPress(active);
     }
 
+    if (
+      !this.lastActive &&
+      // NativeViewGestureHandler sends different events based on platform
+      state === (Platform.OS !== 'android' ? State.ACTIVE : State.BEGAN) &&
+      pointerInside
+    ) {
+      this.longPressDetected = false;
+      if (this.props.onLongPress) {
+        this.longPressTimeout = setTimeout(
+          this.onLongPress,
+          this.props.delayLongPress
+        );
+      }
+    } else if (
+      // cancel longpress timeout if it's set and the finger moved out of the view
+      state === State.ACTIVE &&
+      !pointerInside &&
+      this.longPressTimeout !== undefined
+    ) {
+      clearTimeout(this.longPressTimeout);
+      this.longPressTimeout = undefined;
+    } else if (
+      // cancel longpress timeout if it's set and the gesture has finished
+      this.longPressTimeout !== undefined &&
+      (state === State.END ||
+        state === State.CANCELLED ||
+        state === State.FAILED)
+    ) {
+      clearTimeout(this.longPressTimeout);
+      this.longPressTimeout = undefined;
+    }
+
     this.lastActive = active;
+  };
+
+  private onLongPress = () => {
+    this.longPressDetected = true;
+    this.props.onLongPress?.();
   };
 
   // Normally, the parent would execute it's handler first, then forward the


### PR DESCRIPTION
## Description

This PR adds `onLongPress` to Gesture Handler buttons as suggested in https://github.com/software-mansion/react-native-gesture-handler/issues/2060, implemented in the same way as on Gesture Handler Touchables. The long press delay is customizable using `delayLongPress` prop.

## Test plan

Tested on the Example app.
