### PR TITLE
Fix missing `begin` event on Android for Pinch and Rotation

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/PinchGestureHandler.kt
@@ -55,6 +55,11 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       scaleGestureDetector = ScaleGestureDetector(context, gestureListener)
       val configuration = ViewConfiguration.get(context)
       spanSlop = configuration.scaledTouchSlop.toFloat()
+
+      // set the focal point to the position of the first pointer as NaN causes the event not to arrive
+      this.focalPointX = event.x
+      this.focalPointY = event.y
+
       begin()
     }
     scaleGestureDetector?.onTouchEvent(sourceEvent)

--- a/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/RotationGestureHandler.kt
@@ -45,6 +45,11 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
     if (state == STATE_UNDETERMINED) {
       resetProgress()
       rotationGestureDetector = RotationGestureDetector(gestureListener)
+
+      // set the anchor to the position of the first pointer as NaN causes the event not to arrive
+      this.anchorX = event.x
+      this.anchorY = event.y
+
       begin()
     }
     rotationGestureDetector?.onTouchEvent(sourceEvent)


### PR DESCRIPTION
## Description

This PR sets the focal point/anchor to the position of the pointer before sending `begin` event on Android. At the position it's being sent, it's always `NaN` at the moment, which causes the event not to be received by the detector.

## Test plan

Add pinch & rotation gestures to the app and check whether the `begin` event is called.
