### PR TITLE
Fix RefreshControl on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.kt
@@ -5,6 +5,8 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
+import android.widget.ScrollView
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout
 import com.facebook.react.views.textinput.ReactEditText
 
 class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
@@ -64,6 +66,9 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   }
 
   override fun shouldBeCancelledBy(handler: GestureHandler<*>): Boolean {
+    if (hook.shouldBeCancelledBy(handler)) {
+      return true
+    }
     return !disallowInterruption
   }
 
@@ -71,6 +76,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     when (val view = view) {
       is NativeViewGestureHandlerHook -> this.hook = view
       is ReactEditText -> this.hook = EditTextHook(this, view)
+      is ScrollView -> this.hook = ScrollViewHook()
     }
   }
 
@@ -151,6 +157,12 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     fun shouldRecognizeSimultaneously(handler: GestureHandler<*>) = false
 
     /**
+     * @return Boolean value signalling whether the gesture can be canceled by another handler.
+     * Returning false doesn't necessarily prevent it from happening.
+     */
+    fun shouldBeCancelledBy(handler: GestureHandler<*>) = false
+
+    /**
      * shouldActivateOnStart and tryIntercept have priority over this method
      *
      * @return Boolean value signalling if the hook wants to handle events passed to the handler
@@ -206,5 +218,12 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     }
 
     override fun shouldCancelRootViewGestureHandlerIfNecessary() = true
+  }
+
+  private class ScrollViewHook() : NativeViewGestureHandlerHook {
+    override fun shouldRecognizeSimultaneously(handler: GestureHandler<*>) =
+            handler.view is SwipeRefreshLayout
+    override fun shouldBeCancelledBy(handler: GestureHandler<*>) =
+            handler.view is SwipeRefreshLayout
   }
 }

--- a/src/components/GestureComponents.tsx
+++ b/src/components/GestureComponents.tsx
@@ -6,6 +6,7 @@ import {
   ReactElement,
 } from 'react';
 import {
+  Platform,
   ScrollView as RNScrollView,
   ScrollViewProps as RNScrollViewProps,
   Switch as RNSwitch,
@@ -16,6 +17,8 @@ import {
   DrawerLayoutAndroidProps as RNDrawerLayoutAndroidProps,
   FlatList as RNFlatList,
   FlatListProps as RNFlatListProps,
+  RefreshControl as RNRefreshControl,
+  RefreshControlProps as RNRefreshControlProps,
 } from 'react-native';
 
 import createNativeWrapper from '../handlers/createNativeWrapper';
@@ -35,6 +38,16 @@ export const ScrollView = createNativeWrapper<
 // include methods of wrapped components by creating an intersection type with the RN component instead of duplicating them.
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type ScrollView = typeof ScrollView & RNScrollView;
+
+export const RefreshControl =
+  Platform.OS === 'android'
+    ? createNativeWrapper<RNRefreshControlProps>(RNRefreshControl, {
+        disallowInterruption: true,
+        shouldCancelWhenOutside: false,
+      })
+    : RNRefreshControl;
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type RefreshControl = typeof RefreshControl & RNRefreshControl;
 
 export const Switch = createNativeWrapper<RNSwitchProps>(RNSwitch, {
   shouldCancelWhenOutside: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export {
   TextInput,
   DrawerLayoutAndroid,
   FlatList,
+  RefreshControl,
 } from './components/GestureComponents';
 export type {
   //events


### PR DESCRIPTION
## Description

Adds a hook to fix interaction between SwipeRefreshLayout and ScrollView. Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1067.

## Test plan

Tested in an app that pull to refresh works properly after this fix.