### PR TITLE
Disable context menu on LongPressGestureHandler

### DIFF
--- a/src/web/handlers/LongPressGestureHandler.ts
+++ b/src/web/handlers/LongPressGestureHandler.ts
@@ -23,6 +23,8 @@ export default class LongPressGestureHandler extends GestureHandler {
   public init(ref: number, propsRef: React.RefObject<unknown>) {
     super.init(ref, propsRef);
     this.setShouldCancelWhenOutside(true);
+
+    this.view.oncontextmenu = () => false;
   }
 
   protected transformNativeEvent() {


### PR DESCRIPTION
## Description

This PR disables context menu on `LongPressGestureHandler`. It can become pretty annoying when there's image inside handler, because doing long press on image triggers default menu to pop up.

## Test plan

Tested on example app
