### PR TITLE
Recycle obtained `MotionEvents` on Android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -120,6 +120,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
       action = MotionEvent.ACTION_CANCEL
     }
     view!!.onTouchEvent(event)
+    event.recycle()
   }
 
   override fun onReset() {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -76,6 +76,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
       if (rootView is RootView) {
         rootView.onChildStartedNativeGesture(event)
       }
+      event.recycle()
     }
   }
 


### PR DESCRIPTION
## Description

Adds recycling for `MotionEvents` after they've been used.

Closes https://github.com/software-mansion/react-native-gesture-handler/issues/2517

## Test plan

Tested on the Example app
