### PR TITLE
Use `cloneElement` when assigning a refresh control

### DIFF
--- a/src/components/GestureComponents.tsx
+++ b/src/components/GestureComponents.tsx
@@ -57,14 +57,12 @@ export const ScrollView = React.forwardRef<
       waitFor={[...toArray(waitFor ?? []), refreshControlGestureRef]}
       // @ts-ignore we don't pass `refreshing` prop as we only want to override the ref
       refreshControl={
-        refreshControl ? (
-          <RefreshControl
-            {...refreshControl.props}
-            ref={refreshControlGestureRef}
-          />
-        ) : (
-          refreshControl
-        )
+        refreshControl
+          ? React.cloneElement(refreshControl, {
+              // @ts-ignore for reasons unknown to me, `ref` doesn't exist on the type inferred by TS
+              ref: refreshControlGestureRef,
+            })
+          : undefined
       }
     />
   );
@@ -129,14 +127,12 @@ export const FlatList = React.forwardRef((props, ref) => {
       )}
       // @ts-ignore we don't pass `refreshing` prop as we only want to override the ref
       refreshControl={
-        refreshControl ? (
-          <RefreshControl
-            {...refreshControl.props}
-            ref={refreshControlGestureRef}
-          />
-        ) : (
-          refreshControl
-        )
+        refreshControl
+          ? React.cloneElement(refreshControl, {
+              // @ts-ignore for reasons unknown to me, `ref` doesn't exist on the type inferred by TS
+              ref: refreshControlGestureRef,
+            })
+          : undefined
       }
     />
   );


### PR DESCRIPTION
## Description

#2137 added a custom `RefreshControl` component and the logic necessary to handle it. I missed one use case in that PR: a custom component that renders the added `RefreshControl`. This PR fixes this by cloning the provided component instead of copying the props.

## Test plan

```jsx
const RefreshControlWrapper = React.forwardRef((props, ref) => {
  const [refreshing, setRefreshing] = React.useState(false);

  useEffect(() => {
    setTimeout(() => {
      setRefreshing(false);
    }, 1000);
  }, [refreshing]);

  return (
    <RefreshControl
      ref={ref}
      refreshing={refreshing}
      onRefresh={() => {
        setRefreshing(true);
      }}>
      {props.children}
    </RefreshControl>
  );
});

export default function App() {
  return (
    <GestureHandlerRootView style={{ flex: 1 }}>
      <ScrollView refreshControl={<RefreshControlWrapper />}>
        <View style={{ width: 100, height: 200, backgroundColor: 'red' }} />
        <View style={{ width: 100, height: 200, backgroundColor: 'green' }} />
        <View style={{ width: 100, height: 200, backgroundColor: 'blue' }} />
        <View style={{ width: 100, height: 200, backgroundColor: 'red' }} />
        <View style={{ width: 100, height: 200, backgroundColor: 'green' }} />
        <View style={{ width: 100, height: 200, backgroundColor: 'blue' }} />
      </ScrollView>
    </GestureHandlerRootView>
  );
}
```
