### PR TITLE
Add a method `reset` to component `Swipeable`

### DIFF
--- a/docs/docs/api/components/swipeable.md
+++ b/docs/docs/api/components/swipeable.md
@@ -149,6 +149,12 @@ method that opens component on left side.
 
 method that opens component on right side.
 
+### `reset`
+
+method that resets the swiping states of this `Swipeable` component.
+
+Unlike method `close`, this method does not trigger any animation.
+
 ### Example:
 
 See the [swipeable example](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example/src/showcase/swipeable/index.tsx) from GestureHandler Example App or view it directly on your phone by visiting [our expo demo](https://snack.expo.io/@adamgrzybowski/react-native-gesture-handler-demo).

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -442,6 +442,13 @@ export default class Swipeable extends Component<
     this.animateRow(this.currentOffset(), -rightWidth);
   };
 
+  reset = () => {
+    const { dragX, rowTranslation } = this.state;
+    dragX.setValue(0);
+    rowTranslation.setValue(0);
+    this.setState({ rowState: 0 });
+  };
+
   render() {
     const { rowState } = this.state;
     const { children, renderLeftActions, renderRightActions } = this.props;


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

In certain applications, users may hope to reset the swipeable status without triggering any animations. The existing method `close` cannot fulfill the requirement as it springs from current state to reset state.

Therefore, I am adding a method `reset` that resets the states immediately. (At the very least, this modification does not break anything.)

## Test plan

<!--
Describe how did you test this change here.
-->

```TypeScript
import React, { Component } from 'react';
import { Animated, StyleSheet, View } from 'react-native';
import { RectButton } from 'react-native-gesture-handler';
import Swipeable from 'react-native-gesture-handler/Swipeable';

class AppleStyleSwipeableRow extends Component {
  renderLeftActions = (progress, dragX) => {
    const trans = dragX.interpolate({
      inputRange: [0, 50, 100, 101],
      outputRange: [-20, 0, 0, 1],
    });
    return (
      <RectButton style={styles.leftAction} onPress={this.reset}>
        <Animated.Text
          style={[
            styles.actionText,
            {
              transform: [{ translateX: trans }],
            },
          ]}>
          Archive
        </Animated.Text>
      </RectButton>
    );
  };
  render() {
    return (
      <Swipeable renderLeftActions={this.renderLeftActions}>
        <Text>"hello"</Text>
      </Swipeable>
    );
  }
}
```

Copied from the example code [here](https://docs.swmansion.com/react-native-gesture-handler/docs/api/components/swipeable/#example) except changing `this.close` to `this.reset`. The `Swipeable` should be closed **immediately** (without a spring animation) when the left panel is pressed.