### PR TITLE
Prevent i beam on safari if userSelect is none

### DIFF
--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -83,7 +83,7 @@ export default abstract class GestureHandler {
       this.view.style['userSelect'] = this.config.userSelect;
     }
 
-    this.view.onselectstart = () => !!this.config.userSelect && this.config.userSelect !== 'none';
+    this.view.onselectstart = () => this.config.userSelect !== 'none';
   }
 
   private addEventManager(manager: EventManager): void {

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -82,6 +82,9 @@ export default abstract class GestureHandler {
       this.view.style['webkitUserSelect'] = this.config.userSelect;
       this.view.style['userSelect'] = this.config.userSelect;
     }
+    if (this.view.style['userSelect'] == 'none') {
+      this.view.onselectstart = () => false;
+    }
   }
 
   private addEventManager(manager: EventManager): void {

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -83,7 +83,7 @@ export default abstract class GestureHandler {
       this.view.style['userSelect'] = this.config.userSelect;
     }
 
-    this.view.onselectstart = () => this.config.userSelect && this.config.userSelect !== 'none';
+    this.view.onselectstart = () => !!this.config.userSelect && this.config.userSelect !== 'none';
   }
 
   private addEventManager(manager: EventManager): void {

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -82,9 +82,8 @@ export default abstract class GestureHandler {
       this.view.style['webkitUserSelect'] = this.config.userSelect;
       this.view.style['userSelect'] = this.config.userSelect;
     }
-    if (this.view.style['userSelect'] == 'none') {
-      this.view.onselectstart = () => false;
-    }
+
+    this.view.onselectstart = () => this.config.userSelect && this.config.userSelect !== 'none';
   }
 
   private addEventManager(manager: EventManager): void {

--- a/src/web_hammer/GestureHandler.ts
+++ b/src/web_hammer/GestureHandler.ts
@@ -6,6 +6,7 @@ import { findNodeHandle } from 'react-native';
 import { State } from '../State';
 import { EventMap } from './constants';
 import * as NodeManager from './NodeManager';
+import { UserSelect } from '../handlers/gestureHandlerCommon';
 
 // TODO(TS) Replace with HammerInput if https://github.com/DefinitelyTyped/DefinitelyTyped/pull/50438/files is merged
 export type HammerInputExt = Omit<HammerInput, 'destroy' | 'handler' | 'init'>;
@@ -30,6 +31,7 @@ export type Config = Partial<{
   activeOffsetYEnd: number;
   waitFor: any[] | null;
   simultaneousHandlers: any[] | null;
+  useSelect?: UserSelect;
 }>;
 
 type NativeEvent = ReturnType<GestureHandler['transformEventData']>;
@@ -283,6 +285,8 @@ abstract class GestureHandler {
     this.ref = ref;
 
     this.view = findNodeHandle(ref);
+    const viewAsElement = this.view as unknown as HTMLElement;
+    viewAsElement.onselectstart = () => this.config.useSelect && this.config.useSelect !== 'none';
 
     // When the browser starts handling the gesture (e.g. scrolling), it sends a pointercancel event and stops
     // sending additional pointer events. This is not the case with touch events, so if the gesture is simultaneous

--- a/src/web_hammer/GestureHandler.ts
+++ b/src/web_hammer/GestureHandler.ts
@@ -285,7 +285,7 @@ abstract class GestureHandler {
     this.ref = ref;
 
     this.view = findNodeHandle(ref);
-    (this.view as unknown as HTMLElement).onselectstart = () => this.config.userSelect && this.config.userSelect !== 'none';
+    (this.view as unknown as HTMLElement).onselectstart = () => !!this.config.userSelect && this.config.userSelect !== 'none';
 
     // When the browser starts handling the gesture (e.g. scrolling), it sends a pointercancel event and stops
     // sending additional pointer events. This is not the case with touch events, so if the gesture is simultaneous

--- a/src/web_hammer/GestureHandler.ts
+++ b/src/web_hammer/GestureHandler.ts
@@ -31,7 +31,7 @@ export type Config = Partial<{
   activeOffsetYEnd: number;
   waitFor: any[] | null;
   simultaneousHandlers: any[] | null;
-  useSelect?: UserSelect;
+  userSelect?: UserSelect;
 }>;
 
 type NativeEvent = ReturnType<GestureHandler['transformEventData']>;
@@ -286,7 +286,7 @@ abstract class GestureHandler {
 
     this.view = findNodeHandle(ref);
     const viewAsElement = this.view as unknown as HTMLElement;
-    viewAsElement.onselectstart = () => this.config.useSelect && this.config.useSelect !== 'none';
+    viewAsElement.onselectstart = () => this.config.userSelect && this.config.userSelect !== 'none';
 
     // When the browser starts handling the gesture (e.g. scrolling), it sends a pointercancel event and stops
     // sending additional pointer events. This is not the case with touch events, so if the gesture is simultaneous

--- a/src/web_hammer/GestureHandler.ts
+++ b/src/web_hammer/GestureHandler.ts
@@ -285,8 +285,7 @@ abstract class GestureHandler {
     this.ref = ref;
 
     this.view = findNodeHandle(ref);
-    const viewAsElement = this.view as unknown as HTMLElement;
-    viewAsElement.onselectstart = () => this.config.userSelect && this.config.userSelect !== 'none';
+    (this.view as unknown as HTMLElement).onselectstart = () => this.config.userSelect && this.config.userSelect !== 'none';
 
     // When the browser starts handling the gesture (e.g. scrolling), it sends a pointercancel event and stops
     // sending additional pointer events. This is not the case with touch events, so if the gesture is simultaneous

--- a/src/web_hammer/GestureHandler.ts
+++ b/src/web_hammer/GestureHandler.ts
@@ -285,7 +285,7 @@ abstract class GestureHandler {
     this.ref = ref;
 
     this.view = findNodeHandle(ref);
-    (this.view as unknown as HTMLElement).onselectstart = () => !!this.config.userSelect && this.config.userSelect !== 'none';
+    (this.view as unknown as HTMLElement).onselectstart = () => this.config.userSelect !== 'none';
 
     // When the browser starts handling the gesture (e.g. scrolling), it sends a pointercancel event and stops
     // sending additional pointer events. This is not the case with touch events, so if the gesture is simultaneous


### PR DESCRIPTION
## Description

Safari use I-Beam cursor on drag on most of the elements, exclude some native element like button, anchor tag etc...
We are using gesture on div that's way safari show I-Beam cursor on drag.
We already have userSelect prop which we can use to prevent text select. This PR extending the use of userSelect prop, if userSelect is none prevent safari default behaviour to show I-Beam cursor on drag.

As indicate in Safari webkit source code:
https://github.com/WebKit/WebKit/blob/3c53378a77e57141a3b53f344e4bc1c14f7cef39/Source/WebCore/page/EventHandler.cpp#L1553

What we are trying to fix:

https://user-images.githubusercontent.com/114683042/212810714-5615bc84-94d8-44f4-bfc1-6ec825170789.mp4

As in video on drag slider cursor changing to I-Beam cursor even when userSelect passed as none.

## Test plan

Tested on Expensify app in https://github.com/Expensify/App/issues/13688
