### PR TITLE
Fix ripple effect staying after cancellation

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -174,6 +174,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
     override fun onTouchEvent(event: MotionEvent): Boolean {
       if (event.action == MotionEvent.ACTION_CANCEL) {
         tryFreeingResponder()
+        return super.onTouchEvent(event)
       }
 
       val eventTime = event.eventTime


### PR DESCRIPTION
## Description

Sometimes when our `Button` (like `BaseButton`) is cancelled, it gets stuck at ripple animation. This may also prevent other components form receiving events, until the button will be pressed again (which will release it). This PR changes behavior after receiving `ACTION_CANCEL`, so that buttons don't get stuck anymore.

Fixes #2585

## Test plan

Tested on example from [issue](https://github.com/software-mansion/react-native-gesture-handler/issues/2585) and `NestedButtons` example from our example app.
