### PR TITLE
Fix `onBegin` and `onTouchesDown` events ordering on Android

### DIFF
--- a/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
+++ b/android/lib/src/main/java/com/swmansion/gesturehandler/GestureHandlerOrchestrator.kt
@@ -253,21 +253,10 @@ class GestureHandlerOrchestrator(
 
     val action = sourceEvent.actionMasked
     val event = transformEventToViewCoords(handler.view, MotionEvent.obtain(sourceEvent))
-    
-    // Touch events are sent before the handler itself has a chance to process them,
-    // mainly because `onTouchesUp` shoul be send befor gesture finishes. This means that
-    // the first `onTouchesDown` event is sent before a gesture begins, activation in 
-    // callback for this event causes problems because the handler doesn't have a chance
-    // to initialize itself with starting values of pointer (in pan this causes translation
-    // to be equal to the coordinates of the pointer). The simplest solution is to send
-    // the first `onTouchesDown` event after the handler processes it and changes state
-    // to `BEGAN`.
-    if (handler.needsPointerData && handler.state != 0) {
-      handler.updatePointerData(event)
-    }
+
+    handler.updatePointerData(event)
 
     if (!handler.isAwaiting || action != MotionEvent.ACTION_MOVE) {
-      val isFirstEvent = handler.state == 0
       handler.handle(event, sourceEvent)
       if (handler.isActive) {
         // After handler is done waiting for other one to fail its progress should be
@@ -282,10 +271,6 @@ class GestureHandlerOrchestrator(
           handler.resetProgress()
         }
         handler.dispatchHandlerUpdate(event)
-      }
-
-      if (handler.needsPointerData && isFirstEvent) {
-        handler.updatePointerData(event)
       }
 
       // if event was of type UP or POINTER_UP we request handler to stop tracking now that

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -434,7 +434,12 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   override fun setGestureHandlerState(handlerTag: Int, newState: Int) {
     registry.getHandler(handlerTag)?.let { handler ->
       when (newState) {
-        GestureHandler.STATE_ACTIVE -> handler.activate(force = true)
+        GestureHandler.STATE_ACTIVE -> {
+          // also call begin to force correct state flow in case the `activate` is called in the
+          // UNDETERMINED state
+          handler.begin()
+          handler.activate(force = true)
+        }
         GestureHandler.STATE_BEGAN -> handler.begin()
         GestureHandler.STATE_END -> handler.end()
         GestureHandler.STATE_FAILED -> handler.fail()

--- a/ios/Handlers/RNFlingHandler.m
+++ b/ios/Handlers/RNFlingHandler.m
@@ -2,12 +2,12 @@
 
 @interface RNBetterSwipeGestureRecognizer : UISwipeGestureRecognizer
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
 
 @end
 
 @implementation RNBetterSwipeGestureRecognizer {
-  __weak RNGestureHandler* _gestureHandler;
+  __weak RNGestureHandler *_gestureHandler;
   CGPoint _lastPoint; // location of the most recently updated touch, relative to the view
   bool _hasBegan; // whether the `BEGAN` event has been sent
 }
@@ -27,6 +27,7 @@
   _lastPoint = [[[touches allObjects] objectAtIndex:0] locationInView:_gestureHandler.recognizer.view];
   [_gestureHandler reset];
   [super touchesBegan:touches withEvent:event];
+  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 
   // self.numberOfTouches doesn't work for this because in case than one finger is required,
   // when holding one finger on the screen and tapping with the second one, numberOfTouches is equal
@@ -35,8 +36,6 @@
     [self triggerAction];
     _hasBegan = YES;
   }
-
-  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<UITouch *> *)touches withEvent:(UIEvent *)event
@@ -73,7 +72,8 @@
   [super reset];
 }
 
-- (CGPoint)getLastLocation {
+- (CGPoint)getLastLocation
+{
   // I think keeping the location of only one touch is enough since it would be used to determine the direction
   // of the movement, and if it's wrong the recognizer fails anyway.
   // In case the location of all touches is required, touch events are the way to go
@@ -103,48 +103,50 @@
 
 - (void)configure:(NSDictionary *)config
 {
-    [super configure:config];
-    UISwipeGestureRecognizer *recognizer = (UISwipeGestureRecognizer *)_recognizer;
+  [super configure:config];
+  UISwipeGestureRecognizer *recognizer = (UISwipeGestureRecognizer *)_recognizer;
 
-    id prop = config[@"direction"];
-    if (prop != nil) {
-        recognizer.direction = [RCTConvert NSInteger:prop];
-    }
-    
+  id prop = config[@"direction"];
+  if (prop != nil) {
+    recognizer.direction = [RCTConvert NSInteger:prop];
+  }
+
 #if !TARGET_OS_TV
-    prop = config[@"numberOfPointers"];
-    if (prop != nil) {
-        recognizer.numberOfTouchesRequired = [RCTConvert NSInteger:prop];
-    }
+  prop = config[@"numberOfPointers"];
+  if (prop != nil) {
+    recognizer.numberOfTouchesRequired = [RCTConvert NSInteger:prop];
+  }
 #endif
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
-    RNGestureHandlerState savedState = _lastState;
-    BOOL shouldBegin = [super gestureRecognizerShouldBegin:gestureRecognizer];
-    _lastState = savedState;
-    
-    return shouldBegin;
+  RNGestureHandlerState savedState = _lastState;
+  BOOL shouldBegin = [super gestureRecognizerShouldBegin:gestureRecognizer];
+  _lastState = savedState;
+
+  return shouldBegin;
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(id)_recognizer
 {
-    // For some weird reason [recognizer locationInView:recognizer.view.window] returns (0, 0).
-    // To calculate the correct absolute position, first calculate the absolute position of the
-    // view inside the root view controller (https://stackoverflow.com/a/7448573) and then
-    // add the relative touch position to it.
-    
-    RNBetterSwipeGestureRecognizer *recognizer = (RNBetterSwipeGestureRecognizer *)_recognizer;
-    
-    CGPoint viewAbsolutePosition = [recognizer.view convertPoint:recognizer.view.bounds.origin toView:[UIApplication sharedApplication].keyWindow.rootViewController.view];
-    CGPoint locationInView = [recognizer getLastLocation];
-    
-    return [RNGestureHandlerEventExtraData
-            forPosition:locationInView
-            withAbsolutePosition:CGPointMake(viewAbsolutePosition.x + locationInView.x, viewAbsolutePosition.y + locationInView.y)
-            withNumberOfTouches:recognizer.numberOfTouches];
+  // For some weird reason [recognizer locationInView:recognizer.view.window] returns (0, 0).
+  // To calculate the correct absolute position, first calculate the absolute position of the
+  // view inside the root view controller (https://stackoverflow.com/a/7448573) and then
+  // add the relative touch position to it.
+
+  RNBetterSwipeGestureRecognizer *recognizer = (RNBetterSwipeGestureRecognizer *)_recognizer;
+
+  CGPoint viewAbsolutePosition =
+      [recognizer.view convertPoint:recognizer.view.bounds.origin
+                             toView:[UIApplication sharedApplication].keyWindow.rootViewController.view];
+  CGPoint locationInView = [recognizer getLastLocation];
+
+  return [RNGestureHandlerEventExtraData
+               forPosition:locationInView
+      withAbsolutePosition:CGPointMake(
+                               viewAbsolutePosition.x + locationInView.x, viewAbsolutePosition.y + locationInView.y)
+       withNumberOfTouches:recognizer.numberOfTouches];
 }
 
 @end
-

--- a/ios/Handlers/RNPanHandler.m
+++ b/ios/Handlers/RNPanHandler.m
@@ -26,11 +26,9 @@
 @property (nonatomic) CGFloat failOffsetYEnd;
 @property (nonatomic) CGFloat activateAfterLongPress;
 
-
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler;
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
 
 @end
-
 
 @implementation RNBetterPanGestureRecognizer {
   __weak RNGestureHandler *_gestureHandler;
@@ -38,7 +36,7 @@
   BOOL _hasCustomActivationCriteria;
 }
 
-- (id)initWithGestureHandler:(RNGestureHandler*)gestureHandler
+- (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler
 {
   if ((self = [super initWithTarget:gestureHandler action:@selector(handleGesture:)])) {
     _gestureHandler = gestureHandler;
@@ -96,9 +94,9 @@
   }
 #endif
   [super touchesBegan:touches withEvent:event];
-  [self triggerAction];
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
-    
+  [self triggerAction];
+
   if (!isnan(_activateAfterLongPress)) {
     [self performSelector:@selector(activateAfterLongPress) withObject:nil afterDelay:_activateAfterLongPress];
   }
@@ -108,7 +106,7 @@
 {
   [super touchesMoved:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
-  
+
   if (self.state == UIGestureRecognizerStatePossible && [self shouldFailUnderCustomCriteria]) {
     self.state = UIGestureRecognizerStateFailed;
     return;
@@ -119,14 +117,14 @@
       // then UIGestureRecognizer's sate machine will only transition to
       // UIGestureRecognizerStateCancelled even if you set the state to
       // UIGestureRecognizerStateFailed here. Making the behavior explicit.
-      self.state = (self.state == UIGestureRecognizerStatePossible)
-      ? UIGestureRecognizerStateFailed
-      : UIGestureRecognizerStateCancelled;
+      self.state = (self.state == UIGestureRecognizerStatePossible) ? UIGestureRecognizerStateFailed
+                                                                    : UIGestureRecognizerStateCancelled;
       [self reset];
       return;
     }
   }
-  if (_hasCustomActivationCriteria && self.state == UIGestureRecognizerStatePossible && [self shouldActivateUnderCustomCriteria]) {
+  if (_hasCustomActivationCriteria && self.state == UIGestureRecognizerStatePossible &&
+      [self shouldActivateUnderCustomCriteria]) {
 #if !TARGET_OS_TV
     super.minimumNumberOfTouches = _realMinimumNumberOfTouches;
     if ([self numberOfTouches] >= _realMinimumNumberOfTouches) {
@@ -160,10 +158,9 @@
 
 - (void)updateHasCustomActivationCriteria
 {
-  _hasCustomActivationCriteria = !isnan(_minDistSq)
-  || !isnan(_minVelocityX) || !isnan(_minVelocityY) || !isnan(_minVelocitySq)
-  || !isnan(_activeOffsetXStart) || !isnan(_activeOffsetXEnd)
-  ||  !isnan(_activeOffsetYStart) || !isnan(_activeOffsetYEnd);
+  _hasCustomActivationCriteria = !isnan(_minDistSq) || !isnan(_minVelocityX) || !isnan(_minVelocityY) ||
+      !isnan(_minVelocitySq) || !isnan(_activeOffsetXStart) || !isnan(_activeOffsetXEnd) ||
+      !isnan(_activeOffsetYStart) || !isnan(_activeOffsetYEnd);
 }
 
 - (BOOL)shouldFailUnderCustomCriteria
@@ -174,7 +171,7 @@
     [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(activateAfterLongPress) object:nil];
     return YES;
   }
-    
+
   if (!isnan(_failOffsetXStart) && trans.x < _failOffsetXStart) {
     return YES;
   }
@@ -205,11 +202,11 @@
   if (!isnan(_activeOffsetYEnd) && trans.y > _activeOffsetYEnd) {
     return YES;
   }
-  
+
   if (TEST_MIN_IF_NOT_NAN(VEC_LEN_SQ(trans), _minDistSq)) {
     return YES;
   }
-  
+
   CGPoint velocity = [self velocityInView:self.view];
   if (TEST_MIN_IF_NOT_NAN(velocity.x, _minVelocityX)) {
     return YES;
@@ -220,7 +217,7 @@
   if (TEST_MIN_IF_NOT_NAN(VEC_LEN_SQ(velocity), _minVelocitySq)) {
     return YES;
   }
-  
+
   return NO;
 }
 
@@ -269,7 +266,7 @@
 {
   [super configure:config];
   RNBetterPanGestureRecognizer *recognizer = (RNBetterPanGestureRecognizer *)_recognizer;
-  
+
   APPLY_FLOAT_PROP(minVelocityX);
   APPLY_FLOAT_PROP(minVelocityY);
   APPLY_FLOAT_PROP(activeOffsetXStart);
@@ -284,7 +281,7 @@
 #if !TARGET_OS_TV && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
   if (@available(iOS 13.4, *)) {
     bool enableTrackpadTwoFingerGesture = [RCTConvert BOOL:config[@"enableTrackpadTwoFingerGesture"]];
-    if(enableTrackpadTwoFingerGesture){
+    if (enableTrackpadTwoFingerGesture) {
       recognizer.allowedScrollTypesMask = UIScrollTypeMaskAll;
     }
   }
@@ -292,19 +289,19 @@
   APPLY_NAMED_INT_PROP(minimumNumberOfTouches, @"minPointers");
   APPLY_NAMED_INT_PROP(maximumNumberOfTouches, @"maxPointers");
 #endif
-    
+
   id prop = config[@"minDist"];
   if (prop != nil) {
     CGFloat dist = [RCTConvert CGFloat:prop];
     recognizer.minDistSq = dist * dist;
   }
-  
+
   prop = config[@"minVelocity"];
   if (prop != nil) {
     CGFloat velocity = [RCTConvert CGFloat:prop];
     recognizer.minVelocitySq = velocity * velocity;
   }
-    
+
   prop = config[@"activateAfterLongPress"];
   if (prop != nil) {
     recognizer.activateAfterLongPress = [RCTConvert CGFloat:prop] / 1000.0;
@@ -313,23 +310,22 @@
   [recognizer updateHasCustomActivationCriteria];
 }
 
-- (BOOL) gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
+- (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer
 {
   RNGestureHandlerState savedState = _lastState;
   BOOL shouldBegin = [super gestureRecognizerShouldBegin:gestureRecognizer];
   _lastState = savedState;
-  
+
   return shouldBegin;
 }
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIPanGestureRecognizer *)recognizer
 {
-  return [RNGestureHandlerEventExtraData
-          forPan:[recognizer locationInView:recognizer.view]
-          withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
-          withTranslation:[recognizer translationInView:recognizer.view.window]
-          withVelocity:[recognizer velocityInView:recognizer.view.window]
-          withNumberOfTouches:recognizer.numberOfTouches];
+  return [RNGestureHandlerEventExtraData forPan:[recognizer locationInView:recognizer.view]
+                           withAbsolutePosition:[recognizer locationInView:recognizer.view.window]
+                                withTranslation:[recognizer translationInView:recognizer.view.window]
+                                   withVelocity:[recognizer velocityInView:recognizer.view.window]
+                            withNumberOfTouches:recognizer.numberOfTouches];
 }
 
 @end


### PR DESCRIPTION
## Description

This PR changes the ordering of `onBegin` and `onTouchesDown` events on Android. `onBegin` was invoked first, as some gestures required additional setup when they started tracking the first pointer, which is happening after the touch events are dispatched. The workaround for that was to send `onTouchesDown` later but it resulted in inconsistent behavior between platforms.
This behavior is now updated to defer sending the first `onTouchesDown` to a point in time where the gesture is initialized, but `onBegin` hasn't been called yet - just before sending the `UNDETERMINED` -> `BEGIN` state change event. This way the correct behavior is kept alongside the correct event ordering without the need to modify every handler.

Fixes part of https://github.com/software-mansion/react-native-gesture-handler/issues/2263.

## Test plan

Tested on the example app and on the code from the issue.
