### PR TITLE
Check if loaded module is really Reanimated in `reanimatedWrapper`

### DIFF
--- a/src/handlers/gestures/reanimatedWrapper.ts
+++ b/src/handlers/gestures/reanimatedWrapper.ts
@@ -30,6 +30,13 @@ let Reanimated: {
 try {
   Reanimated = require('react-native-reanimated');
 
+  if (!Reanimated.useSharedValue) {
+    // @ts-ignore Make sure the loaded module is actually Reanimated, if it's not
+    // reset the module to undefined so we can fallback to the default implementation
+    Reanimated = undefined;
+    throw new Error('react-native-reanimated is not found');
+  }
+
   if (!Reanimated.setGestureState) {
     Reanimated.setGestureState = () => {
       'worklet';


### PR DESCRIPTION
## Description

In some cases `reanimatedWrapper` would not fail when loading `react-native-reanimated` even though it was not installed, instead loading some other file/module. In my case it was `utils` file. This caused exception when calling `useAnimatedGesture` in `GestureDetector` as methods required by it were not present in the wrapper.

This PR updates `reanimatedWrapper` so that it checks for existence of `useSharedValue` on the loaded module and setting it back to `undefined` if it's not present.

## Test plan

I'm not sure how to reliably reproduce it but it worked for me 🤷.
