### PR TITLE
Replace `setImmediate` and `requestAnimationFrame` with `queueMicrotask`

### DIFF
--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -191,16 +191,15 @@ export function findNodeHandle(
   return findNodeHandleRN(node);
 }
 
-let scheduledFlushOperationsId: ReturnType<
-  typeof requestAnimationFrame
-> | null = null;
+let flushOperationsScheduled = false;
 
 export function scheduleFlushOperations() {
-  if (scheduledFlushOperationsId === null) {
-    scheduledFlushOperationsId = requestAnimationFrame(() => {
+  if (!flushOperationsScheduled) {
+    flushOperationsScheduled = true;
+    queueMicrotask(() => {
       RNGestureHandlerModule.flushOperations();
 
-      scheduledFlushOperationsId = null;
+      flushOperationsScheduled = false;
     });
   }
 }

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -71,9 +71,6 @@ export type GestureConfigReference = {
   useReanimatedHook: boolean;
 };
 
-const scheduleUpdate =
-  Platform.OS === 'web' ? requestAnimationFrame : setImmediate;
-
 function convertToHandlerTag(ref: GestureRef): number {
   if (typeof ref === 'number') {
     return ref;
@@ -153,9 +150,9 @@ function attachHandlers({
     preparedGesture.firstExecution = false;
   }
 
-  // use scheduleUpdate to extract handlerTags, because all refs should be initialized
+  // use queueMicrotask to extract handlerTags, because all refs should be initialized
   // when it's ran
-  scheduleUpdate(() => {
+  queueMicrotask(() => {
     if (!mountedRef.current) {
       return;
     }
@@ -173,9 +170,9 @@ function attachHandlers({
     registerHandler(handler.handlerTag, handler, handler.config.testId);
   }
 
-  // use scheduleUpdate to extract handlerTags, because all refs should be initialized
+  // use queueMicrotask to extract handlerTags, because all refs should be initialized
   // when it's ran
-  scheduleUpdate(() => {
+  queueMicrotask(() => {
     if (!mountedRef.current) {
       return;
     }
@@ -260,10 +257,10 @@ function updateHandlers(
     }
   }
 
-  // use scheduleUpdate to extract handlerTags, because when it's ran, all refs should be updated
+  // use queueMicrotask to extract handlerTags, because when it's ran, all refs should be updated
   // and handlerTags in BaseGesture references should be updated in the loop above (we need to wait
   // in case of external relations)
-  scheduleUpdate(() => {
+  queueMicrotask(() => {
     if (!mountedRef.current) {
       return;
     }

--- a/src/web_hammer/GestureHandler.ts
+++ b/src/web_hammer/GestureHandler.ts
@@ -508,7 +508,7 @@ abstract class GestureHandler {
         .filter((v) => v);
 
       if (shouldUseTouchEvents !== this.shouldUseTouchEvents(props)) {
-        requestAnimationFrame(() => {
+        queueMicrotask(() => {
           // if the undelying event API needs to be changed, we need to unmount and mount
           // the hammer instance again.
           this.destroy();


### PR DESCRIPTION
## Description

- `setImmediate` is not available on web & when using server-side-rendering
- `requestAnimationFrame` is not available when using server-side-rendering

## Test plan

Test on Example and FabricExample apps.
