### PR TITLE
Fix buttons getting locked in some cases on Android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -331,6 +331,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       // don't preform click when a child button is pressed (mainly to prevent sound effect of
       // a parent button from playing)
       return if (!isChildTouched() && soundResponder == this) {
+        tryFreeingResponder()
         soundResponder = null
         super.performClick()
       } else {


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2312

Buttons rely on the NativeViewGestureHandler that wraps them for some of the state management, mainly for freeing responder which acts as a lock to prevent more than one exclusive buttons from getting pressed at the same time. This proved problematic as this method was not always called.

This PR fixes it by also calling `tryFreeingResponder` in the `performClick` method, which is called by Android, so I assume we can rely on it.

## Test plan

Tested on the code from snack.
