### PR TITLE
Fix `NullPointerException` when evaluating `hitSlop` on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandler.kt
@@ -585,11 +585,11 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     var top = 0f
     var right = view!!.width.toFloat()
     var bottom = view.height.toFloat()
-    if (hitSlop != null) {
-      val padLeft = hitSlop!![HIT_SLOP_LEFT_IDX]
-      val padTop = hitSlop!![HIT_SLOP_TOP_IDX]
-      val padRight = hitSlop!![HIT_SLOP_RIGHT_IDX]
-      val padBottom = hitSlop!![HIT_SLOP_BOTTOM_IDX]
+    hitSlop?.let { hitSlop ->
+      val padLeft = hitSlop[HIT_SLOP_LEFT_IDX]
+      val padTop = hitSlop[HIT_SLOP_TOP_IDX]
+      val padRight = hitSlop[HIT_SLOP_RIGHT_IDX]
+      val padBottom = hitSlop[HIT_SLOP_BOTTOM_IDX]
       if (hitSlopSet(padLeft)) {
         left -= padLeft
       }
@@ -602,8 +602,8 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
       if (hitSlopSet(padBottom)) {
         bottom += padBottom
       }
-      val width = hitSlop!![HIT_SLOP_WIDTH_IDX]
-      val height = hitSlop!![HIT_SLOP_HEIGHT_IDX]
+      val width = hitSlop[HIT_SLOP_WIDTH_IDX]
+      val height = hitSlop[HIT_SLOP_HEIGHT_IDX]
       if (hitSlopSet(width)) {
         if (!hitSlopSet(padLeft)) {
           left = right - width


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2239.

Based on the location of the crash from the issue this seems to be a concurrency issue. Using `?.let` instead of non-null assertions should resolve the problem, as the used variable will be guaranteed not to change while the block is being executed.

## Test plan

I don't really know how to reproduce it, but I also don't see what could be the other solution, so... trust me?
