### PR TITLE
Use `_reactInternalFiber` instead of `_reactInternals` on RN 0.63

### DIFF
--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -35,7 +35,7 @@ import { State } from '../../State';
 import { TouchEventType } from '../../TouchEventType';
 import { ComposedGesture } from './gestureComposition';
 import { ActionType } from '../../ActionType';
-import { isFabric, tagMessage } from '../../utils';
+import { isFabric, REACT_NATIVE_VERSION, tagMessage } from '../../utils';
 import { getShadowNodeFromRef } from '../../getShadowNodeFromRef';
 import { Platform } from 'react-native';
 import type RNGestureHandlerModuleWeb from '../../RNGestureHandlerModule.web';
@@ -539,8 +539,13 @@ function validateDetectorChildren(ref: any) {
   //         /       \
   //   NativeView  NativeView
   if (__DEV__ && Platform.OS !== 'web') {
-    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access
-    const wrapType = ref._reactInternals.elementType;
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const wrapType =
+      REACT_NATIVE_VERSION.minor > 63 || REACT_NATIVE_VERSION.major > 0
+        ? // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          ref._reactInternals.elementType
+        : // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          ref._reactInternalFiber.elementType;
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
     let instance = RNRenderer.findHostInstance_DEPRECATED(ref)
       ._internalFiberInstanceHandleDEV;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,10 @@
 import pack from 'react-native/package.json';
 
-const rnVersion = pack.version;
+const [majorStr, minorStr] = pack.version.split('.');
+export const REACT_NATIVE_VERSION = {
+  major: parseInt(majorStr, 10),
+  minor: parseInt(minorStr, 10),
+};
 
 export function toArray<T>(object: T | T[]): T[] {
   if (!Array.isArray(object)) {
@@ -52,12 +56,8 @@ export function isFabric(): boolean {
 }
 
 export function shouldUseCodegenNativeComponent(): boolean {
-  const [majorStr, minorStr] = rnVersion.split('.');
-  const major = Number.parseInt(majorStr);
-  const minor = Number.parseInt(minorStr);
-
   // use codegenNativeComponent starting with RN 0.68
-  return minor >= 68 || major > 0;
+  return REACT_NATIVE_VERSION.minor >= 68 || REACT_NATIVE_VERSION.major > 0;
 }
 
 export function isRemoteDebuggingEnabled(): boolean {


### PR DESCRIPTION
## Description

This PR fixes an error caused by the `_reactInternals` property missing on ref objects on React Native 0.63. Instead, the `_reactInternalFiber` prop should be used on that version.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2233.

## Test plan

Add `GestureDetector` in an app based on React Native 0.63.
