### PR TITLE
fix: export SwipeableProps

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -147,6 +147,7 @@ export type {
   BorderlessButtonProperties,
 } from './handlers/gestureHandlerTypesCompat';
 
+export type { SwipeableProps } from './components/Swipeable';
 export { default as Swipeable } from './components/Swipeable';
 export type {
   DrawerLayoutProps,


### PR DESCRIPTION
## Description

Allows library consumer to import them.

## Test plan

Generated a new build and tested with types from `lib/typescript`.