### PR TITLE
Make grep pattern for detecting multiple installations stronger

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -4,7 +4,7 @@ fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED']
 
 isUserApp = File.exists?(File.join(__dir__, "..", "..", "node_modules", "react-native", "package.json"))
 if isUserApp
-  libInstances = %x[find ../../ -name "package.json" | grep "/react-native-gesture-handler/"]
+  libInstances = %x[find ../../ -name "package.json" | grep "/react-native-gesture-handler/package.json"]
   libInstancesArray = libInstances.split("\n")
   if libInstancesArray.length() > 1
     parsedLocation = ''


### PR DESCRIPTION
## Description

Previous pattern caused problems when library was used directly from GitHub (not downloaded from package repository) as there were multiple `package.json` files with `"/react-native-gesture-handler/"` in their path (example applications, etc.).

This commit narrows down the search to look only for "main package.json" files.

## Test plan

Install `react-native-gesture-handler` directly from repository and see that it works after applying this patch.
