### PR TITLE
Update message about the new API in docs

### DIFF
--- a/docs/docs/gesture-handlers/api/common-gh.md
+++ b/docs/docs/gesture-handlers/api/common-gh.md
@@ -4,9 +4,8 @@ title: Common handler properties
 sidebar_label: Common handler properties
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 This page covers the common set of properties all gesture handler components expose.

--- a/docs/docs/gesture-handlers/api/create-native-wrapper.md
+++ b/docs/docs/gesture-handlers/api/create-native-wrapper.md
@@ -4,9 +4,8 @@ title: createNativeWrapper
 sidebar_label: createNativeWrapper()
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 Creates provided component with NativeViewGestureHandler, allowing it to be part of RNGH's

--- a/docs/docs/gesture-handlers/api/fling-gh.md
+++ b/docs/docs/gesture-handlers/api/fling-gh.md
@@ -4,9 +4,8 @@ title: FlingGestureHandler
 sidebar_label: Fling
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that activates when the movement is sufficiently long and fast.

--- a/docs/docs/gesture-handlers/api/force-gh.md
+++ b/docs/docs/gesture-handlers/api/force-gh.md
@@ -4,9 +4,8 @@ title: ForceTouchGestureHandler (iOS only)
 sidebar_label: Force touch
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that recognizes force of a touch. It allows for tracking pressure of touch on some iOS devices.

--- a/docs/docs/gesture-handlers/api/longpress-gh.md
+++ b/docs/docs/gesture-handlers/api/longpress-gh.md
@@ -4,9 +4,8 @@ title: LongPressGestureHandler
 sidebar_label: Long press
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that activates when the corresponding view is pressed for a sufficiently long time.

--- a/docs/docs/gesture-handlers/api/nativeview-gh.md
+++ b/docs/docs/gesture-handlers/api/nativeview-gh.md
@@ -4,9 +4,8 @@ title: NativeViewGestureHandler
 sidebar_label: NativeView
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A gesture handler that allows other touch handling components to participate in

