### PR TITLE
Fix root view error for jest

### DIFF
--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -402,7 +402,7 @@ export default function createHandler<
     }
 
     render() {
-      if (__DEV__ && !this.context) {
+      if (__DEV__ && !this.context && !isJestEnv()) {
         throw new Error(
           name +
             ' must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/installation for more details.'

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -36,7 +36,12 @@ import { State } from '../../State';
 import { TouchEventType } from '../../TouchEventType';
 import { ComposedGesture } from './gestureComposition';
 import { ActionType } from '../../ActionType';
-import { isFabric, REACT_NATIVE_VERSION, tagMessage } from '../../utils';
+import {
+  isFabric,
+  isJestEnv,
+  REACT_NATIVE_VERSION,
+  tagMessage,
+} from '../../utils';
 import { getShadowNodeFromRef } from '../../getShadowNodeFromRef';
 import { Platform } from 'react-native';
 import type RNGestureHandlerModuleWeb from '../../RNGestureHandlerModule.web';
@@ -607,7 +612,7 @@ interface GestureDetectorState {
 }
 export const GestureDetector = (props: GestureDetectorProps) => {
   const rootViewContext = useContext(GestureHandlerRootViewContext);
-  if (__DEV__ && !rootViewContext) {
+  if (__DEV__ && !rootViewContext && !isJestEnv()) {
     throw new Error(
       'GestureDetector must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/installation for more details.'
     );


### PR DESCRIPTION
## Description
This PR fixed a problem related to `HandlerName must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/installation for more details.` in jest. 
<!--
Description and motivation for this PR.
In some project 

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Related issues

[2488](https://github.com/software-mansion/react-native-gesture-handler/issues/2488)

## Test plan

tested locally on my project :)

