### PR TITLE
Fix wrong coordinates when multiple gestures are tracking different pointers on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -257,9 +257,9 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     }
     initPointerProps(trackedPointersIDsCount)
     var count = 0
-    val oldX = event.x
-    val oldY = event.y
-    event.setLocation(event.rawX, event.rawY)
+    val deltaX = event.rawX - event.x
+    val deltaY = event.rawY - event.y
+    event.offsetLocation(deltaX, deltaY)
     var index = 0
     val size = event.pointerCount
     while (index < size) {
@@ -302,8 +302,8 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     } catch (e: IllegalArgumentException) {
       throw AdaptEventException(this, event, e)
     }
-    event.setLocation(oldX, oldY)
-    result.setLocation(oldX, oldY)
+    event.offsetLocation(-deltaX, -deltaY)
+    result.offsetLocation(-deltaX, -deltaY)
     return result
   }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1385

It's not exactly explained in the docs what [`MotionEvent.setLocation`](https://developer.android.com/reference/android/view/MotionEvent#setLocation(float,%20float)) and [`MotionEvent.offsetLocation`](https://developer.android.com/reference/android/view/MotionEvent#offsetLocation(float,%20float)) do besides the fact that the the former calls the latter, because the concept of event location is not clearly defined. From what I've noticed, the event location seems to be the same as the location of the first pointer it carries. This would make `MotionEvent.offsetLocation` move coordinates of all pointers by the vector supplied in the arguments and `MotionEvent.setLocation` also calculate the vector that would move the first pointer to the location supplied in the argument.

With that out of the way, I believe the current code for adapting events is a bit wrong. It stores the location of the first pointer, and changes the event location to its raw position, then when irrelevant pointers are filtered out of the event it sets the event location back to the stored position (meaning that the first pointer in the adapted event is now where the first pointer in the original event was and the others are moved accordingly). There's a pretty big problem with this approach: the first pointer from the original event doesn't have to be in the adapted one - this is the case when there are multiple handlers active and they are tracking different pointers.

This PR changes this logic so it no longer stores the original location, but the offset itself so no matter what pointers end up in the adapted event, they can be moved back to their position.

As a sidenote, I haven't been able to figure out what is the reason for changing the event location, as it's (at least I believe that was the intention) changed back after pointers are filtered in both the original, and the adapted event. It's possible that it could be simply removed.

## Test plan

Tested on the code from the issue and on the Example app.