--- a/docs/docs/gesture-handlers/api/pan-gh.md
+++ b/docs/docs/gesture-handlers/api/pan-gh.md
@@ -4,9 +4,8 @@ title: PanGestureHandler
 sidebar_label: Pan
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that can recognize a panning (dragging) gesture and track its movement.
@@ -192,8 +191,7 @@ class Circle extends Component {
             style={{
               height: 150,
               justifyContent: 'center',
-            }}
-          >
+            }}>
             <Animated.View
               style={[
                 {
@@ -207,7 +205,7 @@ class Circle extends Component {
                     {
                       translateX: Animated.add(
                         this._touchX,
-                        new Animated.Value(-circleRadius),
+                        new Animated.Value(-circleRadius)
                       ),
                     },
                   ],

--- a/docs/docs/gesture-handlers/api/pinch-gh.md
+++ b/docs/docs/gesture-handlers/api/pinch-gh.md
@@ -4,9 +4,8 @@ title: PinchGestureHandler
 sidebar_label: Pinch
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that recognizes pinch gesture. It allows for tracking the distance between two fingers and use that information to scale or zoom your content.

--- a/docs/docs/gesture-handlers/api/rotation-gh.md
+++ b/docs/docs/gesture-handlers/api/rotation-gh.md
@@ -4,9 +4,8 @@ title: RotationGestureHandler
 sidebar_label: Rotation
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that can recognize a rotation gesture and track its movement.

--- a/docs/docs/gesture-handlers/api/tap-gh.md
+++ b/docs/docs/gesture-handlers/api/tap-gh.md
@@ -4,9 +4,8 @@ title: TapGestureHandler
 sidebar_label: Tap
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that recognizes one or many taps.

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -130,7 +130,7 @@ module.exports = {
           editUrl: undefined, // hide edit button
           versions: {
             '2.4.0': {
-              label: '2.4.0-2.5.0',
+              label: '2.4.0 – 2.5.0',
             },
           },
         },

--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -128,6 +128,11 @@ module.exports = {
           path: 'docs',
           sidebarPath: require.resolve('./sidebars.js'),
           editUrl: undefined, // hide edit button
+          versions: {
+            '2.4.0': {
+              label: '2.4.0-2.5.0',
+            },
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),

--- a/docs/versioned_docs/version-2.3.0/gesture-handlers/api/common-gh.md
+++ b/docs/versioned_docs/version-2.3.0/gesture-handlers/api/common-gh.md
@@ -4,9 +4,8 @@ title: Common handler properties
 sidebar_label: Common handler properties
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 This page covers the common set of properties all gesture handler components expose.

--- a/docs/versioned_docs/version-2.3.0/gesture-handlers/api/create-native-wrapper.md
+++ b/docs/versioned_docs/version-2.3.0/gesture-handlers/api/create-native-wrapper.md
@@ -4,9 +4,8 @@ title: createNativeWrapper
 sidebar_label: createNativeWrapper()
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 Creates provided component with NativeViewGestureHandler, allowing it to be part of RNGH's

--- a/docs/versioned_docs/version-2.3.0/gesture-handlers/api/fling-gh.md
+++ b/docs/versioned_docs/version-2.3.0/gesture-handlers/api/fling-gh.md
@@ -4,9 +4,8 @@ title: FlingGestureHandler
 sidebar_label: Fling
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that activates when the movement is sufficiently long and fast.

--- a/docs/versioned_docs/version-2.3.0/gesture-handlers/api/force-gh.md
+++ b/docs/versioned_docs/version-2.3.0/gesture-handlers/api/force-gh.md
@@ -4,9 +4,8 @@ title: ForceTouchGestureHandler (iOS only)
 sidebar_label: Force touch
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that recognizes force of a touch. It allows for tracking pressure of touch on some iOS devices.

--- a/docs/versioned_docs/version-2.3.0/gesture-handlers/api/longpress-gh.md
+++ b/docs/versioned_docs/version-2.3.0/gesture-handlers/api/longpress-gh.md
@@ -4,9 +4,8 @@ title: LongPressGestureHandler
 sidebar_label: Long press
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that activates when the corresponding view is pressed for a sufficiently long time.

--- a/docs/versioned_docs/version-2.3.0/gesture-handlers/api/nativeview-gh.md
+++ b/docs/versioned_docs/version-2.3.0/gesture-handlers/api/nativeview-gh.md
@@ -4,9 +4,8 @@ title: NativeViewGestureHandler
 sidebar_label: NativeView
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A gesture handler that allows other touch handling components to participate in

--- a/docs/versioned_docs/version-2.3.0/gesture-handlers/api/pan-gh.md
+++ b/docs/versioned_docs/version-2.3.0/gesture-handlers/api/pan-gh.md
@@ -4,9 +4,8 @@ title: PanGestureHandler
 sidebar_label: Pan
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that can recognize a panning (dragging) gesture and track its movement.

--- a/docs/versioned_docs/version-2.3.0/gesture-handlers/api/pinch-gh.md
+++ b/docs/versioned_docs/version-2.3.0/gesture-handlers/api/pinch-gh.md
@@ -4,9 +4,8 @@ title: PinchGestureHandler
 sidebar_label: Pinch
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that recognizes pinch gesture. It allows for tracking the distance between two fingers and use that information to scale or zoom your content.

--- a/docs/versioned_docs/version-2.3.0/gesture-handlers/api/rotation-gh.md
+++ b/docs/versioned_docs/version-2.3.0/gesture-handlers/api/rotation-gh.md
@@ -4,9 +4,8 @@ title: RotationGestureHandler
 sidebar_label: Rotation
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that can recognize a rotation gesture and track its movement.

--- a/docs/versioned_docs/version-2.3.0/gesture-handlers/api/tap-gh.md
+++ b/docs/versioned_docs/version-2.3.0/gesture-handlers/api/tap-gh.md
@@ -4,9 +4,8 @@ title: TapGestureHandler
 sidebar_label: Tap
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that recognizes one or many taps.

--- a/docs/versioned_docs/version-2.4.0/gesture-handlers/api/common-gh.md
+++ b/docs/versioned_docs/version-2.4.0/gesture-handlers/api/common-gh.md
@@ -4,9 +4,8 @@ title: Common handler properties
 sidebar_label: Common handler properties
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 This page covers the common set of properties all gesture handler components expose.

--- a/docs/versioned_docs/version-2.4.0/gesture-handlers/api/create-native-wrapper.md
+++ b/docs/versioned_docs/version-2.4.0/gesture-handlers/api/create-native-wrapper.md
@@ -4,9 +4,8 @@ title: createNativeWrapper
 sidebar_label: createNativeWrapper()
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 Creates provided component with NativeViewGestureHandler, allowing it to be part of RNGH's

--- a/docs/versioned_docs/version-2.4.0/gesture-handlers/api/fling-gh.md
+++ b/docs/versioned_docs/version-2.4.0/gesture-handlers/api/fling-gh.md
@@ -4,9 +4,8 @@ title: FlingGestureHandler
 sidebar_label: Fling
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that activates when the movement is sufficiently long and fast.

--- a/docs/versioned_docs/version-2.4.0/gesture-handlers/api/force-gh.md
+++ b/docs/versioned_docs/version-2.4.0/gesture-handlers/api/force-gh.md
@@ -4,9 +4,8 @@ title: ForceTouchGestureHandler (iOS only)
 sidebar_label: Force touch
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that recognizes force of a touch. It allows for tracking pressure of touch on some iOS devices.

--- a/docs/versioned_docs/version-2.4.0/gesture-handlers/api/longpress-gh.md
+++ b/docs/versioned_docs/version-2.4.0/gesture-handlers/api/longpress-gh.md
@@ -4,9 +4,8 @@ title: LongPressGestureHandler
 sidebar_label: Long press
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that activates when the corresponding view is pressed for a sufficiently long time.

--- a/docs/versioned_docs/version-2.4.0/gesture-handlers/api/nativeview-gh.md
+++ b/docs/versioned_docs/version-2.4.0/gesture-handlers/api/nativeview-gh.md
@@ -4,9 +4,8 @@ title: NativeViewGestureHandler
 sidebar_label: NativeView
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A gesture handler that allows other touch handling components to participate in

--- a/docs/versioned_docs/version-2.4.0/gesture-handlers/api/pan-gh.md
+++ b/docs/versioned_docs/version-2.4.0/gesture-handlers/api/pan-gh.md
@@ -4,9 +4,8 @@ title: PanGestureHandler
 sidebar_label: Pan
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that can recognize a panning (dragging) gesture and track its movement.
@@ -192,8 +191,7 @@ class Circle extends Component {
             style={{
               height: 150,
               justifyContent: 'center',
-            }}
-          >
+            }}>
             <Animated.View
               style={[
                 {
@@ -207,7 +205,7 @@ class Circle extends Component {
                     {
                       translateX: Animated.add(
                         this._touchX,
-                        new Animated.Value(-circleRadius),
+                        new Animated.Value(-circleRadius)
                       ),
                     },
                   ],

--- a/docs/versioned_docs/version-2.4.0/gesture-handlers/api/pinch-gh.md
+++ b/docs/versioned_docs/version-2.4.0/gesture-handlers/api/pinch-gh.md
@@ -4,9 +4,8 @@ title: PinchGestureHandler
 sidebar_label: Pinch
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that recognizes pinch gesture. It allows for tracking the distance between two fingers and use that information to scale or zoom your content.

--- a/docs/versioned_docs/version-2.4.0/gesture-handlers/api/rotation-gh.md
+++ b/docs/versioned_docs/version-2.4.0/gesture-handlers/api/rotation-gh.md
@@ -4,9 +4,8 @@ title: RotationGestureHandler
 sidebar_label: Rotation
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that can recognize a rotation gesture and track its movement.

--- a/docs/versioned_docs/version-2.4.0/gesture-handlers/api/tap-gh.md
+++ b/docs/versioned_docs/version-2.4.0/gesture-handlers/api/tap-gh.md
@@ -4,9 +4,8 @@ title: TapGestureHandler
 sidebar_label: Tap
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that recognizes one or many taps.

--- a/docs/versioned_docs/version-2.6.0/gesture-handlers/api/common-gh.md
+++ b/docs/versioned_docs/version-2.6.0/gesture-handlers/api/common-gh.md
@@ -4,9 +4,8 @@ title: Common handler properties
 sidebar_label: Common handler properties
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 This page covers the common set of properties all gesture handler components expose.

--- a/docs/versioned_docs/version-2.6.0/gesture-handlers/api/create-native-wrapper.md
+++ b/docs/versioned_docs/version-2.6.0/gesture-handlers/api/create-native-wrapper.md
@@ -4,9 +4,8 @@ title: createNativeWrapper
 sidebar_label: createNativeWrapper()
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 Creates provided component with NativeViewGestureHandler, allowing it to be part of RNGH's

--- a/docs/versioned_docs/version-2.6.0/gesture-handlers/api/fling-gh.md
+++ b/docs/versioned_docs/version-2.6.0/gesture-handlers/api/fling-gh.md
@@ -4,9 +4,8 @@ title: FlingGestureHandler
 sidebar_label: Fling
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that activates when the movement is sufficiently long and fast.

--- a/docs/versioned_docs/version-2.6.0/gesture-handlers/api/force-gh.md
+++ b/docs/versioned_docs/version-2.6.0/gesture-handlers/api/force-gh.md
@@ -4,9 +4,8 @@ title: ForceTouchGestureHandler (iOS only)
 sidebar_label: Force touch
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that recognizes force of a touch. It allows for tracking pressure of touch on some iOS devices.

--- a/docs/versioned_docs/version-2.6.0/gesture-handlers/api/longpress-gh.md
+++ b/docs/versioned_docs/version-2.6.0/gesture-handlers/api/longpress-gh.md
@@ -4,9 +4,8 @@ title: LongPressGestureHandler
 sidebar_label: Long press
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that activates when the corresponding view is pressed for a sufficiently long time.

--- a/docs/versioned_docs/version-2.6.0/gesture-handlers/api/nativeview-gh.md
+++ b/docs/versioned_docs/version-2.6.0/gesture-handlers/api/nativeview-gh.md
@@ -4,9 +4,8 @@ title: NativeViewGestureHandler
 sidebar_label: NativeView
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A gesture handler that allows other touch handling components to participate in

--- a/docs/versioned_docs/version-2.6.0/gesture-handlers/api/pan-gh.md
+++ b/docs/versioned_docs/version-2.6.0/gesture-handlers/api/pan-gh.md
@@ -4,9 +4,8 @@ title: PanGestureHandler
 sidebar_label: Pan
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that can recognize a panning (dragging) gesture and track its movement.
@@ -192,8 +191,7 @@ class Circle extends Component {
             style={{
               height: 150,
               justifyContent: 'center',
-            }}
-          >
+            }}>
             <Animated.View
               style={[
                 {
@@ -207,7 +205,7 @@ class Circle extends Component {
                     {
                       translateX: Animated.add(
                         this._touchX,
-                        new Animated.Value(-circleRadius),
+                        new Animated.Value(-circleRadius)
                       ),
                     },
                   ],

--- a/docs/versioned_docs/version-2.6.0/gesture-handlers/api/pinch-gh.md
+++ b/docs/versioned_docs/version-2.6.0/gesture-handlers/api/pinch-gh.md
@@ -4,9 +4,8 @@ title: PinchGestureHandler
 sidebar_label: Pinch
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that recognizes pinch gesture. It allows for tracking the distance between two fingers and use that information to scale or zoom your content.

--- a/docs/versioned_docs/version-2.6.0/gesture-handlers/api/rotation-gh.md
+++ b/docs/versioned_docs/version-2.6.0/gesture-handlers/api/rotation-gh.md
@@ -4,9 +4,8 @@ title: RotationGestureHandler
 sidebar_label: Rotation
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A continuous gesture handler that can recognize a rotation gesture and track its movement.

--- a/docs/versioned_docs/version-2.6.0/gesture-handlers/api/tap-gh.md
+++ b/docs/versioned_docs/version-2.6.0/gesture-handlers/api/tap-gh.md
@@ -4,9 +4,8 @@ title: TapGestureHandler
 sidebar_label: Tap
 ---
 
-:::info
-We recently released RNGH 2.0 with new Gestures system. Check out [RNGH 2.0
-section in Introduction](../../introduction.md#rngh-20) for more information.
+:::warning
+Consider using the new [gestures API](../../api/gestures/gesture.md) instead. The old API is not actively supported and is not receiving the new features. Check out [RNGH 2.0 section in Introduction](../../introduction.md#rngh-20) for more information.
 :::
 
 A discrete gesture handler that recognizes one or many taps.


### PR DESCRIPTION
## Description

This PR updates the message about the new API, which can be found in the pages related to the old API, in the documentation, and changes the level from `info` to `warning`.

It also updates the displayed label from `2.4.0` to `2.4.0-2.5.0` since there were no API changes between those versions and it could be confusing for some people.
