### PR TITLE
Cancel gestures when an uninterruptible native gesture becomes active

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.kt
@@ -9,7 +9,8 @@ import com.facebook.react.views.textinput.ReactEditText
 
 class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   private var shouldActivateOnStart = false
-  private var disallowInterruption = false
+  var disallowInterruption = false
+    private set
 
   private var hook: NativeViewGestureHandlerHook = defaultHook
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
@@ -4,6 +4,7 @@ import android.util.SparseArray
 import com.facebook.react.bridge.ReadableMap
 import com.swmansion.gesturehandler.GestureHandler
 import com.swmansion.gesturehandler.GestureHandlerInteractionController
+import com.swmansion.gesturehandler.NativeViewGestureHandler
 
 class RNGestureHandlerInteractionManager : GestureHandlerInteractionController {
   private val waitForRelations = SparseArray<IntArray>()
@@ -42,8 +43,13 @@ class RNGestureHandlerInteractionManager : GestureHandlerInteractionController {
     otherHandler: GestureHandler<*>,
   ) = false
 
-  override fun shouldHandlerBeCancelledBy(handler: GestureHandler<*>, otherHandler: GestureHandler<*>) = false
+  override fun shouldHandlerBeCancelledBy(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean {
+    if (otherHandler is NativeViewGestureHandler) {
+      return otherHandler.disallowInterruption
+    }
 
+    return false
+  }
   override fun shouldRecognizeSimultaneously(
     handler: GestureHandler<*>,
     otherHandler: GestureHandler<*>,


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2118.

This change basically changes behavior in [this](https://github.com/software-mansion/react-native-gesture-handler/blob/ba2d8bb3e576c785159565e46f8294aa84cbc854/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt#L605) place, which [delegates it](https://github.com/software-mansion/react-native-gesture-handler/blob/ba2d8bb3e576c785159565e46f8294aa84cbc854/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt#L580) to the interaction manager later. This method is called when [this](https://github.com/software-mansion/react-native-gesture-handler/blob/ba2d8bb3e576c785159565e46f8294aa84cbc854/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt#L602) condition is met, which for a `NativeViewGestureHandler` with `disallowInterruption` set to `true` is when it was awaiting failure of some gesture and another handler activated in the meantime - [both if branches](https://github.com/software-mansion/react-native-gesture-handler/blob/ba2d8bb3e576c785159565e46f8294aa84cbc854/android/lib/src/main/java/com/swmansion/gesturehandler/NativeViewGestureHandler.kt#L58-L63) will return false when `disallowInterruption` is `true`, preventing other handlers from activating alongside it.

This PR adds a check to the `shouldHandlerBeCancelledBy` method, so that if the other handler is uninterruptible (and not simultaneous with the currently considered one), the currently considered gesture will be cancelled and not recognized simultaneously with it.

## Test plan

Tested on the Example app and on the snippet from the issue
