### PR TITLE
fix: PureNativeButton is not exported

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -92,6 +92,7 @@ export {
   BaseButton,
   RectButton,
   BorderlessButton,
+  PureNativeButton,
 } from './components/GestureButtons';
 export {
   TouchableHighlight,


### PR DESCRIPTION
## Description

`PureNativeButton` is not exported, and it should be as written in the doc.
https://docs.swmansion.com/react-native-gesture-handler/docs/api/components/buttons/#purenativebutton
