### PR TITLE
Make gestures work on non-editable `TextInput` on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -5,6 +5,7 @@ import android.graphics.PointF
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
+import android.widget.EditText
 import java.util.*
 
 class GestureHandlerOrchestrator(
@@ -474,14 +475,24 @@ class GestureHandlerOrchestrator(
       }
       PointerEventsConfig.BOX_NONE -> {
         // This view can't be the target, but its children might
-        if (view is ViewGroup) {
-          extractGestureHandlers(view, coords, pointerId).also { found ->
-            // A child view is handling touch, also extract handlers attached to this view
-            if (found) {
-              recordViewHandlersForPointer(view, coords, pointerId)
+        when (view) {
+          is ViewGroup -> {
+            extractGestureHandlers(view, coords, pointerId).also { found ->
+              // A child view is handling touch, also extract handlers attached to this view
+              if (found) {
+                recordViewHandlersForPointer(view, coords, pointerId)
+              }
             }
           }
-        } else false
+          // When <TextInput> has editable set to `false` getPointerEventsConfigForView returns
+          // `BOX_NONE` as it's `isEnabled` property is false. In this case we still want to extract
+          // handlers attached to the text input, as it makes sense that gestures would work on a
+          // non-editable TextInput.
+          is EditText -> {
+            recordViewHandlersForPointer(view, coords, pointerId)
+          }
+          else -> false
+        }
       }
       PointerEventsConfig.AUTO -> {
         // Either this view or one of its children is the target


### PR DESCRIPTION
## Description

Closes https://github.com/software-mansion/react-native-gesture-handler/issues/774.

This PR makes gestures work on `TextInputs` with `editable` property set to `false` by extracting the handlers attached to the `EditText` even when it's disabled (by setting `editable=false`). On native side, its `EditText` has `isEnabled` property set to `false`. Because of that it fell into `PointerEventsConfig.BOX_NONE` branch of `when` expression and handlers attached to it weren't extracted (mainly the `NativeViewGestureHandler`). This caused the RN's gesture system to take over and call `requestDisallowInterceptTouchEvent` causing other gestures to fail.

## Test plan

Tested on the modified code from the issue:

```jsx
import React, { useRef } from 'react';
import { Animated, StyleSheet } from 'react-native';

import {
  State,
  GestureHandlerRootView,
  TapGestureHandler,
  TextInput,
} from 'react-native-gesture-handler';

export default function Example() {
  const [state, setState] = React.useState<any>(State.UNDETERMINED);
  const [oldState, setOldState] = React.useState<any>(State.UNDETERMINED);
  const ref = useRef();

  return (
    <GestureHandlerRootView style={{ flex: 1, paddingTop: 100 }}>
      <TapGestureHandler
        simultaneousHandlers={ref}
        onHandlerStateChange={(e) => {
          console.log(e.nativeEvent.oldState, e.nativeEvent.state);
          setState(e.nativeEvent.state);
          setOldState(e.nativeEvent.oldState);
        }}>
        <Animated.View style={{ flex: 1 }}>
          <TextInput
            ref={ref}
            style={{
              borderWidth: StyleSheet.hairlineWidth,
              borderColor: 'red',
            }}
            editable={false}>
            {state} - {oldState}
          </TextInput>
        </Animated.View>
      </TapGestureHandler>
    </GestureHandlerRootView>
  );
}
```
