### PR TITLE
Change order of sending touch events and assigning new state

### DIFF
--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -127,9 +127,7 @@ export default abstract class GestureHandler {
     if (
       this.tracker.getTrackedPointersCount() > 0 &&
       this.config.needsPointerData &&
-      (newState === State.END ||
-        newState === State.CANCELLED ||
-        newState === State.FAILED)
+      this.isFinished()
     ) {
       this.cancelTouches();
     }
@@ -773,6 +771,14 @@ export default abstract class GestureHandler {
 
   public isEnabled(): boolean {
     return this.enabled;
+  }
+
+  private isFinished(): boolean {
+    return (
+      this.currentState === State.END ||
+      this.currentState === State.FAILED ||
+      this.currentState === State.CANCELLED
+    );
   }
 
   protected setShouldCancelWhenOutside(shouldCancel: boolean) {

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -120,6 +120,7 @@ export default abstract class GestureHandler {
     if (this.currentState === newState) {
       return;
     }
+
     const oldState = this.currentState;
     this.currentState = newState;
 

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -120,6 +120,8 @@ export default abstract class GestureHandler {
     if (this.currentState === newState) {
       return;
     }
+    const oldState = this.currentState;
+    this.currentState = newState;
 
     if (
       this.tracker.getTrackedPointersCount() > 0 &&
@@ -130,9 +132,6 @@ export default abstract class GestureHandler {
     ) {
       this.cancelTouches();
     }
-
-    const oldState = this.currentState;
-    this.currentState = newState;
 
     GestureHandlerOrchestrator.getInstance().onHandlerStateChange(
       this,


### PR DESCRIPTION
## Description

This PR makes small change in `moveToState` method. Some handlers require `TouchEvents` to work. These events are not connected with state management system, unless we are talking about `ManualGestureHandler`. Right now example with this handler throws "Maximum call stack size exceeded". Stack trace points out, that the problem originates in `onCancelTouches` method.

What is happening, is that each `GestureHandler` in `moveToState` method calls `cancelTouches`, which triggers `onTouchesCancelled`. This happens, if new state will be finished (i.e. `end/failed/cancelled`). When order is not flipped, after calling `cancelTouches`, state manager calls `fail` method, which one more time triggers `moveToState`. We end up with this loop: `fail() -> moveToState() -> cancelTouches() -> fail() ...`. `Fail` method checks if current handler state is `active` or `began`, however without flipping order, `fail` is being called while handler is still in `active` state. When we flip order, `cancelTouches` is called when handler is in `end` state - that prevents falling into endless loop.

## Test plan

Tested on example app