### PR TITLE
fix a potential race on component unmount

### DIFF
--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef } from 'react';
+import React, { useEffect, useRef, RefObject } from 'react';
 import {
   GestureType,
   HandlerCallbacks,
@@ -226,7 +226,8 @@ function attachHandlers({
 function updateHandlers(
   preparedGesture: GestureConfigReference,
   gestureConfig: ComposedGesture | GestureType | undefined,
-  gesture: GestureType[]
+  gesture: GestureType[],
+  mountedRef: RefObject<boolean>
 ) {
   gestureConfig?.prepare();
 
@@ -246,6 +247,7 @@ function updateHandlers(
   // and handlerTags in BaseGesture references should be updated in the loop above (we need to wait
   // in case of external relations)
   setImmediate(() => {
+    if (!mountedRef.current) return;
     for (let i = 0; i < gesture.length; i++) {
       const handler = preparedGesture.config[i];
 
@@ -575,6 +577,7 @@ export const GestureDetector = (props: GestureDetectorProps) => {
   const useReanimatedHook = gesture.some((g) => g.shouldUseReanimated);
   const viewRef = useRef(null);
   const firstRenderRef = useRef(true);
+  const mountedRef = useRef(false);
   const webEventHandlersRef = useRef<WebEventHandler>({
     onGestureHandlerEvent: (e: HandlerStateChangeEvent<unknown>) => {
       onGestureHandlerEvent(e.nativeEvent);
@@ -619,6 +622,7 @@ export const GestureDetector = (props: GestureDetectorProps) => {
 
   useEffect(() => {
     firstRenderRef.current = true;
+    mountedRef.current = true;
     const viewTag = findNodeHandle(viewRef.current) as number;
 
     validateDetectorChildren(viewRef.current);
@@ -631,6 +635,7 @@ export const GestureDetector = (props: GestureDetectorProps) => {
     });
 
     return () => {
+      mountedRef.current = false;
       dropHandlers(preparedGesture);
     };
   }, []);
@@ -650,7 +655,7 @@ export const GestureDetector = (props: GestureDetectorProps) => {
           webEventHandlersRef,
         });
       } else {
-        updateHandlers(preparedGesture, gestureConfig, gesture);
+        updateHandlers(preparedGesture, gestureConfig, gesture, mountedRef);
       }
     } else {
       firstRenderRef.current = false;

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -247,7 +247,9 @@ function updateHandlers(
   // and handlerTags in BaseGesture references should be updated in the loop above (we need to wait
   // in case of external relations)
   setImmediate(() => {
-    if (!mountedRef.current) return;
+    if (!mountedRef.current) {
+      return;
+    }
     for (let i = 0; i < gesture.length; i++) {
       const handler = preparedGesture.config[i];
 


### PR DESCRIPTION
## Description

This fixes a potential race condition where the component unmounted before the callback passed into `setImmediate` in `updateHandlers` could execute. 

That would lead to a "No handler for tag X" error, since the handler would not have been registered any more at that point in time.

There might also be other race conditions because of that `setImmediate`, but this is the only one I could reproduce.

## Test plan

I encountered this in our project code and debugged it with a [replay recording](https://www.replay.io/). 
I might be able to provide that replay if contacted on a private side channel for verification purposes, but I assume the problem & solution are probably already understandable just by the explanation above.