### PR TITLE
Remove hardcoded version of `cocoapods`

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -34,8 +34,7 @@ jobs:
         run: yarn
       - name: Install pods
         working-directory: ${{ matrix.working-directory }}/ios
-        run: bundle install
-        run: bundle exec pod install
+        run: bundle install && bundle exec pod install
       - name: Build app
         working-directory: ${{ matrix.working-directory }}
         run: yarn ios --simulator=\"iPhone 14\" --mode Debug --verbose --terminal /bin/zsh

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -34,7 +34,8 @@ jobs:
         run: yarn
       - name: Install pods
         working-directory: ${{ matrix.working-directory }}/ios
-        run: pod install
+        run: bundle install
+        run: bundle exec pod install
       - name: Build app
         working-directory: ${{ matrix.working-directory }}
         run: yarn ios --simulator=\"iPhone 14\" --mode Debug --verbose --terminal /bin/zsh

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -29,10 +29,6 @@ jobs:
         with:
           node-version: 18
           cache: 'yarn'
-      - name: setup-cocoapods
-        uses: maxim-lobanov/setup-cocoapods@v1
-        with:
-          version: 1.15.2
       - name: Install node dependencies
         working-directory: ${{ matrix.working-directory }}
         run: yarn


### PR DESCRIPTION
## Description

In #2765 I've updated `cocoapods` on CI in order to fix iOS build action. The problem with this approach was that I had to hardcode `cocoapods` version to `1.15.2`. This PR changes workflow to use `bundle install && bundle exec` instead.

## Test plan

See that CI passes.