### PR TITLE
Prevent GH buttons from activating when scrolling list

### DIFF
--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -80,17 +80,22 @@ export default class NativeViewGestureHandler extends GestureHandler {
     const dy = this.startY - this.tracker.getLastAvgY();
     const distSq = dx * dx + dy * dy;
 
-    if (
-      !this.buttonRole &&
-      distSq >= this.minDistSq &&
-      this.currentState === State.BEGAN
-    ) {
-      this.activate();
+    if (distSq >= this.minDistSq) {
+      if (this.buttonRole && this.currentState === State.ACTIVE) {
+        this.cancel();
+      } else if (!this.buttonRole && this.currentState === State.BEGAN) {
+        this.activate();
+      }
     }
   }
 
   protected onPointerOut(): void {
-    this.cancel();
+    if (
+      this.currentState === State.BEGAN ||
+      this.currentState === State.ACTIVE
+    ) {
+      this.cancel();
+    }
   }
 
   protected onPointerUp(event: AdaptedEvent): void {


### PR DESCRIPTION
## Description

If Gesture Handler buttons were inside a list, they could activate during the scroll, which is undesirable. This PR makes them cancel when the pointer moves more than the touch slop, preventing the activation.

It also adds a sanity check to the `onPointerOut` callback, so the buttons won't be canceled twice, in between calls to `reset`, which was breaking the state logic and causing them to be unresponsive every second time.

## Test plan

Tested on the example app.
