### PR TITLE
Don't create a `RippleDrawable` when the color is transparent

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -212,7 +212,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
         // Therefore it might be used as long as:
         // 1. ReactViewManager is not a generic class with a possibility to handle another ViewGroup
         // 2. There's no way to force native behavior of ReactViewGroup's superclass's onTouchEvent
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP && selectable is RippleDrawable) {
+        if (selectable is RippleDrawable) {
           val mask = PaintDrawable(Color.WHITE)
           mask.setCornerRadius(borderRadius)
           selectable.setDrawableByLayerId(android.R.id.mask, mask)
@@ -239,13 +239,6 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
     }
 
     private fun createSelectableDrawable(): Drawable? {
-      // TODO: remove once support for RN 0.63 is dropped, since 0.64 minSdkVersion is 21
-      if (Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-        context.theme.resolveAttribute(android.R.attr.selectableItemBackground, resolveOutValue, true)
-        @Suppress("Deprecation")
-        return resources.getDrawable(resolveOutValue.resourceId)
-      }
-
       // don't create ripple drawable at all when it's not supposed to be visible
       if (rippleColor == Color.TRANSPARENT) {
         return null

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -246,9 +246,8 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
         return resources.getDrawable(resolveOutValue.resourceId)
       }
 
-      // Since Android 13, alpha channel in RippleDrawable is clamped between [128, 255]
-      // see https://github.com/aosp-mirror/platform_frameworks_base/blob/c1bd0480261460584753508327ca8a0c6fc80758/graphics/java/android/graphics/drawable/RippleDrawable.java#L1012
-      if (rippleColor == Color.TRANSPARENT && Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      // don't create ripple drawable at all when it's not supposed to be visible
+      if (rippleColor == Color.TRANSPARENT) {
         return null
       }
 


### PR DESCRIPTION
## Description

When the `GestureHandlerButton` was disabled immediately after clicking it, the ripple animation would show even if its color was set to transparent. This PR updates the background creation logic not to create the `RippleDrawable` when its color would be transparent, which prevents the issue from happening.

It also removes some unnecessary SDK version checks, since RN 0.64 is the last supported version starting with Gesture Handler 2.10.0

## Test plan

Tested on the snippet from https://github.com/software-mansion/react-native-gesture-handler/pull/2418#issuecomment-1685239555
