### PR TITLE
Inline adding spec dependencies

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -3,30 +3,6 @@ require "json"
 new_arch_enabled = ENV['RCT_NEW_ARCH_ENABLED'] == '1'
 apple_platform = new_arch_enabled ? '11.0' : '9.0'
 
-# Utility function to install dependencies if React Native's
-# install_modules_dependencies is not defined
-def install_dependencies(s, new_arch_enabled)
-  if new_arch_enabled
-    folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
-
-    s.pod_target_xcconfig = {
-      'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native" "$(PODS_ROOT)/RCT-Folly"',
-      'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
-    }
-    s.compiler_flags  = folly_compiler_flags + ' -DRCT_NEW_ARCH_ENABLED'
-
-    s.dependency "React"
-    s.dependency "React-RCTFabric" # This is for fabric component
-    s.dependency "React-Codegen"
-    s.dependency "RCT-Folly"
-    s.dependency "RCTRequired"
-    s.dependency "RCTTypeSafety"
-    s.dependency "ReactCommon/turbomodule/core"
-  else
-    s.dependency "React-Core"
-  end
-end
-
 Pod::Spec.new do |s|
   # NPM package specification
   package = JSON.parse(File.read(File.join(File.dirname(__FILE__), "package.json")))
@@ -45,6 +21,24 @@ Pod::Spec.new do |s|
   if defined?(install_modules_dependencies()) != nil
     install_modules_dependencies(s);
   else
-    install_dependencies(s, new_arch_enabled)
+    if new_arch_enabled
+      folly_compiler_flags = '-DFOLLY_NO_CONFIG -DFOLLY_MOBILE=1 -DFOLLY_USE_LIBCPP=1 -Wno-comma -Wno-shorten-64-to-32'
+  
+      s.pod_target_xcconfig = {
+        'HEADER_SEARCH_PATHS' => '"$(PODS_ROOT)/boost" "$(PODS_ROOT)/boost-for-react-native" "$(PODS_ROOT)/RCT-Folly"',
+        'CLANG_CXX_LANGUAGE_STANDARD' => 'c++17',
+      }
+      s.compiler_flags  = folly_compiler_flags + ' -DRCT_NEW_ARCH_ENABLED'
+  
+      s.dependency "React"
+      s.dependency "React-RCTFabric" # This is for fabric component
+      s.dependency "React-Codegen"
+      s.dependency "RCT-Folly"
+      s.dependency "RCTRequired"
+      s.dependency "RCTTypeSafety"
+      s.dependency "ReactCommon/turbomodule/core"
+    else
+      s.dependency "React-Core"
+    end
   end
 end


### PR DESCRIPTION
## Description

Inlines adding spec dependencies in case `install_modules_dependencies` doesn't exist.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2652, https://github.com/software-mansion/react-native-gesture-handler/issues/2645
