### PR TITLE
Display a more expressive error message when Gesture Handler receives more than one child

### DIFF
--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -469,42 +469,9 @@ export default function createHandler<
 
       this.propsRef.current = events;
 
+      let child: any = null;
       try {
-        const child: any = React.Children.only(this.props.children);
-        let grandChildren = child.props.children;
-        if (
-          __DEV__ &&
-          child.type &&
-          (child.type === 'RNGestureHandlerButton' ||
-            child.type.name === 'View' ||
-            child.type.displayName === 'View')
-        ) {
-          grandChildren = React.Children.toArray(grandChildren);
-          grandChildren.push(
-            <PressabilityDebugView
-              key="pressabilityDebugView"
-              color="mediumspringgreen"
-              hitSlop={child.props.hitSlop}
-            />
-          );
-        }
-
-        return React.cloneElement(
-          child,
-          {
-            ref: this.refHandler,
-            collapsable: false,
-            ...(isJestEnv()
-              ? {
-                  handlerType: name,
-                  handlerTag: this.handlerTag,
-                }
-              : {}),
-            testID: this.props.testID ?? child.props.testID,
-            ...events,
-          },
-          grandChildren
-        );
+        child = React.Children.only(this.props.children);
       } catch (e) {
         throw new Error(
           tagMessage(
@@ -512,6 +479,41 @@ export default function createHandler<
           )
         );
       }
+
+      let grandChildren = child.props.children;
+      if (
+        __DEV__ &&
+        child.type &&
+        (child.type === 'RNGestureHandlerButton' ||
+          child.type.name === 'View' ||
+          child.type.displayName === 'View')
+      ) {
+        grandChildren = React.Children.toArray(grandChildren);
+        grandChildren.push(
+          <PressabilityDebugView
+            key="pressabilityDebugView"
+            color="mediumspringgreen"
+            hitSlop={child.props.hitSlop}
+          />
+        );
+      }
+
+      return React.cloneElement(
+        child,
+        {
+          ref: this.refHandler,
+          collapsable: false,
+          ...(isJestEnv()
+            ? {
+                handlerType: name,
+                handlerTag: this.handlerTag,
+              }
+            : {}),
+          testID: this.props.testID ?? child.props.testID,
+          ...events,
+        },
+        grandChildren
+      );
     }
   }
   return Handler;

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -633,18 +633,26 @@ class Wrap extends React.Component<{
   children?: React.ReactNode;
 }> {
   render() {
-    // I don't think that fighting with types over such a simple function is worth it
-    // The only thing it does is add 'collapsable: false' to the child component
-    // to make sure it is in the native view hierarchy so the detector can find
-    // correct viewTag to attach to.
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const child: any = React.Children.only(this.props.children);
-    return React.cloneElement(
-      child,
-      { collapsable: false },
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-      child.props.children
-    );
+    try {
+      // I don't think that fighting with types over such a simple function is worth it
+      // The only thing it does is add 'collapsable: false' to the child component
+      // to make sure it is in the native view hierarchy so the detector can find
+      // correct viewTag to attach to.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const child: any = React.Children.only(this.props.children);
+      return React.cloneElement(
+        child,
+        { collapsable: false },
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+        child.props.children
+      );
+    } catch (e) {
+      throw new Error(
+        tagMessage(
+          `GestureDetector got more than one view as a child. If you want the gesture to work on multiple views, wrap them with a common parent and attach the gesture to that view.`
+        )
+      );
+    }
   }
 }
 


### PR DESCRIPTION
## Description

Display a more expressive error message when a Gesture Handler receives more than one child.

## Test plan

Tested on the Example app.
