### PR TITLE
fix RNGH not working in pnpm project

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -93,6 +93,7 @@ def noMultipleInstancesAssertion() {
     Set<File> files = fileTree(rootDir.parent) {
         include "node_modules/**/react-native-gesture-handler/package.json"
         exclude "**/.yarn/**"
+        exclude "**/.pnpm/**"
     }.files
 
     if (files.size() > 1) {


### PR DESCRIPTION
in pnpm project, there will be many RNGH instances since some package has depend on RNGH, pnpm will generate such folder, which will break `noMultipleInstancesAssertion` function

## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

<!--
Describe how did you test this change here.
-->
