### PR TITLE
Make single instance assertion work with Gradle Configuration Cache

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,5 +1,7 @@
 import groovy.json.JsonSlurper
-import java.nio.file.Paths
+
+import javax.inject.Inject
+import java.nio.file.Files
 
 buildscript {
     def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNGH_kotlinVersion']
@@ -66,6 +68,14 @@ if (project == rootProject) {
     apply from: "spotless.gradle"
 }
 
+def shouldAssertNoMultipleInstances() {
+  if (rootProject.hasProperty("disableMultipleInstancesCheck")) {
+    return rootProject.property("disableMultipleInstancesCheck") != "true"
+  } else {
+    return true
+  }
+}
+
 // Check whether Reanimated 2.3 or higher is installed alongside Gesture Handler
 def shouldUseCommonInterfaceFromReanimated() {
     def reanimated = rootProject.subprojects.find { it.name == 'react-native-reanimated' }
@@ -94,28 +104,63 @@ def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
 
-def objects = objects
-def applicationRootPath = rootDir.parent
-def shouldAssertNoMultipleInstances = rootProject.hasProperty("disableMultipleInstancesCheck") ? rootProject.property("disableMultipleInstancesCheck") != "true" : true
+abstract class NoMultipleInstancesAssertionTask extends DefaultTask {
+    @Inject abstract ObjectFactory getObjectFactory()
 
-def assertionTask = task assertNoMultipleInstances {
-    onlyIf {
-        return shouldAssertNoMultipleInstances
+    @Input abstract Property<File> getProjectDirFile()
+    @Input abstract Property<File> getRootDirFile()
+    @Input abstract Property<Boolean> getShouldCheck()
+
+    def findGestureHandlerInstancesForPath(String path) {
+        return objectFactory.fileTree().from(path)
+                .include("**/react-native-gesture-handler/package.json")
+                .exclude("**/.yarn/**")
+                .exclude({ Files.isSymbolicLink(it.getFile().toPath()) })
+                .findAll()
     }
-    doFirst {
-        Set<File> files = objects.fileTree().from(applicationRootPath).include("node_modules/**/react-native-gesture-handler/package.json").exclude("**/.yarn/**", "**/.pnpm/**").findAll()
 
-        if (files.size() > 1) {
-            String parsedLocation = files.stream().map({ File file -> "- " + file.toString().replace("/package.json", "") }).collect().join("\n")
-            String exceptionMessage = "\n[Gesture Handler] Multiple instances of Gesture Handler were detected. Only one instance of react-native-gesture-handler can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-gesture-handler/docs/troubleshooting#multiple-instances-of-gesture-handler-were-detected \n\nConflict between: \n" + parsedLocation + "\n";
-            throw new Exception(exceptionMessage);
+    @TaskAction
+    def check() {
+        if (shouldCheck.get()) {
+            // Assert there are no multiple installations of Gesture Handler
+            Set<File> files
+
+            if (projectDirFile.get().parent.contains(rootDirFile.get().parent)) {
+                // standard app
+                files = findGestureHandlerInstancesForPath(rootDirFile.get().parent + "/node_modules")
+            } else {
+                // monorepo
+                files = findGestureHandlerInstancesForPath(rootDirFile.get().parent + "/node_modules")
+                files.addAll(
+                    findGestureHandlerInstancesForPath(projectDirFile.get().parentFile.parent)
+                )
+            }
+
+            if (files.size() > 1) {
+                String parsedLocation = files.stream().map({
+                    File file -> "- " + file.toString().replace("/package.json", "")
+                }).collect().join("\n")
+                String exceptionMessage = "\n[react-native-gesture-handler] Multiple versions of Gesture Handler " +
+                        "were detected. Only one instance of react-native-gesture-handler can be installed in a " +
+                        "project. You need to resolve the conflict manually. Check out the documentation: " +
+                        "https://docs.swmansion.com/react-native-gesture-handler/docs/troubleshooting" +
+                        "#multiple-instances-of-gesture-handler-were-detected \n\nConflict between: \n" +
+                        parsedLocation + "\n"
+                throw new GradleException(exceptionMessage)
+            }
         }
     }
 }
 
-tasks.preBuild {
-    dependsOn assertionTask
+tasks.register('assertNoMultipleInstances', NoMultipleInstancesAssertionTask) {
+    shouldCheck = shouldAssertNoMultipleInstances()
+    rootDirFile = rootDir
+    projectDirFile = projectDir
 }
+
+ tasks.preBuild {
+     dependsOn assertNoMultipleInstances
+ }
 
 repositories {
     mavenCentral()

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -85,28 +85,6 @@ def reactNativeArchitectures() {
     return value ? value.split(",") : ["armeabi-v7a", "x86", "x86_64", "arm64-v8a"]
 }
 
-def shouldAssertNoMultipleInstances() {
-  if (rootProject.hasProperty("disableMultipleInstancesCheck")) {
-    return rootProject.property("disableMultipleInstancesCheck") != "true"
-  } else {
-    return true
-  }
-}
-
-def noMultipleInstancesAssertion() {
-    Set<File> files = fileTree(rootDir.parent) {
-        include "node_modules/**/react-native-gesture-handler/package.json"
-        exclude "**/.yarn/**"
-        exclude "**/.pnpm/**"
-    }.files
-
-    if (files.size() > 1) {
-        String parsedLocation = files.stream().map({ File file -> "- " + file.toString().replace("/package.json", "") }).collect().join("\n")
-        String exceptionMessage = "\n[Gesture Handler] Multiple instances of Gesture Handler were detected. Only one instance of react-native-gesture-handler can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-gesture-handler/docs/troubleshooting#multiple-instances-of-gesture-handler-were-detected \n\nConflict between: \n" + parsedLocation + "\n";
-        throw new Exception(exceptionMessage);
-    }
-}
-
 def REACT_NATIVE_DIR = resolveReactNativeDirectory()
 
 def reactProperties = new Properties()
@@ -115,10 +93,23 @@ file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { react
 def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
 
+
+def objects = objects
+def applicationRootPath = rootDir.parent
+def shouldAssertNoMultipleInstances = rootProject.hasProperty("disableMultipleInstancesCheck") ? rootProject.property("disableMultipleInstancesCheck") != "true" : true
+
 def assertionTask = task assertNoMultipleInstances {
-    onlyIf { shouldAssertNoMultipleInstances() }
+    onlyIf {
+        return shouldAssertNoMultipleInstances
+    }
     doFirst {
-        noMultipleInstancesAssertion()
+        Set<File> files = objects.fileTree().from(applicationRootPath).include("node_modules/**/react-native-gesture-handler/package.json").exclude("**/.yarn/**", "**/.pnpm/**").findAll()
+
+        if (files.size() > 1) {
+            String parsedLocation = files.stream().map({ File file -> "- " + file.toString().replace("/package.json", "") }).collect().join("\n")
+            String exceptionMessage = "\n[Gesture Handler] Multiple instances of Gesture Handler were detected. Only one instance of react-native-gesture-handler can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-gesture-handler/docs/troubleshooting#multiple-instances-of-gesture-handler-were-detected \n\nConflict between: \n" + parsedLocation + "\n";
+            throw new Exception(exceptionMessage);
+        }
     }
 }
 

--- a/docs/docs/troubleshooting.md
+++ b/docs/docs/troubleshooting.md
@@ -41,7 +41,8 @@ This error usually happens when in your project there exists more than one insta
 You can check which libraries are using Gesture Handler, for example, with the command:
 
 ```bash
-npm why react-native-gesture-handler
+npm ls react-native-gesture-handler
+yarn why react-native-gesture-handler
 ```
 
 If you use `yarn` you should add [`resolution` property](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/).

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -41,3 +41,5 @@ newArchEnabled=false
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
+
+disableMultipleInstancesCheck=false


### PR DESCRIPTION
## Description

Makes `assertNoMultipleInstances` task not break when [Gradle Configuration Cache](https://docs.gradle.org/current/userguide/configuration_cache.html#config_cache:intro) is enabled. 

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2449.

## Test plan

Enable configuration cache by adding `org.gradle.unsafe.configuration-cache=true` in `gradle.properties` file and build the app twice. Do it once without this patch and once with it.