### PR TITLE
fix: RCT_NEW_ARCH_ENABLED=0 to disable new arch

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -1,6 +1,6 @@
 require "json"
 
-fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED']
+fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
 isUserApp = File.exists?(File.join(__dir__, "..", "..", "node_modules", "react-native", "package.json"))
 if isUserApp


### PR DESCRIPTION
## Description
`RCT_NEW_ARCH_ENABLED=0` is not working, sometimes disturb when we enable and disable the new arch
<!--
Description and motivation for this PR.

Inlude 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan
`RCT_NEW_ARCH_ENABLED=1` enable new arch and then try to disable `RCT_NEW_ARCH_ENABLED=0` then you will get this error `react/renderer/components/rngesturehandler/Props.h failed`

<!--
Describe how did you test this change here.
-->
