### PR TITLE
Add `mouseButton` description to docs.

### DIFF
--- a/docs/docs/components/drawer-layout.mdx
+++ b/docs/docs/components/drawer-layout.mdx
@@ -87,6 +87,19 @@ Enables two-finger gestures on supported devices, for example iPads with trackpa
 
 component or function. Children is a component which is rendered by default and is wrapped by drawer. However, it could be also a render function which takes an Animated value as a parameter that indicates the progress of drawer opening/closing animation (progress value is 0 when closed and 1 when opened) is the same way like `renderNavigationView` prop.
 
+### `mouseButton(value: MouseButton)` (Web | Android)
+
+Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
+
+- `LEFT`
+- `RIGHT`
+- `MIDDLE`
+- `BUTTON_4`
+- `BUTTON_5`
+- `ALL`
+
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is set to `MouseButton.LEFT`.
+
 ## Methods
 
 ### `openDrawer(options)`

--- a/docs/docs/components/drawer-layout.mdx
+++ b/docs/docs/components/drawer-layout.mdx
@@ -87,7 +87,7 @@ Enables two-finger gestures on supported devices, for example iPads with trackpa
 
 component or function. Children is a component which is rendered by default and is wrapped by drawer. However, it could be also a render function which takes an Animated value as a parameter that indicates the progress of drawer opening/closing animation (progress value is 0 when closed and 1 when opened) is the same way like `renderNavigationView` prop.
 
-### `mouseButton(value: MouseButton)` (Web | Android)
+### `mouseButton(value: MouseButton)` (Web & Android only)
 
 Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
 

--- a/docs/docs/components/swipeable.md
+++ b/docs/docs/components/swipeable.md
@@ -141,7 +141,7 @@ style object for the children container (Animated.View), for example to apply `f
 
 Enables two-finger gestures on supported devices, for example iPads with trackpads. If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
 
-### `mouseButton(value: MouseButton)` (Web | Android)
+### `mouseButton(value: MouseButton)` (Web & Android only)
 
 Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
 

--- a/docs/docs/components/swipeable.md
+++ b/docs/docs/components/swipeable.md
@@ -141,6 +141,19 @@ style object for the children container (Animated.View), for example to apply `f
 
 Enables two-finger gestures on supported devices, for example iPads with trackpads. If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
 
+### `mouseButton(value: MouseButton)` (Web | Android)
+
+Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
+
+- `LEFT`
+- `RIGHT`
+- `MIDDLE`
+- `BUTTON_4`
+- `BUTTON_5`
+- `ALL`
+
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is set to `MouseButton.LEFT`.
+
 ## Methods
 
 Using reference to `Swipeable` it's possible to trigger some actions on it

--- a/docs/docs/gestures/fling-gesture.md
+++ b/docs/docs/gestures/fling-gesture.md
@@ -62,7 +62,7 @@ fling.direction(Directions.DOWN);
 
 Determine exact number of points required to handle the fling gesture.
 
-### `mouseButton(value: MouseButton)` (Web | Android)
+### `mouseButton(value: MouseButton)` (Web & Android only)
 
 Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
 

--- a/docs/docs/gestures/fling-gesture.md
+++ b/docs/docs/gestures/fling-gesture.md
@@ -62,6 +62,19 @@ fling.direction(Directions.DOWN);
 
 Determine exact number of points required to handle the fling gesture.
 
+### `mouseButton(value: MouseButton)` (Web | Android)
+
+Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
+
+- `LEFT`
+- `RIGHT`
+- `MIDDLE`
+- `BUTTON_4`
+- `BUTTON_5`
+- `ALL`
+
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`.
+
 <BaseEventConfig />
 
 ## Callbacks

--- a/docs/docs/gestures/fling-gesture.md
+++ b/docs/docs/gestures/fling-gesture.md
@@ -73,7 +73,7 @@ Allows users to choose which mouse button should handler respond to. The enum `M
 - `BUTTON_5`
 - `ALL`
 
-Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`.
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is `MouseButton.LEFT`.
 
 <BaseEventConfig />
 

--- a/docs/docs/gestures/fling-gesture.md
+++ b/docs/docs/gestures/fling-gesture.md
@@ -73,7 +73,7 @@ Allows users to choose which mouse button should handler respond to. The enum `M
 - `BUTTON_5`
 - `ALL`
 
-Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is `MouseButton.LEFT`.
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is set to `MouseButton.LEFT`.
 
 <BaseEventConfig />
 

--- a/docs/docs/gestures/long-press-gesture.md
+++ b/docs/docs/gestures/long-press-gesture.md
@@ -61,7 +61,7 @@ Allows users to choose which mouse button should handler respond to. The enum `M
 - `BUTTON_5`
 - `ALL`
 
-Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is `MouseButton.LEFT`.
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is set to `MouseButton.LEFT`.
 
 <BaseEventConfig />
 

--- a/docs/docs/gestures/long-press-gesture.md
+++ b/docs/docs/gestures/long-press-gesture.md
@@ -61,7 +61,7 @@ Allows users to choose which mouse button should handler respond to. The enum `M
 - `BUTTON_5`
 - `ALL`
 
-Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`.
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is `MouseButton.LEFT`.
 
 <BaseEventConfig />
 

--- a/docs/docs/gestures/long-press-gesture.md
+++ b/docs/docs/gestures/long-press-gesture.md
@@ -50,6 +50,19 @@ Minimum time, expressed in milliseconds, that a finger must remain pressed on th
 
 Maximum distance, expressed in points, that defines how far the finger is allowed to travel during a long press gesture. If the finger travels further than the defined distance and the gesture hasn't yet [activated](/docs/fundamentals/states-events#active), it will fail to recognize the gesture. The default value is 10.
 
+### `mouseButton(value: MouseButton)` (Web | Android)
+
+Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
+
+- `LEFT`
+- `RIGHT`
+- `MIDDLE`
+- `BUTTON_4`
+- `BUTTON_5`
+- `ALL`
+
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`.
+
 <BaseEventConfig />
 
 ## Callbacks

--- a/docs/docs/gestures/long-press-gesture.md
+++ b/docs/docs/gestures/long-press-gesture.md
@@ -50,7 +50,7 @@ Minimum time, expressed in milliseconds, that a finger must remain pressed on th
 
 Maximum distance, expressed in points, that defines how far the finger is allowed to travel during a long press gesture. If the finger travels further than the defined distance and the gesture hasn't yet [activated](/docs/fundamentals/states-events#active), it will fail to recognize the gesture. The default value is 10.
 
-### `mouseButton(value: MouseButton)` (Web | Android)
+### `mouseButton(value: MouseButton)` (Web & Android only)
 
 Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
 

--- a/docs/docs/gestures/pan-gesture.md
+++ b/docs/docs/gestures/pan-gesture.md
@@ -123,7 +123,7 @@ Allows users to choose which mouse button should handler respond to. The enum `M
 - `BUTTON_5`
 - `ALL`
 
-Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`.
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is `MouseButton.LEFT`.
 
 <BaseEventConfig />
 <BaseContinousEventConfig />

--- a/docs/docs/gestures/pan-gesture.md
+++ b/docs/docs/gestures/pan-gesture.md
@@ -112,6 +112,19 @@ Android, by default, will calculate translation values based on the position of 
 
 Enables two-finger gestures on supported devices, for example iPads with trackpads. If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
 
+### `mouseButton(value: MouseButton)` (Web | Android)
+
+Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
+
+- `LEFT`
+- `RIGHT`
+- `MIDDLE`
+- `BUTTON_4`
+- `BUTTON_5`
+- `ALL`
+
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`.
+
 <BaseEventConfig />
 <BaseContinousEventConfig />
 

--- a/docs/docs/gestures/pan-gesture.md
+++ b/docs/docs/gestures/pan-gesture.md
@@ -112,7 +112,7 @@ Android, by default, will calculate translation values based on the position of 
 
 Enables two-finger gestures on supported devices, for example iPads with trackpads. If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
 
-### `mouseButton(value: MouseButton)` (Web | Android)
+### `mouseButton(value: MouseButton)` (Web & Android only)
 
 Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
 

--- a/docs/docs/gestures/pan-gesture.md
+++ b/docs/docs/gestures/pan-gesture.md
@@ -123,7 +123,7 @@ Allows users to choose which mouse button should handler respond to. The enum `M
 - `BUTTON_5`
 - `ALL`
 
-Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is `MouseButton.LEFT`.
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is set to `MouseButton.LEFT`.
 
 <BaseEventConfig />
 <BaseContinousEventConfig />

--- a/docs/docs/gestures/tap-gesture.md
+++ b/docs/docs/gestures/tap-gesture.md
@@ -75,6 +75,19 @@ Maximum distance, expressed in points, that defines how far the finger is allowe
 
 Maximum distance, expressed in points, that defines how far the finger is allowed to travel during a tap gesture. If the finger travels further than the defined distance and the gesture hasn't yet [activated](/docs/fundamentals/states-events#active), it will fail to recognize the gesture.
 
+### `mouseButton(value: MouseButton)` (Web | Android)
+
+Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
+
+- `LEFT`
+- `RIGHT`
+- `MIDDLE`
+- `BUTTON_4`
+- `BUTTON_5`
+- `ALL`
+
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`.
+
 <BaseEventConfig />
 
 ## Callbacks

--- a/docs/docs/gestures/tap-gesture.md
+++ b/docs/docs/gestures/tap-gesture.md
@@ -86,7 +86,7 @@ Allows users to choose which mouse button should handler respond to. The enum `M
 - `BUTTON_5`
 - `ALL`
 
-Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is `MouseButton.LEFT`.
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is set to `MouseButton.LEFT`.
 
 <BaseEventConfig />
 

--- a/docs/docs/gestures/tap-gesture.md
+++ b/docs/docs/gestures/tap-gesture.md
@@ -75,7 +75,7 @@ Maximum distance, expressed in points, that defines how far the finger is allowe
 
 Maximum distance, expressed in points, that defines how far the finger is allowed to travel during a tap gesture. If the finger travels further than the defined distance and the gesture hasn't yet [activated](/docs/fundamentals/states-events#active), it will fail to recognize the gesture.
 
-### `mouseButton(value: MouseButton)` (Web | Android)
+### `mouseButton(value: MouseButton)` (Web & Android only)
 
 Allows users to choose which mouse button should handler respond to. The enum `MouseButton` consists of the following predefined fields:
 

--- a/docs/docs/gestures/tap-gesture.md
+++ b/docs/docs/gestures/tap-gesture.md
@@ -86,7 +86,7 @@ Allows users to choose which mouse button should handler respond to. The enum `M
 - `BUTTON_5`
 - `ALL`
 
-Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`.
+Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`. Default value is `MouseButton.LEFT`.
 
 <BaseEventConfig />
 


### PR DESCRIPTION
## Description

This PR adds `mouseButton` property description to our documentation.

## Test plan

Run docs