### PR TITLE
Hide `back-to-top` button in the docs

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -665,3 +665,7 @@ header > .container {
 .imageHolder-sponsor {
   max-width: 100px;
 }
+
+.theme-back-to-top-button {
+  display: none;
+}


### PR DESCRIPTION
## Description

This PR hides the broken back-to-top button in the docs.

## Test plan

Open the docs and scroll a bit.
