### PR TITLE
Build only required architectures on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -59,6 +59,11 @@ def shouldUseCommonInterfaceFromReanimated() {
     }
 }
 
+def reactNativeArchitectures() {
+    def value = project.getProperties().get("reactNativeArchitectures")
+    return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
+}
+
 repositories {
     mavenCentral()
 }
@@ -97,6 +102,10 @@ android {
                     targets "rngesturehandler_modules"
                 }
             }
+        }
+
+        ndk {
+            abiFilters (*reactNativeArchitectures())
         }
     }
 


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2117.

Add `abiFilters` to `build.gradle` in order to build only required ABIs.

## Test plan

Run `npx react-native run-android --variant release --active-arch-only` before and after the change.
