### PR TITLE
Adjust Android build.gradle to to run project with Gradle 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -155,6 +155,10 @@ android {
         targetCompatibility JavaVersion.VERSION_11
     }
 
+    kotlinOptions {
+        jvmTarget = '11'
+    }
+
     if (isNewArchitectureEnabled()) {
         externalNativeBuild {
             cmake {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -151,8 +151,8 @@ android {
     }
 
     compileOptions {
-        sourceCompatibility JavaVersion.VERSION_1_8
-        targetCompatibility JavaVersion.VERSION_1_8
+        sourceCompatibility JavaVersion.VERSION_11
+        targetCompatibility JavaVersion.VERSION_11
     }
 
     if (isNewArchitectureEnabled()) {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -109,6 +109,9 @@ android {
         }
     }
 
+    buildFeatures.buildConfig true
+    namespace 'com.swmansion.gesturehandler'
+
     // Used to override the NDK path/version on internal CI or by allowing
     // users to customize the NDK path/version from their root project (e.g. for M1 support)
     if (rootProject.hasProperty("ndkPath")) {


### PR DESCRIPTION
## Description

To build the `android` project with gradle 8+, the added configs are required.

## Test plan

Tested in Android project with ...
- gradle 8.2
- gradle 7.6