### PR TITLE
Change `MouseButton` export type.

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -18,8 +18,8 @@ export type {
   // new api event types
   GestureUpdateEvent,
   GestureStateChangeEvent,
-  MouseButton,
 } from './handlers/gestureHandlerCommon';
+export { MouseButton } from './handlers/gestureHandlerCommon';
 export type { GestureType } from './handlers/gestures/gesture';
 export type {
   TapGestureHandlerEventPayload,


### PR DESCRIPTION
## Description

In #2783 I've moved `MouseButton` enum to `gestureHandlerCommon.ts`, so naturally I had to change export in `index.ts`. The problem is that I've put it inside of `export type` which resulted in TypeScript errors when trying to use it.

### Before 

<img width="1063" alt="Zrzut ekranu 2024-03-13 o 09 34 47" src="https://github.com/software-mansion/react-native-gesture-handler/assets/63123542/274edcd4-8e0e-49a4-aac0-803e301bdd0f">

### After

<img width="664" alt="Zrzut ekranu 2024-03-13 o 09 35 07" src="https://github.com/software-mansion/react-native-gesture-handler/assets/63123542/b994102a-440b-4635-9d0d-ce100c223cfd">


## Test plan

Run `yarn lint:js-root`
