### PR TITLE
Fix default max distance for long press on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.kt
@@ -19,7 +19,9 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
 
   init {
     setShouldCancelWhenOutside(true)
-    defaultMaxDistSq = DEFAULT_MAX_DIST_DP * context.resources.displayMetrics.density
+
+    val defaultMaxDist = DEFAULT_MAX_DIST_DP * context.resources.displayMetrics.density
+    defaultMaxDistSq = defaultMaxDist * defaultMaxDist
     maxDistSq = defaultMaxDistSq
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2094

As described in the issue, the `defaultMaxDistSq` property of `LongPressGestureHandler` was calculated in the wrong way - it was not squared. This resulted in long press gesture effectively  failing even during slightest moves if the `maxDist` prop was not configured.

## Test plan

Tested on the snack from the issue.
