### PR TITLE
Fix default `shouldCancelWhenOutside` on iOS and Android

### DIFF
--- a/src/handlers/LongPressGestureHandler.ts
+++ b/src/handlers/LongPressGestureHandler.ts
@@ -82,5 +82,7 @@ export const LongPressGestureHandler = createHandler<
     ...baseGestureHandlerProps,
     ...longPressGestureHandlerProps,
   ] as const,
-  config: {},
+  config: {
+    shouldCancelWhenOutside: true,
+  },
 });

--- a/src/handlers/TapGestureHandler.ts
+++ b/src/handlers/TapGestureHandler.ts
@@ -88,5 +88,7 @@ export const TapGestureHandler = createHandler<
     ...baseGestureHandlerProps,
     ...tapGestureHandlerProps,
   ] as const,
-  config: {},
+  config: {
+    shouldCancelWhenOutside: true,
+  },
 });

--- a/src/handlers/gestures/longPressGesture.ts
+++ b/src/handlers/gestures/longPressGesture.ts
@@ -11,6 +11,7 @@ export class LongPressGesture extends BaseGesture<LongPressGestureHandlerEventPa
     super();
 
     this.handlerName = 'LongPressGestureHandler';
+    this.shouldCancelWhenOutside(true);
   }
 
   minDuration(duration: number) {

--- a/src/handlers/gestures/tapGesture.ts
+++ b/src/handlers/gestures/tapGesture.ts
@@ -11,6 +11,7 @@ export class TapGesture extends BaseGesture<TapGestureHandlerEventPayload> {
     super();
 
     this.handlerName = 'TapGestureHandler';
+    this.shouldCancelWhenOutside(true);
   }
 
   minPointers(minPointers: number) {

--- a/src/web/handlers/LongPressGestureHandler.ts
+++ b/src/web/handlers/LongPressGestureHandler.ts
@@ -22,7 +22,6 @@ export default class LongPressGestureHandler extends GestureHandler {
 
   public init(ref: number, propsRef: React.RefObject<unknown>) {
     super.init(ref, propsRef);
-    this.setShouldCancelWhenOutside(true);
 
     this.view.oncontextmenu = () => false;
   }

--- a/src/web/handlers/TapGestureHandler.ts
+++ b/src/web/handlers/TapGestureHandler.ts
@@ -33,7 +33,6 @@ export default class TapGestureHandler extends GestureHandler {
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
-    this.setShouldCancelWhenOutside(true);
   }
 
   public updateGestureConfig({ enabled = true, ...props }: Config): void {


### PR DESCRIPTION
## Description

This PR makes the same changes as #2286. It was created because the other one got really messy, since there were some problems with iOS linter.

## Test plan

Tested on example app with provided repro.
