### PR TITLE
Fix background color when `foreground` is set.

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -234,8 +234,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       if (useDrawableOnForeground && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
         foreground = selectable
         if (_backgroundColor != Color.TRANSPARENT) {
-          setBackgroundColor(_backgroundColor)
-          updateBackgroundColor(_backgroundColor, borderRadius, selectable)
+          updateBackgroundColor(_backgroundColor, borderRadius, null)
         }
       } else if (_backgroundColor == Color.TRANSPARENT && rippleColor == null) {
         background = selectable

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -188,12 +188,21 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       return false
     }
 
+    private fun updateBackgroundColor(backgroundColor: Int, borderRadius: Float, selectable: Drawable?) {
+      val colorDrawable = PaintDrawable(backgroundColor)
+
+      if (borderRadius != 0f) {
+        colorDrawable.setCornerRadius(borderRadius)
+      }
+
+      val layerDrawable = LayerDrawable(if (selectable != null) arrayOf(colorDrawable, selectable) else arrayOf(colorDrawable))
+      background = layerDrawable
+    }
+
     fun updateBackground() {
       if (!needBackgroundUpdate) {
         return
       }
-      needBackgroundUpdate = false
-
       if (_backgroundColor == Color.TRANSPARENT) {
         // reset background
         background = null
@@ -224,18 +233,12 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
         foreground = selectable
         if (_backgroundColor != Color.TRANSPARENT) {
           setBackgroundColor(_backgroundColor)
+          updateBackgroundColor(_backgroundColor, borderRadius, selectable)
         }
       } else if (_backgroundColor == Color.TRANSPARENT && rippleColor == null) {
         background = selectable
       } else {
-        val colorDrawable = PaintDrawable(_backgroundColor)
-
-        if (borderRadius != 0f) {
-          colorDrawable.setCornerRadius(borderRadius)
-        }
-
-        val layerDrawable = LayerDrawable(if (selectable != null) arrayOf(colorDrawable, selectable) else arrayOf(colorDrawable))
-        background = layerDrawable
+        updateBackgroundColor(_backgroundColor, borderRadius, selectable)
       }
     }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -203,6 +203,8 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       if (!needBackgroundUpdate) {
         return
       }
+      needBackgroundUpdate = false
+
       if (_backgroundColor == Color.TRANSPARENT) {
         // reset background
         background = null


### PR DESCRIPTION
## Description

This PR aims to fix background color issue on android. If you set `foreground` prop to `true` on our `Buttons`, background color doesn't update.

Fixes #2632 

## Test plan

Tested on the code from issue.