### PR TITLE
Only cancel JS responder when activating recognizer comes from Gesture Handler

### DIFF
--- a/ios/RNRootViewGestureRecognizer.m
+++ b/ios/RNRootViewGestureRecognizer.m
@@ -57,8 +57,13 @@
 - (BOOL)canBePreventedByGestureRecognizer:(UIGestureRecognizer *)preventingGestureRecognizer
 {
   // When this method is called it means that one of handlers has activated, in this case we want
-  // to send an info to JS so that it cancells all JS responders
-  [self.delegate gestureRecognizer:preventingGestureRecognizer didActivateInViewWithTouchHandler:self.view];
+  // to send an info to JS so that it cancells all JS responders, as long as the preventing
+  // recognizer is from Gesture Handler, otherwise we might break some interactions
+  RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:preventingGestureRecognizer];
+  if (handler != nil) {
+    [self.delegate gestureRecognizer:preventingGestureRecognizer didActivateInViewWithTouchHandler:self.view];
+  }
+
   return [super canBePreventedByGestureRecognizer:preventingGestureRecognizer];
 }
 


### PR DESCRIPTION
## Description

Upon activation of a gesture recognizer, the iOS root view recognizer would cancel JS responders so they wouldn't conflict with each other, however this is currently done even if the activating recognizer doesn't come from Gesture Handler which may result in different behaviors for custom native components when used with or without Gesture Handler.

This PR adds a check to ensure the activating recognizer has an associated gesture handler before canceling JS responders.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2530

## Test plan

Tested on Example app and on the repro from the linked issue
