### PR TITLE
Change how velocity is calculated on the new web implementation

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -42,7 +42,8 @@ import BottomSheetNewApi from './new_api/bottom_sheet';
 import ChatHeadsNewApi from './new_api/chat_heads';
 import DragNDrop from './new_api/drag_n_drop';
 import BetterHorizontalDrawer from './new_api/betterHorizontalDrawer';
-import ManualGestures from './new_api/manualGestures/index';
+import ManualGestures from './new_api/manualGestures';
+import VelocityTest from './new_api/velocityTest';
 
 interface Example {
   name: string;
@@ -116,6 +117,7 @@ const EXAMPLES: ExamplesSection[] = [
         component: ReanimatedSimple,
       },
       { name: 'Camera', component: Camera },
+      { name: 'Velocity test', component: VelocityTest },
       { name: 'Transformations', component: Transformations },
       { name: 'Overlap parents', component: OverlapParents },
       { name: 'Overlap siblings', component: OverlapSiblings },

--- a/example/src/new_api/velocityTest/index.tsx
+++ b/example/src/new_api/velocityTest/index.tsx
@@ -1,0 +1,69 @@
+import { StyleSheet, View } from 'react-native';
+import Animated, {
+  measure,
+  useAnimatedRef,
+  useAnimatedStyle,
+  useSharedValue,
+  withDecay,
+} from 'react-native-reanimated';
+
+import React from 'react';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+
+const BOX_SIZE = 120;
+
+export default function App() {
+  const aref = useAnimatedRef() as React.RefObject<View>;
+  const offsetX = useSharedValue(0);
+  const offsetY = useSharedValue(0);
+
+  const pan = Gesture.Pan()
+    .onChange((event) => {
+      offsetX.value += event.changeX;
+      offsetY.value += event.changeY;
+    })
+    .onFinalize((event) => {
+      const size = measure(aref)!;
+
+      offsetX.value = withDecay({
+        velocity: event.velocityX,
+        clamp: [-size.width / 2 + BOX_SIZE / 2, size.width / 2 - BOX_SIZE / 2],
+      });
+
+      offsetY.value = withDecay({
+        velocity: event.velocityY,
+        clamp: [
+          -size.height / 2 + BOX_SIZE / 2,
+          size.height / 2 - BOX_SIZE / 2,
+        ],
+      });
+    });
+
+  const animatedStyles = useAnimatedStyle(() => ({
+    transform: [{ translateX: offsetX.value }, { translateY: offsetY.value }],
+  }));
+
+  return (
+    <View style={styles.container} ref={aref}>
+      <GestureDetector gesture={pan}>
+        <Animated.View style={[styles.box, animatedStyles]} />
+      </GestureDetector>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+  },
+  box: {
+    height: BOX_SIZE,
+    width: BOX_SIZE,
+    backgroundColor: '#001A72',
+    borderRadius: 20,
+    cursor: 'grab',
+  },
+});

--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -1,4 +1,3 @@
-import { PixelRatio } from 'react-native';
 import { State } from '../../State';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
 import { AdaptedEvent, Config } from '../interfaces';
@@ -188,7 +187,6 @@ export default class PanGestureHandler extends GestureHandler {
 
   protected transformNativeEvent() {
     const rect: DOMRect = this.view.getBoundingClientRect();
-    const ratio = PixelRatio.get();
 
     const translationX: number = this.getTranslationX();
     const translationY: number = this.getTranslationY();
@@ -198,8 +196,8 @@ export default class PanGestureHandler extends GestureHandler {
       translationY: isNaN(translationY) ? 0 : translationY,
       absoluteX: this.tracker.getLastAvgX(),
       absoluteY: this.tracker.getLastAvgY(),
-      velocityX: this.velocityX * ratio * 10,
-      velocityY: this.velocityY * ratio * 10,
+      velocityX: this.velocityX,
+      velocityY: this.velocityY,
       x: this.tracker.getLastAvgX() - rect.left,
       y: this.tracker.getLastAvgY() - rect.top,
     };

--- a/src/web/tools/CircularBuffer.ts
+++ b/src/web/tools/CircularBuffer.ts
@@ -1,0 +1,42 @@
+export default class CircularBuffer<T> {
+  private bufferSize: number;
+  private buffer: T[];
+  private index: number;
+  private actualSize: number;
+
+  constructor(size: number) {
+    this.bufferSize = size;
+    this.buffer = new Array<T>(size);
+    this.index = 0;
+    this.actualSize = 0;
+  }
+
+  public get size(): number {
+    return this.actualSize;
+  }
+
+  public push(element: T): void {
+    this.buffer[this.index] = element;
+    this.index = (this.index + 1) % this.bufferSize;
+    this.actualSize = Math.min(this.actualSize + 1, this.bufferSize);
+  }
+
+  public get(at: number): T {
+    if (this.actualSize === this.bufferSize) {
+      let index = (this.index + at) % this.bufferSize;
+      if (index < 0) {
+        index += this.bufferSize;
+      }
+
+      return this.buffer[index];
+    } else {
+      return this.buffer[at];
+    }
+  }
+
+  public clear(): void {
+    this.buffer = new Array<T>(this.bufferSize);
+    this.index = 0;
+    this.actualSize = 0;
+  }
+}


### PR DESCRIPTION
## Description

Changes how pointer velocity is calculated on the web. Previously, it was using only the last two events which wasn't the best solution as the speed of the pointer just before it's released may not represent the speed of the swipe.

This changes it to be calculated from the last 5 events, with the possibility to easily change it in the future (although some work may be required to handle quick direction changes correctly).

I've also removed a lot of magic numbers and replaced them with one magic formula 😅.

## Test plan

Use the `Velocity test` example added to the app
