### PR TITLE
Fix some edge cases in state flow on Android when handler is waiting for another one

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -129,6 +129,13 @@ class GestureHandlerOrchestrator(
           if (newState == GestureHandler.STATE_END) {
             // gesture has ended, we need to kill the awaiting handler
             otherHandler.cancel()
+            if (otherHandler.state == GestureHandler.STATE_END) {
+              // Handle edge case, where discrete gestures end immediately after activation thus
+              // their state is set to END and when the gesture they are waiting for activates they
+              // should be cancelled, however `cancel` was never sent as gestures were already in the END state.
+              // Send synthetic BEGAN -> CANCELLED to properly handle JS logic
+              otherHandler.dispatchStateChange(GestureHandler.STATE_CANCELLED, GestureHandler.STATE_BEGAN)
+            }
             otherHandler.isAwaiting = false
           } else {
             // gesture has failed recognition, we may try activating
@@ -143,9 +150,12 @@ class GestureHandlerOrchestrator(
     } else if (prevState == GestureHandler.STATE_ACTIVE || prevState == GestureHandler.STATE_END) {
       if (handler.isActive) {
         handler.dispatchStateChange(newState, prevState)
-      } else if (prevState == GestureHandler.STATE_ACTIVE) {
-        // handle edge case where handler awaiting for another one tries to activate but finishes
-        // before the other would not send state change event upon ending
+      } else if (prevState == GestureHandler.STATE_ACTIVE && (newState == GestureHandler.STATE_CANCELLED || newState == GestureHandler.STATE_FAILED)) {
+        // Handle edge case where handler awaiting for another one tries to activate but finishes
+        // before the other would not send state change event upon ending. Note that we only want
+        // to do this if the newState is either CANCELLED or FAILED, if it is END we still want to
+        // wait for the other handler to finish as in that case synthetic events will be sent by the
+        // makeActive method.
         handler.dispatchStateChange(newState, GestureHandler.STATE_BEGAN)
       }
     } else if (prevState != GestureHandler.STATE_UNDETERMINED || newState != GestureHandler.STATE_CANCELLED) {


### PR DESCRIPTION
## Description

This PR fixes two edge cases:
- Discrete gestures (in this case with focus on tap) transition to `END` state just after transitioning to `ACTIVE`, this means that while they are awaiting failure of other gesture they are waiting in the `END` state. This was preventing them from being cancelled as it checks that the gesture is not already in the finished state (which it is) before sending the event, which results in the gesture handler on JS side receiving the `BEGAN` state and no other changes. This PR fixes this by sending synthetic `BEGAN` -> `CANCELLED` event when a gesture in the `END` state gets cancelled.
- When a handler was transitioning from `ACTIVE` state to another one while awaiting failure of another handler, synthetic event `BEGAN` -> new state was sent. This is the desired behavior when the new state is either `CANCELLED` or `FAILED`, but was also happening when the new state was `END`. This PR adds explicit check for the desired states.

## Test plan

Check the state changes of gestures in the `Multitap` example before and after applying this PR.
