### PR TITLE
feat: add visionOS support

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -16,7 +16,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/software-mansion/react-native-gesture-handler", :tag => "#{s.version}" }
   s.source_files = "apple/**/*.{h,m,mm}"
   s.requires_arc = true
-  s.platforms       = { ios: apple_platform, tvos: apple_platform, osx: '10.15' }
+  s.platforms       = { ios: apple_platform, tvos: apple_platform, osx: '10.15', visionos: '1.0' }
 
   if defined?(install_modules_dependencies()) != nil
     install_modules_dependencies(s);

--- a/apple/Handlers/RNFlingHandler.m
+++ b/apple/Handlers/RNFlingHandler.m
@@ -143,7 +143,7 @@
 
   CGPoint viewAbsolutePosition =
       [recognizer.view convertPoint:recognizer.view.bounds.origin
-                             toView:[UIApplication sharedApplication].keyWindow.rootViewController.view];
+                             toView:RCTKeyWindow().rootViewController.view];
   CGPoint locationInView = [recognizer getLastLocation];
 
   return [RNGestureHandlerEventExtraData

--- a/apple/Handlers/RNForceTouchHandler.m
+++ b/apple/Handlers/RNForceTouchHandler.m
@@ -86,7 +86,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
 
 - (void)performFeedbackIfRequired
 {
-#if !TARGET_OS_TV
+#if !TARGET_OS_TV && !TARGET_OS_VISION
   if (_feedbackOnActivation) {
     if (@available(iOS 10.0, *)) {
       [[[UIImpactFeedbackGenerator alloc] initWithStyle:(UIImpactFeedbackStyleMedium)] impactOccurred];


### PR DESCRIPTION
## Description

This PR adds support for visionOS platform. Based on https://github.com/software-mansion/react-native-reanimated/pull/5627.

## Test plan

```
npx @callstack/react-native-visionos@latest init VisionApp
yarn add software-mansion-labs/react-native-gesture-handler#@tomekzaw/visionos
cd visionos
pod install
```
