### PR TITLE
Provide proper Algolia Search API key

### DIFF
--- a/docs/docusaurus.config.js
+++ b/docs/docusaurus.config.js
@@ -83,7 +83,7 @@ module.exports = {
   themeConfig: {
     algolia: {
       appId: 'BKGDKVWG6F',
-      apiKey: 'd738e28e9c67a26dd7933b011fe2b9e4',
+      apiKey: '742696612cb124b06465cf68bce6ec92',
       indexName: 'react-native-gesture-handler',
       // contextualSearch: true, // doesn't work for some reason
     },


### PR DESCRIPTION
## Description

Algolia Search isn't working in the React Native Gesture Handler documentation due to a mismatched Search API key.

This PR provides a proper API key from Algolia's dashboard which you can witness for yourself in this screenshot 😁 

![image](https://user-images.githubusercontent.com/39658211/200256993-7cb0b3ff-a6ee-49b2-9697-1547c840f556.png)



## Test plan

Run docs locally:

```
cd docs
yarn start
```

### Before

![image](https://user-images.githubusercontent.com/39658211/200256336-bc92be6c-8e88-491b-8294-824f230ce261.png)


### After

![image](https://user-images.githubusercontent.com/39658211/200256143-b77efa28-9737-4b71-9654-a32ed6f1936b.png)



