### PR TITLE
Pass `disabled` prop to the `BaseButton` in `TouchableNativeFeedback`

### DIFF
--- a/src/components/touchables/GenericTouchable.tsx
+++ b/src/components/touchables/GenericTouchable.tsx
@@ -278,6 +278,7 @@ export default class GenericTouchable extends Component<
         disallowInterruption={this.props.disallowInterruption}
         testID={this.props.testID}
         touchSoundDisabled={this.props.touchSoundDisabled ?? false}
+        enabled={!this.props.disabled}
         {...this.props.extraButtonProps}>
         <Animated.View {...coreProps} style={this.props.style}>
           {this.props.children}


### PR DESCRIPTION
## Description

The `disabled` prop on Touchables from Gesture Handler was not passed to the `BaseButton`, instead it was used to ignore incoming events. This successfully made them not call `onPress*()` callbacks, but in case of `TouchableNativeFeedback` it didn't disable the event handling on the native side.
This PR makes `GenericTouchable` pass `disabled` prop further down to `BaseButton`, which in turn passes it to the native view, disabling touch interaction on it.

## Test plan

Tested on the Example app
