### PR TITLE
Update pods on CI

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -29,6 +29,10 @@ jobs:
         with:
           node-version: 18
           cache: 'yarn'
+      - name: setup-cocoapods
+        uses: maxim-lobanov/setup-cocoapods@v1
+        with:
+          version: 1.15.2
       - name: Install node dependencies
         working-directory: ${{ matrix.working-directory }}
         run: yarn


### PR DESCRIPTION
## Description

Our CI fails on iOS build because of hermes-engine pod. This was fixed in cocapods 1.15.2 ([link](https://github.com/CocoaPods/CocoaPods/issues/12226#issuecomment-1930604302)), but our currently CI uses 1.15.0. This PR bumps version to 1.15.2

## Test plan

Tested on `nestedTaps` PR 
