### PR TITLE
Improve RectButton border styles on Android

### DIFF
--- a/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerDelegate.java
+++ b/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerDelegate.java
@@ -44,7 +44,10 @@ public class RNGestureHandlerButtonManagerDelegate<T extends View, U extends Bas
         mViewManager.setTouchSoundDisabled(view, value == null ? false : (boolean) value);
         break;
       case "borderWidth":
-        mViewManager.setBorderWidth(view, value == null ? 0f : ((Double)value).floatValue());
+        mViewManager.setBorderWidth(view, value == null ? 0f : ((Double) value).floatValue());
+        break;
+      case "borderColor":
+        mViewManager.setBorderColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       default:
         super.setProperty(view, propName, value);

--- a/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerDelegate.java
+++ b/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerDelegate.java
@@ -43,6 +43,9 @@ public class RNGestureHandlerButtonManagerDelegate<T extends View, U extends Bas
       case "touchSoundDisabled":
         mViewManager.setTouchSoundDisabled(view, value == null ? false : (boolean) value);
         break;
+      case "borderWidth":
+        mViewManager.setBorderWidth(view, value == null ? 0f : ((Double)value).floatValue());
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerDelegate.java
+++ b/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerDelegate.java
@@ -49,6 +49,9 @@ public class RNGestureHandlerButtonManagerDelegate<T extends View, U extends Bas
       case "borderColor":
         mViewManager.setBorderColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
+      case "borderStyle":
+        mViewManager.setBorderStyle(view, value == null ? "solid" : (String) value);
+        break;
       default:
         super.setProperty(view, propName, value);
     }

--- a/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
+++ b/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
@@ -22,4 +22,5 @@ public interface RNGestureHandlerButtonManagerInterface<T extends View> {
   void setTouchSoundDisabled(T view, boolean value);
   void setBorderWidth(T view, float value);
   void setBorderColor(T view, @Nullable Integer value);
+  void setBorderStyle(T view, @Nullable String value);
 }

--- a/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
+++ b/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
@@ -21,4 +21,5 @@ public interface RNGestureHandlerButtonManagerInterface<T extends View> {
   void setRippleRadius(T view, int value);
   void setTouchSoundDisabled(T view, boolean value);
   void setBorderWidth(T view, float value);
+  void setBorderColor(T view, @Nullable Integer value);
 }

--- a/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
+++ b/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
@@ -20,4 +20,5 @@ public interface RNGestureHandlerButtonManagerInterface<T extends View> {
   void setRippleColor(T view, @Nullable Integer value);
   void setRippleRadius(T view, int value);
   void setTouchSoundDisabled(T view, boolean value);
+  void setBorderWidth(T view, float value);
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -5,6 +5,7 @@ import android.annotation.TargetApi
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
+import android.graphics.Paint
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import android.graphics.drawable.PaintDrawable
@@ -85,6 +86,11 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
     view.borderBottomRightRadius = borderBottomRightRadius
   }
 
+  @ReactProp(name = "borderWidth")
+  override fun setBorderWidth(view: ButtonViewGroup, borderWidth: Float) {
+    view.borderWidth = borderWidth
+  }
+
   @ReactProp(name = "rippleColor")
   override fun setRippleColor(view: ButtonViewGroup, rippleColor: Int?) {
     view.rippleColor = rippleColor
@@ -150,6 +156,11 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
     var borderBottomRightRadius = 0f
       set(radius) = withBackgroundUpdate {
         field = radius * resources.displayMetrics.density
+      }
+
+    var borderWidth = 0f
+      set(width) = withBackgroundUpdate {
+        field = width * resources.displayMetrics.density
       }
 
     private val hasBorderRadii: Boolean
@@ -250,12 +261,22 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
 
     private fun updateBackgroundColor(backgroundColor: Int, selectable: Drawable?) {
       val colorDrawable = PaintDrawable(backgroundColor)
+      val borderDrawable = PaintDrawable(Color.TRANSPARENT)
 
       if (hasBorderRadii) {
         colorDrawable.setCornerRadii(buildBorderRadii())
+        borderDrawable.setCornerRadii(buildBorderRadii())
       }
 
-      val layerDrawable = LayerDrawable(if (selectable != null) arrayOf(colorDrawable, selectable) else arrayOf(colorDrawable))
+      if (borderWidth > 0f) {
+        borderDrawable.paint.apply {
+          style = Paint.Style.STROKE
+          strokeWidth = borderWidth
+          color = Color.BLACK
+        }
+      }
+
+      val layerDrawable = LayerDrawable(if (selectable != null) arrayOf(colorDrawable, selectable, borderDrawable) else arrayOf(colorDrawable, borderDrawable))
       background = layerDrawable
     }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -5,7 +5,9 @@ import android.annotation.TargetApi
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Color
+import android.graphics.DashPathEffect
 import android.graphics.Paint
+import android.graphics.PathEffect
 import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import android.graphics.drawable.PaintDrawable
@@ -96,6 +98,11 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
     view.borderColor = borderColor
   }
 
