### PR TITLE
Returning Swipeable reference

### DIFF
--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -111,7 +111,10 @@ export interface SwipeableProps
   /**
    * Called when action panel is closed.
    */
-  onSwipeableClose?: (direction: 'left' | 'right', swipeable: Swipeable) => void;
+  onSwipeableClose?: (
+    direction: 'left' | 'right',
+    swipeable: Swipeable
+  ) => void;
 
   /**
    * @deprecated Use `direction` argument of onSwipeableWillOpen()

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -106,7 +106,10 @@ export interface SwipeableProps
   /**
    * Called when action panel gets open (either right or left).
    */
-  onSwipeableOpen?: (direction: 'left' | 'right', swipeable: Swipeable) => void;
+  onSwipeableOpen?: (
+    direction: 'left' | 'right',
+    swipeable: Swipeable
+  ) => void;
 
   /**
    * Called when action panel is closed.

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -106,10 +106,7 @@ export interface SwipeableProps
   /**
    * Called when action panel gets open (either right or left).
    */
-  onSwipeableOpen?: (
-    direction: 'left' | 'right',
-    swipeable: Swipeable
-  ) => void;
+  onSwipeableOpen?: (direction: 'left' | 'right', swipeable: Swipeable) => void;
 
   /**
    * Called when action panel is closed.

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -162,7 +162,7 @@ export interface SwipeableProps
   renderRightActions?: (
     progressAnimatedValue: Animated.AnimatedInterpolation,
     dragAnimatedValue: Animated.AnimatedInterpolation,
-    swipeable: Swipeable,
+    swipeable: Swipeable
   ) => React.ReactNode;
 
   useNativeAnimations?: boolean;

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -106,12 +106,12 @@ export interface SwipeableProps
   /**
    * Called when action panel gets open (either right or left).
    */
-  onSwipeableOpen?: (direction: 'left' | 'right') => void;
+  onSwipeableOpen?: (direction: 'left' | 'right', swipeable: Swipeable) => void;
 
   /**
    * Called when action panel is closed.
    */
-  onSwipeableClose?: (direction: 'left' | 'right') => void;
+  onSwipeableClose?: (direction: 'left' | 'right', swipeable: Swipeable) => void;
 
   /**
    * @deprecated Use `direction` argument of onSwipeableWillOpen()
@@ -161,7 +161,8 @@ export interface SwipeableProps
    * */
   renderRightActions?: (
     progressAnimatedValue: Animated.AnimatedInterpolation,
-    dragAnimatedValue: Animated.AnimatedInterpolation
+    dragAnimatedValue: Animated.AnimatedInterpolation,
+    swipeable: Swipeable,
   ) => React.ReactNode;
 
   useNativeAnimations?: boolean;
@@ -379,13 +380,13 @@ export default class Swipeable extends Component<
       if (finished) {
         if (toValue > 0) {
           this.props.onSwipeableLeftOpen?.();
-          this.props.onSwipeableOpen?.('left');
+          this.props.onSwipeableOpen?.('left', this);
         } else if (toValue < 0) {
           this.props.onSwipeableRightOpen?.();
-          this.props.onSwipeableOpen?.('right');
+          this.props.onSwipeableOpen?.('right', this);
         } else {
           const closingDirection = fromValue > 0 ? 'left' : 'right';
-          this.props.onSwipeableClose?.(closingDirection);
+          this.props.onSwipeableClose?.(closingDirection, this);
         }
       }
     });
@@ -461,7 +462,7 @@ export default class Swipeable extends Component<
           styles.rightActions,
           { transform: [{ translateX: this.rightActionTranslate! }] },
         ]}>
-        {renderRightActions(this.showRightAction!, this.transX!)}
+        {renderRightActions(this.showRightAction!, this.transX!, this)}
         <View
           onLayout={({ nativeEvent }) =>
             this.setState({ rightOffset: nativeEvent.layout.x })


### PR DESCRIPTION
## Description


The following code allows me to do the following two things:

1. Close any previously opened Swipeable views when one is opened

````
  const openedRow = useRef();
  function renderItem({item: payable, index, separators}) {
    return (
      <Swipeable
        onSwipeableWillOpen={() => openedRow.current?.close()} // Close a previously opened row
        onSwipeableOpen={(_, swipeable) => (openedRow.current = swipeable)} // Keep a link to the currenlty
````

2. Close a Swipeable view when it is being deleted.
````
        renderRightActions={(_, __, swipeable) => {
          return (
             <TouchableOpacity
                onPress={() => {
                  swipeable.close(); // Close the Swipeable when the user presses the button
````

Resolves this issue: https://github.com/software-mansion/react-native-gesture-handler/issues/764


## Test plan

Made these changes in my own app and used patch-package. It has been working fine for my needs.