### PR TITLE
Fix operation scheduling on iOS

### DIFF
--- a/ios/RNGestureHandlerManager.mm
+++ b/ios/RNGestureHandlerManager.mm
@@ -199,8 +199,9 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 #ifdef RCT_NEW_ARCH_ENABLED
   UIView *touchHandlerView = childView;
 
-  while (touchHandlerView != nil && ![touchHandlerView isKindOfClass:[RCTSurfaceView class]])
+  while (touchHandlerView != nil && ![touchHandlerView isKindOfClass:[RCTSurfaceView class]]) {
     touchHandlerView = touchHandlerView.superview;
+  }
 #else
   UIView *parent = childView;
   while (parent != nil && ![parent respondsToSelector:@selector(touchHandler)])

--- a/ios/RNGestureHandlerManager.mm
+++ b/ios/RNGestureHandlerManager.mm
@@ -260,7 +260,7 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
   }
 #else
   RCTTouchHandler *touchHandler = [viewWithTouchHandler performSelector:@selector(touchHandler)];
-#endif
+#endif // RCT_NEW_ARCH_ENABLED
   [touchHandler setEnabled:NO];
   [touchHandler setEnabled:YES];
 }

--- a/ios/RNGestureHandlerManager.mm
+++ b/ios/RNGestureHandlerManager.mm
@@ -38,7 +38,7 @@
   RCTDefaultLogFunction(     \
       RCTLogLevelInfo, RCTLogSourceNative, @(__FILE__), @(__LINE__), [NSString stringWithFormat:__VA_ARGS__])
 
-#define NEW_ARCH_NUMBER_OF_ATTACH_RETRIES 25
+constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 
 @interface RNGestureHandlerManager () <RNGestureHandlerEventEmitter, RNRootViewGestureRecognizerDelegate>
 

--- a/ios/RNGestureHandlerManager.mm
+++ b/ios/RNGestureHandlerManager.mm
@@ -16,6 +16,7 @@
 
 #ifdef RCT_NEW_ARCH_ENABLED
 #import <React/RCTSurfaceTouchHandler.h>
+#import <React/RCTSurfaceView.h>
 #import <React/RCTViewComponentView.h>
 #else
 #import <React/RCTTouchHandler.h>
@@ -37,6 +38,8 @@
   RCTDefaultLogFunction(     \
       RCTLogLevelInfo, RCTLogSourceNative, @(__FILE__), @(__LINE__), [NSString stringWithFormat:__VA_ARGS__])
 
+#define NEW_ARCH_NUMBER_OF_ATTACH_RETRIES 25
+
 @interface RNGestureHandlerManager () <RNGestureHandlerEventEmitter, RNRootViewGestureRecognizerDelegate>
 
 @end
@@ -45,6 +48,7 @@
   RNGestureHandlerRegistry *_registry;
   RCTUIManager *_uiManager;
   NSHashTable<RNRootViewGestureRecognizer *> *_rootViewGestureRecognizers;
+  NSMutableDictionary<NSNumber *, NSNumber *> *_attachRetryCounter;
   RCTEventDispatcher *_eventDispatcher;
   id _reanimatedModule;
 }
@@ -56,6 +60,7 @@
     _eventDispatcher = eventDispatcher;
     _registry = [RNGestureHandlerRegistry new];
     _rootViewGestureRecognizers = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory];
+    _attachRetryCounter = [[NSMutableDictionary alloc] init];
     _reanimatedModule = nil;
   }
   return self;
@@ -100,11 +105,38 @@
   UIView *view = [_uiManager viewForReactTag:viewTag];
 
 #ifdef RCT_NEW_ARCH_ENABLED
-  if (view == nil) {
-    // Happens when the view with given tag has been flattened.
-    // We cannot attach gesture handler to a non-existent view.
+  if (view == nil || view.superview == nil) {
+    // There are a few reasons we could end up here:
+    // - the native view corresponding to the viewtag hasn't yet been created
+    // - the native view has been created, but it's not attached to window
+    // - the native view will not exist because it got flattened
+    // In the first two cases we just want to wait until the view gets created or gets attached to its superview
+    // In the third case we don't want to do anything but we cannot easily distinguish it here, hece the abomination
+    // below
+    // TODO: would be great to have a better solution, although it might require migration to the shadow nodes from
+    // viewTags
+
+    NSNumber *counter = [_attachRetryCounter objectForKey:viewTag];
+    if (counter == nil) {
+      counter = @1;
+    } else {
+      counter = [NSNumber numberWithInt:counter.intValue + 1];
+    }
+
+    if (counter.intValue > NEW_ARCH_NUMBER_OF_ATTACH_RETRIES) {
+      [_attachRetryCounter removeObjectForKey:viewTag];
+    } else {
+      [_attachRetryCounter setObject:counter forKey:viewTag];
+
+      dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
+        [self attachGestureHandler:handlerTag toViewWithTag:viewTag withActionType:actionType];
+      });
+    }
+
     return;
   }
