### PR TITLE
Pan shouldCancelWhenOutside fix

### DIFF
--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -98,8 +98,8 @@ export default class PanGestureHandler extends GestureHandler {
       this.activateAfterLongPress = this.config.activateAfterLongPress;
     }
 
-    if (this.config.shouldCancelWhenOutside) {
-      this.setShouldCancelWhenOutside(false);
+    if (this.config.shouldCancelWhenOutside !== undefined) {
+      this.setShouldCancelWhenOutside(this.config.shouldCancelWhenOutside);
     }
 
     if (this.config.activeOffsetXStart !== undefined) {


### PR DESCRIPTION
## Description

Current `updateGestureConfig` function in `PanGestureHandler` assigns false value to `shouldCancelWhenOutside` pretty much all the time. This happens especially when the value passed in config is `true` - that shouldn't happen because it basically flips the logic.

## Test plan

Tested on example app
