### PR TITLE
Prevent handlers from crashing when they don't use touch events

### DIFF
--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -123,6 +123,7 @@ export default abstract class GestureHandler {
 
     if (
       this.tracker.getTrackedPointersCount() > 0 &&
+      this.config.needsPointerData &&
       (newState === State.END ||
         newState === State.CANCELLED ||
         newState === State.FAILED)


### PR DESCRIPTION
## Description

When handlers are about to end and there are still remaining pointers on them, these touches should be cancelled. However current version lacks important check whether handler do use touch events or not. If they don't, they shouldn't receive event to cancel all touches - otherwise they crash.

## Test plan

Tested on example app