### PR TITLE
fix: types for gestureHandlerRootHOC

### DIFF
--- a/src/components/gestureHandlerRootHOC.tsx
+++ b/src/components/gestureHandlerRootHOC.tsx
@@ -4,7 +4,7 @@ import hoistNonReactStatics from 'hoist-non-react-statics';
 import GestureHandlerRootView from './GestureHandlerRootView';
 
 export default function gestureHandlerRootHOC<
-  P extends Record<string, unknown>
+  P extends object,
 >(
   Component: React.ComponentType<P>,
   containerStyles?: StyleProp<ViewStyle>

--- a/src/components/gestureHandlerRootHOC.tsx
+++ b/src/components/gestureHandlerRootHOC.tsx
@@ -3,9 +3,7 @@ import { StyleSheet, StyleProp, ViewStyle } from 'react-native';
 import hoistNonReactStatics from 'hoist-non-react-statics';
 import GestureHandlerRootView from './GestureHandlerRootView';
 
-export default function gestureHandlerRootHOC<
-  P extends object,
->(
+export default function gestureHandlerRootHOC<P extends object>(
   Component: React.ComponentType<P>,
   containerStyles?: StyleProp<ViewStyle>
 ): React.ComponentType<P> {


### PR DESCRIPTION
## Description

fix gestureHandlerRootHOC type error props declared as an interface


Fixes #2711

## Test plan

Check type gestureHandlerRootHOC
