### PR TITLE
Allows to apply different border radius to RectButton component

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -227,23 +227,14 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
     private fun updateBackgroundColor(backgroundColor: Int, borderRadius: Float, selectable: Drawable?) {
       val colorDrawable = PaintDrawable(backgroundColor)
 
-      if (borderRadius != 0f) {
+      val radii = floatArrayOf(borderTopLeftRadius, borderTopRightRadius, borderBottomRightRadius, borderBottomLeftRadius)
+        .map { it.takeIf { it != 0f } ?: borderRadius }
+        .flatMap { listOf(it, it) }
+        .toFloatArray()
+      if (radii.any { it != 0f }) {
+        colorDrawable.setCornerRadii(radii)
+      } else if (borderRadius != 0f) {
         colorDrawable.setCornerRadius(borderRadius)
-      }
-
-      if (borderTopLeftRadius != 0f || borderTopRightRadius != 0f || borderBottomLeftRadius != 0f || borderBottomRightRadius != 0f) {
-        colorDrawable.setCornerRadii(
-          floatArrayOf(
-            borderTopLeftRadius,
-            borderTopLeftRadius,
-            borderTopRightRadius,
-            borderTopRightRadius,
-            borderBottomRightRadius,
-            borderBottomRightRadius,
-            borderBottomLeftRadius,
-            borderBottomLeftRadius
-          )
-        )
       }
 
       val layerDrawable = LayerDrawable(if (selectable != null) arrayOf(colorDrawable, selectable) else arrayOf(colorDrawable))

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -65,6 +65,26 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
     view.borderRadius = borderRadius
   }
 
+  @ReactProp(name = "borderTopLeftRadius")
+  override fun setBorderTopLeftRadius(view: ButtonViewGroup, borderTopLeftRadius: Float) {
+    view.borderTopLeftRadius = borderTopLeftRadius
+  }
+
+  @ReactProp(name = "borderTopRightRadius")
+  override fun setBorderTopRightRadius(view: ButtonViewGroup, borderTopRightRadius: Float) {
+    view.borderTopRightRadius = borderTopRightRadius
+  }
+
+  @ReactProp(name = "borderBottomLeftRadius")
+  override fun setBorderBottomLeftRadius(view: ButtonViewGroup, borderBottomLeftRadius: Float) {
+    view.borderBottomLeftRadius = borderBottomLeftRadius
+  }
+
+  @ReactProp(name = "borderBottomRightRadius")
+  override fun setBorderBottomRightRadius(view: ButtonViewGroup, borderBottomRightRadius: Float) {
+    view.borderBottomRightRadius = borderBottomRightRadius
+  }
+
   @ReactProp(name = "rippleColor")
   override fun setRippleColor(view: ButtonViewGroup, rippleColor: Int?) {
     view.rippleColor = rippleColor
@@ -112,6 +132,22 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       }
     var useBorderlessDrawable = false
     var borderRadius = 0f
+      set(radius) = withBackgroundUpdate {
+        field = radius * resources.displayMetrics.density
+      }
+    var borderTopLeftRadius = 0f
+      set(radius) = withBackgroundUpdate {
+        field = radius * resources.displayMetrics.density
+      }
+    var borderTopRightRadius = 0f
+      set(radius) = withBackgroundUpdate {
+        field = radius * resources.displayMetrics.density
+      }
+    var borderBottomLeftRadius = 0f
+      set(radius) = withBackgroundUpdate {
+        field = radius * resources.displayMetrics.density
+      }
+    var borderBottomRightRadius = 0f
       set(radius) = withBackgroundUpdate {
         field = radius * resources.displayMetrics.density
       }
@@ -193,6 +229,21 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
 
       if (borderRadius != 0f) {
         colorDrawable.setCornerRadius(borderRadius)
+      }
+
+      if (borderTopLeftRadius != 0f || borderTopRightRadius != 0f || borderBottomLeftRadius != 0f || borderBottomRightRadius != 0f) {
+        colorDrawable.setCornerRadii(
+          floatArrayOf(
+            borderTopLeftRadius,
+            borderTopLeftRadius,
+            borderTopRightRadius,
+            borderTopRightRadius,
+            borderBottomRightRadius,
+            borderBottomRightRadius,
+            borderBottomLeftRadius,
+            borderBottomLeftRadius
+          )
+        )
       }
 
       val layerDrawable = LayerDrawable(if (selectable != null) arrayOf(colorDrawable, selectable) else arrayOf(colorDrawable))

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -51,6 +51,7 @@ import HoverableIcons from './new_api/hoverable_icons';
 import VelocityTest from './new_api/velocityTest';
 
 import EmptyExample from './empty/EmptyExample';
+import RectButtonBorders from './release_tests/rectButton';
 
 interface Example {
   name: string;
@@ -121,6 +122,7 @@ const EXAMPLES: ExamplesSection[] = [
       { name: 'MouseButtons', component: MouseButtons },
       { name: 'ContextMenu (web only)', component: ContextMenu },
       { name: 'PointerType', component: PointerType },
+      { name: 'RectButton (borders)', component: RectButtonBorders },
     ],
   },
   {

--- a/example/src/release_tests/rectButton/index.tsx
+++ b/example/src/release_tests/rectButton/index.tsx
@@ -26,6 +26,30 @@ export default function RectButtonBorders() {
         onPress={() => alert(`Pressed borderTopRadius!`)}>
         <Text>border Bottom Radius</Text>
       </RectButton>
+      <RectButton
+        style={[
+          styles.button,
+          {
+            borderRadius: 8,
+            borderTopLeftRadius: 32,
+            borderTopRightRadius: 32,
+          },
+        ]}
+        onPress={() => alert(`Pressed borderTopRadius!`)}>
+        <Text>borderRadius and Top Radius</Text>
+      </RectButton>
+      <RectButton
+        style={[
+          styles.button,
+          {
+            borderRadius: 8,
+            borderBottomLeftRadius: 32,
+            borderBottomRightRadius: 32,
+          },
+        ]}
+        onPress={() => alert(`Pressed borderTopRadius!`)}>
+        <Text>borderRadius and Bottom Radius</Text>
+      </RectButton>
     </View>
   );
 }

--- a/example/src/release_tests/rectButton/index.tsx
+++ b/example/src/release_tests/rectButton/index.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { StyleSheet, Text, View } from 'react-native';
-import { RectButton } from '../../../../src/components/GestureButtons';
+import { RectButton } from 'react-native-gesture-handler';
 
 export default function RectButtonBorders() {
   return (

--- a/example/src/release_tests/rectButton/index.tsx
+++ b/example/src/release_tests/rectButton/index.tsx
@@ -1,0 +1,70 @@
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+import { RectButton } from '../../../../src/components/GestureButtons';
+
+export default function RectButtonBorders() {
+  return (
+    <View style={styles.container}>
+      <Button type="borderRadius" />
+      <Button type="borderTopLeftRadius" />
+      <Button type="borderTopRightRadius" />
+      <Button type="borderBottomLeftRadius" />
+      <Button type="borderBottomRightRadius" />
+      <RectButton
+        style={[
+          styles.button,
+          { borderTopLeftRadius: 16, borderTopRightRadius: 16 },
+        ]}
+        onPress={() => alert(`Pressed borderTopRadius!`)}>
+        <Text>border Top Radius</Text>
+      </RectButton>
+      <RectButton
+        style={[
+          styles.button,
+          { borderBottomLeftRadius: 16, borderBottomRightRadius: 16 },
+        ]}
+        onPress={() => alert(`Pressed borderTopRadius!`)}>
+        <Text>border Bottom Radius</Text>
+      </RectButton>
+    </View>
+  );
+}
+
+type BorderTypes =
+  | 'borderRadius'
+  | 'borderTopLeftRadius'
+  | 'borderTopRightRadius'
+  | 'borderBottomLeftRadius'
+  | 'borderBottomRightRadius';
+
+function Button({ type }: { type: BorderTypes }) {
+  return (
+    <RectButton
+      style={[styles.button, { [type]: 16 }]}
+      onPress={() => alert(`Pressed ${type}!`)}>
+      <Text style={styles.text}>{type}</Text>
+    </RectButton>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    flexDirection: 'row',
+    gap: 8,
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    alignContent: 'center',
+  },
+  button: {
+    width: 100,
+    height: 100,
+    backgroundColor: '#782aeb',
+    justifyContent: 'center',
+    alignItems: 'center',
+    padding: 8,
+  },
+  text: {
+    color: '#f8f9ff',
+  },
+});


### PR DESCRIPTION
## Description
This PR is intended to allow the use of different border radius values on the RectButton component. As mentioned in comments on #477 , it doesn’t work on Android.
I tried to follow the same implementation pattern from `borderRadius`, but using `setCornerRadii` method when informed at least one prop from specific corner.
Also, it is possible to merge the values from `borderRadius` or from specific corner.

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

<!--
Describe how did you test this change here.
-->
I added a component (RectButtonBorders) on example app with some variations of values to test the changes.
