### PR TITLE
Export custom `RefreshControl` component and add logic required to handle it

### DIFF
--- a/src/components/GestureComponents.tsx
+++ b/src/components/GestureComponents.tsx
@@ -46,7 +46,7 @@ export const ScrollView = React.forwardRef<
   RNScrollView,
   RNScrollViewProps & NativeViewGestureHandlerProps
 >((props, ref) => {
-  const refreshControlGestureRef = React.useRef<any>();
+  const refreshControlGestureRef = React.useRef<RefreshControl>(null);
   const { refreshControl, waitFor, ...rest } = props;
 
   return (
@@ -54,7 +54,7 @@ export const ScrollView = React.forwardRef<
       {...rest}
       // @ts-ignore `ref` exists on `GHScrollView`
       ref={ref}
-      waitFor={[...toArray(waitFor ? waitFor : []), refreshControlGestureRef]}
+      waitFor={[...toArray(waitFor ?? []), refreshControlGestureRef]}
       // @ts-ignore we don't pass `refreshing` prop as we only want to override the ref
       refreshControl={
         refreshControl ? (
@@ -94,7 +94,7 @@ export type DrawerLayoutAndroid = typeof DrawerLayoutAndroid &
   RNDrawerLayoutAndroid;
 
 export const FlatList = React.forwardRef((props, ref) => {
-  const refreshControlGestureRef = React.useRef<any>();
+  const refreshControlGestureRef = React.useRef<RefreshControl>(null);
 
   const { waitFor, refreshControl, ...rest } = props;
 
@@ -123,10 +123,7 @@ export const FlatList = React.forwardRef((props, ref) => {
           {...{
             ...scrollProps,
             ...scrollViewProps,
-            waitFor: [
-              ...toArray(waitFor ? waitFor : []),
-              refreshControlGestureRef,
-            ],
+            waitFor: [...toArray(waitFor ?? []), refreshControlGestureRef],
           }}
         />
       )}

--- a/src/components/GestureComponents.tsx
+++ b/src/components/GestureComponents.tsx
@@ -28,6 +28,13 @@ import {
 
 import { toArray } from '../utils';
 
+export const RefreshControl = createNativeWrapper(RNRefreshControl, {
+  disallowInterruption: true,
+  shouldCancelWhenOutside: false,
+});
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type RefreshControl = typeof RefreshControl & RNRefreshControl;
+
 const GHScrollView = createNativeWrapper<PropsWithChildren<RNScrollViewProps>>(
   RNScrollView,
   {
@@ -39,21 +46,8 @@ export const ScrollView = React.forwardRef<
   RNScrollView,
   RNScrollViewProps & NativeViewGestureHandlerProps
 >((props, ref) => {
-  const refreshControlGestureRef = React.useRef();
+  const refreshControlGestureRef = React.useRef<any>();
   const { refreshControl, waitFor, ...rest } = props;
-
-  const refHandler = (node: any) => {
-    refreshControlGestureRef.current = node;
-
-    const { ref }: any = refreshControl;
-    if (ref !== null) {
-      if (typeof ref === 'function') {
-        ref(node);
-      } else {
-        ref.current = node;
-      }
-    }
-  };
 
   return (
     <GHScrollView
@@ -63,10 +57,14 @@ export const ScrollView = React.forwardRef<
       waitFor={[...toArray(waitFor ? waitFor : []), refreshControlGestureRef]}
       // @ts-ignore we don't pass `refreshing` prop as we only want to override the ref
       refreshControl={
-        refreshControl
-          ? // @ts-ignore `ref` does indeed exist on the element we're cloning
-            React.cloneElement(refreshControl, { ref: refHandler })
-          : refreshControl
+        refreshControl ? (
+          <RefreshControl
+            {...refreshControl.props}
+            ref={refreshControlGestureRef}
+          />
+        ) : (
+          refreshControl
+        )
       }
     />
   );
@@ -95,15 +93,8 @@ export const DrawerLayoutAndroid = createNativeWrapper<
 export type DrawerLayoutAndroid = typeof DrawerLayoutAndroid &
   RNDrawerLayoutAndroid;
 
-export const RefreshControl = createNativeWrapper(RNRefreshControl, {
-  disallowInterruption: true,
-  shouldCancelWhenOutside: false,
-});
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export type RefreshControl = typeof RefreshControl & RNRefreshControl;
-
 export const FlatList = React.forwardRef((props, ref) => {
-  const refreshControlGestureRef = React.useRef();
+  const refreshControlGestureRef = React.useRef<any>();
 
   const { waitFor, refreshControl, ...rest } = props;
 
@@ -121,19 +112,6 @@ export const FlatList = React.forwardRef((props, ref) => {
       flatListProps[propName] = value;
     }
   }
-
-  const refHandler = (node: any) => {
-    refreshControlGestureRef.current = node;
-
-    const { ref }: any = refreshControl;
-    if (ref !== null) {
-      if (typeof ref === 'function') {
-        ref(node);
-      } else {
-        ref.current = node;
-      }
-    }
-  };
 
   return (
     // @ts-ignore - this function cannot have generic type so we have to ignore this error
@@ -154,10 +132,14 @@ export const FlatList = React.forwardRef((props, ref) => {
       )}
       // @ts-ignore we don't pass `refreshing` prop as we only want to override the ref
       refreshControl={
-        refreshControl
-          ? // @ts-ignore `ref` does indeed exist on the element we're cloning
-            React.cloneElement(refreshControl, { ref: refHandler })
-          : refreshControl
+        refreshControl ? (
+          <RefreshControl
+            {...refreshControl.props}
+            ref={refreshControlGestureRef}
+          />
+        ) : (
+          refreshControl
+        )
       }
     />
   );

--- a/src/components/GestureComponents.web.tsx
+++ b/src/components/GestureComponents.web.tsx
@@ -6,6 +6,7 @@ import {
   TextInput as RNTextInput,
   ScrollView as RNScrollView,
   FlatListProps,
+  View,
 } from 'react-native';
 
 import createNativeWrapper from '../handlers/createNativeWrapper';
@@ -25,6 +26,10 @@ export const DrawerLayoutAndroid = createNativeWrapper(RNDrawerLayoutAndroid, {
 });
 // @ts-ignore -- TODO(TS) to investigate if it's needed
 DrawerLayoutAndroid.positions = RNDrawerLayoutAndroid.positions;
+// RefreshControl is implemented as a functional component, rendering a View
+// NativeViewGestureHandler needs to set a ref on its child, which cannot be done
+// on functional components
+export const RefreshControl = createNativeWrapper(View);
 
 export const FlatList = React.forwardRef(
   <ItemT extends any>(props: FlatListProps<ItemT>, ref: any) => (

--- a/src/index.ts
+++ b/src/index.ts
@@ -105,6 +105,7 @@ export {
   TextInput,
   DrawerLayoutAndroid,
   FlatList,
+  RefreshControl,
 } from './components/GestureComponents';
 export type {
   //events


### PR DESCRIPTION
## Description

Closes https://github.com/software-mansion/react-native-gesture-handler/issues/1067.

The problem with `RefreshControl` on Android was that it wasn't a part of the Gesture Handler system. This PR adds a custom `RefreshControl` component exported by GH in the same way as `ScrollView`, `Switch` etc. It also adds custom logic to `ScrollView` and `FlatList` components exported by Gesture Handler that handles setting relations between native gestures properly.

## Test plan

Tested on the Example app and on code [from the issue](https://github.com/software-mansion/react-native-gesture-handler/issues/1067#issuecomment-1013765946)
