### PR TITLE
fix(worklet): fix workletization of touch event gesture callbacks

### DIFF
--- a/src/handlers/gestures/gestureStateManager.ts
+++ b/src/handlers/gestures/gestureStateManager.ts
@@ -18,8 +18,7 @@ const warningMessage = tagMessage(
 const REANIMATED_AVAILABLE = Reanimated?.useSharedValue !== undefined;
 const setGestureState = Reanimated?.setGestureState;
 
-export const GestureStateManager = {
-  create(handlerTag: number): GestureStateManagerType {
+function create(handlerTag: number): GestureStateManagerType {
     'worklet';
     return {
       begin: () => {
@@ -58,5 +57,8 @@ export const GestureStateManager = {
         }
       },
     };
-  },
+  }
+
+export const GestureStateManager = {
+  create,
 };

--- a/src/handlers/gestures/gestureStateManager.ts
+++ b/src/handlers/gestures/gestureStateManager.ts
@@ -19,45 +19,45 @@ const REANIMATED_AVAILABLE = Reanimated?.useSharedValue !== undefined;
 const setGestureState = Reanimated?.setGestureState;
 
 function create(handlerTag: number): GestureStateManagerType {
-    'worklet';
-    return {
-      begin: () => {
-        'worklet';
-        if (REANIMATED_AVAILABLE) {
-          setGestureState(handlerTag, State.BEGAN);
-        } else {
-          console.warn(warningMessage);
-        }
-      },
+  'worklet';
+  return {
+    begin: () => {
+      'worklet';
+      if (REANIMATED_AVAILABLE) {
+        setGestureState(handlerTag, State.BEGAN);
+      } else {
+        console.warn(warningMessage);
+      }
+    },
 
-      activate: () => {
-        'worklet';
-        if (REANIMATED_AVAILABLE) {
-          setGestureState(handlerTag, State.ACTIVE);
-        } else {
-          console.warn(warningMessage);
-        }
-      },
+    activate: () => {
+      'worklet';
+      if (REANIMATED_AVAILABLE) {
+        setGestureState(handlerTag, State.ACTIVE);
+      } else {
+        console.warn(warningMessage);
+      }
+    },
 
-      fail: () => {
-        'worklet';
-        if (REANIMATED_AVAILABLE) {
-          setGestureState(handlerTag, State.FAILED);
-        } else {
-          console.warn(warningMessage);
-        }
-      },
+    fail: () => {
+      'worklet';
+      if (REANIMATED_AVAILABLE) {
+        setGestureState(handlerTag, State.FAILED);
+      } else {
+        console.warn(warningMessage);
+      }
+    },
 
-      end: () => {
-        'worklet';
-        if (REANIMATED_AVAILABLE) {
-          setGestureState(handlerTag, State.END);
-        } else {
-          console.warn(warningMessage);
-        }
-      },
-    };
-  }
+    end: () => {
+      'worklet';
+      if (REANIMATED_AVAILABLE) {
+        setGestureState(handlerTag, State.END);
+      } else {
+        console.warn(warningMessage);
+      }
+    },
+  };
+}
 
 export const GestureStateManager = {
   create,


### PR DESCRIPTION
## Description

Workletized touch event gesture callbacks were causing Reanimated errors to be thrown in RN 73 (Expo 50 beta).
Not sure if this is a bug in RNGH or Reanimated, but moving the function definition outside of the object seems to fix the issue (sounds like a bug in the reanimated babel plugin if nested functions should be able to be workiletized?)

Fixes https://github.com/software-mansion/react-native-reanimated/issues/5555

This case was previously broken:

```tsx
function Demo() {

  const panGesture = Gesture.Pan()
  
  panGesture.onTouchesMove((evt, mgr) => {
    'worklet'
    console.log('move!!')
  })

  return (
    <GestureHandlerRootView style={{ flex: 1, backgroundColor: 'seashell' }}>
      <GestureDetector gesture={panGesture}>
        <Animated.View style={{ flex: 1 }} />
      </GestureDetector>
    </GestureHandlerRootView>
  )
}
```

