### PR TITLE
Fix `onUp` in `Fling`

### DIFF
--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -5,7 +5,7 @@ import { AdaptedEvent, Config } from '../interfaces';
 import GestureHandler from './GestureHandler';
 
 const DEFAULT_MAX_DURATION_MS = 800;
-const DEFAULT_MIN_ACCEPTABLE_DELTA = 160;
+const DEFAULT_MIN_ACCEPTABLE_DELTA = 32;
 const DEFAULT_DIRECTION = Direction.RIGHT;
 const DEFAULT_NUMBER_OF_TOUCHES_REQUIRED = 1;
 
@@ -141,11 +141,11 @@ export default class FlingGestureHandler extends GestureHandler {
   }
 
   private onUp(event: AdaptedEvent): void {
-    this.tracker.removeFromTracker(event.pointerId);
-    if (this.currentState !== State.BEGAN) {
-      return;
+    if (this.currentState === State.BEGAN) {
+      this.endFling();
     }
-    this.endFling();
+
+    this.tracker.removeFromTracker(event.pointerId);
   }
 
   public activate(force?: boolean): void {


### PR DESCRIPTION
## Description

Fling gesture ends when pointer was moved farther than minimum distance.  The problem is that `onUp` method calls `endFling` after pointer was removed from tracker. This means that calling `this.tracker.getLastX(this.keyPointer)` (the same for `Y` position) inside `tryEndFling` will return undefined.

It is rather cosmetic change - it doesn't really affect behavior since we call `tryEndFling` inside `onPointerMove`. 

This PR also changes minimum distance the pointer has to travel, since `160` is way to big.

## Test plan

<details>
<summary> Tested on the following code </summary>

```jsx
import React from 'react';
import { View, StyleSheet } from 'react-native';
import { Gesture, GestureDetector } from 'react-native-gesture-handler';

export default function App() {
  const f = Gesture.Fling()
    .onEnd((e) => console.log(e))
    .onFinalize((e, s) => console.log(e, s));

  return (
    <View style={styles.container}>
      <GestureDetector gesture={f}>
        <View style={styles.box} />
      </GestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
    backgroundColor: '#ecf0f1',
    padding: 8,
  },
  box: {
    width: 500,
    height: 500,
    backgroundColor: 'blue',
  },
});

```

</details>
