### PR TITLE
Make `ReanimatedEventDispatcher` a class and not an object

### DIFF
--- a/android/noreanimated/src/main/java/com/swmansion/gesturehandler/ReanimatedEventDispatcher.kt
+++ b/android/noreanimated/src/main/java/com/swmansion/gesturehandler/ReanimatedEventDispatcher.kt
@@ -3,7 +3,7 @@ package com.swmansion.gesturehandler
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.events.Event
 
-object ReanimatedEventDispatcher {
+class ReanimatedEventDispatcher {
     fun <T : Event<T>>sendEvent(event: T, reactApplicationContext: ReactContext) {
         // no-op
     }

--- a/android/reanimated/src/main/java/com/swmansion/gesturehandler/ReanimatedEventDispatcher.kt
+++ b/android/reanimated/src/main/java/com/swmansion/gesturehandler/ReanimatedEventDispatcher.kt
@@ -4,7 +4,7 @@ import com.facebook.react.bridge.ReactContext
 import com.facebook.react.uimanager.events.Event
 import com.swmansion.reanimated.ReanimatedModule
 
-object ReanimatedEventDispatcher {
+class ReanimatedEventDispatcher {
     private var reanimatedModule: ReanimatedModule? = null
 
     fun <T : Event<T>>sendEvent(event: T, reactApplicationContext: ReactContext) {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -346,7 +346,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
   val registry: RNGestureHandlerRegistry = RNGestureHandlerRegistry()
   private val interactionManager = RNGestureHandlerInteractionManager()
   private val roots: MutableList<RNGestureHandlerRootHelper> = ArrayList()
-  private val enqueuedRootViewInit: MutableList<Int> = ArrayList()
+  private val reanimatedEventDispatcher = ReanimatedEventDispatcher()
   override fun getName() = MODULE_NAME
 
   @ReactMethod
@@ -593,7 +593,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?)
     // Delivers the event to Reanimated.
     if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
       // Send event directly to Reanimated
-      ReanimatedEventDispatcher.sendEvent(event, reactApplicationContext)
+      reanimatedEventDispatcher.sendEvent(event, reactApplicationContext)
     } else {
       // In the old architecture, Reanimated subscribes for specific direct events.
       sendEventForDirectEvent(event)


### PR DESCRIPTION
## Description

This PR changes `ReanimatedEventDispatcher` from `object` to `class` and makes it a field in the `RNGestureHandlerModule`. This way the old Reanimated module shouldn't be preserved during reload, as the dispatcher will be dropped alongside everything else.
