### PR TITLE
Improve multi-pointer behavior (with ScrollView) on Android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -325,6 +325,8 @@ class GestureHandlerOrchestrator(
     return parent === wrapperView
   }
 
+  fun isAnyHandlerActive() = gestureHandlers.any { it?.state == GestureHandler.STATE_ACTIVE }
+
   /**
    * Transforms an event in the coordinates of wrapperView into the coordinate space of the received view.
    *

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -6,6 +6,7 @@ import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.widget.ScrollView
+import com.facebook.react.views.scroll.ReactScrollView
 import com.facebook.react.views.swiperefresh.ReactSwipeRefreshLayout
 import com.facebook.react.views.textinput.ReactEditText
 
@@ -75,6 +76,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
       is NativeViewGestureHandlerHook -> this.hook = view
       is ReactEditText -> this.hook = EditTextHook(this, view)
       is ReactSwipeRefreshLayout -> this.hook = SwipeRefreshLayoutHook(this, view)
+      is ReactScrollView -> this.hook = ScrollViewHook()
     }
   }
 
@@ -247,5 +249,9 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
       // - one to actually refresh
       // oh well  ¯\_(ツ)_/¯
     }
+  }
+
+  private class ScrollViewHook : NativeViewGestureHandlerHook {
+    override fun shouldCancelRootViewGestureHandlerIfNecessary() = true
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -58,6 +58,8 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
   private inner class RootViewGestureHandler : GestureHandler<RootViewGestureHandler>() {
     override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
       val currentState = state
+      // we shouldn't stop intercepting events when there is an active handler already, which could happen when
+      // adding a new pointer to the screen after a handler activates
       if (currentState == STATE_UNDETERMINED && (!shouldIntercept || orchestrator?.isAnyHandlerActive() != true)) {
         begin()
         shouldIntercept = false

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -59,8 +59,10 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
       val currentState = state
       if (currentState == STATE_UNDETERMINED) {
-        begin()
-        shouldIntercept = false
+        if (!shouldIntercept || orchestrator?.isAnyHandlerActive() != true) {
+          begin()
+          shouldIntercept = false
+        }
       }
       if (event.actionMasked == MotionEvent.ACTION_UP) {
         end()

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -58,11 +58,9 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
   private inner class RootViewGestureHandler : GestureHandler<RootViewGestureHandler>() {
     override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
       val currentState = state
-      if (currentState == STATE_UNDETERMINED) {
-        if (!shouldIntercept || orchestrator?.isAnyHandlerActive() != true) {
-          begin()
-          shouldIntercept = false
-        }
+      if (currentState == STATE_UNDETERMINED && (!shouldIntercept || orchestrator?.isAnyHandlerActive() != true)) {
+        begin()
+        shouldIntercept = false
       }
       if (event.actionMasked == MotionEvent.ACTION_UP) {
         end()


### PR DESCRIPTION
## Description

This PR solves two problems:
- `ScrollView` wrapped with `NativeViewGestureHandler` wasn't canceling the root view handler, which in turn meant that [`shouldIntercept` flag was never set](https://github.com/software-mansion/react-native-gesture-handler/blob/355a82fd3cf39b1bd4a57af958f040b563a1823e/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt#L71) and event was [dispatched to both, the handler and the view](https://github.com/software-mansion/react-native-gesture-handler/blob/355a82fd3cf39b1bd4a57af958f040b563a1823e/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt#L35-L37).
- After a handler was activated and the root handler was canceled (setting `shouldIntercept` to true), and a new pointer was added to the screen, the root handler would begin and set `shouldIntercept` back to false. Again, this meant dispatching events both to the handler and the view.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/1679

## Test plan

Tested on the Example app and [reproduction from the issue](https://github.com/software-mansion/react-native-gesture-handler/issues/1679#issuecomment-1471576215)
