### PR TITLE
Decouple the JS implementation from the web APIs

### DIFF
--- a/src/RNGestureHandlerModule.macos.ts
+++ b/src/RNGestureHandlerModule.macos.ts
@@ -23,6 +23,7 @@ import HammerPinchGestureHandler from './web_hammer/PinchGestureHandler';
 import HammerRotationGestureHandler from './web_hammer/RotationGestureHandler';
 import HammerFlingGestureHandler from './web_hammer/FlingGestureHandler';
 import { Config } from './web/interfaces';
+import { GestureHandlerWebDelegate } from './web/tools/GestureHandlerWebDelegate';
 
 export const Gestures = {
   NativeViewGestureHandler,
@@ -65,7 +66,10 @@ export default {
       }
 
       const GestureClass = Gestures[handlerName];
-      NodeManager.createGestureHandler(handlerTag, new GestureClass());
+      NodeManager.createGestureHandler(
+        handlerTag,
+        new GestureClass(new GestureHandlerWebDelegate())
+      );
       InteractionManager.getInstance().configureInteractions(
         NodeManager.getHandler(handlerTag),
         config as unknown as Config

--- a/src/RNGestureHandlerModule.web.ts
+++ b/src/RNGestureHandlerModule.web.ts
@@ -26,6 +26,7 @@ import HammerPinchGestureHandler from './web_hammer/PinchGestureHandler';
 import HammerRotationGestureHandler from './web_hammer/RotationGestureHandler';
 import HammerFlingGestureHandler from './web_hammer/FlingGestureHandler';
 import { Config } from './web/interfaces';
+import { GestureHandlerWebDelegate } from './web/tools/GestureHandlerWebDelegate';
 
 export const Gestures = {
   NativeViewGestureHandler,
@@ -69,7 +70,10 @@ export default {
       }
 
       const GestureClass = Gestures[handlerName];
-      NodeManager.createGestureHandler(handlerTag, new GestureClass());
+      NodeManager.createGestureHandler(
+        handlerTag,
+        new GestureClass(new GestureHandlerWebDelegate())
+      );
       InteractionManager.getInstance().configureInteractions(
         NodeManager.getHandler(handlerTag),
         config as unknown as Config

--- a/src/RNGestureHandlerModule.windows.ts
+++ b/src/RNGestureHandlerModule.windows.ts
@@ -25,6 +25,7 @@ import HammerPinchGestureHandler from './web_hammer/PinchGestureHandler';
 import HammerRotationGestureHandler from './web_hammer/RotationGestureHandler';
 import HammerFlingGestureHandler from './web_hammer/FlingGestureHandler';
 import { Config } from './web/interfaces';
+import { GestureHandlerWebDelegate } from './web/tools/GestureHandlerWebDelegate';
 
 export const Gestures = {
   NativeViewGestureHandler,
@@ -67,7 +68,10 @@ export default {
       }
 
       const GestureClass = Gestures[handlerName];
-      NodeManager.createGestureHandler(handlerTag, new GestureClass());
+      NodeManager.createGestureHandler(
+        handlerTag,
+        new GestureClass(new GestureHandlerWebDelegate())
+      );
       InteractionManager.getInstance().configureInteractions(
         NodeManager.getHandler(handlerTag),
         config as unknown as Config

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -39,17 +39,6 @@ export default class FlingGestureHandler extends GestureHandler {
     }
   }
 
-  protected transformNativeEvent() {
-    const rect: DOMRect = this.view.getBoundingClientRect();
-
-    return {
-      x: this.tracker.getLastAvgX() - rect.left,
-      y: this.tracker.getLastAvgY() - rect.top,
-      absoluteX: this.tracker.getLastAvgX(),
-      absoluteY: this.tracker.getLastAvgY(),
-    };
-  }
-
   private startFling(): void {
     this.startX = this.tracker.getLastX(this.keyPointer);
     this.startY = this.tracker.getLastY(this.keyPointer);

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -34,7 +34,7 @@ export default abstract class GestureHandler {
   protected config: Config = { enabled: false };
   protected view!: HTMLElement;
 
-  protected eventManagers: EventManager[] = [];
+  protected eventManagers: EventManager<unknown>[] = [];
   protected tracker: PointerTracker = new PointerTracker();
 
   // Orchestrator properties
@@ -84,7 +84,7 @@ export default abstract class GestureHandler {
     }
   }
 
-  private addEventManager(manager: EventManager): void {
+  private addEventManager(manager: EventManager<unknown>): void {
     manager.setOnPointerDown(this.onPointerDown.bind(this));
     manager.setOnPointerAdd(this.onPointerAdd.bind(this));
     manager.setOnPointerUp(this.onPointerUp.bind(this));
@@ -113,7 +113,7 @@ export default abstract class GestureHandler {
     this.tracker.resetTracker();
     this.onReset();
     this.resetProgress();
-    this.eventManagers.forEach((manager: EventManager) =>
+    this.eventManagers.forEach((manager: EventManager<unknown>) =>
       manager.resetManager()
     );
     this.currentState = State.UNDETERMINED;
@@ -816,7 +816,7 @@ export default abstract class GestureHandler {
     return this.view;
   }
 
-  public getEventManagers(): EventManager[] {
+  public getEventManagers(): EventManager<unknown>[] {
     return this.eventManagers;
   }
 

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -30,7 +30,6 @@ export default abstract class GestureHandler {
   private handlerTag!: number;
   protected config: Config = { enabled: false };
 
-  protected eventManagers: EventManager<unknown>[] = [];
   protected tracker: PointerTracker = new PointerTracker();
 
   // Orchestrator properties
@@ -59,7 +58,7 @@ export default abstract class GestureHandler {
     this.delegate.init(viewRef, this);
   }
 
-  public addEventManager(manager: EventManager<unknown>): void {
+  public attachEventManager(manager: EventManager<unknown>): void {
     manager.setOnPointerDown(this.onPointerDown.bind(this));
     manager.setOnPointerAdd(this.onPointerAdd.bind(this));
     manager.setOnPointerUp(this.onPointerUp.bind(this));
@@ -72,8 +71,6 @@ export default abstract class GestureHandler {
     manager.setOnPointerMoveOver(this.onPointerMoveOver.bind(this));
     manager.setOnPointerMoveOut(this.onPointerMoveOut.bind(this));
     manager.setListeners();
-
-    this.eventManagers.push(manager);
   }
 
   //
@@ -88,9 +85,7 @@ export default abstract class GestureHandler {
     this.tracker.resetTracker();
     this.onReset();
     this.resetProgress();
-    this.eventManagers.forEach((manager: EventManager<unknown>) =>
-      manager.resetManager()
-    );
+    this.delegate.reset();
     this.currentState = State.UNDETERMINED;
   }
 

--- a/src/web/handlers/HoverGestureHandler.ts
+++ b/src/web/handlers/HoverGestureHandler.ts
@@ -12,17 +12,6 @@ export default class HoverGestureHandler extends GestureHandler {
     super.updateGestureConfig({ enabled: enabled, ...props });
   }
 
-  protected transformNativeEvent() {
-    const rect: DOMRect = this.view.getBoundingClientRect();
-
-    return {
-      x: this.tracker.getLastAvgX() - rect.left,
-      y: this.tracker.getLastAvgY() - rect.top,
-      absoluteX: this.tracker.getLastAvgX(),
-      absoluteY: this.tracker.getLastAvgY(),
-    };
-  }
-
   protected onPointerMoveOver(event: AdaptedEvent): void {
     GestureHandlerOrchestrator.getInstance().recordHandlerIfNotPresent(this);
 

--- a/src/web/handlers/LongPressGestureHandler.ts
+++ b/src/web/handlers/LongPressGestureHandler.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import { State } from '../../State';
 import { AdaptedEvent, Config } from '../interfaces';
 
@@ -23,17 +24,14 @@ export default class LongPressGestureHandler extends GestureHandler {
   public init(ref: number, propsRef: React.RefObject<unknown>) {
     super.init(ref, propsRef);
 
-    this.view.oncontextmenu = () => false;
+    if (Platform.OS === 'web') {
+      (this.delegate.view as HTMLElement).oncontextmenu = () => false;
+    }
   }
 
   protected transformNativeEvent() {
-    const rect: DOMRect = this.view.getBoundingClientRect();
-
     return {
-      x: this.tracker.getLastAvgX() - rect.left,
-      y: this.tracker.getLastAvgY() - rect.top,
-      absoluteX: this.tracker.getLastAvgX(),
-      absoluteY: this.tracker.getLastAvgY(),
+      ...super.transformNativeEvent(),
       duration: Date.now() - this.startTime,
     };
   }

--- a/src/web/handlers/LongPressGestureHandler.ts
+++ b/src/web/handlers/LongPressGestureHandler.ts
@@ -25,7 +25,7 @@ export default class LongPressGestureHandler extends GestureHandler {
     super.init(ref, propsRef);
 
     if (Platform.OS === 'web') {
-      (this.delegate.view as HTMLElement).oncontextmenu = () => false;
+      (this.delegate.getView() as HTMLElement).oncontextmenu = () => false;
     }
   }
 

--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -1,3 +1,4 @@
+import { Platform } from 'react-native';
 import { State } from '../../State';
 import { DEFAULT_TOUCH_SLOP } from '../constants';
 import { AdaptedEvent, Config } from '../interfaces';
@@ -20,15 +21,19 @@ export default class NativeViewGestureHandler extends GestureHandler {
 
     this.setShouldCancelWhenOutside(true);
 
-    this.view.style['touchAction'] = 'auto';
+    if (Platform.OS === 'web') {
+      const view = this.delegate.view as HTMLElement;
 
-    //@ts-ignore Turns on defualt touch behavior on Safari
-    this.view.style['WebkitTouchCallout'] = 'auto';
+      view.style['touchAction'] = 'auto';
 
-    if (this.view.hasAttribute('role')) {
-      this.buttonRole = true;
-    } else {
-      this.buttonRole = false;
+      //@ts-ignore Turns on defualt touch behavior on Safari
+      view.style['WebkitTouchCallout'] = 'auto';
+
+      if (view.hasAttribute('role')) {
+        this.buttonRole = true;
+      } else {
+        this.buttonRole = false;
+      }
     }
   }
 

--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -25,7 +25,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
       return;
     }
 
-    const view = this.delegate.view as HTMLElement;
+    const view = this.delegate.getView() as HTMLElement;
 
     view.style['touchAction'] = 'auto';
 

--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -21,19 +21,21 @@ export default class NativeViewGestureHandler extends GestureHandler {
 
     this.setShouldCancelWhenOutside(true);
 
-    if (Platform.OS === 'web') {
-      const view = this.delegate.view as HTMLElement;
+    if (Platform.OS !== 'web') {
+      return;
+    }
 
-      view.style['touchAction'] = 'auto';
+    const view = this.delegate.view as HTMLElement;
 
-      //@ts-ignore Turns on defualt touch behavior on Safari
-      view.style['WebkitTouchCallout'] = 'auto';
+    view.style['touchAction'] = 'auto';
 
-      if (view.hasAttribute('role')) {
-        this.buttonRole = true;
-      } else {
-        this.buttonRole = false;
-      }
+    //@ts-ignore Turns on defualt touch behavior on Safari
+    view.style['WebkitTouchCallout'] = 'auto';
+
+    if (view.hasAttribute('role')) {
+      this.buttonRole = true;
+    } else {
+      this.buttonRole = false;
     }
   }
 

--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -186,20 +186,15 @@ export default class PanGestureHandler extends GestureHandler {
   }
 
   protected transformNativeEvent() {
-    const rect: DOMRect = this.view.getBoundingClientRect();
-
     const translationX: number = this.getTranslationX();
     const translationY: number = this.getTranslationY();
 
     return {
+      ...super.transformNativeEvent(),
       translationX: isNaN(translationX) ? 0 : translationX,
       translationY: isNaN(translationY) ? 0 : translationY,
-      absoluteX: this.tracker.getLastAvgX(),
-      absoluteY: this.tracker.getLastAvgY(),
       velocityX: this.velocityX,
       velocityY: this.velocityY,
-      x: this.tracker.getLastAvgX() - rect.left,
-      y: this.tracker.getLastAvgY() - rect.top,
     };
   }
 
@@ -469,7 +464,6 @@ export default class PanGestureHandler extends GestureHandler {
     }
 
     super.activate(force);
-    this.view.style.cursor = 'grab';
   }
 
   protected onCancel(): void {
@@ -478,7 +472,6 @@ export default class PanGestureHandler extends GestureHandler {
 
   protected onReset(): void {
     this.clearActivationTimeout();
-    this.view.style.cursor = 'auto';
   }
 
   protected resetProgress(): void {

--- a/src/web/handlers/TapGestureHandler.ts
+++ b/src/web/handlers/TapGestureHandler.ts
@@ -79,17 +79,6 @@ export default class TapGestureHandler extends GestureHandler {
     this.minNumberOfPointers = DEFAULT_MIN_NUMBER_OF_POINTERS;
   }
 
-  protected transformNativeEvent() {
-    const rect: DOMRect = this.view.getBoundingClientRect();
-
-    return {
-      x: this.tracker.getLastAvgX() - rect.left,
-      y: this.tracker.getLastAvgY() - rect.top,
-      absoluteX: this.tracker.getLastAvgX(),
-      absoluteY: this.tracker.getLastAvgY(),
-    };
-  }
-
   private clearTimeouts(): void {
     clearTimeout(this.waitTimeout);
     clearTimeout(this.delayTimeout);

--- a/src/web/tools/EventManager.ts
+++ b/src/web/tools/EventManager.ts
@@ -1,12 +1,12 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { AdaptedEvent, EventTypes, TouchEventType } from '../interfaces';
 
-export default abstract class EventManager {
-  protected readonly view: HTMLElement;
+export default abstract class EventManager<T> {
+  protected readonly view: T;
   protected pointersInBounds: number[] = [];
   protected activePointersCounter: number;
 
-  constructor(view: HTMLElement) {
+  constructor(view: T) {
     this.view = view;
     this.activePointersCounter = 0;
   }

--- a/src/web/tools/GestureHandlerDelegate.ts
+++ b/src/web/tools/GestureHandlerDelegate.ts
@@ -1,0 +1,23 @@
+import type GestureHandler from '../handlers/GestureHandler';
+
+export interface MeasureResult {
+  pageX: number;
+  pageY: number;
+  width: number;
+  height: number;
+}
+
+export interface GestureHandlerDelegate<T> {
+  readonly view: T;
+
+  init(viewRef: number, handler: GestureHandler): void;
+  isPointerInBounds({ x, y }: { x: number; y: number }): boolean;
+  measureView(): MeasureResult;
+  reset(): void;
+
+  onBegin(): void;
+  onActivate(): void;
+  onEnd(): void;
+  onCancel(): void;
+  onFail(): void;
+}

--- a/src/web/tools/GestureHandlerDelegate.ts
+++ b/src/web/tools/GestureHandlerDelegate.ts
@@ -8,7 +8,7 @@ export interface MeasureResult {
 }
 
 export interface GestureHandlerDelegate<T> {
-  readonly view: T;
+  getView(): T;
 
   init(viewRef: number, handler: GestureHandler): void;
   isPointerInBounds({ x, y }: { x: number; y: number }): boolean;

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -300,7 +300,7 @@ export default class GestureHandlerOrchestrator {
 
     if (
       !PointerTracker.shareCommonPointers(handlerPointers, otherPointers) &&
-      handler.getDelegate().view !== otherHandler.getDelegate().view
+      handler.getDelegate().getView() !== otherHandler.getDelegate().getView()
     ) {
       return this.checkOverlap(handler, otherHandler);
     }

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -3,7 +3,6 @@ import { PointerType } from '../interfaces';
 
 import GestureHandler from '../handlers/GestureHandler';
 import PointerTracker from './PointerTracker';
-import { isPointerInBounds } from '../utils';
 
 export default class GestureHandlerOrchestrator {
   private static instance: GestureHandlerOrchestrator;
@@ -301,7 +300,7 @@ export default class GestureHandlerOrchestrator {
 
     if (
       !PointerTracker.shareCommonPointers(handlerPointers, otherPointers) &&
-      handler.getView() !== otherHandler.getView()
+      handler.getDelegate().view !== otherHandler.getDelegate().view
     ) {
       return this.checkOverlap(handler, otherHandler);
     }
@@ -329,8 +328,10 @@ export default class GestureHandlerOrchestrator {
       const handlerY: number = handler.getTracker().getLastY(pointer);
 
       if (
-        isPointerInBounds(handler.getView(), { x: handlerX, y: handlerY }) &&
-        isPointerInBounds(otherHandler.getView(), { x: handlerX, y: handlerY })
+        handler.getDelegate().isPointerInBounds({ x: handlerX, y: handlerY }) &&
+        otherHandler
+          .getDelegate()
+          .isPointerInBounds({ x: handlerX, y: handlerY })
       ) {
         overlap = true;
       }
@@ -341,8 +342,8 @@ export default class GestureHandlerOrchestrator {
       const otherY: number = otherHandler.getTracker().getLastY(pointer);
 
       if (
-        isPointerInBounds(handler.getView(), { x: otherX, y: otherY }) &&
-        isPointerInBounds(otherHandler.getView(), { x: otherX, y: otherY })
+        handler.getDelegate().isPointerInBounds({ x: otherX, y: otherY }) &&
+        otherHandler.getDelegate().isPointerInBounds({ x: otherX, y: otherY })
       ) {
         overlap = true;
       }

--- a/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/src/web/tools/GestureHandlerWebDelegate.ts
@@ -13,12 +13,12 @@ import EventManager from './EventManager';
 export class GestureHandlerWebDelegate
   implements GestureHandlerDelegate<HTMLElement>
 {
-  private _view!: HTMLElement;
+  private view!: HTMLElement;
   private gestureHandler!: GestureHandler;
   private eventManagers: EventManager<unknown>[] = [];
 
-  get view(): HTMLElement {
-    return this._view;
+  getView(): HTMLElement {
+    return this.view;
   }
 
   init(viewRef: number, handler: GestureHandler): void {
@@ -29,7 +29,7 @@ export class GestureHandlerWebDelegate
     }
 
     this.gestureHandler = handler;
-    this._view = findNodeHandle(viewRef) as unknown as HTMLElement;
+    this.view = findNodeHandle(viewRef) as unknown as HTMLElement;
 
     this.view.style['touchAction'] = 'none';
     //@ts-ignore This one disables default events on Safari

--- a/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/src/web/tools/GestureHandlerWebDelegate.ts
@@ -1,0 +1,119 @@
+import { findNodeHandle } from 'react-native';
+import type GestureHandler from '../handlers/GestureHandler';
+import {
+  GestureHandlerDelegate,
+  MeasureResult,
+} from './GestureHandlerDelegate';
+import PointerEventManager from './PointerEventManager';
+import TouchEventManager from './TouchEventManager';
+import { State } from '../../State';
+import { isPointerInBounds } from '../utils';
+
+export class GestureHandlerWebDelegate
+  implements GestureHandlerDelegate<HTMLElement>
+{
+  private _view!: HTMLElement;
+  private gestureHandler!: GestureHandler;
+
+  get view(): HTMLElement {
+    return this._view;
+  }
+
+  init(viewRef: number, handler: GestureHandler): void {
+    if (!viewRef) {
+      throw new Error(
+        `Cannot find HTML Element for handler ${handler.getTag()}`
+      );
+    }
+
+    this.gestureHandler = handler;
+    this._view = findNodeHandle(viewRef) as unknown as HTMLElement;
+
+    this.view.style['touchAction'] = 'none';
+    //@ts-ignore This one disables default events on Safari
+    this.view.style['WebkitTouchCallout'] = 'none';
+
+    const config = handler.getConfig();
+
+    if (!config.userSelect) {
+      this.view.style['webkitUserSelect'] = 'none';
+      this.view.style['userSelect'] = 'none';
+    } else {
+      this.view.style['webkitUserSelect'] = config.userSelect;
+      this.view.style['userSelect'] = config.userSelect;
+    }
+
+    handler.addEventManager(new PointerEventManager(this.view));
+    handler.addEventManager(new TouchEventManager(this.view));
+  }
+
+  isPointerInBounds({ x, y }: { x: number; y: number }): boolean {
+    return isPointerInBounds(this.view, { x, y });
+  }
+
+  measureView(): MeasureResult {
+    const rect = this.view.getBoundingClientRect();
+
+    return {
+      pageX: rect.left,
+      pageY: rect.top,
+      width: rect.width,
+      height: rect.height,
+    };
+  }
+
+  reset(): void {
+    throw new Error('Method not implemented.');
+  }
+
+  onBegin(): void {
+    // no-op for now
+  }
+
+  onActivate(): void {
+    const config = this.gestureHandler.getConfig();
+
+    if (
+      (!this.view.style.cursor || this.view.style.cursor === 'auto') &&
+      config.activeCursor
+    ) {
+      this.view.style.cursor = config.activeCursor;
+    }
+  }
+
+  onEnd(): void {
+    const config = this.gestureHandler.getConfig();
+
+    if (
+      config.activeCursor &&
+      config.activeCursor !== 'auto' &&
+      this.gestureHandler.getState() === State.ACTIVE
+    ) {
+      this.view.style.cursor = 'auto';
+    }
+  }
+
+  onCancel(): void {
+    const config = this.gestureHandler.getConfig();
+
+    if (
+      config.activeCursor &&
+      config.activeCursor !== 'auto' &&
+      this.gestureHandler.getState() === State.ACTIVE
+    ) {
+      this.view.style.cursor = 'auto';
+    }
+  }
+
+  onFail(): void {
+    const config = this.gestureHandler.getConfig();
+
+    if (
+      config.activeCursor &&
+      config.activeCursor !== 'auto' &&
+      this.gestureHandler.getState() === State.ACTIVE
+    ) {
+      this.view.style.cursor = 'auto';
+    }
+  }
+}

--- a/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/src/web/tools/GestureHandlerWebDelegate.ts
@@ -74,6 +74,18 @@ export class GestureHandlerWebDelegate
     );
   }
 
+  tryResetCursor() {
+    const config = this.gestureHandler.getConfig();
+
+    if (
+      config.activeCursor &&
+      config.activeCursor !== 'auto' &&
+      this.gestureHandler.getState() === State.ACTIVE
+    ) {
+      this.view.style.cursor = 'auto';
+    }
+  }
+
   onBegin(): void {
     // no-op for now
   }
@@ -90,38 +102,14 @@ export class GestureHandlerWebDelegate
   }
 
   onEnd(): void {
-    const config = this.gestureHandler.getConfig();
-
-    if (
-      config.activeCursor &&
-      config.activeCursor !== 'auto' &&
-      this.gestureHandler.getState() === State.ACTIVE
-    ) {
-      this.view.style.cursor = 'auto';
-    }
+    this.tryResetCursor();
   }
 
   onCancel(): void {
-    const config = this.gestureHandler.getConfig();
-
-    if (
-      config.activeCursor &&
-      config.activeCursor !== 'auto' &&
-      this.gestureHandler.getState() === State.ACTIVE
-    ) {
-      this.view.style.cursor = 'auto';
-    }
+    this.tryResetCursor();
   }
 
   onFail(): void {
-    const config = this.gestureHandler.getConfig();
-
-    if (
-      config.activeCursor &&
-      config.activeCursor !== 'auto' &&
-      this.gestureHandler.getState() === State.ACTIVE
-    ) {
-      this.view.style.cursor = 'auto';
-    }
+    this.tryResetCursor();
   }
 }

--- a/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/src/web/tools/GestureHandlerWebDelegate.ts
@@ -8,12 +8,14 @@ import PointerEventManager from './PointerEventManager';
 import TouchEventManager from './TouchEventManager';
 import { State } from '../../State';
 import { isPointerInBounds } from '../utils';
+import EventManager from './EventManager';
 
 export class GestureHandlerWebDelegate
   implements GestureHandlerDelegate<HTMLElement>
 {
   private _view!: HTMLElement;
   private gestureHandler!: GestureHandler;
+  private eventManagers: EventManager<unknown>[] = [];
 
   get view(): HTMLElement {
     return this._view;
@@ -43,8 +45,12 @@ export class GestureHandlerWebDelegate
       this.view.style['userSelect'] = config.userSelect;
     }
 
-    handler.addEventManager(new PointerEventManager(this.view));
-    handler.addEventManager(new TouchEventManager(this.view));
+    this.eventManagers.push(new PointerEventManager(this.view));
+    this.eventManagers.push(new TouchEventManager(this.view));
+
+    this.eventManagers.forEach((manager) =>
+      this.gestureHandler.attachEventManager(manager)
+    );
   }
 
   isPointerInBounds({ x, y }: { x: number; y: number }): boolean {
@@ -63,7 +69,9 @@ export class GestureHandlerWebDelegate
   }
 
   reset(): void {
-    throw new Error('Method not implemented.');
+    this.eventManagers.forEach((manager: EventManager<unknown>) =>
+      manager.resetManager()
+    );
   }
 
   onBegin(): void {

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -2,7 +2,7 @@ import { AdaptedEvent, EventTypes, PointerType } from '../interfaces';
 import EventManager from './EventManager';
 import { isPointerInBounds } from '../utils';
 
-export default class PointerEventManager extends EventManager {
+export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();
 
   public setListeners(): void {

--- a/src/web/tools/TouchEventManager.ts
+++ b/src/web/tools/TouchEventManager.ts
@@ -8,7 +8,7 @@ import {
 import EventManager from './EventManager';
 import { isPointerInBounds } from '../utils';
 
-export default class TouchEventManager extends EventManager {
+export default class TouchEventManager extends EventManager<HTMLElement> {
   public setListeners(): void {
     this.view.addEventListener('touchstart', (event: TouchEvent) => {
       for (let i = 0; i < event.changedTouches.length; ++i) {


### PR DESCRIPTION
## Description

- adds a `GestureHandlerDelegate` interface to encapsulate web-specific calls from the js implementation
- makes `EventManager` generic so it doesn't rely on web types
- in some places adds `Platform.OS` checks, when there is the need to manipulate the underlying `HTMLElement`

It could still be beneficial to pass the ref to the js implementation instead of the node handle (which is the same thing on the web, but not on other platforms).

## Test plan

Tested on the example app.
