### PR TITLE
Add `runOnJS` where necessary in Drag and Drop example

### DIFF
--- a/example/src/new_api/drag_n_drop/DragAndDrop.tsx
+++ b/example/src/new_api/drag_n_drop/DragAndDrop.tsx
@@ -12,7 +12,6 @@ import {
   PanGestureHandlerEventPayload,
 } from 'react-native-gesture-handler';
 import {
-  runOnJS,
   useSharedValue,
   withSpring,
   withTiming,
@@ -202,17 +201,20 @@ function DragAndDrop<T extends { id: string }>({
       };
 
   const dragGesture = Gesture.Pan()
+    .runOnJS(true)
     .onUpdate((e) => {
-      runOnJS(onUpdateHandler)(e);
+      onUpdateHandler(e);
     })
     .onEnd(() => {
-      runOnJS(onDragEnd)();
+      onDragEnd();
     });
-  const tapEndedGesture = Gesture.Tap().onEnd((_, isFinished) => {
-    if (isFinished) {
-      runOnJS(updateDataOnEnd)();
-    }
-  });
+  const tapEndedGesture = Gesture.Tap()
+    .runOnJS(true)
+    .onEnd((_, isFinished) => {
+      if (isFinished) {
+        updateDataOnEnd();
+      }
+    });
 
   const _renderItems = () => {
     const newData = [...data];

--- a/example/src/new_api/drag_n_drop/DragAndDrop.tsx
+++ b/example/src/new_api/drag_n_drop/DragAndDrop.tsx
@@ -202,12 +202,8 @@ function DragAndDrop<T extends { id: string }>({
 
   const dragGesture = Gesture.Pan()
     .runOnJS(true)
-    .onUpdate((e) => {
-      onUpdateHandler(e);
-    })
-    .onEnd(() => {
-      onDragEnd();
-    });
+    .onUpdate(onUpdateHandler)
+    .onEnd(onDragEnd);
   const tapEndedGesture = Gesture.Tap()
     .runOnJS(true)
     .onEnd((_, isFinished) => {

--- a/example/src/new_api/drag_n_drop/DragAndDrop.tsx
+++ b/example/src/new_api/drag_n_drop/DragAndDrop.tsx
@@ -12,6 +12,7 @@ import {
   PanGestureHandlerEventPayload,
 } from 'react-native-gesture-handler';
 import {
+  runOnJS,
   useSharedValue,
   withSpring,
   withTiming,
@@ -200,10 +201,16 @@ function DragAndDrop<T extends { id: string }>({
         /* empty handler */
       };
 
-  const dragGesture = Gesture.Pan().onUpdate(onUpdateHandler).onEnd(onDragEnd);
+  const dragGesture = Gesture.Pan()
+    .onUpdate((e) => {
+      runOnJS(onUpdateHandler)(e);
+    })
+    .onEnd(() => {
+      runOnJS(onDragEnd)();
+    });
   const tapEndedGesture = Gesture.Tap().onEnd((_, isFinished) => {
     if (isFinished) {
-      updateDataOnEnd();
+      runOnJS(updateDataOnEnd)();
     }
   });
 


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2143

Drag and drop example was trying to run non-worklet functions on UI thread, this resulted in the app crashing in some cases. This PR wraps those functions in `runOnJS`, preventing crashes.

## Test plan

Checked if the example app crashes
