### PR TITLE
Returns Swipeable reference on renderLeftActions

### DIFF
--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -156,7 +156,8 @@ export interface SwipeableProps
    * */
   renderLeftActions?: (
     progressAnimatedValue: AnimatedInterpolation,
-    dragAnimatedValue: AnimatedInterpolation
+    dragAnimatedValue: AnimatedInterpolation,
+    swipeable: Swipeable
   ) => React.ReactNode;
   /**
    *
@@ -455,7 +456,7 @@ export default class Swipeable extends Component<
           // it for some reason
           { transform: [{ translateX: this.leftActionTranslate! }] },
         ]}>
-        {renderLeftActions(this.showLeftAction!, this.transX!)}
+        {renderLeftActions(this.showLeftAction!, this.transX!, this)}
         <View
           onLayout={({ nativeEvent }) =>
             this.setState({ leftWidth: nativeEvent.layout.x })


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

https://github.com/software-mansion/react-native-gesture-handler/pull/2105 returned the Swipeable reference, but only for `renderRightActions`.

This MR aims to return that same reference on `renderLeftActions` also. The use case is the same.

## Test plan

<!--
Describe how did you test this change here.
-->

I've been using my fork on a few personal projects and it's working as expected.
