### PR TITLE
Add exclude list for PointerCapture

### DIFF
--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -2,7 +2,7 @@ import { AdaptedEvent, EventTypes, PointerType } from '../interfaces';
 import EventManager from './EventManager';
 import { isPointerInBounds } from '../utils';
 
-const PointerCaptureBlacklist = new Set<string>(['SELECT', 'INPUT']);
+const POINTER_CAPTURE_EXCLUSION_LIST = new Set<string>(['SELECT', 'INPUT']);
 
 export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();
@@ -21,7 +21,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.DOWN);
       const target = event.target as HTMLElement;
 
-      if (!PointerCaptureBlacklist.has(target.tagName)) {
+      if (!POINTER_CAPTURE_EXCLUSION_LIST.has(target.tagName)) {
         target.setPointerCapture(adaptedEvent.pointerId);
       }
 
@@ -52,7 +52,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.UP);
       const target = event.target as HTMLElement;
 
-      if (!PointerCaptureBlacklist.has(target.tagName)) {
+      if (!POINTER_CAPTURE_EXCLUSION_LIST.has(target.tagName)) {
         target.releasePointerCapture(adaptedEvent.pointerId);
       }
 
@@ -89,7 +89,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       // God, I do love web development.
       if (
         !target.hasPointerCapture(event.pointerId) &&
-        !PointerCaptureBlacklist.has(target.tagName)
+        !POINTER_CAPTURE_EXCLUSION_LIST.has(target.tagName)
       ) {
         target.setPointerCapture(event.pointerId);
       }

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -2,7 +2,7 @@ import { AdaptedEvent, EventTypes, PointerType } from '../interfaces';
 import EventManager from './EventManager';
 import { isPointerInBounds } from '../utils';
 
-const POINTER_CAPTURE_EXCLUSION_LIST = new Set<string>(['SELECT', 'INPUT']);
+const POINTER_CAPTURE_EXCLUDE_LIST = new Set<string>(['SELECT', 'INPUT']);
 
 export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();
@@ -21,7 +21,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.DOWN);
       const target = event.target as HTMLElement;
 
-      if (!POINTER_CAPTURE_EXCLUSION_LIST.has(target.tagName)) {
+      if (!POINTER_CAPTURE_EXCLUDE_LIST.has(target.tagName)) {
         target.setPointerCapture(adaptedEvent.pointerId);
       }
 
@@ -52,7 +52,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.UP);
       const target = event.target as HTMLElement;
 
-      if (!POINTER_CAPTURE_EXCLUSION_LIST.has(target.tagName)) {
+      if (!POINTER_CAPTURE_EXCLUDE_LIST.has(target.tagName)) {
         target.releasePointerCapture(adaptedEvent.pointerId);
       }
 
@@ -89,7 +89,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       // God, I do love web development.
       if (
         !target.hasPointerCapture(event.pointerId) &&
-        !POINTER_CAPTURE_EXCLUSION_LIST.has(target.tagName)
+        !POINTER_CAPTURE_EXCLUDE_LIST.has(target.tagName)
       ) {
         target.setPointerCapture(event.pointerId);
       }

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -2,6 +2,8 @@ import { AdaptedEvent, EventTypes, PointerType } from '../interfaces';
 import EventManager from './EventManager';
 import { isPointerInBounds } from '../utils';
 
+const PointerCaptureBlacklist = new Set<String>(['SELECT', 'INPUT']);
+
 export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();
 
@@ -19,7 +21,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.DOWN);
       const target = event.target as HTMLElement;
 
-      if (target instanceof HTMLDivElement) {
+      if (!PointerCaptureBlacklist.has(target.tagName)) {
         target.setPointerCapture(adaptedEvent.pointerId);
       }
 
@@ -50,7 +52,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.UP);
       const target = event.target as HTMLElement;
 
-      if (target instanceof HTMLDivElement) {
+      if (!PointerCaptureBlacklist.has(target.tagName)) {
         target.releasePointerCapture(adaptedEvent.pointerId);
       }
 
@@ -87,7 +89,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       // God, I do love web development.
       if (
         !target.hasPointerCapture(event.pointerId) &&
-        target instanceof HTMLDivElement
+        !PointerCaptureBlacklist.has(target.tagName)
       ) {
         target.setPointerCapture(event.pointerId);
       }

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -2,7 +2,7 @@ import { AdaptedEvent, EventTypes, PointerType } from '../interfaces';
 import EventManager from './EventManager';
 import { isPointerInBounds } from '../utils';
 
-const PointerCaptureBlacklist = new Set<String>(['SELECT', 'INPUT']);
+const PointerCaptureBlacklist = new Set<string>(['SELECT', 'INPUT']);
 
 export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();


### PR DESCRIPTION
## Description

#2675 was created to fix inputs on safari. It turns out that our discussion about this PR was correct and it did break some things (namely chat heads examples). To fix that, we introduce exclude list for tags that shouldn't have PointerCapture.

## Test plan

Verified that inputs on safari work correctly and chat heads example works as expected.

<details>
<summary> Test code </summary>

```jsx
import React from 'react';
import { Gesture, GestureDetector } from 'react-native-gesture-handler';

function Picker() {
  return (
    <select
      name="choice"
      onBlur={(e) => e.stopPropagation()}
      onChange={(e) => e.currentTarget.blur()}>
      <option value="first">First Value</option>
      <option value="second">Second Value</option>
      <option value="third">Third Value</option>
    </select>
  );
}

export default function App() {
  const p = Gesture.Pan();
  return (
    <GestureDetector gesture={p}>
      <Picker />
    </GestureDetector>
  );
}

```

<details>
