### PR TITLE
Pass `{ flex: 1 }` as default style to `GestureHandlerRootView`

### DIFF
--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -161,7 +161,7 @@ const Stack = createStackNavigator<RootStackParamList>();
 
 export default function App() {
   return (
-    <GestureHandlerRootView style={styles.root}>
+    <GestureHandlerRootView>
       <NavigationContainer>
         <Stack.Navigator>
           <Stack.Screen
@@ -220,9 +220,6 @@ function MainScreenItem({ name, onPressItem }: MainScreenItemProps) {
 }
 
 const styles = StyleSheet.create({
-  root: {
-    flex: 1,
-  },
   sectionTitle: {
     ...Platform.select({
       ios: {

--- a/src/components/GestureHandlerRootView.android.tsx
+++ b/src/components/GestureHandlerRootView.android.tsx
@@ -8,15 +8,14 @@ import GestureHandlerRootViewNativeComponent from '../specs/RNGestureHandlerRoot
 export interface GestureHandlerRootViewProps
   extends PropsWithChildren<ViewProps> {}
 
-export default function GestureHandlerRootView(
-  props: GestureHandlerRootViewProps
-) {
+export default function GestureHandlerRootView({
+  style,
+  ...rest
+}: GestureHandlerRootViewProps) {
   // try initialize fabric on the first render, at this point we can
   // reliably check if fabric is enabled (the function contains a flag
   // to make sure it's called only once)
   maybeInitializeFabric();
-
-  const { style, ...rest } = props;
 
   return (
     <GestureHandlerRootViewContext.Provider value>

--- a/src/components/GestureHandlerRootView.android.tsx
+++ b/src/components/GestureHandlerRootView.android.tsx
@@ -21,15 +21,13 @@ export default function GestureHandlerRootView(
   return (
     <GestureHandlerRootViewContext.Provider value>
       <GestureHandlerRootViewNativeComponent
-        {...rest}
         style={style ?? styles.container}
+        {...rest}
       />
     </GestureHandlerRootViewContext.Provider>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
+  container: { flex: 1 },
 });

--- a/src/components/GestureHandlerRootView.android.tsx
+++ b/src/components/GestureHandlerRootView.android.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PropsWithChildren } from 'react';
-import { ViewProps } from 'react-native';
+import { ViewProps, StyleSheet } from 'react-native';
 import { maybeInitializeFabric } from '../init';
 import GestureHandlerRootViewContext from '../GestureHandlerRootViewContext';
 import GestureHandlerRootViewNativeComponent from '../specs/RNGestureHandlerRootViewNativeComponent';
@@ -16,9 +16,20 @@ export default function GestureHandlerRootView(
   // to make sure it's called only once)
   maybeInitializeFabric();
 
+  const { style, ...rest } = props;
+
   return (
     <GestureHandlerRootViewContext.Provider value>
-      <GestureHandlerRootViewNativeComponent {...props} />
+      <GestureHandlerRootViewNativeComponent
+        {...rest}
+        style={style ?? styles.container}
+      />
     </GestureHandlerRootViewContext.Provider>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/components/GestureHandlerRootView.tsx
+++ b/src/components/GestureHandlerRootView.tsx
@@ -7,15 +7,14 @@ import GestureHandlerRootViewContext from '../GestureHandlerRootViewContext';
 export interface GestureHandlerRootViewProps
   extends PropsWithChildren<ViewProps> {}
 
-export default function GestureHandlerRootView(
-  props: GestureHandlerRootViewProps
-) {
+export default function GestureHandlerRootView({
+  style,
+  ...rest
+}: GestureHandlerRootViewProps) {
   // try initialize fabric on the first render, at this point we can
   // reliably check if fabric is enabled (the function contains a flag
   // to make sure it's called only once)
   maybeInitializeFabric();
-
-  const { style, ...rest } = props;
 
   return (
     <GestureHandlerRootViewContext.Provider value>

--- a/src/components/GestureHandlerRootView.tsx
+++ b/src/components/GestureHandlerRootView.tsx
@@ -19,13 +19,11 @@ export default function GestureHandlerRootView(
 
   return (
     <GestureHandlerRootViewContext.Provider value>
-      <View {...rest} style={style ?? styles.container} />
+      <View style={style ?? styles.container} {...rest} />
     </GestureHandlerRootViewContext.Provider>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
+  container: { flex: 1 },
 });

--- a/src/components/GestureHandlerRootView.tsx
+++ b/src/components/GestureHandlerRootView.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PropsWithChildren } from 'react';
-import { View, ViewProps } from 'react-native';
+import { View, ViewProps, StyleSheet } from 'react-native';
 import { maybeInitializeFabric } from '../init';
 import GestureHandlerRootViewContext from '../GestureHandlerRootViewContext';
 
@@ -15,9 +15,17 @@ export default function GestureHandlerRootView(
   // to make sure it's called only once)
   maybeInitializeFabric();
 
+  const { style, ...rest } = props;
+
   return (
     <GestureHandlerRootViewContext.Provider value>
-      <View {...props} />
+      <View {...rest} style={style ?? styles.container} />
     </GestureHandlerRootViewContext.Provider>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});

--- a/src/components/GestureHandlerRootView.web.tsx
+++ b/src/components/GestureHandlerRootView.web.tsx
@@ -13,13 +13,11 @@ export default function GestureHandlerRootView(
 
   return (
     <GestureHandlerRootViewContext.Provider value>
-      <View {...rest} style={style ?? styles.container} />
+      <View style={style ?? styles.container} {...rest} />
     </GestureHandlerRootViewContext.Provider>
   );
 }
 
 const styles = StyleSheet.create({
-  container: {
-    flex: 1,
-  },
+  container: { flex: 1 },
 });

--- a/src/components/GestureHandlerRootView.web.tsx
+++ b/src/components/GestureHandlerRootView.web.tsx
@@ -6,11 +6,10 @@ import GestureHandlerRootViewContext from '../GestureHandlerRootViewContext';
 export interface GestureHandlerRootViewProps
   extends PropsWithChildren<ViewProps> {}
 
-export default function GestureHandlerRootView(
-  props: GestureHandlerRootViewProps
-) {
-  const { style, ...rest } = props;
-
+export default function GestureHandlerRootView({
+  style,
+  ...rest
+}: GestureHandlerRootViewProps) {
   return (
     <GestureHandlerRootViewContext.Provider value>
       <View style={style ?? styles.container} {...rest} />

--- a/src/components/GestureHandlerRootView.web.tsx
+++ b/src/components/GestureHandlerRootView.web.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { PropsWithChildren } from 'react';
-import { View, ViewProps } from 'react-native';
+import { View, ViewProps, StyleSheet } from 'react-native';
 import GestureHandlerRootViewContext from '../GestureHandlerRootViewContext';
 
 export interface GestureHandlerRootViewProps
@@ -9,9 +9,17 @@ export interface GestureHandlerRootViewProps
 export default function GestureHandlerRootView(
   props: GestureHandlerRootViewProps
 ) {
+  const { style, ...rest } = props;
+
   return (
     <GestureHandlerRootViewContext.Provider value>
-      <View {...props} />
+      <View {...rest} style={style ?? styles.container} />
     </GestureHandlerRootViewContext.Provider>
   );
 }
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+  },
+});


### PR DESCRIPTION
## Description
Adding `{ flex: 1 }` style is [described in the installation docs](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation#js) but I _always_ forget to add it when creating a new app that uses gestures. I think others developers can relate.

This PR adds a `{ flex: 1 }`  fallback style to `GestureHandlerRootView` so users won't see a blank screen when they wrap their app with `GestureHandlerRootView`. 
 
## Test plan

Run an example app