### PR TITLE
Remove error with `GestureHandlerRootView` on web

### DIFF
--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -402,7 +402,7 @@ export default function createHandler<
     }
 
     render() {
-      if (__DEV__ && !this.context && !isJestEnv()) {
+      if (__DEV__ && !this.context && !isJestEnv() && Platform.OS !== 'web') {
         throw new Error(
           name +
             ' must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/installation for more details.'

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -612,7 +612,7 @@ interface GestureDetectorState {
 }
 export const GestureDetector = (props: GestureDetectorProps) => {
   const rootViewContext = useContext(GestureHandlerRootViewContext);
-  if (__DEV__ && !rootViewContext && !isJestEnv()) {
+  if (__DEV__ && !rootViewContext && !isJestEnv() && Platform.OS !== 'web') {
     throw new Error(
       'GestureDetector must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/installation for more details.'
     );


### PR DESCRIPTION
## Description

Gestures on web don't work, unless they are wrapped inside `GestureHandlerRootView`. This PR removes the error, so that root view is no longer necessary.

Fixes #2557 

## Test plan

Tested on example app.
