### PR TITLE
Remove calling web implementation on native apps

### DIFF
--- a/src/EnableExperimentalWebImplementation.ts
+++ b/src/EnableExperimentalWebImplementation.ts
@@ -1,7 +1,16 @@
+import { Platform } from 'react-native';
+
 let EXPERIMENTAL_WEB_IMPLEMENTATION = false;
 let getWasCalled = false;
 
 export function enableExperimentalWebImplementation(shouldEnable = true): void {
+  if (
+    Platform.OS !== 'web' ||
+    EXPERIMENTAL_WEB_IMPLEMENTATION === shouldEnable
+  ) {
+    return;
+  }
+
   if (getWasCalled) {
     console.error(
       'Some parts of this application have already started using old gesture handler implementation. No changes will be applied. You can try enabling new implementation earlier.'


### PR DESCRIPTION
## Description

This PR fixes issue where `enableExperimentalWebImplementation` was called on native apps when new api was used.

## Test plan

Tested on example app
