### PR TITLE
Wrap Gesture Handler button with `View` and transform styles

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -35,6 +35,11 @@ export function hasProperty(object: object, key: string) {
   return Object.prototype.hasOwnProperty.call(object, key);
 }
 
+// eslint-disable-next-line @typescript-eslint/ban-types
+export function hasOneOfProperties(object: object, props: string[]) {
+  return props.some((key) => hasProperty(object, key));
+}
+
 export function isJestEnv(): boolean {
   // @ts-ignore Do not use `@types/node` because it will prioritise Node types over RN types which breaks the types (ex. setTimeout) in React Native projects.
   return hasProperty(global, 'process') && !!process.env.JEST_WORKER_ID;


### PR DESCRIPTION
## Description

There are many issues with styling buttons provided by Gesture Handler, mostly on Android where the class responsible for button extends `ViewGroup` instead of `ReactViewGroup` as it changes the behavior of onTouchEvent.

The best solution to those issues is wrapping the button with a `View` and styling the outer view instead. This PR attempts to make it happen auto-magically, which should make the buttons look as expected.

The main problem is correctly transforming the provided styles into two separate objects that when applied to two composed views give the same effect as the original styles applied to just one view.

## Test plan

For now, made sure that the changes don't break the Example app.
