### PR TITLE
Remove unsafe methods

### DIFF
--- a/example/src/basic/panResponder/index.tsx
+++ b/example/src/basic/panResponder/index.tsx
@@ -33,7 +33,8 @@ class PanResponderExample extends Component {
   };
   private circle: React.ElementRef<typeof View> | null = null;
 
-  UNSAFE_componentWillMount() {
+  constructor(props: Record<string, unknown>) {
+    super(props);
     this.panResponder = PanResponder.create({
       onStartShouldSetPanResponder: this.handleStartShouldSetPanResponder,
       onMoveShouldSetPanResponder: this.handleMoveShouldSetPanResponder,

--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -203,10 +203,7 @@ export default class DrawerLayout extends Component<
     this.updateAnimatedEvent(props, this.state);
   }
 
-  UNSAFE_componentWillUpdate(
-    props: DrawerLayoutProps,
-    state: DrawerLayoutState
-  ) {
+  shouldComponentUpdate(props: DrawerLayoutProps, state: DrawerLayoutState) {
     if (
       this.props.drawerPosition !== props.drawerPosition ||
       this.props.drawerWidth !== props.drawerWidth ||
@@ -215,6 +212,8 @@ export default class DrawerLayout extends Component<
     ) {
       this.updateAnimatedEvent(props, state);
     }
+
+    return true;
   }
 
   private openValue?: Animated.AnimatedInterpolation;

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -219,7 +219,7 @@ export default class Swipeable extends Component<
     );
   }
 
-  UNSAFE_componentWillUpdate(props: SwipeableProps, state: SwipeableState) {
+  shouldComponentUpdate(props: SwipeableProps, state: SwipeableState) {
     if (
       this.props.friction !== props.friction ||
       this.props.overshootLeft !== props.overshootLeft ||
@@ -231,6 +231,8 @@ export default class Swipeable extends Component<
     ) {
       this.updateAnimatedEvent(props, state);
     }
+
+    return true;
   }
 
   private onGestureEvent?: (


### PR DESCRIPTION
## Description

Closes https://github.com/software-mansion/react-native-gesture-handler/issues/2127.

This PR gets rid of the `UNSAFE_` methods:
- replacing `UNSAFE_componentWillUpdate` with `shouldComponentUpdate`
- moving the creation of `PanResponder` to constructor from `UNSAFE_componentWillMount`

## Test plan

Tested on the example app.
