### PR TITLE
Fix Reanimated worklet recognition on Fabric

### DIFF
--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -329,8 +329,10 @@ export default function createHandler<
 
         const actionType = (() => {
           if (
-            this.props?.onGestureEvent &&
-            'current' in this.props.onGestureEvent
+            (this.props?.onGestureEvent &&
+              'current' in this.props.onGestureEvent) ||
+            (this.props?.onHandlerStateChange &&
+              'current' in this.props.onHandlerStateChange)
           ) {
             // Reanimated worklet
             return ActionType.REANIMATED_WORKLET;


### PR DESCRIPTION
## Description

On the new architecture, a handler that is using reanimated worklet should be attached with an action type `REANIMATED_WORKLET`, so it will send an event directly to reanimatedEventDispatcher, instead of emitting an event on which reanimated should subscribe as it was on old architecture. Emitting and handling an event may fail in some cases, since handler might be an object based on type: `MutableRefObject<WorkletEventHandler<T> | null>` rather than a function.

## Test plan

Tested on an example app named 'accordion' for Fabric from reanimated repo: https://github.com/software-mansion/react-native-reanimated/blob/main/app/src/examples/OldMeasureExample.tsx#L212
