### PR TITLE
Add `touchAction` description to docs.

### DIFF
--- a/docs/docs/gestures/gesture-detector.md
+++ b/docs/docs/gestures/gesture-detector.md
@@ -42,6 +42,10 @@ Starting with Reanimated 2.3.0 Gesture Handler will provide a [StateManager](/do
 
 This parameter allows to specify which `userSelect` property should be applied to underlying view. Possible values are `"none" | "auto" | "text"`. Default value is set to `"none"`.
 
+### `touchAction` (Web only)
+
+This parameter allows to specify which `touchAction` property should be applied to underlying view. Supports all CSS `touch-action` values (e.g. `"none"`, `"pan-y"`). Default value is set to `"none"`.
+
 ### `enableContextMenu(value: boolean)` (Web only)
 
 Specifies whether context menu should be enabled after clicking on underlying view with right mouse button. Default value is set to `false`.


### PR DESCRIPTION
## Description

This PR adds `touchAction` property description to our documentation.

## Test plan

Run docs.

