### PR TITLE
`activeCursor` prop

### DIFF
--- a/docs/docs/api/gestures/base-gesture-config.md
+++ b/docs/docs/api/gestures/base-gesture-config.md
@@ -58,3 +58,7 @@ Adds a gesture that should be recognized simultaneously with this one.
 Adds a relation requiring another gesture to fail, before this one can activate.
 
 **IMPORTANT:** Note that this method only marks the relation between gestures, without [composing them](../../gesture-composition).[`GestureDetector`](gesture-detector) will not recognize the `otherGestures` and it needs to be added to another detector in order to be recognized.
+
+### `activeCursor(value)` (**web only**)
+
+This parameter allows to specify which cursor should be used when gesture activates. Supports all CSS cursor values (e.g. `"grab"`, `"zoom-in"`). Default value is set to `"auto"`.

--- a/docs/docs/api/gestures/gesture-detector.md
+++ b/docs/docs/api/gestures/gesture-detector.md
@@ -29,7 +29,3 @@ Starting with Reanimated-2.3.0-beta.4 Gesture Handler will provide a [StateManag
 ### `userSelect` (**web only**)
 
 This parameter allows to specify which `userSelect` property should be applied to underlying view. Possible values are `"none" | "auto" | "text"`. Default value is set to `"none"`.
-
-### `activeCursor` (**web only**)
-
-This parameter allows to specify which cursor should be used when gesture activates. Supports all CSS cursor values (e.g. `"grab"`, `"zoom-in"`). Default value is set to `"auto"`.

--- a/docs/docs/api/gestures/gesture-detector.md
+++ b/docs/docs/api/gestures/gesture-detector.md
@@ -28,4 +28,8 @@ Starting with Reanimated-2.3.0-beta.4 Gesture Handler will provide a [StateManag
 
 ### `userSelect` (**web only**)
 
-This parameter allows to specify which `userSelect` property should be applied to underlying view. Possible values are `"none" | "auto" | "text"`. Defaults to `"none"`.
+This parameter allows to specify which `userSelect` property should be applied to underlying view. Possible values are `"none" | "auto" | "text"`. Default value is set to `"none"`.
+
+### `activeCursor` (**web only**)
+
+This parameter allows to specify which cursor should be used when gesture activates. Supports all CSS cursor values (e.g. `"grab"`, `"zoom-in"`). Default value is set to `"auto"`.

--- a/docs/docs/gesture-handlers/api/common-gh.md
+++ b/docs/docs/gesture-handlers/api/common-gh.md
@@ -65,7 +65,11 @@ Specifying `width` or `height` is useful if we only want the gesture to activate
 
 ### `userSelect` (**web only**)
 
-This parameter allows to specify which `userSelect` property should be applied to underlying view. Possible values are `"none" | "auto" | "text"`. Defaults to `"none"`.
+This parameter allows to specify which `userSelect` property should be applied to underlying view. Possible values are `"none" | "auto" | "text"`. Default value is set to `"none"`.
+
+### `activeCursor` (**web only**)
+
+This parameter allows to specify which cursor should be used when gesture activates. Supports all CSS cursor values (e.g. `"grab"`, `"zoom-in"`). Default value is set to `"auto"`.
 
 ### `onGestureEvent`
 

--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -167,6 +167,11 @@ export interface DrawerLayoutProps {
    */
   userSelect?: UserSelect;
 
+  /**
+   * @default 'auto'
+   * Defines which cursor property should be used when gesture activates.
+   * Values: see CSS cursor values
+   */
   activeCursor?: ActiveCursor;
 }
 

--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -27,6 +27,7 @@ import {
   GestureEvent,
   HandlerStateChangeEvent,
   UserSelect,
+  ActiveCursor,
 } from '../handlers/gestureHandlerCommon';
 import {
   PanGestureHandler,
@@ -165,6 +166,8 @@ export interface DrawerLayoutProps {
    * Values: 'none'|'text'|'auto'
    */
   userSelect?: UserSelect;
+
+  activeCursor?: ActiveCursor;
 }
 
 export type DrawerLayoutState = {
@@ -691,6 +694,7 @@ export default class DrawerLayout extends Component<
       <PanGestureHandler
         // @ts-ignore could be fixed in handler types
         userSelect={this.props.userSelect}
+        activeCursor={this.props.activeCursor}
         ref={this.setPanGestureRef}
         hitSlop={hitSlop}
         activeOffsetX={gestureOrientation * minSwipeDistance!}

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -19,6 +19,7 @@ const commonProps = [
   'hitSlop',
   'cancelsTouchesInView',
   'userSelect',
+  'activeCursor',
 ] as const;
 
 const componentInteractionProps = ['waitFor', 'simultaneousHandlers'] as const;
@@ -64,6 +65,43 @@ export type HitSlop =
   | Record<'height' | 'bottom', number>;
 
 export type UserSelect = 'none' | 'auto' | 'text';
+export type ActiveCursor =
+  | 'auto'
+  | 'default'
+  | 'none'
+  | 'context-menu'
+  | 'help'
+  | 'pointer'
+  | 'progress'
+  | 'wait'
+  | 'cell'
+  | 'crosshair'
+  | 'text'
+  | 'vertical-text'
+  | 'alias'
+  | 'copy'
+  | 'move'
+  | 'no-drop'
+  | 'not-allowed'
+  | 'grab'
+  | 'grabbing'
+  | 'e-resize'
+  | 'n-resize'
+  | 'ne-resize'
+  | 'nw-resize'
+  | 's-resize'
+  | 'se-resize'
+  | 'sw-resize'
+  | 'w-resize'
+  | 'ew-resize'
+  | 'ns-resize'
+  | 'nesw-resize'
+  | 'nwse-resize'
+  | 'col-resize'
+  | 'row-resize'
+  | 'all-scroll'
+  | 'zoom-in'
+  | 'zoom-out';
 
 //TODO(TS) events in handlers
 
@@ -105,6 +143,7 @@ export type CommonGestureConfig = {
   shouldCancelWhenOutside?: boolean;
   hitSlop?: HitSlop;
   userSelect?: UserSelect;
+  activeCursor?: ActiveCursor;
 };
 
 // Events payloads are types instead of interfaces due to TS limitation.

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -19,6 +19,7 @@ import {
   HandlerStateChangeEvent,
   scheduleFlushOperations,
   UserSelect,
+  ActiveCursor,
 } from '../gestureHandlerCommon';
 import {
   GestureStateManager,
@@ -599,9 +600,19 @@ const applyUserSelectProp = (
   }
 };
 
+const applyCursorProp = (
+  activeCursor: ActiveCursor,
+  gesture: ComposedGesture | GestureType
+): void => {
+  for (const g of gesture.toGestureArray()) {
+    g.config.cursor = activeCursor;
+  }
+};
+
 interface GestureDetectorProps {
   gesture: ComposedGesture | GestureType;
   userSelect?: UserSelect;
+  activeCursor?: ActiveCursor;
   children?: React.ReactNode;
 }
 interface GestureDetectorState {
@@ -622,6 +633,10 @@ export const GestureDetector = (props: GestureDetectorProps) => {
 
   if (props.userSelect) {
     applyUserSelectProp(props.userSelect, gestureConfig);
+  }
+
+  if (props.activeCursor) {
+    applyCursorProp(props.activeCursor, gestureConfig);
   }
 
   const gesture = gestureConfig.toGestureArray();

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -605,7 +605,7 @@ const applyCursorProp = (
   gesture: ComposedGesture | GestureType
 ): void => {
   for (const g of gesture.toGestureArray()) {
-    g.config.cursor = activeCursor;
+    g.config.activeCursor = activeCursor;
   }
 };
 

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -19,7 +19,6 @@ import {
   HandlerStateChangeEvent,
   scheduleFlushOperations,
   UserSelect,
-  ActiveCursor,
 } from '../gestureHandlerCommon';
 import {
   GestureStateManager,
@@ -600,19 +599,9 @@ const applyUserSelectProp = (
   }
 };
 
-const applyActiveCursorProp = (
-  activeCursor: ActiveCursor,
-  gesture: ComposedGesture | GestureType
-): void => {
-  for (const g of gesture.toGestureArray()) {
-    g.config.activeCursor = activeCursor;
-  }
-};
-
 interface GestureDetectorProps {
   gesture: ComposedGesture | GestureType;
   userSelect?: UserSelect;
-  activeCursor?: ActiveCursor;
   children?: React.ReactNode;
 }
 interface GestureDetectorState {
@@ -633,10 +622,6 @@ export const GestureDetector = (props: GestureDetectorProps) => {
 
   if (props.userSelect) {
     applyUserSelectProp(props.userSelect, gestureConfig);
-  }
-
-  if (props.activeCursor) {
-    applyActiveCursorProp(props.activeCursor, gestureConfig);
   }
 
   const gesture = gestureConfig.toGestureArray();

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -600,7 +600,7 @@ const applyUserSelectProp = (
   }
 };
 
-const applyCursorProp = (
+const applyActiveCursorProp = (
   activeCursor: ActiveCursor,
   gesture: ComposedGesture | GestureType
 ): void => {
@@ -636,7 +636,7 @@ export const GestureDetector = (props: GestureDetectorProps) => {
   }
 
   if (props.activeCursor) {
-    applyCursorProp(props.activeCursor, gestureConfig);
+    applyActiveCursorProp(props.activeCursor, gestureConfig);
   }
 
   const gesture = gestureConfig.toGestureArray();

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -6,6 +6,7 @@ import {
   GestureTouchEvent,
   GestureStateChangeEvent,
   GestureUpdateEvent,
+  ActiveCursor,
 } from '../gestureHandlerCommon';
 import { getNextHandlerTag } from '../handlersRegistry';
 import { GestureStateManagerType } from './gestureStateManager';
@@ -247,6 +248,11 @@ export abstract class BaseGesture<
 
   hitSlop(hitSlop: HitSlop) {
     this.config.hitSlop = hitSlop;
+    return this;
+  }
+
+  activeCursor(activeCursor: ActiveCursor) {
+    this.config.activeCursor = activeCursor;
     return this;
   }
 

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -167,10 +167,18 @@ export default abstract class GestureHandler {
       this.currentState === State.ACTIVE ||
       this.currentState === State.BEGAN
     ) {
-      this.moveToState(State.FAILED, sendIfDisabled);
-      if (this.config.activeCursor && this.config.activeCursor != 'auto') {
+      // Here the order of this if statement and moveToState call is important.
+      // At this point we can use currentState as previuos state, because immediately after changing cursor we call moveToState method.
+      // By checking whether previous state was ACTIVE, we can decide if we should reset the cursor or not.
+      if (
+        this.config.activeCursor &&
+        this.config.activeCursor != 'auto' &&
+        this.currentState === State.ACTIVE
+      ) {
         this.view.style.cursor = 'auto';
       }
+
+      this.moveToState(State.FAILED, sendIfDisabled);
     }
 
     this.resetProgress();
@@ -186,10 +194,17 @@ export default abstract class GestureHandler {
       this.currentState === State.BEGAN
     ) {
       this.onCancel();
-      this.moveToState(State.CANCELLED, sendIfDisabled);
-      if (this.config.activeCursor && this.config.activeCursor != 'auto') {
+
+      // Same as above - order matters
+      if (
+        this.config.activeCursor &&
+        this.config.activeCursor != 'auto' &&
+        this.currentState === State.ACTIVE
+      ) {
         this.view.style.cursor = 'auto';
       }
+
+      this.moveToState(State.CANCELLED, sendIfDisabled);
     }
   }
 
@@ -214,11 +229,16 @@ export default abstract class GestureHandler {
       this.currentState === State.BEGAN ||
       this.currentState === State.ACTIVE
     ) {
-      this.moveToState(State.END);
-
-      if (this.config.activeCursor && this.config.activeCursor != 'auto') {
+      // Same as above - order matters
+      if (
+        this.config.activeCursor &&
+        this.config.activeCursor != 'auto' &&
+        this.currentState === State.ACTIVE
+      ) {
         this.view.style.cursor = 'auto';
       }
+
+      this.moveToState(State.END);
     }
 
     this.resetProgress();

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -195,7 +195,9 @@ export default abstract class GestureHandler {
       this.currentState === State.BEGAN
     ) {
       this.moveToState(State.ACTIVE);
-      this.view.style.cursor = 'grab';
+      this.view.style.cursor = this.config.activeCursor
+        ? this.config.activeCursor
+        : 'auto';
     }
   }
 

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -201,7 +201,7 @@ export default abstract class GestureHandler {
       this.moveToState(State.ACTIVE);
 
       if (
-        (this.view.style.cursor === 'auto' || this.view.style.cursor === '') &&
+        (!this.view.style.cursor || this.view.style.cursor === 'auto') &&
         this.config.activeCursor
       ) {
         this.view.style.cursor = this.config.activeCursor;

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -172,7 +172,7 @@ export default abstract class GestureHandler {
       // By checking whether previous state was ACTIVE, we can decide if we should reset the cursor or not.
       if (
         this.config.activeCursor &&
-        this.config.activeCursor != 'auto' &&
+        this.config.activeCursor !== 'auto' &&
         this.currentState === State.ACTIVE
       ) {
         this.view.style.cursor = 'auto';
@@ -198,7 +198,7 @@ export default abstract class GestureHandler {
       // Same as above - order matters
       if (
         this.config.activeCursor &&
-        this.config.activeCursor != 'auto' &&
+        this.config.activeCursor !== 'auto' &&
         this.currentState === State.ACTIVE
       ) {
         this.view.style.cursor = 'auto';
@@ -232,7 +232,7 @@ export default abstract class GestureHandler {
       // Same as above - order matters
       if (
         this.config.activeCursor &&
-        this.config.activeCursor != 'auto' &&
+        this.config.activeCursor !== 'auto' &&
         this.currentState === State.ACTIVE
       ) {
         this.view.style.cursor = 'auto';

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -168,7 +168,9 @@ export default abstract class GestureHandler {
       this.currentState === State.BEGAN
     ) {
       this.moveToState(State.FAILED, sendIfDisabled);
-      this.view.style.cursor = 'auto';
+      if (this.config.activeCursor && this.config.activeCursor != 'auto') {
+        this.view.style.cursor = 'auto';
+      }
     }
 
     this.resetProgress();
@@ -185,7 +187,9 @@ export default abstract class GestureHandler {
     ) {
       this.onCancel();
       this.moveToState(State.CANCELLED, sendIfDisabled);
-      this.view.style.cursor = 'auto';
+      if (this.config.activeCursor && this.config.activeCursor != 'auto') {
+        this.view.style.cursor = 'auto';
+      }
     }
   }
 
@@ -195,9 +199,13 @@ export default abstract class GestureHandler {
       this.currentState === State.BEGAN
     ) {
       this.moveToState(State.ACTIVE);
-      this.view.style.cursor = this.config.activeCursor
-        ? this.config.activeCursor
-        : 'auto';
+
+      if (
+        (this.view.style.cursor === 'auto' || this.view.style.cursor === '') &&
+        this.config.activeCursor
+      ) {
+        this.view.style.cursor = this.config.activeCursor;
+      }
     }
   }
 
@@ -207,7 +215,10 @@ export default abstract class GestureHandler {
       this.currentState === State.ACTIVE
     ) {
       this.moveToState(State.END);
-      this.view.style.cursor = 'auto';
+
+      if (this.config.activeCursor && this.config.activeCursor != 'auto') {
+        this.view.style.cursor = 'auto';
+      }
     }
 
     this.resetProgress();

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -170,7 +170,11 @@ export default abstract class GestureHandler {
       // Here the order of this if statement and moveToState call is important.
       // At this point we can use currentState as previuos state, because immediately after changing cursor we call moveToState method.
       // By checking whether previous state was ACTIVE, we can decide if we should reset the cursor or not.
-      if (this.config.activeCursor && this.currentState === State.ACTIVE) {
+      if (
+        this.config.activeCursor &&
+        this.config.activeCursor !== 'auto' &&
+        this.currentState === State.ACTIVE
+      ) {
         this.view.style.cursor = 'auto';
       }
 
@@ -192,7 +196,11 @@ export default abstract class GestureHandler {
       this.onCancel();
 
       // Same as above - order matters
-      if (this.config.activeCursor && this.currentState === State.ACTIVE) {
+      if (
+        this.config.activeCursor &&
+        this.config.activeCursor !== 'auto' &&
+        this.currentState === State.ACTIVE
+      ) {
         this.view.style.cursor = 'auto';
       }
 
@@ -222,7 +230,11 @@ export default abstract class GestureHandler {
       this.currentState === State.ACTIVE
     ) {
       // Same as above - order matters
-      if (this.config.activeCursor && this.currentState === State.ACTIVE) {
+      if (
+        this.config.activeCursor &&
+        this.config.activeCursor !== 'auto' &&
+        this.currentState === State.ACTIVE
+      ) {
         this.view.style.cursor = 'auto';
       }
 

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -170,11 +170,7 @@ export default abstract class GestureHandler {
       // Here the order of this if statement and moveToState call is important.
       // At this point we can use currentState as previuos state, because immediately after changing cursor we call moveToState method.
       // By checking whether previous state was ACTIVE, we can decide if we should reset the cursor or not.
-      if (
-        this.config.activeCursor &&
-        this.config.activeCursor !== 'auto' &&
-        this.currentState === State.ACTIVE
-      ) {
+      if (this.config.activeCursor && this.currentState === State.ACTIVE) {
         this.view.style.cursor = 'auto';
       }
 
@@ -196,11 +192,7 @@ export default abstract class GestureHandler {
       this.onCancel();
 
       // Same as above - order matters
-      if (
-        this.config.activeCursor &&
-        this.config.activeCursor !== 'auto' &&
-        this.currentState === State.ACTIVE
-      ) {
+      if (this.config.activeCursor && this.currentState === State.ACTIVE) {
         this.view.style.cursor = 'auto';
       }
 
@@ -230,11 +222,7 @@ export default abstract class GestureHandler {
       this.currentState === State.ACTIVE
     ) {
       // Same as above - order matters
-      if (
-        this.config.activeCursor &&
-        this.config.activeCursor !== 'auto' &&
-        this.currentState === State.ACTIVE
-      ) {
+      if (this.config.activeCursor && this.currentState === State.ACTIVE) {
         this.view.style.cursor = 'auto';
       }
 

--- a/src/web/interfaces.ts
+++ b/src/web/interfaces.ts
@@ -1,4 +1,4 @@
-import { UserSelect } from '../handlers/gestureHandlerCommon';
+import { UserSelect, ActiveCursor } from '../handlers/gestureHandlerCommon';
 import { Directions } from '../Directions';
 import { State } from '../State';
 
@@ -22,6 +22,7 @@ type ConfigArgs =
   | boolean
   | HitSlop
   | UserSelect
+  | ActiveCursor
   | Directions
   | Handler[]
   | null
@@ -34,6 +35,7 @@ export interface Config extends Record<string, ConfigArgs> {
   hitSlop?: HitSlop;
   shouldCancelWhenOutside?: boolean;
   userSelect?: UserSelect;
+  activeCursor?: ActiveCursor;
 
   activateAfterLongPress?: number;
   failOffsetXStart?: number;


### PR DESCRIPTION
## Description

This PR adds `activeCursor` prop which allows users to change cursor appearance upon handler activation. Initially it was added in [2.6.1](https://github.com/software-mansion/react-native-gesture-handler/releases/tag/2.6.1) as a response to [this issue](https://github.com/software-mansion/react-native-gesture-handler/issues/700). However, not everyone liked the idea (which is understandable), so we decided to turn this change into property. This way anyone who was using it still will be able to do so, and those who didn't like the change don't have to remove it on their own.

## Old API example

```jsx
<PanGestureHandler activeCursor="grab">
      <View style={styles.box}></View>
</PanGestureHandler>
```

## New API example

```jsx
  const panGesture = Gesture.Pan().activeCursor('wait');

  return (
    <GestureDetector gesture={panGesture}>
      <View style={styles.box}></View>
    </GestureDetector>
  );
```

## Test plan

Tested on example app
