### PR TITLE
Remove Gesture Handler limits on Android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -22,7 +22,6 @@ class GestureHandlerOrchestrator(
   private val gestureHandlers = arrayListOf<GestureHandler<*>>()
   private val awaitingHandlers = arrayListOf<GestureHandler<*>>()
   private val preparedHandlers = arrayListOf<GestureHandler<*>>()
-  private val handlersToCancel = arrayListOf<GestureHandler<*>>()
   private var isHandlingTouch = false
   private var handlingChangeSemaphore = 0
   private var finishedHandlersCleanupScheduled = false
@@ -160,18 +159,11 @@ class GestureHandlerOrchestrator(
       activationIndex = this@GestureHandlerOrchestrator.activationIndex++
     }
 
-    // Cancel all handlers that are required to be cancel upon current handler's activation
-    for (otherHandler in gestureHandlers) {
+    for (otherHandler in gestureHandlers.reversed()) {
       if (shouldHandlerBeCancelledBy(otherHandler, handler)) {
-        handlersToCancel.add(otherHandler)
+        otherHandler.cancel()
       }
     }
-
-    for (otherHandler in handlersToCancel.reversed()) {
-      otherHandler.cancel()
-    }
-
-    handlersToCancel.clear()
 
     // Clear all awaiting handlers waiting for the current handler to fail
     for (otherHandler in awaitingHandlers.reversed()) {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -159,7 +159,7 @@ class GestureHandlerOrchestrator(
       activationIndex = this@GestureHandlerOrchestrator.activationIndex++
     }
 
-    for (otherHandler in gestureHandlers.reversed()) {
+    for (otherHandler in gestureHandlers.asReversed()) {
       if (shouldHandlerBeCancelledBy(otherHandler, handler)) {
         otherHandler.cancel()
       }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -7,7 +7,6 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
 import java.util.*
-import kotlin.collections.ArrayList
 
 class GestureHandlerOrchestrator(
   private val wrapperView: ViewGroup,
@@ -58,16 +57,6 @@ class GestureHandlerOrchestrator(
     }
   }
 
-  private inline fun compactHandlersIf(handlers: ArrayList<GestureHandler<*>>, predicate: (handler: GestureHandler<*>?) -> Boolean): Int {
-    var out = 0
-    for (i in 0 until handlers.size) {
-      if (predicate(handlers[i])) {
-        handlers[out++] = handlers[i]
-      }
-    }
-    return out
-  }
-
   private fun cleanupFinishedHandlers() {
     for (handler in gestureHandlers.reversed()) {
       if (isFinished(handler.state) && !handler.isAwaiting) {
@@ -105,11 +94,7 @@ class GestureHandlerOrchestrator(
   }
 
   private fun cleanupAwaitingHandlers() {
-    val awaitingHandlersCount = compactHandlersIf(awaitingHandlers) { handler ->
-      handler!!.isAwaiting
-    }
-
-    awaitingHandlers.subList(awaitingHandlersCount, awaitingHandlers.size).clear()
+    awaitingHandlers.removeAll { !it.isAwaiting }
   }
 
   /*package*/

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -58,9 +58,8 @@ class GestureHandlerOrchestrator(
   }
 
   private fun cleanupFinishedHandlers() {
-    for (handler in gestureHandlers.reversed()) {
+    for (handler in gestureHandlers.asReversed()) {
       if (isFinished(handler.state) && !handler.isAwaiting) {
-        gestureHandlers.remove(handler)
         handler.reset()
         handler.apply {
           isActive = false
@@ -69,6 +68,8 @@ class GestureHandlerOrchestrator(
         }
       }
     }
+
+    gestureHandlers.removeAll { isFinished(it.state) && !it.isAwaiting }
 
     finishedHandlersCleanupScheduled = false
   }


### PR DESCRIPTION
## Description

While looking at PRs I've stumbled upon [this one](https://github.com/software-mansion/react-native-gesture-handler/pull/2664). Turns out that `SIMULTANEOUS_GESTURE_HANDLER_LIMIT` does not refer to simultaneous gestures, but to all gesture handlers present in app. The upper limit shouldn't exist - this PR aims to remove it.

## Test plan

Tested on example app.
