### PR TITLE
Hotfix: Hover not working on web

### DIFF
--- a/src/web/handlers/HoverGestureHandler.ts
+++ b/src/web/handlers/HoverGestureHandler.ts
@@ -1,4 +1,4 @@
-import { State } from '../../../src/State';
+import { State } from '../../State';
 import { AdaptedEvent, Config } from '../interfaces';
 import GestureHandlerOrchestrator from '../tools/GestureHandlerOrchestrator';
 import GestureHandler from './GestureHandler';


### PR DESCRIPTION
## Description

When using the new `Hover` gesture handler on web (with Expo + Metro) I got the following error:

```
Unable to resolve "../../../src/State" from "../../node_modules/react-native-gesture-handler/lib/module/web/handlers/HoverGestureHandler.js"
```

After checking the `lib/module/web/handlers/HoverGestureHandler.js`, I saw that the import for the `State` variable is the following:
```typescript
import { State } from '../../../src/State';
```

And that should be changed to this (to be consistent with other files in the same directory):
```typescript
import { State } from '../../State';
```

After applying these changes, I can use the new version without any issue.
