### PR TITLE
Add `Handler state` section to sidebar

### DIFF
--- a/docs/sidebars.js
+++ b/docs/sidebars.js
@@ -74,7 +74,7 @@ module.exports = {
     {
       type: 'category',
       label: 'Under the hood',
-      items: ['under-the-hood/how-does-it-work'],
+      items: ['under-the-hood/how-does-it-work', 'gesture-handlers/basics/state'],
     },
   ],
 };

--- a/docs/versioned_sidebars/version-2.3.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.3.0-sidebars.json
@@ -199,6 +199,10 @@
         {
           "type": "doc",
           "id": "version-2.3.0/under-the-hood/how-does-it-work"
+        },
+        {
+          "type": "doc",
+          "id": "version-2.3.0/gesture-handlers/basics/state"
         }
       ]
     }

--- a/docs/versioned_sidebars/version-2.4.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.4.0-sidebars.json
@@ -207,6 +207,10 @@
         {
           "type": "doc",
           "id": "version-2.4.0/under-the-hood/how-does-it-work"
+        },
+        {
+          "type": "doc",
+          "id": "version-2.4.0/gesture-handlers/basics/state"
         }
       ]
     }

--- a/docs/versioned_sidebars/version-2.6.0-sidebars.json
+++ b/docs/versioned_sidebars/version-2.6.0-sidebars.json
@@ -87,7 +87,8 @@
       "type": "category",
       "label": "Under the hood",
       "items": [
-        "under-the-hood/how-does-it-work"
+        "under-the-hood/how-does-it-work",
+        "gesture-handlers/basics/state"
       ]
     }
   ]


### PR DESCRIPTION
## Description

It looks like when the structure of the docs changed at `2.3.0` tag, the `Handler state` section got lost in the changes. This PR adds it back to the sidebar.

## Test plan

Check the docs
