### PR TITLE
Change Alert to console.log in new docs

### DIFF
--- a/docs/docs/gestures/long-press-gesture.md
+++ b/docs/docs/gestures/long-press-gesture.md
@@ -85,13 +85,13 @@ Duration of the long press (time since the start of the gesture), expressed in m
 ## Example
 
 ```jsx
-import { View, StyleSheet, Alert } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 export default function App() {
   const longPressGesture = Gesture.LongPress().onEnd((e, success) => {
     if (success) {
-      Alert.alert(`Long pressed for ${e.duration} ms!`);
+      console.log(`Long pressed for ${e.duration} ms!`);
     }
   });
 

--- a/docs/docs/gestures/tap-gesture.md
+++ b/docs/docs/gestures/tap-gesture.md
@@ -106,21 +106,21 @@ Y coordinate, expressed in points, of the current position of the pointer (finge
 ## Example
 
 ```jsx
-import { View, Alert, StyleSheet } from 'react-native';
+import { View, StyleSheet } from 'react-native';
 import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 export default function App() {
   const singleTap = Gesture.Tap()
     .maxDuration(250)
     .onStart(() => {
-      Alert.alert('Single tap!');
+      console.log('Single tap!');
     });
 
   const doubleTap = Gesture.Tap()
     .maxDuration(250)
     .numberOfTaps(2)
     .onStart(() => {
-      Alert.alert('Double tap!');
+      console.log('Double tap!');
     });
 
   return (

--- a/docs/docs/under-the-hood/state.md
+++ b/docs/docs/under-the-hood/state.md
@@ -26,7 +26,7 @@ Each state has its own description below.
 We can monitor a handler's state changes by using the [`onHandlerStateChange`](/docs/gesture-handlers/common-gh#onhandlerstatechange) callback and the destructured `nativeEvent` argument passed to it.
 This can be done by comparing the `nativeEvent`'s [`state`](/docs/gesture-handlers/common-gh#state) attribute to one of the constants exported under the `State` object (see example below).
 
-```
+```jsx
 import { State, LongPressGestureHandler } from 'react-native-gesture-handler';
 
 class Demo extends Component {


### PR DESCRIPTION
## Description

Some examples in our docs use `Alert.alert`, even though callbacks in new api are automatically workletized. They won't work, because there's no way to access `Alert` on UI thread.

Fixes #2667 

## Test plan

Checked that both `LongPress` and `Tap` pages were updated.
