### PR TITLE
Fix pointers count on iOS

### DIFF
--- a/apple/Handlers/RNRotationHandler.m
+++ b/apple/Handlers/RNRotationHandler.m
@@ -97,25 +97,25 @@
 - (void)touchesBegan:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesBegan:touches withEvent:event];
-  [self interactionsBegan:[NSSet setWithObject:event] withEvent:event];
+  [self interactionsBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesMoved:touches withEvent:event];
-  [self interactionsMoved:[NSSet setWithObject:event] withEvent:event];
+  [self interactionsMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesEnded:touches withEvent:event];
-  [self interactionsEnded:[NSSet setWithObject:event] withEvent:event];
+  [self interactionsEnded:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesCancelled:touches withEvent:event];
-  [self interactionsCancelled:[NSSet setWithObject:event] withEvent:event];
+  [self interactionsCancelled:touches withEvent:event];
 }
 #endif
 

--- a/apple/Handlers/RNTapHandler.m
+++ b/apple/Handlers/RNTapHandler.m
@@ -185,25 +185,25 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 - (void)touchesBegan:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesBegan:touches withEvent:event];
-  [self interactionsBegan:[NSSet setWithObject:event] withEvent:event];
+  [self interactionsBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesMoved:touches withEvent:event];
-  [self interactionsMoved:[NSSet setWithObject:event] withEvent:event];
+  [self interactionsMoved:touches withEvent:event];
 }
 
 - (void)touchesEnded:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesEnded:touches withEvent:event];
-  [self interactionsEnded:[NSSet setWithObject:event] withEvent:event];
+  [self interactionsEnded:touches withEvent:event];
 }
 
 - (void)touchesCancelled:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [super touchesCancelled:touches withEvent:event];
-  [self interactionsCancelled:[NSSet setWithObject:event] withEvent:event];
+  [self interactionsCancelled:touches withEvent:event];
 }
 
 #endif


### PR DESCRIPTION
## Description

In 2.15.0 we released partial support for macOS. In `Tap` and `Rotation`, instead of passing original `touches` parameter  to keep iOS behavior, we changed that to `NSSet` with `event` object.  This means that instead of having multiple `UITouch` objects in that set, we only had one object which cumulates all touches. Because we use `[touches count]` to find number of touches, change mentioned above resulted in obtaining wrong values.

Fixes #2754

## Test plan
<details>
<summary> Tested on code from #2754 </summary>

```jsx
import React, { useState } from 'react';
import { Text, StyleSheet, View, ScrollView, Button } from 'react-native';
import { GestureDetector, Gesture } from 'react-native-gesture-handler';

export default function Home() {
  const [log, setLog] = useState<string[]>([]);

  const tap = Gesture.Tap()
    .minPointers(2)
    .runOnJS(true)
    .onBegin((event) => {
      console.log('onBegin', JSON.stringify({ event }));
      setLog((prev) => [`onBegin: ${JSON.stringify({ event })}`, ...prev]);
    })
    .onStart((event) => {
      console.log('onStart', JSON.stringify({ event }));
      setLog((prev) => [`onStart: ${JSON.stringify({ event })}`, ...prev]);
    })
    .onFinalize((event, success) => {
      console.log('onFinalize', { event, success });
      setLog((prev) => [
        `onEnd: ${JSON.stringify({ event })}; success:${success}`,
        ...prev,
      ]);
    });

  return (
    <View style={styles.container}>
      <Button title="Reset" onPress={() => setLog([])} />
      <GestureDetector gesture={tap}>
        <View style={styles.container}>
          {/* <ScrollView> */}
          {log.map((line, i) => (
            <Text key={i} style={[styles.log, i === 0 && styles.logNew]}>
              {line}
            </Text>
          ))}
          {/* </ScrollView> */}
        </View>
      </GestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    width: '100%',
    height: '100%',
    backgroundColor: 'white',
  },
  log: {
    fontSize: 12,
    color: 'grey',
    padding: 5,
  },
  logNew: {
    backgroundColor: '#e6ffec',
    color: 'black',
  },
});

```

</details>