### PR TITLE
Move `customDirectEventTypes` to separate files.

### DIFF
--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -5,7 +5,7 @@ import {
   DeviceEventEmitter,
   EmitterSubscription,
 } from 'react-native';
-import customDirectEventTypes from './customDirectEventTypes';
+import { customDirectEventTypes } from './customDirectEventTypes';
 // @ts-ignore - it isn't typed by TS & don't have definitelyTyped types
 import deepEqual from 'lodash/isEqual';
 import RNGestureHandlerModule from '../RNGestureHandlerModule';

--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -5,8 +5,7 @@ import {
   DeviceEventEmitter,
   EmitterSubscription,
 } from 'react-native';
-// @ts-ignore - its taken straight from RN
-import { customDirectEventTypes } from 'react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
+import customDirectEventTypes from './customDirectEventTypes';
 // @ts-ignore - it isn't typed by TS & don't have definitelyTyped types
 import deepEqual from 'lodash/isEqual';
 import RNGestureHandlerModule from '../RNGestureHandlerModule';

--- a/src/handlers/customDirectEventTypes.ts
+++ b/src/handlers/customDirectEventTypes.ts
@@ -1,8 +1,2 @@
 // @ts-ignore - its taken straight from RN
-import { customDirectEventTypes } from 'react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
-
-customDirectEventTypes.topGestureHandlerEvent = {
-  registrationName: 'onGestureHandlerEvent',
-};
-
-export default customDirectEventTypes;
+export { customDirectEventTypes } from 'react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry';

--- a/src/handlers/customDirectEventTypes.ts
+++ b/src/handlers/customDirectEventTypes.ts
@@ -1,0 +1,8 @@
+// @ts-ignore - its taken straight from RN
+import { customDirectEventTypes } from 'react-native/Libraries/Renderer/shims/ReactNativeViewConfigRegistry';
+
+customDirectEventTypes.topGestureHandlerEvent = {
+  registrationName: 'onGestureHandlerEvent',
+};
+
+export default customDirectEventTypes;

--- a/src/handlers/customDirectEventTypes.web.ts
+++ b/src/handlers/customDirectEventTypes.web.ts
@@ -1,3 +1,5 @@
 // customDirectEventTypes doesn't exist in react-native-web, therefore importing it
 // directly in createHandler.tsx would end in crash.
-export default {};
+const customDirectEventTypes = {};
+
+export { customDirectEventTypes };

--- a/src/handlers/customDirectEventTypes.web.ts
+++ b/src/handlers/customDirectEventTypes.web.ts
@@ -1,0 +1,3 @@
+// customDirectEventTypes doesn't exist in react-native-web, therefore importing it
+// directly in createHandler.tsx would end in crash.
+export default {};


### PR DESCRIPTION
## Description

`customDirectEventTypes` import inside `createHandler` introduced in #2766 makes web unable to compile since `react-native-web` doesn't provide this object. This PR moves mentioned import into separate file and splits it into `.ts` and `.web.ts` parts 

## Test plan

Tested on web and FabricExample app.