### PR TITLE
Remove conditional imports for native components

### DIFF
--- a/src/GestureHandlerRootView.android.tsx
+++ b/src/GestureHandlerRootView.android.tsx
@@ -1,14 +1,9 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
 import * as React from 'react';
 import { PropsWithChildren } from 'react';
-import { requireNativeComponent, ViewProps } from 'react-native';
+import { ViewProps } from 'react-native';
 import { maybeInitializeFabric } from './init';
-import { shouldUseCodegenNativeComponent } from './utils';
 import GestureHandlerRootViewContext from './GestureHandlerRootViewContext';
-
-const GestureHandlerRootViewNativeComponent = shouldUseCodegenNativeComponent()
-  ? require('./fabric/RNGestureHandlerRootViewNativeComponent').default
-  : requireNativeComponent('RNGestureHandlerRootView');
+import GestureHandlerRootViewNativeComponent from './fabric/RNGestureHandlerRootViewNativeComponent';
 
 export interface GestureHandlerRootViewProps
   extends PropsWithChildren<ViewProps> {}

--- a/src/components/GestureHandlerButton.tsx
+++ b/src/components/GestureHandlerButton.tsx
@@ -1,10 +1,5 @@
-/* eslint-disable @typescript-eslint/no-var-requires */
-import { HostComponent, requireNativeComponent } from 'react-native';
+import { HostComponent } from 'react-native';
 import { RawButtonProps } from './GestureButtons';
-import { shouldUseCodegenNativeComponent } from '../utils';
-
-const RNGestureHandlerButtonNativeComponent = shouldUseCodegenNativeComponent()
-  ? require('../fabric/RNGestureHandlerButtonNativeComponent').default
-  : requireNativeComponent('RNGestureHandlerButton');
+import RNGestureHandlerButtonNativeComponent from '../fabric/RNGestureHandlerButtonNativeComponent';
 
 export default RNGestureHandlerButtonNativeComponent as HostComponent<RawButtonProps>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -55,11 +55,6 @@ export function isFabric(): boolean {
   return !!global?.nativeFabricUIManager;
 }
 
-export function shouldUseCodegenNativeComponent(): boolean {
-  // use codegenNativeComponent starting with RN 0.68
-  return REACT_NATIVE_VERSION.minor >= 68 || REACT_NATIVE_VERSION.major > 0;
-}
-
 export function isRemoteDebuggingEnabled(): boolean {
   // react-native-reanimated checks if in remote debugging in the same way
   // @ts-ignore global is available but node types are not included


### PR DESCRIPTION
## Description

Removes the conditional `requires` based on the React Native version.

Note that this change makes the library incompatible with React Native 0.63, where `codegenNativeComponent` is not available.

## Test plan

Test the Example and FabricExample apps.
