### PR TITLE
Use non-deprecated `Handler` constructor

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/FlingGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/FlingGestureHandler.kt
@@ -1,6 +1,7 @@
 package com.swmansion.gesturehandler
 
 import android.os.Handler
+import android.os.Looper
 import android.view.MotionEvent
 
 class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
@@ -27,7 +28,7 @@ class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
     begin()
     maxNumberOfPointersSimultaneously = 1
     if (handler == null) {
-      handler = Handler() // lazy delegate?
+      handler = Handler(Looper.getMainLooper()) // lazy delegate?
     } else {
       handler!!.removeCallbacksAndMessages(null)
     }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/LongPressGestureHandler.kt
@@ -2,6 +2,7 @@ package com.swmansion.gesturehandler
 
 import android.content.Context
 import android.os.Handler
+import android.os.Looper
 import android.os.SystemClock
 import android.view.MotionEvent
 
@@ -43,7 +44,7 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
       begin()
       startX = event.rawX
       startY = event.rawY
-      handler = Handler()
+      handler = Handler(Looper.getMainLooper())
       if (minDurationMs > 0) {
         handler!!.postDelayed({ activate() }, minDurationMs)
       } else if (minDurationMs == 0L) {

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PanGestureHandler.kt
@@ -2,6 +2,7 @@ package com.swmansion.gesturehandler
 
 import android.content.Context
 import android.os.Handler
+import android.os.Looper
 import android.view.MotionEvent
 import android.view.VelocityTracker
 import android.view.ViewConfiguration
@@ -233,7 +234,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
 
       if (activateAfterLongPress > 0) {
         if (handler == null) {
-          handler = Handler()
+          handler = Handler(Looper.getMainLooper())
         }
         handler!!.postDelayed(activateDelayed, activateAfterLongPress)
       }

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/TapGestureHandler.kt
@@ -1,6 +1,7 @@
 package com.swmansion.gesturehandler
 
 import android.os.Handler
+import android.os.Looper
 import android.view.MotionEvent
 import com.swmansion.gesturehandler.GestureUtils.getLastPointerX
 import com.swmansion.gesturehandler.GestureUtils.getLastPointerY
@@ -70,7 +71,7 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
 
   private fun startTap() {
     if (handler == null) {
-      handler = Handler() // TODO: lazy init (handle else branch correctly)
+      handler = Handler(Looper.getMainLooper()) // TODO: lazy init (handle else branch correctly)
     } else {
       handler!!.removeCallbacksAndMessages(null)
     }
@@ -79,7 +80,7 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
 
   private fun endTap() {
     if (handler == null) {
-      handler = Handler()
+      handler = Handler(Looper.getMainLooper())
     } else {
       handler!!.removeCallbacksAndMessages(null)
     }


### PR DESCRIPTION
## Description

Closes https://github.com/software-mansion/react-native-gesture-handler/issues/2161

`Handler()` constructor has been deprecated. This PR changes all the constructors to `Handler(looper: Looper)`.

## Test plan

Build the example app