### PR TITLE
Make Gesture Handler on web respect `simultaneousHandlers` prop when used on a `ScrollView`

### DIFF
--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -269,8 +269,7 @@ abstract class GestureHandler {
   shouldUseTouchEvents(config: Config) {
     return (
       config.simultaneousHandlers
-        ?.map((handler) => handler.isNative)
-        ?.reduce((prev, current) => prev || current, false) ?? false
+        ?.some((handler) => handler.isNative) ?? false
     );
   }
 

--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -268,8 +268,7 @@ abstract class GestureHandler {
 
   shouldUseTouchEvents(config: Config) {
     return (
-      config.simultaneousHandlers
-        ?.some((handler) => handler.isNative) ?? false
+      config.simultaneousHandlers?.some((handler) => handler.isNative) ?? false
     );
   }
 

--- a/src/web/GestureHandler.ts
+++ b/src/web/GestureHandler.ts
@@ -63,7 +63,7 @@ abstract class GestureHandler {
   }
 
   // a simple way to check if GestureHandler is NativeViewGestureHandler, since importing it
-  // here to use instanceof woulf cause import cycle
+  // here to use instanceof would cause import cycle
   get isNative() {
     return false;
   }

--- a/src/web/NativeViewGestureHandler.ts
+++ b/src/web/NativeViewGestureHandler.ts
@@ -5,6 +5,10 @@ import PressGestureHandler from './PressGestureHandler';
 import { TEST_MIN_IF_NOT_NAN, VEC_LEN_SQ } from './utils';
 
 class NativeViewGestureHandler extends PressGestureHandler {
+  get isNative() {
+    return true;
+  }
+
   onRawEvent(ev: HammerInputExt) {
     super.onRawEvent(ev);
     if (!ev.isFinal) {


### PR DESCRIPTION
## Description

Should fix https://github.com/software-mansion/react-native-gesture-handler/issues/2091

HammerJS (which is used by Gesture Handler on web) by default tries to use [pointer events](https://developer.mozilla.org/en-US/docs/Web/API/Pointer_events), which can be [cancelled](https://developer.mozilla.org/en-US/docs/Web/API/Element/pointercancel_event) when the browser starts recognizing its own gestures (e.g. scrolling). Because of that all gestures would fail upon receiving `pointercancel` event. This is not the case when using [touch events](https://developer.mozilla.org/en-US/docs/Web/API/Touch_events), which do not get cancelled.
This PR forces Hammer to use touch events when a gesture is simultaneous with a `NativeViewGestureHandler` and keeps its default behavior in other cases. This way the gesture keeps receiving events event when a browses is handling a gesture be itself.
Unfortunately, I don't think we can accomplish feature-parity between web and native platforms using Hammer. For example, one of the missing things is the possibility to prevent the scroll from starting.

## Test plan

Tested on the Example app and on the code from the issue.