+
+  [_attachRetryCounter removeObjectForKey:viewTag];
 
   // I think it should be moved to RNNativeViewHandler, but that would require
   // additional logic for setting contentView.reactTag, this works for now
@@ -164,18 +196,25 @@
 
 - (void)registerViewWithGestureRecognizerAttachedIfNeeded:(UIView *)childView
 {
+#ifdef RCT_NEW_ARCH_ENABLED
+  UIView *touchHandlerView = childView;
+
+  while (touchHandlerView != nil && ![touchHandlerView isKindOfClass:[RCTSurfaceView class]])
+    touchHandlerView = touchHandlerView.superview;
+#else
   UIView *parent = childView;
   while (parent != nil && ![parent respondsToSelector:@selector(touchHandler)])
     parent = parent.superview;
 
-  // Many views can return the same touchHandler so we check if the one we want to register
-  // is not already present in the set.
   UIView *touchHandlerView = [[parent performSelector:@selector(touchHandler)] view];
+#endif // RCT_NEW_ARCH_ENABLED
 
   if (touchHandlerView == nil) {
     return;
   }
 
+  // Many views can return the same touchHandler so we check if the one we want to register
+  // is not already present in the set.
   for (UIGestureRecognizer *recognizer in touchHandlerView.gestureRecognizers) {
     if ([recognizer isKindOfClass:[RNRootViewGestureRecognizer class]]) {
       return;
@@ -208,7 +247,16 @@
     return;
 
 #ifdef RCT_NEW_ARCH_ENABLED
-  RCTSurfaceTouchHandler *touchHandler = [viewWithTouchHandler performSelector:@selector(touchHandler)];
+  UIGestureRecognizer *touchHandler = nil;
+
+  // touchHandler (RCTSurfaceTouchHandler) is private in RCTFabricSurface so we have to do
+  // this little trick to get access to it
+  for (UIGestureRecognizer *recognizer in [viewWithTouchHandler gestureRecognizers]) {
+    if ([recognizer isKindOfClass:[RCTSurfaceTouchHandler class]]) {
+      touchHandler = recognizer;
+      break;
+    }
+  }
 #else
   RCTTouchHandler *touchHandler = [viewWithTouchHandler performSelector:@selector(touchHandler)];
 #endif

--- a/ios/RNGestureHandlerModule.mm
+++ b/ios/RNGestureHandlerModule.mm
@@ -200,7 +200,7 @@ RCT_EXPORT_METHOD(flushOperations)
           operation(self->_manager);
         }
       }];
-#endif
+#endif // RCT_NEW_ARCH_ENABLED
 }
 
 - (void)setGestureState:(int)state forHandler:(int)handlerTag

--- a/ios/RNGestureHandlerModule.mm
+++ b/ios/RNGestureHandlerModule.mm
@@ -184,6 +184,9 @@ RCT_EXPORT_METHOD(handleClearJSResponder)
 
 RCT_EXPORT_METHOD(flushOperations)
 {
+  // On the new arch we rely on `flushOperations` for scheduling the operations on the UI thread.
+  // On the old arch we rely on `uiManagerWillPerformMounting`
+#ifdef RCT_NEW_ARCH_ENABLED
   if (_operations.count == 0) {
     return;
   }
@@ -197,6 +200,7 @@ RCT_EXPORT_METHOD(flushOperations)
           operation(self->_manager);
         }
       }];
+#endif
 }
 
 - (void)setGestureState:(int)state forHandler:(int)handlerTag


### PR DESCRIPTION
## Description

https://github.com/software-mansion/react-native-gesture-handler/pull/2467 replaces calls to `setImmediate` and `requestAnimationFrame` with `queueMicrotask`. This introduces a bug, where on iOS the `flushOperations` method would get called too early.

This PR changes `flushOperations` to only be used on the new architecture, where it's actually required, and adds a retry mechanism for attaching handlers to native views. It also updates parts of the new arch-related code to function properly - finding the recognizer responsible for the touch responder and attaching the root view handler.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2482

## Test plan

Test on the Example and FabricExample apps.
