### PR TITLE
fix: do not apply namespace if it is not available in agp

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -132,7 +132,10 @@ repositories {
 
 android {
     compileSdkVersion safeExtGet("compileSdkVersion", 28)
-    namespace "com.swmansion.gesturehandler"
+    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+        namespace "com.swmansion.gesturehandler"
+    }
 
     // Used to override the NDK path/version on internal CI or by allowing
     // users to customize the NDK path/version from their root project (e.g. for M1 support)


### PR DESCRIPTION
## Description

`namespace` method is available since AGP 7.x.



## Test plan

<!--
Describe how did you test this change here.
-->
