### PR TITLE
Show error when gestures are used without root view

### DIFF
--- a/src/GestureHandlerRootView.android.tsx
+++ b/src/GestureHandlerRootView.android.tsx
@@ -4,6 +4,7 @@ import { PropsWithChildren } from 'react';
 import { requireNativeComponent, ViewProps } from 'react-native';
 import { maybeInitializeFabric } from './init';
 import { shouldUseCodegenNativeComponent } from './utils';
+import GestureHandlerRootViewContext from './GestureHandlerRootViewContext';
 
 const GestureHandlerRootViewNativeComponent = shouldUseCodegenNativeComponent()
   ? require('./fabric/RNGestureHandlerRootViewNativeComponent').default
@@ -20,5 +21,9 @@ export default function GestureHandlerRootView(
   // to make sure it's called only once)
   maybeInitializeFabric();
 
-  return <GestureHandlerRootViewNativeComponent {...props} />;
+  return (
+    <GestureHandlerRootViewContext.Provider value>
+      <GestureHandlerRootViewNativeComponent {...props} />
+    </GestureHandlerRootViewContext.Provider>
+  );
 }

--- a/src/GestureHandlerRootView.tsx
+++ b/src/GestureHandlerRootView.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 import { PropsWithChildren } from 'react';
 import { View, ViewProps } from 'react-native';
 import { maybeInitializeFabric } from './init';
+import GestureHandlerRootViewContext from './GestureHandlerRootViewContext';
 
 export interface GestureHandlerRootViewProps
   extends PropsWithChildren<ViewProps> {}
@@ -14,5 +15,9 @@ export default function GestureHandlerRootView(
   // to make sure it's called only once)
   maybeInitializeFabric();
 
-  return <View {...props} />;
+  return (
+    <GestureHandlerRootViewContext.Provider value>
+      <View {...props} />
+    </GestureHandlerRootViewContext.Provider>
+  );
 }

--- a/src/GestureHandlerRootView.web.tsx
+++ b/src/GestureHandlerRootView.web.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { PropsWithChildren } from 'react';
 import { View, ViewProps } from 'react-native';
+import GestureHandlerRootViewContext from './GestureHandlerRootViewContext';
 
 export interface GestureHandlerRootViewProps
   extends PropsWithChildren<ViewProps> {}
@@ -8,5 +9,9 @@ export interface GestureHandlerRootViewProps
 export default function GestureHandlerRootView(
   props: GestureHandlerRootViewProps
 ) {
-  return <View {...props} />;
+  return (
+    <GestureHandlerRootViewContext.Provider value>
+      <View {...props} />
+    </GestureHandlerRootViewContext.Provider>
+  );
 }

--- a/src/GestureHandlerRootViewContext.ts
+++ b/src/GestureHandlerRootViewContext.ts
@@ -1,0 +1,3 @@
+import React from 'react';
+
+export default React.createContext(false);

--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -28,6 +28,7 @@ import { ValueOf } from '../typeUtils';
 import { isFabric, isJestEnv, tagMessage } from '../utils';
 import { ActionType } from '../ActionType';
 import { PressabilityDebugView } from './PressabilityDebugView';
+import GestureHandlerRootViewContext from '../GestureHandlerRootViewContext';
 
 const UIManagerAny = UIManager as any;
 
@@ -168,6 +169,7 @@ export default function createHandler<
     HandlerState
   > {
     static displayName = name;
+    static contextType = GestureHandlerRootViewContext;
 
     private handlerTag: number;
     private config: Record<string, unknown>;
@@ -398,6 +400,13 @@ export default function createHandler<
     }
 
     render() {
+      if (__DEV__ && !this.context) {
+        throw new Error(
+          name +
+            ' must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/installation for more details.'
+        );
+      }
+
       let gestureEventHandler = this.onGestureHandlerEvent;
       // Another instance of https://github.com/microsoft/TypeScript/issues/13995
       type OnGestureEventHandlers = {

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useRef, useState } from 'react';
+import React, { useContext, useEffect, useRef, useState } from 'react';
 import {
   GestureType,
   HandlerCallbacks,
@@ -43,6 +43,7 @@ import type RNGestureHandlerModuleWeb from '../../RNGestureHandlerModule.web';
 import { onGestureHandlerEvent } from './eventReceiver';
 import { RNRenderer } from '../../RNRenderer';
 import { isNewWebImplementationEnabled } from '../../EnableNewWebImplementation';
+import GestureHandlerRootViewContext from '../../GestureHandlerRootViewContext';
 
 declare const global: {
   isFormsStackingContext: (node: unknown) => boolean | null; // JSI function
@@ -606,6 +607,13 @@ interface GestureDetectorState {
   forceReattach: boolean;
 }
 export const GestureDetector = (props: GestureDetectorProps) => {
+  const rootViewContext = useContext(GestureHandlerRootViewContext);
+  if (__DEV__ && !rootViewContext) {
+    throw new Error(
+      'GestureDetector must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/installation for more details.'
+    );
+  }
+
   const gestureConfig = props.gesture;
 
   if (props.userSelect) {


### PR DESCRIPTION
## Description

Android requires using GestureHandlerRootView to intercept events, without it the gestures don't work and buttons hang in the "in-between" state of pressed and not pressed.

This PR adds logic responsible for checking if gestures are attached to views mounted under GestureHandlerRootView. If they aren't, the error message is shown.

Supersedes https://github.com/software-mansion/react-native-gesture-handler/pull/2115.

## Test plan

Tested on the Example & FabricExample app.
