### PR TITLE
Prevent GH actions trigger on forks, update template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -55,7 +55,7 @@ body:
     attributes:
       label: Gesture Handler version
       description: What version of react-native-gesture-handler are you using?
-      placeholder: 2.5.0
+      placeholder: 2.14.0
     validations:
       required: true
 
@@ -64,7 +64,7 @@ body:
     attributes:
       label: React Native version
       description: What version of react-native are you using?
-      placeholder: 0.69.0
+      placeholder: 0.73.0
     validations:
       required: true
 
@@ -78,6 +78,7 @@ body:
         - Android
         - iOS
         - Web
+        - MacOS
     validations:
       required: true
 

--- a/.github/workflows/android-build.yml
+++ b/.github/workflows/android-build.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    if: github.repository == 'software-mansion/react-native-gesture-handler'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/close-when-stale.yml
+++ b/.github/workflows/close-when-stale.yml
@@ -10,6 +10,7 @@ on:
 
 jobs:
   main:
+    if: github.repository == 'software-mansion/react-native-gesture-handler'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Actions

--- a/.github/workflows/docs-check.yml
+++ b/.github/workflows/docs-check.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   check:
+    if: github.repository == 'software-mansion/react-native-gesture-handler'
     runs-on: ubuntu-latest
     concurrency:
       group: docs-check-${{ github.ref }}

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -13,6 +13,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    if: github.repository == 'software-mansion/react-native-gesture-handler'
     runs-on: macos-12
     strategy:
       matrix:

--- a/.github/workflows/kotlin-lint.yml
+++ b/.github/workflows/kotlin-lint.yml
@@ -9,6 +9,7 @@ on:
   workflow_dispatch:
 jobs:
   check:
+    if: github.repository == 'software-mansion/react-native-gesture-handler'
     runs-on: ubuntu-latest
     concurrency:
       group: kotlin-lint-${{ github.ref }}

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -12,6 +12,7 @@ on:
   workflow_dispatch:
 jobs:
   build:
+    if: github.repository == 'software-mansion/react-native-gesture-handler'
     runs-on: macos-12
     strategy:
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   publish:
+    if: github.repository == 'software-mansion/react-native-gesture-handler'
     runs-on: ubuntu-latest
     steps:
       - name: Check out

--- a/.github/workflows/needs-more-info.yml
+++ b/.github/workflows/needs-more-info.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   main:
+    if: ${{ github.repository == 'software-mansion/react-native-gesture-handler' && !contains(github.event.issue.labels.*.name, 'Maintainer issue') }}
     runs-on: ubuntu-latest
     concurrency:
       group: needs-more-info-${{ github.event.issue.number }}

--- a/.github/workflows/needs-repro.yml
+++ b/.github/workflows/needs-repro.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   main:
+    if: ${{ github.repository == 'software-mansion/react-native-gesture-handler' && !contains(github.event.issue.labels.*.name, 'Maintainer issue') }}
     runs-on: ubuntu-latest
     concurrency:
       group: needs-repro-${{ github.event.issue.number }}

--- a/.github/workflows/platforms.yml
+++ b/.github/workflows/platforms.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   main:
+    if: ${{ github.repository == 'software-mansion/react-native-gesture-handler' && !contains(github.event.issue.labels.*.name, 'Maintainer issue') }}
     runs-on: ubuntu-latest
     concurrency:
       group: platforms-${{ github.event.issue.number }}

--- a/.github/workflows/static-example-apps-checks.yml
+++ b/.github/workflows/static-example-apps-checks.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 jobs:
   check:
+    if: github.repository == 'software-mansion/react-native-gesture-handler'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/static-root-checks.yml
+++ b/.github/workflows/static-root-checks.yml
@@ -10,6 +10,7 @@ on:
   workflow_dispatch:
 jobs:
   check:
+    if: github.repository == 'software-mansion/react-native-gesture-handler'
     runs-on: ubuntu-latest
     concurrency:
       group: static-root-${{ github.ref }}


### PR DESCRIPTION
## Description

Hippity hoppity your code is now my property (https://github.com/software-mansion/react-native-reanimated/pull/5030).

Also updates the template:
- adds MacOS as platform
- updates placeholder version of GH to 2.14.0 from 2.5.0 (yikes)
- updates placeholder RN version to 0.73.0 from 0.69.0 (not nice, I can be talked out of this)
