### PR TITLE
Add a non-null assertion for `reactApplicationContext.javaScriptContextHolder`

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -466,7 +466,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   fun install(): Boolean {
     return try {
       SoLoader.loadLibrary("gesturehandler")
-      val jsContext = reactApplicationContext.javaScriptContextHolder
+      val jsContext = reactApplicationContext.javaScriptContextHolder!!
       decorateRuntime(jsContext.get())
       true
     } catch (exception: Exception) {


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

According to [the implementation of `getJavaScriptContextHolder()`](https://github.com/facebook/react-native/blob/5c2224deac99bb0ecd67a42a00358e6967990a64/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/bridge/ReactContext.java#L536-L547), `reactApplicationContext.javaScriptContextHolder` here is null-able.

This wasn't a problem, until the release of RN 73, which [marked `getJavaScriptContextHolder()` as `@Nullable`](https://github.com/facebook/react-native/commit/d2e591cb2b927009cf086e10c42c312c04e8614a).

This will cause a compilation error, as in [this action](https://github.com/UNIDY2002/repro-rn-73-react-navigation/actions/runs/6668921351/job/18125570179).

Therefore, I added a non-null assertion for `reactApplicationContext.javaScriptContextHolder` to make the Kotlin compiler happy. It only affects the compilation stage, so the runtime behavior will remain unchanged.

## Test plan

<!--
Describe how did you test this change here.
-->

See this patch:
- https://github.com/UNIDY2002/repro-rn-73-react-navigation/commit/2c2a0984df376b17a7e3b75f0682a035bf844353

And these actions:
- (Before patch): https://github.com/UNIDY2002/repro-rn-73-react-navigation/actions/runs/6668921351/job/18125570179
- (After patch): https://github.com/UNIDY2002/repro-rn-73-react-navigation/actions/runs/6674551533/job/18141511571
