### PR TITLE
Fix selection when TalkBack is enabled

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
@@ -40,7 +40,7 @@ class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {
   override fun dispatchGenericMotionEvent(event: MotionEvent) =
     if (_enabled && rootHelper!!.dispatchTouchEvent(event)) {
       true
-    } else super.dispatchTouchEvent(event)
+    } else super.dispatchGenericMotionEvent(event)
 
   override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
     if (_enabled) {


### PR DESCRIPTION
## Description

[Hover](https://github.com/software-mansion/react-native-gesture-handler/commit/16a266e3af637c24cf690a3c76995b178d40f453) introduced some changes, one of them being overriding `dispatchGenericMotionEvent` inside `GestureHandlerRootView`. It seems that in some cases it returns `super.dispatchTouchEvent` instead of `super.dispatchGenericMotionEvent`.

Fixes #2665

## Test plan

Checked that examples with `Hover` still work