### PR TITLE
Fix types for gestureHandlerRootHOC to accept component with props

### DIFF
--- a/src/gestureHandlerRootHOC.tsx
+++ b/src/gestureHandlerRootHOC.tsx
@@ -4,7 +4,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import GestureHandlerRootView from './GestureHandlerRootView';
 
 export default function gestureHandlerRootHOC<
-  P extends JSX.IntrinsicAttributes
+  P extends Record<string, unknown>
 >(
   Component: React.ComponentType<P>,
   containerStyles?: StyleProp<ViewStyle>


### PR DESCRIPTION
## Description

This PR fixes types for `gestureHandlerRootHOC` because it seems that this HOC accepts only components without any props otherwise it will throw TS error. Check issue for details #2412 

Fixes #2412 

## Test plan

<!--
Describe how did you test this change here.
-->
