### PR TITLE
Update if statments in PointerTracker to correctly return coordinates

### DIFF
--- a/src/web/tools/PointerTracker.ts
+++ b/src/web/tools/PointerTracker.ts
@@ -143,7 +143,7 @@ export default class PointerTracker {
   public getLastX(pointerId: number): number;
 
   public getLastX(pointerId?: number): number {
-    if (pointerId) {
+    if (pointerId !== undefined) {
       return this.trackedPointers.get(pointerId)?.lastX as number;
     } else {
       return this.trackedPointers.get(this.lastMovedPointerId)?.lastX as number;
@@ -164,7 +164,7 @@ export default class PointerTracker {
   public getLastY(pointerId: number): number;
 
   public getLastY(pointerId?: number): number {
-    if (pointerId) {
+    if (pointerId !== undefined) {
       return this.trackedPointers.get(pointerId)?.lastY as number;
     } else {
       return this.trackedPointers.get(this.lastMovedPointerId)?.lastY as number;


### PR DESCRIPTION
## Description

Until this PR, `PointerTracker` was using `if (pointerId) {...}` to check whether pointerId was provided as argument. Right now, touches are handled by `TouchEvents` and by changes in [this PR](https://github.com/software-mansion/react-native-gesture-handler/pull/2188), IDs of touches are mapped to range 0-20. Because of that, when we call `tracker.getLastX(id)`, where `id = 0`, it doesn't return X coordinate of touch with ID 0, but X coordinate of last moved pointer. This makes some handlers malfunction.

## Test plan

Tested on example app
