### PR TITLE
Raise limit on simultaneous gesture handlers from 20 to 50

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -606,9 +606,9 @@ class GestureHandlerOrchestrator(
   }
 
   companion object {
-    // The limit doesn't necessarily need to exists, it was just simpler to implement it that way
+    // The limit doesn't necessarily need to exist, it was just simpler to implement it that way
     // it is also more allocation-wise efficient to have a fixed limit
-    private const val SIMULTANEOUS_GESTURE_HANDLER_LIMIT = 20
+    private const val SIMULTANEOUS_GESTURE_HANDLER_LIMIT = 50
 
     // Be default fully transparent views can receive touch
     private const val DEFAULT_MIN_ALPHA_FOR_TRAVERSAL = 0f


### PR DESCRIPTION
## Description

In `GestureHandlerOrchestrator.kt`, there is a pretty arbitrary limit on the number of simultaneous gesture handlers,
via the constant `SIMULTANEOUS_GESTURE_HANDLER_LIMIT` which is set to 20. A comment with the constant states
that "this limit doesn't necessarily need to exist" but that it is there for simple efficiency reasons.

My company publishes a React Native game app which hits this limit at run-time, so we have been applying a patch to
`react-native-gesture-handler` in our repo to raise this limit to 50. This solves our problem and appears to have
no adverse side effects. Raising the constant from 20 to 50 makes a couple of vectors slightly bigger but the
memory consumption due to this is negligible.

## Test plan

We have been applying this patch to a production app for a couple of months now with no apparent adverse effects.
