### PR TITLE
Update finding the `react-native` package path

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,25 +27,33 @@ def isNewArchitectureEnabled() {
     return project.hasProperty("newArchEnabled") && project.newArchEnabled == "true"
 }
 
-static def findNodeModulePath(baseDir, packageName) {
-    def basePath = baseDir.toPath().normalize()
-    // Node's module resolution algorithm searches up to the root directory,
-    // after which the base path will be null
-    while (basePath) {
-        def candidatePath = Paths.get(basePath.toString(), "node_modules", packageName)
-        if (candidatePath.toFile().exists()) {
-            return candidatePath.toString()
-        }
-        basePath = basePath.getParent()
-    }
-    return null
+def safeExtGet(prop, fallback) {
+    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
-def findNodeModulePath(packageName) {
-    // Don't start in the project dir, as its path ends with node_modules/react-native-gesture-handler/android
-    // we want to go two levels up, so we end up in the first_node modules and eventually
-    // search upwards if the package is not found there
-    return findNodeModulePath(projectDir.toPath().parent.parent.toFile(), packageName)
+def resolveReactNativeDirectory() {
+    def reactNativeLocation = safeExtGet("REACT_NATIVE_NODE_MODULES_DIR", null)
+    if (reactNativeLocation != null) {
+        return file(reactNativeLocation)
+    }
+
+    // monorepo workaround
+    // react-native can be hoisted or in project's own node_modules
+    def reactNativeFromProjectNodeModules = file("${rootProject.projectDir}/../node_modules/react-native")
+    if (reactNativeFromProjectNodeModules.exists()) {
+        return reactNativeFromProjectNodeModules
+    }
+
+    def reactNativeFromNodeModulesWithReanimated = file("${projectDir}/../../react-native")
+    if (reactNativeFromNodeModulesWithReanimated.exists()) {
+        return reactNativeFromNodeModulesWithReanimated
+    }
+
+    throw new Exception(
+        "[react-native-gesture-native] Unable to resolve react-native location in " +
+            "node_modules. You should add project extension property (in app/build.gradle) " +
+            "`REACT_NATIVE_NODE_MODULES_DIR` with path to react-native."
+    )
 }
 
 if (isNewArchitectureEnabled()) {
@@ -56,10 +64,6 @@ apply plugin: 'kotlin-android'
 
 if (project == rootProject) {
     apply from: "spotless.gradle"
-}
-
-def safeExtGet(prop, fallback) {
-    rootProject.ext.has(prop) ? rootProject.ext.get(prop) : fallback
 }
 
 // Check whether Reanimated 2.3 or higher is installed alongside Gesture Handler
@@ -102,7 +106,7 @@ def noMultipleInstancesAssertion() {
     }
 }
 
-def REACT_NATIVE_DIR = findNodeModulePath("react-native")
+def REACT_NATIVE_DIR = resolveReactNativeDirectory()
 
 def assertionTask = task assertNoMultipleInstances {
     onlyIf { shouldAssertNoMultipleInstances() }


### PR DESCRIPTION
## Description

This PR updates the code responsible for finding the `react-native` path on Android to support more cases. The code is borrowed from `react-native-reanimated` so it should be working correctly. 
