### PR TITLE
Remove multiple instances check when building

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -2,21 +2,6 @@ require "json"
 
 fabric_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 
-isUserApp = File.exist?(File.join(__dir__, "..", "..", "node_modules", "react-native", "package.json"))
-if isUserApp
-  libInstances = %x[find ../../ -name "package.json" | grep "/react-native-gesture-handler/package.json" | grep -v "/.yarn/"]
-  libInstancesArray = libInstances.split("\n")
-  if libInstancesArray.length() > 1
-    parsedLocation = ''
-    for location in libInstancesArray
-      location['../../'] = '- '
-      location['/package.json'] = ''
-      parsedLocation += location + "\n"
-    end
-    raise "[Gesture Handler] Multiple versions of Gesture Handler were detected. Only one instance of react-native-gesture-handler can be installed in a project. You need to resolve the conflict manually. Check out the documentation: https://docs.swmansion.com/react-native-gesture-handler/docs/troubleshooting#multiple-versions-of-reanimated-were-detected \n\nConflict between: \n" + parsedLocation
-  end
-end
-
 Pod::Spec.new do |s|
   # NPM package specification
   package = JSON.parse(File.read(File.join(File.dirname(__FILE__), "package.json")))

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -68,14 +68,6 @@ if (project == rootProject) {
     apply from: "spotless.gradle"
 }
 
-def shouldAssertNoMultipleInstances() {
-  if (rootProject.hasProperty("disableMultipleInstancesCheck")) {
-    return rootProject.property("disableMultipleInstancesCheck") != "true"
-  } else {
-    return true
-  }
-}
-
 // Check whether Reanimated 2.3 or higher is installed alongside Gesture Handler
 def shouldUseCommonInterfaceFromReanimated() {
     def reanimated = rootProject.subprojects.find { it.name == 'react-native-reanimated' }
@@ -102,65 +94,6 @@ file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { react
 
 def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
 def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.startsWith("0.0.0-") ? 1000 : REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
-
-
-abstract class NoMultipleInstancesAssertionTask extends DefaultTask {
-    @Inject abstract ObjectFactory getObjectFactory()
-
-    @Input abstract Property<File> getProjectDirFile()
-    @Input abstract Property<File> getRootDirFile()
-    @Input abstract Property<Boolean> getShouldCheck()
-
-    def findGestureHandlerInstancesForPath(String path) {
-        return objectFactory.fileTree().from(path)
-                .include("**/react-native-gesture-handler/package.json")
-                .exclude("**/.yarn/**")
-                .exclude({ Files.isSymbolicLink(it.getFile().toPath()) })
-                .findAll()
-    }
-
-    @TaskAction
-    def check() {
-        if (shouldCheck.get()) {
-            // Assert there are no multiple installations of Gesture Handler
-            Set<File> files
-
-            if (projectDirFile.get().parent.contains(rootDirFile.get().parent)) {
-                // standard app
-                files = findGestureHandlerInstancesForPath(rootDirFile.get().parent + "/node_modules")
-            } else {
-                // monorepo
-                files = findGestureHandlerInstancesForPath(rootDirFile.get().parent + "/node_modules")
-                files.addAll(
-                    findGestureHandlerInstancesForPath(projectDirFile.get().parentFile.parent)
-                )
-            }
-
-            if (files.size() > 1) {
-                String parsedLocation = files.stream().map({
-                    File file -> "- " + file.toString().replace("/package.json", "")
-                }).collect().join("\n")
-                String exceptionMessage = "\n[react-native-gesture-handler] Multiple versions of Gesture Handler " +
-                        "were detected. Only one instance of react-native-gesture-handler can be installed in a " +
-                        "project. You need to resolve the conflict manually. Check out the documentation: " +
-                        "https://docs.swmansion.com/react-native-gesture-handler/docs/troubleshooting" +
-                        "#multiple-instances-of-gesture-handler-were-detected \n\nConflict between: \n" +
-                        parsedLocation + "\n"
-                throw new GradleException(exceptionMessage)
-            }
-        }
-    }
-}
-
-tasks.register('assertNoMultipleInstances', NoMultipleInstancesAssertionTask) {
-    shouldCheck = shouldAssertNoMultipleInstances()
-    rootDirFile = rootDir
-    projectDirFile = projectDir
-}
-
- tasks.preBuild {
-     dependsOn assertNoMultipleInstances
- }
 
 repositories {
     mavenCentral()

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -41,5 +41,3 @@ newArchEnabled=false
 # Use this property to enable or disable the Hermes JS engine.
 # If set to false, you will be using JSC instead.
 hermesEnabled=true
-
-disableMultipleInstancesCheck=false


### PR DESCRIPTION
## Description

Removes the code responsible for checking whether more than one instance of Gesture Handler is installed. While the idea is good, there are some problems with the approach - mainly symlinks. We should consider doing the same thing as Reanimared - comparing the version of native code against JS.

## Test plan

Check example apps