### PR TITLE
Cocoapods: Fix deprecated/removed File.exists method 

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -2,7 +2,7 @@ require "json"
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
-isUserApp = File.exists(File.join(__dir__, "..", "..", "node_modules", "react-native", "package.json"))
+isUserApp = File.exist?(File.join(__dir__, "..", "..", "node_modules", "react-native", "package.json"))
 if isUserApp
   libInstances = %x[find ../../ -name "package.json" | grep "/react-native-gesture-handler/package.json" | grep -v "/.yarn/"]
   libInstancesArray = libInstances.split("\n")

--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -2,7 +2,7 @@ require "json"
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
-isUserApp = File.exists?(File.join(__dir__, "..", "..", "node_modules", "react-native", "package.json"))
+isUserApp = File.exists(File.join(__dir__, "..", "..", "node_modules", "react-native", "package.json"))
 if isUserApp
   libInstances = %x[find ../../ -name "package.json" | grep "/react-native-gesture-handler/package.json" | grep -v "/.yarn/"]
   libInstancesArray = libInstances.split("\n")


### PR DESCRIPTION
## Description
When I upgraded Ruby on accident to 3 - that my pod install failed with:
```
[!] Invalid 'Podfile' file: 
[!] Invalid 'RNGestureHandler.podspec' file: undefined method 'exists?' for File:Class.

 # from /Users/xx/iOSProjects/xx-app/node_modules/react-native-gesture-handler/RNGestureHandler.podspec:5
 # -------------------------------------------
 # reanimated_package_json = JSON.parse(File.read(File.join(__dir__, "package.json")))
 >  config = find_config()
 ```
 
 Resolves the removed method of File.exists in Ruby3. The alternative method of File.exist is recommended and already exists on 2.5 for no breaking changes.

https://rubyapi.org/2.5/o/file#method-c-exist-3F

## Test plan
A local working `pod install`
