### PR TITLE
Make macOS codepath less chatty

### DIFF
--- a/src/RNGestureHandlerModule.macos.ts
+++ b/src/RNGestureHandlerModule.macos.ts
@@ -46,12 +46,8 @@ export const HammerGestures = {
 };
 
 export default {
-  handleSetJSResponder(tag: number, blockNativeResponder: boolean) {
-    console.warn('handleSetJSResponder: ', tag, blockNativeResponder);
-  },
-  handleClearJSResponder() {
-    console.warn('handleClearJSResponder: ');
-  },
+  handleSetJSResponder(_tag: number, _blockNativeResponder: boolean) {},
+  handleClearJSResponder() {},
   createGestureHandler<T>(
     handlerName: keyof typeof Gestures,
     handlerTag: number,

--- a/src/RNGestureHandlerModule.macos.ts
+++ b/src/RNGestureHandlerModule.macos.ts
@@ -46,7 +46,9 @@ export const HammerGestures = {
 };
 
 export default {
-  handleSetJSResponder(_tag: number, _blockNativeResponder: boolean) {},
+  handleSetJSResponder(_tag: number, _blockNativeResponder: boolean) {
+    // NO-OP
+  },
   handleClearJSResponder() {},
   createGestureHandler<T>(
     handlerName: keyof typeof Gestures,

--- a/src/RNGestureHandlerModule.macos.ts
+++ b/src/RNGestureHandlerModule.macos.ts
@@ -49,7 +49,9 @@ export default {
   handleSetJSResponder(_tag: number, _blockNativeResponder: boolean) {
     // NO-OP
   },
-  handleClearJSResponder() {},
+  handleClearJSResponder() {
+    // NO-OP
+  },
   createGestureHandler<T>(
     handlerName: keyof typeof Gestures,
     handlerTag: number,


### PR DESCRIPTION
## Description

Hey.
This is just a small fix for the react-native-macos target.
It's a bit chatty right now, for no good reason (I mistakenly copied this over from the web target).

Everything the user clicks (in debug builds), this will show up, because of how reeact-native handles `console.warn`.
![image](https://user-images.githubusercontent.com/3824379/187670490-ce5055dd-37dc-4d46-9f11-719d2fb96923.png)
