### PR TITLE
Correctly attach root view recognizer in modals on iOS

### DIFF
--- a/ios/RNGestureHandlerManager.mm
+++ b/ios/RNGestureHandlerManager.mm
@@ -3,6 +3,7 @@
 #import <React/RCTComponent.h>
 #import <React/RCTEventDispatcher.h>
 #import <React/RCTLog.h>
+#import <React/RCTModalHostViewController.h>
 #import <React/RCTRootContentView.h>
 #import <React/RCTRootView.h>
 #import <React/RCTUIManager.h>
@@ -15,6 +16,7 @@
 #import "RNRootViewGestureRecognizer.h"
 
 #ifdef RCT_NEW_ARCH_ENABLED
+#import <React/RCTFabricModalHostViewController.h>
 #import <React/RCTSurfaceTouchHandler.h>
 #import <React/RCTSurfaceView.h>
 #import <React/RCTViewComponentView.h>
@@ -199,15 +201,25 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 #ifdef RCT_NEW_ARCH_ENABLED
   UIView *touchHandlerView = childView;
 
-  while (touchHandlerView != nil && ![touchHandlerView isKindOfClass:[RCTSurfaceView class]]) {
-    touchHandlerView = touchHandlerView.superview;
+  if ([[childView reactViewController] isKindOfClass:[RCTFabricModalHostViewController class]]) {
+    touchHandlerView = [childView reactViewController].view;
+  } else {
+    while (touchHandlerView != nil && ![touchHandlerView isKindOfClass:[RCTSurfaceView class]]) {
+      touchHandlerView = touchHandlerView.superview;
+    }
   }
 #else
-  UIView *parent = childView;
-  while (parent != nil && ![parent respondsToSelector:@selector(touchHandler)])
-    parent = parent.superview;
+  UIView *touchHandlerView = nil;
 
-  UIView *touchHandlerView = [[parent performSelector:@selector(touchHandler)] view];
+  if ([[childView reactViewController] isKindOfClass:[RCTModalHostViewController class]]) {
+    touchHandlerView = [childView reactViewController].view.subviews[0];
+  } else {
+    UIView *parent = childView;
+    while (parent != nil && ![parent respondsToSelector:@selector(touchHandler)])
+      parent = parent.superview;
+
+    touchHandlerView = [[parent performSelector:@selector(touchHandler)] view];
+  }
 #endif // RCT_NEW_ARCH_ENABLED
 
   if (touchHandlerView == nil) {
@@ -247,20 +259,19 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
   if ([gestureRecognizer.view isKindOfClass:[UIScrollView class]])
     return;
 
-#ifdef RCT_NEW_ARCH_ENABLED
   UIGestureRecognizer *touchHandler = nil;
 
-  // touchHandler (RCTSurfaceTouchHandler) is private in RCTFabricSurface so we have to do
-  // this little trick to get access to it
+  // this way we can extract the touch handler on both architectures relatively easily
   for (UIGestureRecognizer *recognizer in [viewWithTouchHandler gestureRecognizers]) {
+#ifdef RCT_NEW_ARCH_ENABLED
     if ([recognizer isKindOfClass:[RCTSurfaceTouchHandler class]]) {
+#else
+    if ([recognizer isKindOfClass:[RCTTouchHandler class]]) {
+#endif
       touchHandler = recognizer;
       break;
     }
   }
-#else
-  RCTTouchHandler *touchHandler = [viewWithTouchHandler performSelector:@selector(touchHandler)];
-#endif // RCT_NEW_ARCH_ENABLED
   [touchHandler setEnabled:NO];
   [touchHandler setEnabled:YES];
 }

--- a/ios/RNGestureHandlerManager.mm
+++ b/ios/RNGestureHandlerManager.mm
@@ -215,8 +215,9 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
     touchHandlerView = [childView reactViewController].view.subviews[0];
   } else {
     UIView *parent = childView;
-    while (parent != nil && ![parent respondsToSelector:@selector(touchHandler)])
+    while (parent != nil && ![parent respondsToSelector:@selector(touchHandler)]) {
       parent = parent.superview;
+    }
 
     touchHandlerView = [[parent performSelector:@selector(touchHandler)] view];
   }

--- a/ios/RNGestureHandlerManager.mm
+++ b/ios/RNGestureHandlerManager.mm
@@ -268,7 +268,7 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
     if ([recognizer isKindOfClass:[RCTSurfaceTouchHandler class]]) {
 #else
     if ([recognizer isKindOfClass:[RCTTouchHandler class]]) {
-#endif
+#endif // RCT_NEW_ARCH_ENABLED
       touchHandler = recognizer;
       break;
     }


### PR DESCRIPTION
## Description

On iOS, the conditions to attach `RootViewGestureRecognizer` were satisfied neither on the new nor the old architecture.
This PR changes this logic:
- unifies extracting the RN's touch handler to simply loop on all recognizers attached to the root view, as it works in every case
- adds a check for `ModalHostViewController` when attaching the root view recognizer and if the view is in the modal the logic is different:
  - on the old arch: [RCTModalHostView](https://github.com/facebook/react-native/blob/b50874cad41f06519a263fa53d15f76c836fd167/packages/react-native/React/Views/RCTModalHostView.m#L95-L100) has a `UIView` as its child, and this one may only have one `RCTView` as its child - this one has the `RCTTouchHandler` recognizer attached
  - on the new arch: [RCTFabricModalHostViewController](https://github.com/facebook/react-native/blob/b50874cad41f06519a263fa53d15f76c836fd167/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm#L42) directly attaches `RCTSurfaceTouchHandler` to its direct subview

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2487.

## Test plan

Tested on Example and FabricExample apps and on the code from the issue.
