### PR TITLE
Fix example app with Reanimated

### DIFF
--- a/example/babel.config.js
+++ b/example/babel.config.js
@@ -1,8 +1,8 @@
 module.exports = {
   presets: ['babel-preset-expo'],
   plugins: [
-    'react-native-reanimated/plugin',
     '@babel/plugin-transform-modules-commonjs',
+    'react-native-reanimated/plugin',
     [
       'module-resolver',
       {

--- a/example/babel.config.web.js
+++ b/example/babel.config.web.js
@@ -1,8 +1,9 @@
 module.exports = {
   presets: ['babel-preset-expo'],
   plugins: [
-    'react-native-reanimated/plugin',
+    '@babel/plugin-proposal-export-namespace-from',
     '@babel/plugin-transform-modules-commonjs',
+    'react-native-reanimated/plugin',
     [
       'module-resolver',
       {

--- a/example/package.json
+++ b/example/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.17.8",
+    "@babel/plugin-proposal-export-namespace-from": "^7.18.9",
     "@babel/preset-env": "^7.1.6",
     "@babel/runtime": "^7.12.5",
     "@expo/webpack-config": "^0.12.52",

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -1085,6 +1085,14 @@
     "@babel/helper-plugin-utils" "^7.16.7"
     "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
 
+"@babel/plugin-proposal-export-namespace-from@^7.18.9":
+  version "7.18.9"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-export-namespace-from/-/plugin-proposal-export-namespace-from-7.18.9.tgz#5f7313ab348cdb19d590145f9247540e94761203"
+  integrity sha512-k1NtHyOMvlDDFeb9G5PhUXuGj8m/wiwojgQVEhJ/fsVsMCpLyOP4h0uGEjYJKrRI+EVPlb5Jk+Gt9P97lOGwtA==
+  dependencies:
+    "@babel/helper-plugin-utils" "^7.18.9"
+    "@babel/plugin-syntax-export-namespace-from" "^7.8.3"
+
 "@babel/plugin-proposal-json-strings@^7.12.1":
   version "7.12.1"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-json-strings/-/plugin-proposal-json-strings-7.12.1.tgz#d45423b517714eedd5621a9dfdc03fa9f4eb241c"


### PR DESCRIPTION
## Description

This PR fixes the order of babel plugins and adds `@babel/plugin-proposal-export-namespace-from` to make the new versions of Reanimated work on web.

See https://github.com/software-mansion/react-native-reanimated/pull/3437 for more information.

## Test plan

Run example apps