+  @ReactProp(name = "borderStyle")
+  override fun setBorderStyle(view: ButtonViewGroup, borderStyle: String?) {
+    view.borderStyle = borderStyle
+  }
+
   @ReactProp(name = "rippleColor")
   override fun setRippleColor(view: ButtonViewGroup, rippleColor: Int?) {
     view.rippleColor = rippleColor
@@ -170,6 +177,10 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       set(color) = withBackgroundUpdate {
         field = color
       }
+    var borderStyle: String? = "solid"
+      set(style) = withBackgroundUpdate {
+        field = style
+      }
 
     private val hasBorderRadii: Boolean
       get() = borderRadius != 0f ||
@@ -216,6 +227,14 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       )
         .map { if (it != 0f) it else borderRadius }
         .toFloatArray()
+    }
+
+    private fun buildBorderStyle(): PathEffect? {
+      return when (borderStyle) {
+        "dotted" -> DashPathEffect(floatArrayOf(borderWidth, borderWidth, borderWidth, borderWidth), 0f)
+        "dashed" -> DashPathEffect(floatArrayOf(borderWidth * 3, borderWidth * 3, borderWidth * 3, borderWidth * 3), 0f)
+        else -> null
+      }
     }
 
     override fun setBackgroundColor(color: Int) = withBackgroundUpdate {
@@ -281,6 +300,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
           style = Paint.Style.STROKE
           strokeWidth = borderWidth
           color = borderColor ?: Color.BLACK
+          pathEffect = buildBorderStyle()
         }
       }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -91,6 +91,11 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
     view.borderWidth = borderWidth
   }
 
+  @ReactProp(name = "borderColor")
+  override fun setBorderColor(view: ButtonViewGroup, borderColor: Int?) {
+    view.borderColor = borderColor
+  }
+
   @ReactProp(name = "rippleColor")
   override fun setRippleColor(view: ButtonViewGroup, rippleColor: Int?) {
     view.rippleColor = rippleColor
@@ -157,10 +162,13 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       set(radius) = withBackgroundUpdate {
         field = radius * resources.displayMetrics.density
       }
-
     var borderWidth = 0f
       set(width) = withBackgroundUpdate {
         field = width * resources.displayMetrics.density
+      }
+    var borderColor: Int? = null
+      set(color) = withBackgroundUpdate {
+        field = color
       }
 
     private val hasBorderRadii: Boolean
@@ -272,7 +280,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
         borderDrawable.paint.apply {
           style = Paint.Style.STROKE
           strokeWidth = borderWidth
-          color = Color.BLACK
+          color = borderColor ?: Color.BLACK
         }
       }
 

--- a/example/src/release_tests/rectButton/index.tsx
+++ b/example/src/release_tests/rectButton/index.tsx
@@ -46,8 +46,14 @@ export default function RectButtonBorders() {
           borderBottomRightRadius: 32,
         }}
       />
-      <Button text="Border Dashed" style={{ borderStyle: 'dashed' }} />
-      <Button text="Border Dotted" style={{ borderStyle: 'dotted' }} />
+      <Button
+        text="Border Dashed"
+        style={{ borderStyle: 'dashed', borderWidth: 2, borderColor: 'red' }}
+      />
+      <Button
+        text="Border Dotted"
+        style={{ borderStyle: 'dotted', borderWidth: 2, borderColor: 'red' }}
+      />
       <Button
         text="Border Solid"
         style={{ borderStyle: 'solid', borderWidth: 2, borderColor: 'red' }}

--- a/example/src/release_tests/rectButton/index.tsx
+++ b/example/src/release_tests/rectButton/index.tsx
@@ -50,7 +50,7 @@ export default function RectButtonBorders() {
       <Button text="Border Dotted" style={{ borderStyle: 'dotted' }} />
       <Button
         text="Border Solid"
-        style={{ borderStyle: 'solid', borderWidth: 1, borderColor: 'red' }}
+        style={{ borderStyle: 'solid', borderWidth: 2, borderColor: 'red' }}
       />
     </View>
   );
