### PR TITLE
Update the commit hash in `.git-blame-ignore-revs`

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,3 +1,3 @@
 # .git-blame-ignore-revs
 # Reformatted iOS codebase
-93e0d1d41c0ce985327363c230453846df42d439
+9cf4245740e01f216850da999a7e630da53c7ea6


### PR DESCRIPTION
## Description

This PR updates the commit hash in `.git-blame-ignore-revs` as said in the description of https://github.com/software-mansion/react-native-gesture-handler/pull/2296.
