### PR TITLE
fix: kotlin compiler error inferred type Context?

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -54,7 +54,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
    * position of all the fingers will remain still while doing a rotation gesture.
    */
   init {
-    val vc = ViewConfiguration.get(context)
+    val vc = ViewConfiguration.get(context!!)
     val touchSlop = vc.scaledTouchSlop
     defaultMinDistSq = (touchSlop * touchSlop).toFloat()
     minDistSq = defaultMinDistSq


### PR DESCRIPTION
## Description
this PR will fix android compile error `Type mismatch: inferred type is Context? but Context was expected`

## Test plan

manual build on existing apps