### PR TITLE
Validate children of GestureDetector to check if there is only one native view that can be a target of the gestures

### DIFF
--- a/src/RNRenderer.ts
+++ b/src/RNRenderer.ts
@@ -1,0 +1,3 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+export { default as RNRenderer } from 'react-native/Libraries/Renderer/shims/ReactNative';

--- a/src/RNRenderer.web.ts
+++ b/src/RNRenderer.web.ts
@@ -1,0 +1,3 @@
+export const RNRenderer = {
+  findHostInstance_DEPRECATED: (_ref: any) => null,
+};

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -40,6 +40,7 @@ import { getShadowNodeFromRef } from '../../getShadowNodeFromRef';
 import { Platform } from 'react-native';
 import type RNGestureHandlerModuleWeb from '../../RNGestureHandlerModule.web';
 import { onGestureHandlerEvent } from './eventReceiver';
+import { RNRenderer } from '../../RNRenderer';
 
 declare const global: {
   isFormsStackingContext: (node: unknown) => boolean | null; // JSI function
@@ -511,6 +512,51 @@ function useAnimatedGesture(
   preparedGesture.animatedHandlers = sharedHandlersCallbacks;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function validateDetectorChildren(ref: any) {
+  // finds the first native view under the Wrap component and traverses the fiber tree upwards
+  // to check whether there is more than one native view as a pseudo-direct child of GestureDetector
+  // i.e. this is not ok:
+  //            Wrap
+  //             |
+  //            / \
+  //           /   \
+  //          /     \
+  //         /       \
+  //   NativeView  NativeView
+  //
+  // but this is fine:
+  //            Wrap
+  //             |
+  //         NativeView
+  //             |
+  //            / \
+  //           /   \
+  //          /     \
+  //         /       \
+  //   NativeView  NativeView
+  if (__DEV__ && Platform.OS !== 'web') {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+    const wrapType = ref._reactInternals.elementType;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+    let instance = RNRenderer.findHostInstance_DEPRECATED(ref)
+      ._internalFiberInstanceHandleDEV;
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    while (instance && instance.elementType !== wrapType) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      if (instance.sibling) {
+        throw new Error(
+          'GestureDetector has more than one native view as its children. This can happen if you are using a custom component that renders multiple views, like React.Fragment. You should wrap content of GestureDetector with a <View> or <Animated.View>.'
+        );
+      }
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
+      instance = instance.return;
+    }
+  }
+}
+
 interface GestureDetectorProps {
   gesture?: ComposedGesture | GestureType;
   children?: React.ReactNode;
@@ -561,6 +607,8 @@ export const GestureDetector = (props: GestureDetectorProps) => {
   useEffect(() => {
     firstRenderRef.current = true;
     const viewTag = findNodeHandle(viewRef.current) as number;
+
+    validateDetectorChildren(viewRef.current);
     attachHandlers({
       preparedGesture,
       gestureConfig,
@@ -579,6 +627,7 @@ export const GestureDetector = (props: GestureDetectorProps) => {
       const viewTag = findNodeHandle(viewRef.current) as number;
 
       if (needsToReattach(preparedGesture, gesture)) {
+        validateDetectorChildren(viewRef.current);
         dropHandlers(preparedGesture);
         attachHandlers({
           preparedGesture,


### PR DESCRIPTION
## Description

This PR adds a validation step during rendering of `GestureDetector` that traverses the Fiber tree to check if there is more that one view that could be a candidate to become the gesture target. If there are more the error message will be displayed.
For example, this is not ok:
```mermaid
graph TD;
    Wrap-->NativeView1;
    Wrap-->NativeView2;
```
but this is fine:
```mermaid
graph TD;
    Wrap-->NativeView1;
    NativeView1-->NativeView2;
    NativeView1-->NativeView3;
```

## Test plan

Tested on the Example app.
