### PR TITLE
fix: remove usage of bridge uimanager in one more place

### DIFF
--- a/apple/RNGestureHandlerModule.mm
+++ b/apple/RNGestureHandlerModule.mm
@@ -202,12 +202,11 @@ RCT_EXPORT_METHOD(flushOperations)
   NSArray<GestureHandlerOperation> *operations = _operations;
   _operations = [NSMutableArray new];
 
-  [self.bridge.uiManager
-      addUIBlock:^(__unused RCTUIManager *manager, __unused NSDictionary<NSNumber *, UIView *> *viewRegistry) {
-        for (GestureHandlerOperation operation in operations) {
-          operation(self->_manager);
-        }
-      }];
+  [self.viewRegistry_DEPRECATED addUIBlock:^(RCTViewRegistry *viewRegistry) {
+    for (GestureHandlerOperation operation in operations) {
+      operation(self->_manager);
+    }
+  }];
 #endif // RCT_NEW_ARCH_ENABLED
 }
 


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

Quick fix for one more place where `viewRegistry_DEPRECATED` should be used.

## Test plan

<!--
Describe how did you test this change here.
-->
