### PR TITLE
Fix wrong admonition color on initial render

### DIFF
--- a/docs/src/theme/Admonition/index.js
+++ b/docs/src/theme/Admonition/index.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import clsx from 'clsx';
-import { ThemeClassNames, useColorMode } from '@docusaurus/theme-common';
+import { ThemeClassNames } from '@docusaurus/theme-common';
 import Translate from '@docusaurus/Translate';
 import styles from './styles.module.css';
 
@@ -68,7 +68,6 @@ const aliases = {
 };
 
 export default function Admonition(props) {
-  const { colorMode } = useColorMode();
   const {
     children,
     type,

--- a/docs/src/theme/Admonition/index.js
+++ b/docs/src/theme/Admonition/index.js
@@ -89,7 +89,9 @@ export default function Admonition(props) {
       )}>
       <div className={styles.admonitionHeading}>
         <div className={styles.admonitionIcon}>
-          {colorMode === 'light' ? <Danger /> : <DangerDark />}
+          {/* one of the icons is always hidden in css */}
+          <Danger />
+          <DangerDark />
         </div>
 
         {titleLabel}

--- a/docs/src/theme/Admonition/styles.module.css
+++ b/docs/src/theme/Admonition/styles.module.css
@@ -6,10 +6,6 @@
   margin-bottom: 1.5em;
 }
 
-[data-theme='dark'] .admonition {
-  color: var(--swm-off-white);
-}
-
 .admonitionHeading {
   display: flex;
   font-family: var(--swm-admonition-heading-font-family);
@@ -29,6 +25,14 @@
 
   width: 21px;
   height: 27px;
+}
+
+[data-theme='dark'] .admonitionIcon svg:first-child {
+  display: none;
+}
+
+[data-theme='light'] .admonitionIcon svg:nth-child(2) {
+  display: none;
 }
 
 .admonitionIcon svg {


### PR DESCRIPTION
### Before


https://github.com/software-mansion/react-native-gesture-handler/assets/39658211/04f2494a-ba8f-40dc-a850-f53e6df03d9e


### After


https://github.com/software-mansion/react-native-gesture-handler/assets/39658211/a618b26a-9af7-4a5f-9805-bb4c7b21e894

