### PR TITLE
add buildconfig flag for AGP8+

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -106,6 +106,12 @@ android {
         namespace "com.swmansion.gesturehandler"
     }
 
+    if (agpVersion.tokenize('.')[0].toInteger() >= 8) {
+        buildFeatures {
+            buildConfig = true
+        }
+    }
+
     // Used to override the NDK path/version on internal CI or by allowing
     // users to customize the NDK path/version from their root project (e.g. for M1 support)
     if (rootProject.hasProperty("ndkPath")) {


### PR DESCRIPTION
## Description
Add support for AGP8 by adding the buildConfig Flag indicating that this library uses custom buildconfig fields and needs it's BuildConfig class generated.
Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2571

## Test plan

No idea, need some help here since I'm not a RN person. I'm just trying to push support for AGP8 so we don't have to enable generating BuildConfig classes generally in our project, which has a performance impact.