### PR TITLE
Remove userSelect: none on NativeViewGestureHandler

### DIFF
--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -29,11 +29,8 @@ export default class NativeViewGestureHandler extends GestureHandler {
       this.buttonRole = true;
     } else {
       this.buttonRole = false;
-    }
-
-    if (this.view.tagName.toLowerCase() === 'input') {
-      //Enables text input on Safari
       this.view.style['webkitUserSelect'] = 'auto';
+      this.view.style['userSelect'] = 'auto';
     }
   }
 


### PR DESCRIPTION
## Description

This PR removes `userSelect: none` property from NativeViewGestureHandler, that wraps `ScrollView` and `TextInput`. `Buttons` with NativeView still have this property. This solves issue #2211 

## Test plan

Tested on example app

