### PR TITLE
Fix typo in Composing gestures docs

### DIFF
--- a/docs/docs/fundamentals/gesture-composition.md
+++ b/docs/docs/fundamentals/gesture-composition.md
@@ -107,7 +107,6 @@ function App() {
   const savedScale = useSharedValue(1);
   const rotation = useSharedValue(0);
   const savedRotation = useSharedValue(0);
-  s;
   const animatedStyles = useAnimatedStyle(() => {
     return {
       transform: [


### PR DESCRIPTION
Updated line no.11 and removed the `s;` character from it

## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

<!--
Describe how did you test this change here.
-->
