### PR TITLE
Fix importing `PressabilityDebugView` on web

### DIFF
--- a/src/handlers/PressabilityDebugView.tsx
+++ b/src/handlers/PressabilityDebugView.tsx
@@ -1,0 +1,2 @@
+// @ts-ignore it's not exported so we need to import it from path
+export { PressabilityDebugView } from 'react-native/Libraries/Pressability/PressabilityDebug';

--- a/src/handlers/PressabilityDebugView.web.tsx
+++ b/src/handlers/PressabilityDebugView.web.tsx
@@ -1,0 +1,4 @@
+// PressabilityDebugView is not implemented in react-native-web
+export function PressabilityDebugView() {
+  return null;
+}

--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -27,8 +27,7 @@ import {
 import { ValueOf } from '../typeUtils';
 import { isFabric, isJestEnv } from '../utils';
 import { ActionType } from '../ActionType';
-// @ts-ignore it's not exported so we need to import it from path
-import { PressabilityDebugView } from 'react-native/Libraries/Pressability/PressabilityDebug';
+import { PressabilityDebugView } from './PressabilityDebugView';
 
 const UIManagerAny = UIManager as any;
 
@@ -482,6 +481,7 @@ export default function createHandler<
         grandChildren = React.Children.toArray(grandChildren);
         grandChildren.push(
           <PressabilityDebugView
+            key="pressabilityDebugView"
             color="mediumspringgreen"
             hitSlop={child.props.hitSlop}
           />


### PR DESCRIPTION
## Description

`PressabilityDebugView` is not implemented in `react-native-web` so importing it in `createHandler.tsx` was causing errors on web. This PR moves the import to a separate file with a web-specific version that returns `null`, thus preventing errors.

I also added the `key` property when rendering the `PressabilityDebugView` to prevent errors about it.

## Test plan

Tested on the Example app.
