### PR TITLE
handle case when setImmediate is not available in the browser

### DIFF
--- a/src/ghQueueMicrotask.ts
+++ b/src/ghQueueMicrotask.ts
@@ -2,4 +2,4 @@
 // Because Gesture Handler supports versions 0.64+, we have to handle situations where someone uses older version of react native.
 // That's why if `queueMicrotask` doesn't exist, we use `setImmediate` instead, since it was used before we switched to `queueMicrotask` in version 2.11.0
 export const ghQueueMicrotask =
-  typeof queueMicrotask === 'function' ? queueMicrotask : setImmediate;
+  typeof queueMicrotask === 'function' ? queueMicrotask : (typeof setImmediate === "function" ? setImmediate : setTimeout);


### PR DESCRIPTION
## Description

I found some cases, when setImmediate is not available (f.ex in Coherent browser). This "workaround" seems to solve the issue. I didn't find more places where similar tweak is needed.

## Test plan

Make sure that everything works like before.
