### PR TITLE
Add check for module

### DIFF
--- a/src/RNGestureHandlerModule.ts
+++ b/src/RNGestureHandlerModule.ts
@@ -16,7 +16,10 @@ if (RNGestureHandlerModule == null) {
   );
 }
 
-if (RNGestureHandlerModule.flushOperations === undefined) {
+if (
+  RNGestureHandlerModule &&
+  RNGestureHandlerModule.flushOperations === undefined
+) {
   RNGestureHandlerModule.flushOperations = () => {
     // NO-OP if not defined
   };


### PR DESCRIPTION
## Description

This PR should fix issue #2213 by checking whether module is undefined or not. Navigation has Gesture Handler in dependencies, so the module will be loaded even if Gesture Handler is not used. Change in this PR prevents apps from crashing in that case.