### PR TITLE
Make handlers send touches cancel on gesture end

### DIFF
--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -563,9 +563,7 @@ export default abstract class GestureHandler {
     const { onGestureHandlerEvent }: PropsRef = this.propsRef
       .current as PropsRef;
 
-    if (cancelEvent) {
-      invokeNullableMethod(onGestureHandlerEvent, cancelEvent);
-    }
+    invokeNullableMethod(onGestureHandlerEvent, cancelEvent);
   }
 
   protected transformNativeEvent() {


### PR DESCRIPTION
## Description

This PR adds minor change to web version. Now when gesture handlers move to `end/failed/cancelled` state, they also trigger onTouchesCancelled callback. This will happen, when gesture has ended, but there are still remaining pointers on handler.

## Test plan

Tested on example app
