### PR TITLE
Added disableSelection prop

### DIFF
--- a/docs/docs/api/gestures/gesture-detector.md
+++ b/docs/docs/api/gestures/gesture-detector.md
@@ -29,3 +29,7 @@ Starting with Reanimated-2.3.0-beta.4 Gesture Handler will provide a [StateManag
 ### `userSelect` (**web only**)
 
 This parameter allows to specify which `userSelect` property should be applied to underlying view. Possible values are `"none" | "auto" | "text"`. Defaults to `"none"`.
+
+### `disableSelection` (**web only**)
+
+This parameter disables selection. If enabled `onselectstart` returns `false`. Defaults to `false`.

--- a/docs/docs/gesture-handlers/api/common-gh.md
+++ b/docs/docs/gesture-handlers/api/common-gh.md
@@ -67,6 +67,10 @@ Specifying `width` or `height` is useful if we only want the gesture to activate
 
 This parameter allows to specify which `userSelect` property should be applied to underlying view. Possible values are `"none" | "auto" | "text"`. Defaults to `"none"`.
 
+### `disableSelection` (**web only**)
+
+This parameter disables selection. If enabled `onselectstart` returns `false`. Defaults to `false`.
+
 ### `onGestureEvent`
 
 Takes a callback that is going to be triggered for each subsequent touch event while the handler is in an [ACTIVE](../basics/state.md#active) state. Event payload depends on the particular handler type. Common set of event data attributes is documented [below](#event-data) and handler specific attributes are documented on the corresponding handler pages. E.g. event payload for [`PinchGestureHandler`](./rotation-gh.md#event-data) contains `scale` attribute that represents how the distance between fingers changed since when the gesture started.

--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -165,6 +165,8 @@ export interface DrawerLayoutProps {
    * Values: 'none'|'text'|'auto'
    */
   userSelect?: UserSelect;
+
+  disableSelection?: boolean;
 }
 
 export type DrawerLayoutState = {
@@ -691,6 +693,7 @@ export default class DrawerLayout extends Component<
       <PanGestureHandler
         // @ts-ignore could be fixed in handler types
         userSelect={this.props.userSelect}
+        disableSelection={this.props.disableSelection}
         ref={this.setPanGestureRef}
         hitSlop={hitSlop}
         activeOffsetX={gestureOrientation * minSwipeDistance!}

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -19,6 +19,7 @@ const commonProps = [
   'hitSlop',
   'cancelsTouchesInView',
   'userSelect',
+  'disableSelection',
 ] as const;
 
 const componentInteractionProps = ['waitFor', 'simultaneousHandlers'] as const;
@@ -105,6 +106,7 @@ export type CommonGestureConfig = {
   shouldCancelWhenOutside?: boolean;
   hitSlop?: HitSlop;
   userSelect?: UserSelect;
+  disableSelection?: boolean;
 };
 
 // Events payloads are types instead of interfaces due to TS limitation.

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -591,9 +591,19 @@ const applyUserSelectProp = (
   }
 };
 
+const applyDisableSelectionProp = (
+  disableSelection: boolean,
+  gesture: ComposedGesture | GestureType
+): void => {
+  for (const g of gesture.toGestureArray()) {
+    g.config.disableSelection = disableSelection;
+  }
+};
+
 interface GestureDetectorProps {
   gesture: ComposedGesture | GestureType;
   userSelect?: UserSelect;
+  disableSelection?: boolean;
   children?: React.ReactNode;
 }
 export const GestureDetector = (props: GestureDetectorProps) => {
@@ -601,6 +611,10 @@ export const GestureDetector = (props: GestureDetectorProps) => {
 
   if (props.userSelect) {
     applyUserSelectProp(props.userSelect, gestureConfig);
+  }
+
+  if (props.disableSelection) {
+    applyDisableSelectionProp(props.disableSelection, gestureConfig);
   }
 
   const gesture = gestureConfig.toGestureArray();

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -82,6 +82,10 @@ export default abstract class GestureHandler {
       this.view.style['webkitUserSelect'] = this.config.userSelect;
       this.view.style['userSelect'] = this.config.userSelect;
     }
+
+    if (this.config.disableSelection) {
+      this.view.onselectstart = () => false;
+    }
   }
 
   private addEventManager(manager: EventManager): void {

--- a/src/web/interfaces.ts
+++ b/src/web/interfaces.ts
@@ -34,6 +34,7 @@ export interface Config extends Record<string, ConfigArgs> {
   hitSlop?: HitSlop;
   shouldCancelWhenOutside?: boolean;
   userSelect?: UserSelect;
+  disableSelection?: boolean;
 
   activateAfterLongPress?: number;
   failOffsetXStart?: number;

--- a/src/web_hammer/GestureHandler.ts
+++ b/src/web_hammer/GestureHandler.ts
@@ -287,7 +287,7 @@ abstract class GestureHandler {
 
     if (this.config.disableSelection) {
       const viewHTMLElement = this.view as unknown as HTMLElement;
-      this.viewHTMLElement.onselectstart = () => false;
+      viewHTMLElement.onselectstart = () => false;
     }
 
     // When the browser starts handling the gesture (e.g. scrolling), it sends a pointercancel event and stops

--- a/src/web_hammer/GestureHandler.ts
+++ b/src/web_hammer/GestureHandler.ts
@@ -284,6 +284,10 @@ abstract class GestureHandler {
 
     this.view = findNodeHandle(ref);
 
+    if (this.config.disableSelection) {
+      this.view.onselectstart = () => false;
+    }
+
     // When the browser starts handling the gesture (e.g. scrolling), it sends a pointercancel event and stops
     // sending additional pointer events. This is not the case with touch events, so if the gesture is simultaneous
     // with a NativeGestureHandler, we need to check if touch events are supported and use them if possible.

--- a/src/web_hammer/GestureHandler.ts
+++ b/src/web_hammer/GestureHandler.ts
@@ -30,6 +30,7 @@ export type Config = Partial<{
   activeOffsetYEnd: number;
   waitFor: any[] | null;
   simultaneousHandlers: any[] | null;
+  disableSelection: boolean;
 }>;
 
 type NativeEvent = ReturnType<GestureHandler['transformEventData']>;
@@ -39,7 +40,7 @@ let gestureInstances = 0;
 abstract class GestureHandler {
   public handlerTag: any;
   public isGestureRunning = false;
-  public view: number | null = null;
+  public view: number | HTMLElement | null = null;
   protected hasCustomActivationCriteria: boolean;
   protected hasGestureFailed = false;
   protected hammer: HammerManager | null = null;
@@ -285,7 +286,8 @@ abstract class GestureHandler {
     this.view = findNodeHandle(ref);
 
     if (this.config.disableSelection) {
-      this.view.onselectstart = () => false;
+      const viewHTMLElement = this.view as unknown as HTMLElement;
+      this.viewHTMLElement.onselectstart = () => false;
     }
 
     // When the browser starts handling the gesture (e.g. scrolling), it sends a pointercancel event and stops


### PR DESCRIPTION
## Description

Added `disableSelection` prop

This prop is mostly useful for `PanGestureHandler` especially on Safari.
Because Safari changes the cursor to `text` once you start dragging which is undesirable.
Passing `disableSelection` fixes the issue.

```
<PanGestureHandler onGestureEvent={props.onGesture} disableSelection>
    ...
</PanGestureHandler>
```

## Test plan

Tested on https://github.com/Expensify/App/issues/13688