### PR TITLE
Unify how `reanimated` module is looked for on Android

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,7 +54,7 @@ def safeExtGet(prop, fallback) {
 
 // Check whether Reanimated 2.3 or higher is installed alongside Gesture Handler
 def shouldUseCommonInterfaceFromReanimated() {
-    def reanimated = rootProject.subprojects.find { it.name == 'react-native-reanimated' };
+    def reanimated = rootProject.subprojects.find { it.name == 'react-native-reanimated' }
     if (reanimated != null) {
         def inputFile = new File(reanimated.projectDir, '../package.json')
         def json = new JsonSlurper().parseText(inputFile.text)
@@ -201,7 +201,7 @@ dependencies {
 
     if (shouldUseCommonInterfaceFromReanimated()) {
         // Include Reanimated as dependency to load the common interface
-        implementation (project(':react-native-reanimated')) {
+        implementation (rootProject.subprojects.find { it.name == 'react-native-reanimated' }) {
             exclude group:'com.facebook.fbjni' // resolves "Duplicate class com.facebook.jni.CppException"
         }
     }


### PR DESCRIPTION
## Description

I was able to reproduce the issue https://github.com/software-mansion/react-native-gesture-handler/issues/2195 by removing `implementation (project(':react-native-reanimated'))` on the Example app. This suggests that the Reanimated module may not be included in every case, even though the method that checks for its existence says it should be.

This PR unifies how Reanimated is looked for, which hopefully will solve the problem.

## Test plan

Build the example app
