### PR TITLE
Fix simultaneous gesture when it receives composed gestures as arguments

### DIFF
--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -69,14 +69,24 @@ export class ComposedGesture extends Gesture {
 
 export class SimultaneousGesture extends ComposedGesture {
   prepare() {
-    const simultaneousArray = this.gestures
-      .flatMap((gesture) => gesture.toGestureArray())
-      .concat(this.simultaneousGestures);
+    // this piece of magic works something like this:
+    // for every gesture in the array
+    const simultaneousArrays = this.gestures.map((gesture) =>
+      // we take the array it's in
+      this.gestures
+        // and make a copy without it
+        .filter((x) => x !== gesture)
+        // then we flatmap the restul to get list of raw (not composed) gestures
+        // this way we don't make the gestures simultaneous with themselves, which is
+        // important when the gesture is `ExclusiveGesture` - we don't want to make
+        // exclusive gestures simultaneous
+        .flatMap((x) => x.toGestureArray())
+    );
 
-    for (const gesture of this.gestures) {
+    for (let i = 0; i < this.gestures.length; i++) {
       this.prepareSingleGesture(
-        gesture,
-        simultaneousArray,
+        this.gestures[i],
+        simultaneousArrays[i],
         this.requireGesturesToFail
       );
     }
@@ -85,6 +95,8 @@ export class SimultaneousGesture extends ComposedGesture {
 
 export class ExclusiveGesture extends ComposedGesture {
   prepare() {
+    // transforms the array of gestures into array of grouped raw (not composed) gestures
+    // i.e. [gesture1, gesture2, ComposedGesture(gesture3, gesture4)] -> [[gesture1], [gesture2], [gesture3, gesture4]]
     const gestureArrays = this.gestures.map((gesture) =>
       gesture.toGestureArray()
     );
@@ -98,6 +110,7 @@ export class ExclusiveGesture extends ComposedGesture {
         this.requireGesturesToFail.concat(requireToFail)
       );
 
+      // every group gets to wait for all groups before it
       requireToFail = requireToFail.concat(gestureArrays[i]);
     }
   }

--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -76,7 +76,7 @@ export class SimultaneousGesture extends ComposedGesture {
       this.gestures
         // and make a copy without it
         .filter((x) => x !== gesture)
-        // then we flatmap the restul to get list of raw (not composed) gestures
+        // then we flatmap the result to get list of raw (not composed) gestures
         // this way we don't make the gestures simultaneous with themselves, which is
         // important when the gesture is `ExclusiveGesture` - we don't want to make
         // exclusive gestures simultaneous


### PR DESCRIPTION
## Description

Right now `Simultaneous` gesture transforms received gestures into the array of non-composed gestures (flattening it if necessary) and makes every gesture simultaneous with every gesture in the array. It's not a good approach because `Exclusive` also exists and putting an exclusive gesture into `Simultaneous` meant that gestures meant to be exclusive are now also simultaneous, resulting in different behavior on different platforms.

This PR changes the behavior so it respects groups, meaning exclusive gestures will not be made simultaneous with each other.

## Test plan

Tested on the example app