### PR TITLE
Fix double `onPress`

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt
@@ -13,4 +13,4 @@ val ReactContext.UIManager: UIManagerModule
   get() = this.getNativeModule(UIManagerModule::class.java)!!
 
 fun Context.isScreenReaderOn() =
-  (getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager).isEnabled
+  (getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager).isTouchExplorationEnabled


### PR DESCRIPTION
## Description

One of the changes introduced in release 2.13.0 was [Android TalkBack fix](https://github.com/software-mansion/react-native-gesture-handler/pull/2234). To check whether TalkBack is active or not I used `AccessibilityManager.isEnabled` (see [this line](https://github.com/software-mansion/react-native-gesture-handler/blob/fa721ede0cb1cab60ab8fa77a3a5922ad8462f3b/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt#L16C80-L16C80)). Turns out that it was not the best idea, since this method will return `true` if any accessibility feature is enabled, not only TalkBack.

This PR changes `isEnabled` to `isTouchExplorationEnabled` so that other accessibility settings shouldn't trigger manual activation of our handlers.

## Test plan

Tested on example app on device with other accessibility settings on.
