### PR TITLE
Fix babel config in the root project

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -2,6 +2,6 @@ module.exports = {
   presets: [
     '@babel/preset-env',
     '@babel/preset-typescript',
-    'module:metro-react-native-babel-preset',
+    'module:@react-native/babel-preset',
   ],
 };


### PR DESCRIPTION
## Description

With the upgrade to 0.73, `metro-react-native-babel-preset` got replaced by `@react-native/babel-preset`, but I forgot to change it in the root `babel.config.js`, which resulted in errors about a missing module being shown when running lint. This PR fixes that.

## Test plan

Run `yarn lint:js-root`
