### PR TITLE
fix: restore ReactMethod annotation

### DIFF
--- a/android/paper/src/main/java/com/swmansion/gesturehandler/NativeRNGestureHandlerModuleSpec.java
+++ b/android/paper/src/main/java/com/swmansion/gesturehandler/NativeRNGestureHandlerModuleSpec.java
@@ -7,6 +7,7 @@ import com.facebook.react.bridge.ReactMethod;
 import com.facebook.react.bridge.ReadableMap;
 import com.facebook.react.turbomodule.core.interfaces.TurboModule;
 import javax.annotation.Nonnull;
+import com.facebook.react.bridge.ReactMethod;
 
 public abstract class NativeRNGestureHandlerModuleSpec extends ReactContextBaseJavaModule implements TurboModule {
   public static final String NAME = "RNGestureHandlerModule";
@@ -21,26 +22,34 @@ public abstract class NativeRNGestureHandlerModuleSpec extends ReactContextBaseJ
   }
 
   @DoNotStrip
+  @ReactMethod
   public abstract void handleSetJSResponder(double tag, boolean blockNativeResponder);
 
   @DoNotStrip
+  @ReactMethod
   public abstract void handleClearJSResponder();
 
   @DoNotStrip
+  @ReactMethod
   public abstract void createGestureHandler(String handlerName, double handlerTag, ReadableMap config);
 
   @DoNotStrip
+  @ReactMethod
   public abstract void attachGestureHandler(double handlerTag, double newView, double actionType);
 
   @DoNotStrip
+  @ReactMethod
   public abstract void updateGestureHandler(double handlerTag, ReadableMap newConfig);
 
   @DoNotStrip
+  @ReactMethod
   public abstract void dropGestureHandler(double handlerTag);
 
   @DoNotStrip
+  @ReactMethod
   public abstract boolean install();
 
   @DoNotStrip
+  @ReactMethod
   public abstract void flushOperations();
 }


### PR DESCRIPTION
## Description

Restore `@ReactMethod` annotation so it works on paper.
