### PR TITLE
Use `ReturnType` instead of explicit `AnimatedInterpolation` type

### DIFF
--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -54,6 +54,10 @@ export type DrawerLockMode = 'unlocked' | 'locked-closed' | 'locked-open';
 
 export type DrawerKeyboardDismissMode = 'none' | 'on-drag';
 
+// Animated.AnimatedInterpolation has been converted to a generic type
+// in @types/react-native 0.70. This way we can maintain compatibility
+// with all versions of @types/react-native`
+type AnimatedInterpolation = ReturnType<Animated.Value['interpolate']>;
 export interface DrawerLayoutProps {
   /**
    * This attribute is present in the standard implementation already and is one
@@ -153,7 +157,7 @@ export interface DrawerLayoutProps {
   // implicit `children` prop has been removed in @types/react^18.0.0
   children?:
     | React.ReactNode
-    | ((openValue?: Animated.AnimatedInterpolation) => React.ReactNode);
+    | ((openValue?: AnimatedInterpolation) => React.ReactNode);
 
   /**
    * @default 'none'
@@ -224,7 +228,7 @@ export default class DrawerLayout extends Component<
     return true;
   }
 
-  private openValue?: Animated.AnimatedInterpolation;
+  private openValue?: AnimatedInterpolation;
   private onGestureEvent?: (
     event: GestureEvent<PanGestureHandlerEventPayload>
   ) => void;
@@ -603,7 +607,7 @@ export default class DrawerLayout extends Component<
       };
     }
 
-    let drawerTranslateX: number | Animated.AnimatedInterpolation = 0;
+    let drawerTranslateX: number | AnimatedInterpolation = 0;
     if (drawerSlide) {
       const closedDrawerOffset = fromLeft ? -drawerWidth! : drawerWidth!;
       if (this.state.drawerState !== IDLE) {
@@ -617,7 +621,7 @@ export default class DrawerLayout extends Component<
       }
     }
     const drawerStyles: {
-      transform: { translateX: number | Animated.AnimatedInterpolation }[];
+      transform: { translateX: number | AnimatedInterpolation }[];
       flexDirection: 'row-reverse' | 'row';
     } = {
       transform: [{ translateX: drawerTranslateX }],

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -36,6 +36,11 @@ type SwipeableExcludes = Exclude<
   'onGestureEvent' | 'onHandlerStateChange'
 >;
 
+// Animated.AnimatedInterpolation has been converted to a generic type
+// in @types/react-native 0.70. This way we can maintain compatibility
+// with all versions of @types/react-native
+type AnimatedInterpolation = ReturnType<Animated.Value['interpolate']>;
+
 export interface SwipeableProps
   extends Pick<PanGestureHandlerProps, SwipeableExcludes> {
   /**
@@ -150,8 +155,8 @@ export interface SwipeableProps
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
   renderLeftActions?: (
-    progressAnimatedValue: Animated.AnimatedInterpolation,
-    dragAnimatedValue: Animated.AnimatedInterpolation
+    progressAnimatedValue: AnimatedInterpolation,
+    dragAnimatedValue: AnimatedInterpolation
   ) => React.ReactNode;
   /**
    *
@@ -163,8 +168,8 @@ export interface SwipeableProps
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
   renderRightActions?: (
-    progressAnimatedValue: Animated.AnimatedInterpolation,
-    dragAnimatedValue: Animated.AnimatedInterpolation,
+    progressAnimatedValue: AnimatedInterpolation,
+    dragAnimatedValue: AnimatedInterpolation,
     swipeable: Swipeable
   ) => React.ReactNode;
 
@@ -242,11 +247,11 @@ export default class Swipeable extends Component<
   private onGestureEvent?: (
     event: GestureEvent<PanGestureHandlerEventPayload>
   ) => void;
-  private transX?: Animated.AnimatedInterpolation;
-  private showLeftAction?: Animated.AnimatedInterpolation | Animated.Value;
-  private leftActionTranslate?: Animated.AnimatedInterpolation;
-  private showRightAction?: Animated.AnimatedInterpolation | Animated.Value;
-  private rightActionTranslate?: Animated.AnimatedInterpolation;
+  private transX?: AnimatedInterpolation;
+  private showLeftAction?: AnimatedInterpolation | Animated.Value;
+  private leftActionTranslate?: AnimatedInterpolation;
+  private showRightAction?: AnimatedInterpolation | Animated.Value;
+  private rightActionTranslate?: AnimatedInterpolation;
 
   private updateAnimatedEvent = (
     props: SwipeableProps,


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2259.

In `@types/react-native` 0.70 `AnimatedInterpolation` has been changed to be a generic type. This PR replaces explicit usage of `Animated.AnimatedInterpolation` with `ReturnType<Animated.Value["interpolate"]>`. This way we can maintain compatibility with both - generic and non-generic ones, preventing type errors.

Thanks for @tomekzaw for the suggestion.

## Test plan

`yarn ts-check` with different versions of types installed.
