### PR TITLE
Add `dragOffsetFromLeftEdge` and `dragOffsetFromRightEdge` props to `Swipeable`

### DIFF
--- a/docs/docs/api/components/swipeable.md
+++ b/docs/docs/api/components/swipeable.md
@@ -35,11 +35,11 @@ distance from the left edge at which released panel will animate to the open sta
 
 distance from the right edge at which released panel will animate to the open state (or the open panel will animate into the closed state). By default it's a half of the panel's width.
 
-### `dragOffsetLeft`
+### `dragOffsetFromLeftEdge`
 
 distance that the panel must be dragged from the left edge to be considered a swipe. The default value is 10.
 
-### `dragOffsetRight`
+### `dragOffsetFromRightEdge`
 
 distance that the panel must be dragged from the right edge to be considered a swipe. The default value is 10.
 

--- a/docs/docs/api/components/swipeable.md
+++ b/docs/docs/api/components/swipeable.md
@@ -35,6 +35,14 @@ distance from the left edge at which released panel will animate to the open sta
 
 distance from the right edge at which released panel will animate to the open state (or the open panel will animate into the closed state). By default it's a half of the panel's width.
 
+### `dragOffsetLeft`
+
+distance that the panel must be dragged from the left edge to be considered a swipe. The default value is 10.
+
+### `dragOffsetRight`
+
+distance that the panel must be dragged from the right edge to be considered a swipe. The default value is 10.
+
 ### `overshootLeft`
 
 a boolean value indicating if the swipeable panel can be pulled further than the left actions panel's width. It is set to `true` by default as long as the left panel render method is present.

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -74,6 +74,18 @@ export interface SwipeableProps
   rightThreshold?: number;
 
   /**
+   * Distance that the panel must be dragged from the left edge to be considered
+   * a swipe. The default value is 10.
+   */
+  dragOffsetLeft?: number;
+
+  /**
+   * Distance that the panel must be dragged from the right edge to be considered
+   * a swipe. The default value is 10.
+   */
+  dragOffsetRight?: number;
+
+  /**
    * Value indicating if the swipeable panel can be pulled further than the left
    * actions panel's width. It is set to true by default as long as the left
    * panel render method is present.
@@ -444,7 +456,13 @@ export default class Swipeable extends Component<
 
   render() {
     const { rowState } = this.state;
-    const { children, renderLeftActions, renderRightActions } = this.props;
+    const {
+      children,
+      renderLeftActions,
+      renderRightActions,
+      dragOffsetLeft = 10,
+      dragOffsetRight = 10,
+    } = this.props;
 
     const left = renderLeftActions && (
       <Animated.View
@@ -481,7 +499,7 @@ export default class Swipeable extends Component<
 
     return (
       <PanGestureHandler
-        activeOffsetX={[-10, 10]}
+        activeOffsetX={[-dragOffsetRight, dragOffsetLeft]}
         {...this.props}
         onGestureEvent={this.onGestureEvent}
         onHandlerStateChange={this.onHandlerStateChange}>

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -77,13 +77,13 @@ export interface SwipeableProps
    * Distance that the panel must be dragged from the left edge to be considered
    * a swipe. The default value is 10.
    */
-  dragOffsetLeft?: number;
+  dragOffsetFromLeftEdge?: number;
 
   /**
    * Distance that the panel must be dragged from the right edge to be considered
    * a swipe. The default value is 10.
    */
-  dragOffsetRight?: number;
+  dragOffsetFromRightEdge?: number;
 
   /**
    * Value indicating if the swipeable panel can be pulled further than the left
@@ -460,8 +460,8 @@ export default class Swipeable extends Component<
       children,
       renderLeftActions,
       renderRightActions,
-      dragOffsetLeft = 10,
-      dragOffsetRight = 10,
+      dragOffsetFromLeftEdge = 10,
+      dragOffsetFromRightEdge = 10,
     } = this.props;
 
     const left = renderLeftActions && (
@@ -499,7 +499,7 @@ export default class Swipeable extends Component<
 
     return (
       <PanGestureHandler
-        activeOffsetX={[-dragOffsetRight, dragOffsetLeft]}
+        activeOffsetX={[-dragOffsetFromRightEdge, dragOffsetFromLeftEdge]}
         {...this.props}
         onGestureEvent={this.onGestureEvent}
         onHandlerStateChange={this.onHandlerStateChange}>


### PR DESCRIPTION
## Description

This PR adds `dragOffsetLeft ` and `dragOffsetRight` props to GH's `Swipeable` component. Those props to customize how much the user must swipe from each edge for the gesture to activate.

Closes https://github.com/software-mansion/react-native-gesture-handler/issues/2380

## Test plan

Create the `Swipeable` component, set the new props, and check that they work.
