### PR TITLE
Reset relevant handler when recognizer gets reset.

### DIFF
--- a/apple/Handlers/RNFlingHandler.m
+++ b/apple/Handlers/RNFlingHandler.m
@@ -72,6 +72,7 @@
   [_gestureHandler.pointerTracker reset];
   _hasBegan = NO;
   [super reset];
+  [_gestureHandler reset];
 }
 
 - (CGPoint)getLastLocation

--- a/apple/Handlers/RNForceTouchHandler.m
+++ b/apple/Handlers/RNForceTouchHandler.m
@@ -125,6 +125,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
 {
   [_gestureHandler.pointerTracker reset];
   [super reset];
+  [_gestureHandler reset];
   _force = 0;
   _firstTouch = NULL;
 }

--- a/apple/Handlers/RNHoverHandler.m
+++ b/apple/Handlers/RNHoverHandler.m
@@ -56,6 +56,12 @@ API_AVAILABLE(ios(13.4))
   self.enabled = NO;
 }
 
+- (void)reset
+{
+  [super reset];
+  [_gestureHandler reset];
+}
+
 - (UIPointerStyle *)pointerInteraction:(UIPointerInteraction *)interaction styleForRegion:(UIPointerRegion *)region
 {
   if (interaction.view != nil && _hoverEffect != RNGestureHandlerHoverEffectNone) {

--- a/apple/Handlers/RNLongPressHandler.m
+++ b/apple/Handlers/RNLongPressHandler.m
@@ -103,6 +103,7 @@
   [_gestureHandler.pointerTracker reset];
 
   [super reset];
+  [_gestureHandler reset];
 }
 
 - (NSUInteger)getDuration

--- a/apple/Handlers/RNManualHandler.m
+++ b/apple/Handlers/RNManualHandler.m
@@ -62,6 +62,7 @@
 {
   [_gestureHandler.pointerTracker reset];
   [super reset];
+  [_gestureHandler reset];
 
   _shouldSendBeginEvent = YES;
 }

--- a/apple/Handlers/RNNativeViewHandler.mm
+++ b/apple/Handlers/RNNativeViewHandler.mm
@@ -65,6 +65,7 @@
 {
   [_gestureHandler.pointerTracker reset];
   [super reset];
+  [_gestureHandler reset];
 }
 
 @end

--- a/apple/Handlers/RNPanHandler.m
+++ b/apple/Handlers/RNPanHandler.m
@@ -123,6 +123,7 @@
 
   if (self.state == UIGestureRecognizerStatePossible && [self shouldFailUnderCustomCriteria]) {
     self.state = UIGestureRecognizerStateFailed;
+    [self triggerAction];
     return;
   }
 

--- a/apple/Handlers/RNPanHandler.m
+++ b/apple/Handlers/RNPanHandler.m
@@ -218,6 +218,7 @@
   [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(activateAfterLongPress) object:nil];
   self.enabled = YES;
   [super reset];
+  [_gestureHandler reset];
 }
 
 - (void)updateHasCustomActivationCriteria

--- a/apple/Handlers/RNPinchHandler.m
+++ b/apple/Handlers/RNPinchHandler.m
@@ -120,6 +120,7 @@
 {
   [_gestureHandler.pointerTracker reset];
   [super reset];
+  [_gestureHandler reset];
 }
 
 @end

--- a/apple/Handlers/RNRotationHandler.m
+++ b/apple/Handlers/RNRotationHandler.m
@@ -113,6 +113,7 @@
 {
   [_gestureHandler.pointerTracker reset];
   [super reset];
+  [_gestureHandler reset];
 }
 
 @end

--- a/apple/Handlers/RNTapHandler.m
+++ b/apple/Handlers/RNTapHandler.m
@@ -251,6 +251,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
   _maxNumberOfTouches = 0;
   self.enabled = YES;
   [super reset];
+  [_gestureHandler reset];
 }
 
 @end


### PR DESCRIPTION
## Description

At the moment `reset` method is only called in `gestureRecognizerShouldBegin`: https://github.com/software-mansion/react-native-gesture-handler/blob/35ec17d636220c1ad4226456aa3b03c846ba16a8/apple/RNGestureHandler.m#L487
However, I've noticed that this method is called after some events are already sent, mainly the `BEGIN` event, which is often sent as soon as `onTouchesBegan` is executed for the first pointer.

According to the [apple documentation](https://developer.apple.com/documentation/uikit/uigesturerecognizer/1620004-reset?language=objc), the `reset` method of recognizer is the place to reset the internal state of recognizer, which in this case in my opinion should also include the state of the handler.

The issue this fixes is the one described in https://github.com/software-mansion/react-native-gesture-handler/pull/2628:
> One thing that could be related is the fact that when the gesture fails before activation, the gesture stays in the Began state until the finger is lifted. This still needs to be investigated.

This was coming from the fact that the handler was failing before it was allowed to 'begin' (iOS begin not RNGH begin), so `gestureRecognizerShouldBegin` was not called, thus not resetting the failing handler. Because of that, it was sending events containing wrong states.

## Test plan

Tested on the Example app.
