### PR TITLE
Fix ripple always showing on Touchables when on Android 13

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -234,12 +234,18 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       }
     }
 
-    private fun createSelectableDrawable(): Drawable {
+    private fun createSelectableDrawable(): Drawable? {
       // TODO: remove once support for RN 0.63 is dropped, since 0.64 minSdkVersion is 21
       if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
         context.theme.resolveAttribute(android.R.attr.selectableItemBackground, resolveOutValue, true)
         @Suppress("Deprecation")
         return resources.getDrawable(resolveOutValue.resourceId)
+      }
+
+      // Since Android 13, alpha channel in RippleDrawable is clamped between [128, 255]
+      // see https://github.com/aosp-mirror/platform_frameworks_base/blob/c1bd0480261460584753508327ca8a0c6fc80758/graphics/java/android/graphics/drawable/RippleDrawable.java#L1012
+      if (rippleColor == Color.TRANSPARENT) {
+        return null
       }
 
       val states = arrayOf(intArrayOf(android.R.attr.state_enabled))


### PR DESCRIPTION
## Description

On Android 13 the [default ripple behavior changed](https://github.com/aosp-mirror/platform_frameworks_base/commit/475648ae0250621d62b855546351bc4f6192c417) from limiting ripple's alpha channel to max 128 to enforcing at minimum 128. This resulted in GH's touchables showing ripple when they shouldn't as they relied on setting the ripple color to `transparent` to prevent it.

This PR provides a simple fix that returns `null` instead of `RippleDrawable` when the ripple color is set to `transparent`. Thanks, @bfricka for the investigation!

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2326

## Test plan

Check the `Touchables` example on Android 13 and below
