### PR TITLE
Fix concurrent CI

### DIFF
--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         working-directory: [example, FabricExample]
     concurrency:
-      group: android-${{ github.ref }}
+      group: android-${{ matrix.working-directory }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: checkout

--- a/.github/workflows/static-example-apps-checks.yml
+++ b/.github/workflows/static-example-apps-checks.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         working-directory: [example, FabricExample]
     concurrency:
-      group: static-example-${{ github.ref }}
+      group: typescript-${{ matrix.working-directory }}-${{ github.ref }}
       cancel-in-progress: true
     steps:
       - name: checkout


### PR DESCRIPTION
## Description

This PR should hopefully fix CI jobs for Example and FabricExample apps being cancelled by using `matrix.working_directory` variable in `concurrency.group` identifier.
