### PR TITLE
Make manual activation recognizer not cancel `UIControls`

### DIFF
--- a/ios/RNManualActivationRecognizer.m
+++ b/ios/RNManualActivationRecognizer.m
@@ -10,8 +10,9 @@
 {
   if ((self = [super initWithTarget:self action:@selector(handleGesture:)])) {
     _handler = gestureHandler;
-    self.delegate = self;
     _activePointers = 0;
+    self.delegate = self;
+    self.cancelsTouchesInView = NO;
   }
   return self;
 }


### PR DESCRIPTION
## Description

On iOS, manual activation is implemented in a somewhat hacky way:
- if a gesture is declared with manual activation, an additional MA recognizer is added to a view
- that recognizer activated immediately, and the original recognizer requires it to fail in order to activate
- when we want to activate to original recognizer we simply cancel the MA recognizer

That's because there's no API for delaying or forcing recognizer activation on iOS, but making require-to-fail relations and failing recognizers is pretty straightforward.

The issue with that approach was the fact, that activation of the MA recognizer caused all touches in the view to be canceled, which meant that every UIControl wouldn't work.
This PR adds `cancelsTouchesInView = NO` to the MA recognizer, to prevent it from canceling underlying `UIControls`.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2544

## Test plan

Tested on the Example app and on the code from the issue.