### PR TITLE
Change eslint `ban-types` to warning.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -12,7 +12,11 @@
   },
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
-    "project": ["./tsconfig.json", "./example/tsconfig.json", "./FabricExample/tsconfig.json"]
+    "project": [
+      "./tsconfig.json",
+      "./example/tsconfig.json",
+      "./FabricExample/tsconfig.json"
+    ]
   },
   "env": { "browser": true, "node": true, "jest/globals": true },
   "plugins": ["jest"],
@@ -32,6 +36,7 @@
     "@typescript-eslint/no-unsafe-call": "warn",
     "@typescript-eslint/no-unsafe-assignment": "warn",
     "@typescript-eslint/no-unsafe-return": "warn",
+    "@typescript-eslint/ban-types": "warn",
 
     // common
     "@typescript-eslint/explicit-module-boundary-types": "off",


### PR DESCRIPTION
## Description

While looking at #2711 we decided to change `P extends Record<string, unknown>` to `P extends object` (issue author already created #2712). However, current CI won't allow this change because of `ban-types` eslint rule. I've decided to follow @tjzel suggestion and change this rule to warning instead of error.

## Test plan

Run `yarn lint:js-root`.