@@ -86,7 +86,7 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 8,
-    borderWidth: 0.5,
+    borderWidth: 1,
     borderColor: '#001a72',
   },
   text: {

--- a/example/src/release_tests/rectButton/index.tsx
+++ b/example/src/release_tests/rectButton/index.tsx
@@ -1,72 +1,71 @@
 import React from 'react';
-import { StyleSheet, Text, View } from 'react-native';
+import { StyleProp, StyleSheet, Text, View, ViewStyle } from 'react-native';
 import { RectButton } from 'react-native-gesture-handler';
 
 export default function RectButtonBorders() {
   return (
     <View style={styles.container}>
-      <Button type="borderRadius" />
-      <Button type="borderTopLeftRadius" />
-      <Button type="borderTopRightRadius" />
-      <Button type="borderBottomLeftRadius" />
-      <Button type="borderBottomRightRadius" />
-      <RectButton
-        style={[
-          styles.button,
-          { borderTopLeftRadius: 16, borderTopRightRadius: 16 },
-        ]}
-        onPress={() => alert(`Pressed borderTopRadius!`)}>
-        <Text>border Top Radius</Text>
-      </RectButton>
-      <RectButton
-        style={[
-          styles.button,
-          { borderBottomLeftRadius: 16, borderBottomRightRadius: 16 },
-        ]}
-        onPress={() => alert(`Pressed borderTopRadius!`)}>
-        <Text>border Bottom Radius</Text>
-      </RectButton>
-      <RectButton
-        style={[
-          styles.button,
-          {
-            borderRadius: 8,
-            borderTopLeftRadius: 32,
-            borderTopRightRadius: 32,
-          },
-        ]}
-        onPress={() => alert(`Pressed borderTopRadius!`)}>
-        <Text>borderRadius and Top Radius</Text>
-      </RectButton>
-      <RectButton
-        style={[
-          styles.button,
-          {
-            borderRadius: 8,
-            borderBottomLeftRadius: 32,
-            borderBottomRightRadius: 32,
-          },
-        ]}
-        onPress={() => alert(`Pressed borderTopRadius!`)}>
-        <Text>borderRadius and Bottom Radius</Text>
-      </RectButton>
+      <Button text="Border Radius" style={{ borderRadius: 16 }} />
+      <Button
+        text="Border Top Left Radius"
+        style={{ borderTopLeftRadius: 16 }}
+      />
+      <Button
+        text="Border Top Right Radius"
+        style={{ borderTopRightRadius: 16 }}
+      />
+      <Button
+        text="Border Bottom Left Radius"
+        style={{ borderBottomLeftRadius: 16 }}
+      />
+      <Button
+        text="Border Bottom Right Radius"
+        style={{ borderBottomRightRadius: 16 }}
+      />
+      <Button
+        text="Border Top Radius"
+        style={{ borderTopLeftRadius: 16, borderTopRightRadius: 16 }}
+      />
+      <Button
+        text="Border Bottom Radius"
+        style={{ borderBottomLeftRadius: 16, borderBottomRightRadius: 16 }}
+      />
+      <Button
+        text="Border Radius and Top Radius"
+        style={{
+          borderRadius: 8,
+          borderTopLeftRadius: 32,
+          borderTopRightRadius: 32,
+        }}
+      />
+      <Button
+        text="Border Radius and Bottom Radius"
+        style={{
+          borderRadius: 8,
+          borderBottomLeftRadius: 32,
+          borderBottomRightRadius: 32,
+        }}
+      />
+      <Button text="Border Dashed" style={{ borderStyle: 'dashed' }} />
+      <Button text="Border Dotted" style={{ borderStyle: 'dotted' }} />
+      <Button
+        text="Border Solid"
+        style={{ borderStyle: 'solid', borderWidth: 1, borderColor: 'red' }}
+      />
     </View>
   );
 }
 
-type BorderTypes =
-  | 'borderRadius'
-  | 'borderTopLeftRadius'
-  | 'borderTopRightRadius'
-  | 'borderBottomLeftRadius'
-  | 'borderBottomRightRadius';
+type ButtonProps = { style: StyleProp<ViewStyle>; text: string };
 
-function Button({ type }: { type: BorderTypes }) {
+function Button({ style, text }: ButtonProps) {
+  const rectButtonStyles: StyleProp<ViewStyle> = [styles.button, style];
+
+  const onPress = () => alert(`Pressed ${text}!`);
+
   return (
-    <RectButton
-      style={[styles.button, { [type]: 16 }]}
-      onPress={() => alert(`Pressed ${type}!`)}>
-      <Text style={styles.text}>{type}</Text>
+    <RectButton style={rectButtonStyles} onPress={onPress}>
+      <Text style={styles.text}>{text}</Text>
     </RectButton>
   );
 }
@@ -87,8 +86,11 @@ const styles = StyleSheet.create({
     justifyContent: 'center',
     alignItems: 'center',
     padding: 8,
+    borderWidth: 0.5,
+    borderColor: '#001a72',
   },
   text: {
     color: '#f8f9ff',
+    textAlign: 'center',
   },
 });

--- a/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -2,6 +2,7 @@ import codegenNativeComponent from 'react-native/Libraries/Utilities/codegenNati
 import type {
   Int32,
   WithDefault,
+  Float,
 } from 'react-native/Libraries/Types/CodegenTypes';
 import type { ViewProps, ColorValue } from 'react-native';
 
@@ -13,6 +14,9 @@ interface NativeProps extends ViewProps {
   rippleColor?: ColorValue;
   rippleRadius?: Int32;
   touchSoundDisabled?: WithDefault<boolean, false>;
+  borderWidth?: Float;
+  borderColor?: ColorValue;
+  borderStyle?: WithDefault<string, 'solid'>;
 }
 
 export default codegenNativeComponent<NativeProps>('RNGestureHandlerButton');


### PR DESCRIPTION
## Description

This PR enables the use of `borderWidth`, `borderColor` and `borderStyle` to style the `RectButton` component on Android.
It's a continuation of #2792 

Fixes #477 

## Test plan

Some examples were added to the `RectButtonBorders` screen in the example app using the border styles changed in this PR.

