### PR TITLE
Add corner area detection to Fling gesture.

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/DiagonalDirections.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/DiagonalDirections.kt
@@ -1,0 +1,8 @@
+package com.swmansion.gesturehandler.core
+
+object DiagonalDirections {
+    const val DIRECTION_RIGHT_UP = GestureHandler.DIRECTION_RIGHT or GestureHandler.DIRECTION_UP
+    const val DIRECTION_RIGHT_DOWN = GestureHandler.DIRECTION_RIGHT or GestureHandler.DIRECTION_DOWN
+    const val DIRECTION_LEFT_UP = GestureHandler.DIRECTION_LEFT or GestureHandler.DIRECTION_UP
+    const val DIRECTION_LEFT_DOWN = GestureHandler.DIRECTION_LEFT or GestureHandler.DIRECTION_DOWN
+}

--- a/android/src/main/java/com/swmansion/gesturehandler/core/DiagonalDirections.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/DiagonalDirections.kt
@@ -1,8 +1,8 @@
 package com.swmansion.gesturehandler.core
 
 object DiagonalDirections {
-    const val DIRECTION_RIGHT_UP = GestureHandler.DIRECTION_RIGHT or GestureHandler.DIRECTION_UP
-    const val DIRECTION_RIGHT_DOWN = GestureHandler.DIRECTION_RIGHT or GestureHandler.DIRECTION_DOWN
-    const val DIRECTION_LEFT_UP = GestureHandler.DIRECTION_LEFT or GestureHandler.DIRECTION_UP
-    const val DIRECTION_LEFT_DOWN = GestureHandler.DIRECTION_LEFT or GestureHandler.DIRECTION_DOWN
+  const val DIRECTION_RIGHT_UP = GestureHandler.DIRECTION_RIGHT or GestureHandler.DIRECTION_UP
+  const val DIRECTION_RIGHT_DOWN = GestureHandler.DIRECTION_RIGHT or GestureHandler.DIRECTION_DOWN
+  const val DIRECTION_LEFT_UP = GestureHandler.DIRECTION_LEFT or GestureHandler.DIRECTION_UP
+  const val DIRECTION_LEFT_DOWN = GestureHandler.DIRECTION_LEFT or GestureHandler.DIRECTION_DOWN
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
@@ -3,18 +3,19 @@ package com.swmansion.gesturehandler.core
 import android.os.Handler
 import android.os.Looper
 import android.view.MotionEvent
+import android.view.VelocityTracker
 
 class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
   var numberOfPointersRequired = DEFAULT_NUMBER_OF_TOUCHES_REQUIRED
   var direction = DEFAULT_DIRECTION
 
   private val maxDurationMs = DEFAULT_MAX_DURATION_MS
-  private val minAcceptableDelta = DEFAULT_MIN_ACCEPTABLE_DELTA
-  private var startX = 0f
-  private var startY = 0f
+  private val minVelocity = DEFAULT_MIN_VELOCITY
+  private val minDirectionalAlignment = DEFAULT_MIN_DIRECTION_ALIGNMENT
   private var handler: Handler? = null
   private var maxNumberOfPointersSimultaneously = 0
   private val failDelayed = Runnable { fail() }
+  private var velocityTracker: VelocityTracker? = null
 
   override fun resetConfig() {
     super.resetConfig()
@@ -23,8 +24,7 @@ class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
   }
 
   private fun startFling(event: MotionEvent) {
-    startX = event.rawX
-    startY = event.rawY
+    velocityTracker = VelocityTracker.obtain()
     begin()
     maxNumberOfPointersSimultaneously = 1
     if (handler == null) {
@@ -35,26 +35,40 @@ class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
     handler!!.postDelayed(failDelayed, maxDurationMs)
   }
 
-  private fun tryEndFling(event: MotionEvent) = if (
-    maxNumberOfPointersSimultaneously == numberOfPointersRequired &&
-    (
-      direction and DIRECTION_RIGHT != 0 &&
-        event.rawX - startX > minAcceptableDelta ||
-        direction and DIRECTION_LEFT != 0 &&
-        startX - event.rawX > minAcceptableDelta ||
-        direction and DIRECTION_UP != 0 &&
-        startY - event.rawY > minAcceptableDelta ||
-        direction and DIRECTION_DOWN != 0 &&
-        event.rawY - startY > minAcceptableDelta
-      )
-  ) {
-    handler!!.removeCallbacksAndMessages(null)
-    activate()
-    true
-  } else {
-    false
-  }
+  private fun tryEndFling(event: MotionEvent): Boolean {
+    addVelocityMovement(velocityTracker, event)
 
+    val velocityVector = Vector.fromVelocity(velocityTracker!!)
+
+    fun getVelocityAlignment(
+      direction: Int,
+    ): Boolean = (
+      this.direction and direction != 0 &&
+        velocityVector.isSimilar(Vector.fromDirection(direction), minDirectionalAlignment)
+      )
+
+    val alignmentList = arrayOf(
+      DIRECTION_LEFT,
+      DIRECTION_RIGHT,
+      DIRECTION_UP,
+      DIRECTION_DOWN,
+    ).map { direction -> getVelocityAlignment(direction) }
+
+    val isAligned = alignmentList.any { it }
+    val isFast = velocityVector.magnitude > this.minVelocity
+
+    return if (
+      maxNumberOfPointersSimultaneously == numberOfPointersRequired &&
+      isAligned &&
+      isFast
+    ) {
+      handler!!.removeCallbacksAndMessages(null)
+      activate()
+      true
+    } else {
+      false
+    }
+  }
   override fun activate(force: Boolean) {
     super.activate(force)
     end()
@@ -92,12 +106,23 @@ class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
   }
 
   override fun onReset() {
+    velocityTracker?.recycle()
+    velocityTracker = null
     handler?.removeCallbacksAndMessages(null)
+  }
+
+  private fun addVelocityMovement(tracker: VelocityTracker?, event: MotionEvent) {
+    val offsetX = event.rawX - event.x
+    val offsetY = event.rawY - event.y
+    event.offsetLocation(offsetX, offsetY)
+    tracker!!.addMovement(event)
+    event.offsetLocation(-offsetX, -offsetY)
   }
 
   companion object {
     private const val DEFAULT_MAX_DURATION_MS: Long = 800
-    private const val DEFAULT_MIN_ACCEPTABLE_DELTA: Long = 160
+    private const val DEFAULT_MIN_VELOCITY: Long = 2000
+    private const val DEFAULT_MIN_DIRECTION_ALIGNMENT: Double = 0.75
     private const val DEFAULT_DIRECTION = DIRECTION_RIGHT
     private const val DEFAULT_NUMBER_OF_TOUCHES_REQUIRED = 1
   }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
@@ -135,7 +135,7 @@ class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
 
     private val MAX_AXIAL_DEVIATION: Double =
       GestureUtils.coneToDeviation(DEFAULT_ALIGNMENT_CONE)
-    private  val MAX_DIAGONAL_DEVIATION: Double =
+    private val MAX_DIAGONAL_DEVIATION: Double =
       GestureUtils.coneToDeviation(90 - DEFAULT_ALIGNMENT_CONE)
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureUtils.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureUtils.kt
@@ -1,6 +1,7 @@
 package com.swmansion.gesturehandler.core
 
 import android.view.MotionEvent
+import kotlin.math.cos
 
 object GestureUtils {
   fun getLastPointerX(event: MotionEvent, averageTouches: Boolean): Float {
@@ -44,4 +45,7 @@ object GestureUtils {
       event.getY(lastPointerIdx)
     }
   }
+  fun coneToDeviation(angle: Double): Double =
+    cos(Math.toRadians(angle / 2.0))
+
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureUtils.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureUtils.kt
@@ -47,5 +47,4 @@ object GestureUtils {
   }
   fun coneToDeviation(angle: Double): Double =
     cos(Math.toRadians(angle / 2.0))
-
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/Vector.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/Vector.kt
@@ -1,6 +1,5 @@
 package com.swmansion.gesturehandler.core
 
-import android.graphics.Path.Direction
 import android.view.VelocityTracker
 import com.swmansion.gesturehandler.core.GestureHandler.Companion.DIRECTION_DOWN
 import com.swmansion.gesturehandler.core.GestureHandler.Companion.DIRECTION_LEFT

--- a/android/src/main/java/com/swmansion/gesturehandler/core/Vector.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/Vector.kt
@@ -1,5 +1,6 @@
 package com.swmansion.gesturehandler.core
 
+import android.graphics.Path.Direction
 import android.view.VelocityTracker
 import com.swmansion.gesturehandler.core.GestureHandler.Companion.DIRECTION_DOWN
 import com.swmansion.gesturehandler.core.GestureHandler.Companion.DIRECTION_LEFT
@@ -32,8 +33,14 @@ class Vector(val x: Double, val y: Double) {
     private val VECTOR_RIGHT: Vector = Vector(1.0, 0.0)
     private val VECTOR_UP: Vector = Vector(0.0, -1.0)
     private val VECTOR_DOWN: Vector = Vector(0.0, 1.0)
+
+    private val VECTOR_RIGHT_UP: Vector = Vector(1.0, -1.0)
+    private val VECTOR_RIGHT_DOWN: Vector = Vector(1.0, 1.0)
+    private val VECTOR_LEFT_UP: Vector = Vector(-1.0, -1.0)
+    private val VECTOR_LEFT_DOWN: Vector = Vector(-1.0, 1.0)
+
     private val VECTOR_ZERO: Vector = Vector(0.0, 0.0)
-    const val MINIMAL_MAGNITUDE = 0.1
+    private const val MINIMAL_MAGNITUDE = 0.1
 
     fun fromDirection(direction: Int): Vector =
       when (direction) {
@@ -41,6 +48,10 @@ class Vector(val x: Double, val y: Double) {
         DIRECTION_RIGHT -> VECTOR_RIGHT
         DIRECTION_UP -> VECTOR_UP
         DIRECTION_DOWN -> VECTOR_DOWN
+        DiagonalDirections.DIRECTION_RIGHT_UP -> VECTOR_RIGHT_UP
+        DiagonalDirections.DIRECTION_RIGHT_DOWN -> VECTOR_RIGHT_DOWN
+        DiagonalDirections.DIRECTION_LEFT_UP -> VECTOR_LEFT_UP
+        DiagonalDirections.DIRECTION_LEFT_DOWN -> VECTOR_LEFT_DOWN
         else -> VECTOR_ZERO
       }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/core/Vector.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/Vector.kt
@@ -1,0 +1,56 @@
+package com.swmansion.gesturehandler.core
+
+import android.view.VelocityTracker
+import com.swmansion.gesturehandler.core.GestureHandler.Companion.DIRECTION_DOWN
+import com.swmansion.gesturehandler.core.GestureHandler.Companion.DIRECTION_LEFT
+import com.swmansion.gesturehandler.core.GestureHandler.Companion.DIRECTION_RIGHT
+import com.swmansion.gesturehandler.core.GestureHandler.Companion.DIRECTION_UP
+import kotlin.math.hypot
+
+class Vector(val x: Double, val y: Double) {
+  private val unitX: Double
+  private val unitY: Double
+  val magnitude = hypot(x, y)
+
+  init {
+    val isMagnitudeSufficient = magnitude > MINIMAL_MAGNITUDE
+
+    unitX = if (isMagnitudeSufficient) x / magnitude else 0.0
+    unitY = if (isMagnitudeSufficient) y / magnitude else 0.0
+  }
+
+  private fun computeSimilarity(vector: Vector): Double {
+    return unitX * vector.unitX + unitY * vector.unitY
+  }
+
+  fun isSimilar(vector: Vector, threshold: Double): Boolean {
+    return computeSimilarity(vector) > threshold
+  }
+
+  companion object {
+    private val VECTOR_LEFT: Vector = Vector(-1.0, 0.0)
+    private val VECTOR_RIGHT: Vector = Vector(1.0, 0.0)
+    private val VECTOR_UP: Vector = Vector(0.0, -1.0)
+    private val VECTOR_DOWN: Vector = Vector(0.0, 1.0)
+    private val VECTOR_ZERO: Vector = Vector(0.0, 0.0)
+    const val MINIMAL_MAGNITUDE = 0.1
+
+    fun fromDirection(direction: Int): Vector =
+      when (direction) {
+        DIRECTION_LEFT -> VECTOR_LEFT
+        DIRECTION_RIGHT -> VECTOR_RIGHT
+        DIRECTION_UP -> VECTOR_UP
+        DIRECTION_DOWN -> VECTOR_DOWN
+        else -> VECTOR_ZERO
+      }
+
+    fun fromVelocity(tracker: VelocityTracker): Vector {
+      tracker.computeCurrentVelocity(1000)
+
+      val velocityX = tracker.xVelocity.toDouble()
+      val velocityY = tracker.yVelocity.toDouble()
+
+      return Vector(velocityX, velocityY)
+    }
+  }
+}

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -15,7 +15,7 @@ import DoubleDraggable from './release_tests/doubleDraggable';
 import { ComboWithGHScroll } from './release_tests/combo';
 import { TouchablesIndex, TouchableExample } from './release_tests/touchables';
 import Rows from './release_tests/rows';
-import Fling from './release_tests/fling';
+import NestedFling from './release_tests/nestedFling';
 import MouseButtons from './release_tests/mouseButtons';
 import ContextMenu from './release_tests/contextMenu';
 import NestedTouchables from './release_tests/nestedTouchables';
@@ -34,6 +34,7 @@ import PanResponder from './basic/panResponder';
 import HorizontalDrawer from './basic/horizontalDrawer';
 import PagerAndDrawer from './basic/pagerAndDrawer';
 import ForceTouch from './basic/forcetouch';
+import Fling from './basic/fling'
 
 import ReanimatedSimple from './new_api/reanimated';
 import Camera from './new_api/camera';
@@ -77,6 +78,7 @@ const EXAMPLES: ExamplesSection[] = [
       { name: 'Horizontal drawer', component: HorizontalDrawer },
       { name: 'Pager & drawer', component: PagerAndDrawer },
       { name: 'Force touch', component: ForceTouch },
+      { name: 'Fling', component: Fling },
     ],
   },
   {
@@ -116,7 +118,7 @@ const EXAMPLES: ExamplesSection[] = [
       { name: 'Double pinch & rotate', component: DoublePinchRotate },
       { name: 'Double draggable', component: DoubleDraggable },
       { name: 'Rows', component: Rows },
-      { name: 'Fling', component: Fling },
+      { name: 'Nested Fling', component: NestedFling },
       { name: 'Combo', component: ComboWithGHScroll },
       { name: 'Touchables', component: TouchablesIndex as React.ComponentType },
       { name: 'MouseButtons', component: MouseButtons },

--- a/example/src/App.tsx
+++ b/example/src/App.tsx
@@ -34,7 +34,7 @@ import PanResponder from './basic/panResponder';
 import HorizontalDrawer from './basic/horizontalDrawer';
 import PagerAndDrawer from './basic/pagerAndDrawer';
 import ForceTouch from './basic/forcetouch';
-import Fling from './basic/fling'
+import Fling from './basic/fling';
 
 import ReanimatedSimple from './new_api/reanimated';
 import Camera from './new_api/camera';

--- a/example/src/basic/fling/index.tsx
+++ b/example/src/basic/fling/index.tsx
@@ -1,10 +1,9 @@
-import React, { Component } from 'react';
-import { StyleSheet } from 'react-native';
+import React from 'react';
+import { StyleSheet, View } from 'react-native';
 import {
   Directions,
   Gesture,
   GestureDetector,
-  ScrollView,
 } from 'react-native-gesture-handler';
 import Animated, {
   useSharedValue,
@@ -12,9 +11,8 @@ import Animated, {
   withTiming,
   Easing,
 } from 'react-native-reanimated';
-import { LoremIpsum } from '../../common';
 
-function Fling() {
+export default function Example() {
   const position = useSharedValue(0);
   const beginPosition = useSharedValue(0);
 
@@ -24,8 +22,8 @@ function Fling() {
       beginPosition.value = e.x;
     })
     .onStart((e) => {
-      const offset = (e.x - beginPosition.value) * 2;
-      position.value = withTiming(position.value + offset, {
+      const direction = Math.sign(e.x - beginPosition.value);
+      position.value = withTiming(position.value + direction * 50, {
         duration: 300,
         easing: Easing.bounce,
       });
@@ -36,27 +34,19 @@ function Fling() {
   }));
 
   return (
-    <GestureDetector gesture={flingGesture}>
-      <Animated.View style={[styles.box, animatedStyle]} />
-    </GestureDetector>
+    <View style={styles.centerView}>
+      <GestureDetector gesture={flingGesture}>
+        <Animated.View style={[styles.box, animatedStyle]} />
+      </GestureDetector>
+    </View>
   );
 }
 
-export default class Example extends Component {
-  render() {
-    return (
-      <ScrollView style={styles.scrollView}>
-        <LoremIpsum words={40} />
-        <Fling />
-        <LoremIpsum />
-      </ScrollView>
-    );
-  }
-}
-
 const styles = StyleSheet.create({
-  scrollView: {
+  centerView: {
     flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
   },
   box: {
     height: 120,

--- a/example/src/basic/fling/index.tsx
+++ b/example/src/basic/fling/index.tsx
@@ -1,0 +1,67 @@
+import React, { Component } from 'react';
+import { StyleSheet } from 'react-native';
+import {
+  Directions,
+  Gesture,
+  GestureDetector,
+  ScrollView,
+} from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+  Easing,
+} from 'react-native-reanimated';
+import { LoremIpsum } from '../../common';
+
+function Fling() {
+  const position = useSharedValue(0);
+  const beginPosition = useSharedValue(0);
+
+  const flingGesture = Gesture.Fling()
+    .direction(Directions.LEFT | Directions.RIGHT)
+    .onBegin((e) => {
+      beginPosition.value = e.x;
+    })
+    .onStart((e) => {
+      const offset = (e.x - beginPosition.value) * 2;
+      position.value = withTiming(position.value + offset, {
+        duration: 300,
+        easing: Easing.bounce,
+      });
+    });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: position.value }],
+  }));
+
+  return (
+    <GestureDetector gesture={flingGesture}>
+      <Animated.View style={[styles.box, animatedStyle]} />
+    </GestureDetector>
+  );
+}
+
+export default class Example extends Component {
+  render() {
+    return (
+      <ScrollView style={styles.scrollView}>
+        <LoremIpsum words={40} />
+        <Fling />
+        <LoremIpsum />
+      </ScrollView>
+    );
+  }
+}
+
+const styles = StyleSheet.create({
+  scrollView: {
+    flex: 1,
+  },
+  box: {
+    height: 120,
+    width: 120,
+    backgroundColor: '#b58df1',
+    marginBottom: 30,
+  },
+});

--- a/example/src/release_tests/nestedFling/index.tsx
+++ b/example/src/release_tests/nestedFling/index.tsx
@@ -12,7 +12,7 @@ import { USE_NATIVE_DRIVER } from '../../config';
 const windowWidth = Dimensions.get('window').width;
 const circleRadius = 30;
 
-class Fling extends Component {
+class NestedFling extends Component {
   private touchX: Animated.Value;
   private translateX: Animated.AnimatedAddition<number>;
   private translateY: Animated.Value;
@@ -88,7 +88,7 @@ export default class Example extends Component {
   render() {
     return (
       <View>
-        <Fling />
+        <NestedFling />
         <Text>
           Move up (with two fingers) or right/left (with one finger) and watch
           magic happens

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -13,7 +13,7 @@ export const CornerDirections = {
 } as const;
 
 /* eslint-disable @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value */
-export type Directions = typeof Directions[keyof typeof Directions];
+export type Directions = (typeof Directions)[keyof typeof Directions];
+// prettier-ignore
 export type CornerDirections = typeof CornerDirections[keyof typeof CornerDirections];
 /* eslint-enable @typescript-eslint/no-redeclare */
-

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -5,5 +5,15 @@ export const Directions = {
   DOWN: 8,
 } as const;
 
-// eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value
+export const CornerDirections = {
+  UP_RIGHT: Directions.UP | Directions.RIGHT,
+  DOWN_RIGHT: Directions.DOWN | Directions.RIGHT,
+  UP_LEFT: Directions.UP | Directions.LEFT,
+  DOWN_LEFT: Directions.DOWN | Directions.LEFT,
+} as const;
+
+/* eslint-disable @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value */
 export type Directions = typeof Directions[keyof typeof Directions];
+export type CornerDirections = typeof CornerDirections[keyof typeof CornerDirections];
+/* eslint-enable @typescript-eslint/no-redeclare */
+

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -1,19 +1,18 @@
+const RIGHT = 1;
+const LEFT = 2;
+const UP = 4;
+const DOWN = 8;
+
 export const Directions = {
-  RIGHT: 1,
-  LEFT: 2,
-  UP: 4,
-  DOWN: 8,
+  RIGHT: RIGHT,
+  LEFT: LEFT,
+  UP: UP,
+  DOWN: DOWN,
+  UP_RIGHT: UP | RIGHT,
+  DOWN_RIGHT: DOWN | RIGHT,
+  UP_LEFT: UP | LEFT,
+  DOWN_LEFT: DOWN | LEFT,
 } as const;
 
-export const CompositeDirections = {
-  UP_RIGHT: Directions.UP | Directions.RIGHT,
-  DOWN_RIGHT: Directions.DOWN | Directions.RIGHT,
-  UP_LEFT: Directions.UP | Directions.LEFT,
-  DOWN_LEFT: Directions.DOWN | Directions.LEFT,
-} as const;
-
-/* eslint-disable @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value */
+// eslint-disable-one-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value
 export type Directions = typeof Directions[keyof typeof Directions];
-export type CompositeDirections =
-  typeof CompositeDirections[keyof typeof CompositeDirections];
-/* eslint-enable @typescript-eslint/no-redeclare */

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -14,6 +14,6 @@ export const CornerDirections = {
 
 /* eslint-disable @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value */
 export type Directions = (typeof Directions)[keyof typeof Directions];
-// prettier-ignore
-export type CornerDirections = typeof CornerDirections[keyof typeof CornerDirections];
+export type CornerDirections =
+  (typeof CornerDirections)[keyof typeof CornerDirections];
 /* eslint-enable @typescript-eslint/no-redeclare */

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -1,5 +1,3 @@
-import { lastArrayValues } from './web/utils';
-
 const RIGHT = 1;
 const LEFT = 2;
 const UP = 4;
@@ -14,26 +12,15 @@ export const Directions = {
 } as const;
 
 // internal interface
-export const CompositeDirections = {
-  RIGHT: RIGHT,
-  LEFT: LEFT,
-  UP: UP,
-  DOWN: DOWN,
+export const DiagonalDirections = {
   UP_RIGHT: UP | RIGHT,
   DOWN_RIGHT: DOWN | RIGHT,
   UP_LEFT: UP | LEFT,
   DOWN_LEFT: DOWN | LEFT,
 } as const;
 
-export const axialDirectionsList = Object.values(Directions);
-export const diagonalDirectionsList = lastArrayValues(
-  Object.values(CompositeDirections),
-  4
-);
-
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value
 export type Directions = typeof Directions[keyof typeof Directions];
-
 // eslint-disable-next-line @typescript-eslint/no-redeclare
-export type CompositeDirections =
-  typeof CompositeDirections[keyof typeof CompositeDirections];
+export type DiagonalDirections =
+  typeof DiagonalDirections[keyof typeof DiagonalDirections];

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -1,9 +1,20 @@
+import { firstArrayValues, lastArrayValues } from './web/utils';
+
 const RIGHT = 1;
 const LEFT = 2;
 const UP = 4;
 const DOWN = 8;
 
+// public interface
 export const Directions = {
+  RIGHT: RIGHT,
+  LEFT: LEFT,
+  UP: UP,
+  DOWN: DOWN,
+} as const;
+
+// internal interface
+export const CompositeDirections = {
   RIGHT: RIGHT,
   LEFT: LEFT,
   UP: UP,
@@ -14,5 +25,19 @@ export const Directions = {
   DOWN_LEFT: DOWN | LEFT,
 } as const;
 
+export const axialDirectionsList = firstArrayValues(
+  Object.values(CompositeDirections),
+  4
+);
+
+export const diagnalDirectionsList = lastArrayValues(
+  Object.values(CompositeDirections),
+  4
+);
+
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value
 export type Directions = typeof Directions[keyof typeof Directions];
+
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type CompositeDirections =
+  typeof CompositeDirections[keyof typeof CompositeDirections];

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -13,7 +13,7 @@ export const CornerDirections = {
 } as const;
 
 /* eslint-disable @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value */
-export type Directions = (typeof Directions)[keyof typeof Directions];
+export type Directions = typeof Directions[keyof typeof Directions];
 export type CornerDirections =
-  (typeof CornerDirections)[keyof typeof CornerDirections];
+  typeof CornerDirections[keyof typeof CornerDirections];
 /* eslint-enable @typescript-eslint/no-redeclare */

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -14,5 +14,5 @@ export const Directions = {
   DOWN_LEFT: DOWN | LEFT,
 } as const;
 
-// eslint-disable-one-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value
+// eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value
 export type Directions = typeof Directions[keyof typeof Directions];

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -1,4 +1,4 @@
-import { firstArrayValues, lastArrayValues } from './web/utils';
+import { lastArrayValues } from './web/utils';
 
 const RIGHT = 1;
 const LEFT = 2;
@@ -25,12 +25,8 @@ export const CompositeDirections = {
   DOWN_LEFT: DOWN | LEFT,
 } as const;
 
-export const axialDirectionsList = firstArrayValues(
-  Object.values(CompositeDirections),
-  4
-);
-
-export const diagnalDirectionsList = lastArrayValues(
+export const axialDirectionsList = Object.values(Directions);
+export const diagonalDirectionsList = lastArrayValues(
   Object.values(CompositeDirections),
   4
 );

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -5,7 +5,7 @@ export const Directions = {
   DOWN: 8,
 } as const;
 
-export const CornerDirections = {
+export const CompositeDirections = {
   UP_RIGHT: Directions.UP | Directions.RIGHT,
   DOWN_RIGHT: Directions.DOWN | Directions.RIGHT,
   UP_LEFT: Directions.UP | Directions.LEFT,
@@ -14,6 +14,6 @@ export const CornerDirections = {
 
 /* eslint-disable @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value */
 export type Directions = typeof Directions[keyof typeof Directions];
-export type CornerDirections =
-  typeof CornerDirections[keyof typeof CornerDirections];
+export type CompositeDirections =
+  typeof CompositeDirections[keyof typeof CompositeDirections];
 /* eslint-enable @typescript-eslint/no-redeclare */

--- a/src/web/constants.ts
+++ b/src/web/constants.ts
@@ -1,8 +1,2 @@
 export const DEFAULT_TOUCH_SLOP = 15;
-
-export const Direction = {
-  RIGHT: 1,
-  LEFT: 2,
-  UP: 4,
-  DOWN: 8,
-};
+export const MINIMAL_FLING_VELOCITY = 0.1;

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -1,5 +1,5 @@
 import { State } from '../../State';
-import { CompositeDirections, Directions } from '../../Directions';
+import { Directions } from '../../Directions';
 import { AdaptedEvent, Config } from '../interfaces';
 
 import GestureHandler from './GestureHandler';
@@ -24,7 +24,6 @@ export default class FlingGestureHandler extends GestureHandler {
   private keyPointer = NaN;
 
   private minimalAlignmentCosine = 0;
-  private minimalCornerAlignmentCosine = 0;
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
@@ -32,10 +31,8 @@ export default class FlingGestureHandler extends GestureHandler {
     const degToRad = (degrees: number) => (degrees * Math.PI) / 180;
 
     const alignmentRadians = degToRad(this.minDirectionalAlignment);
-    const cornerAreaRadians = degToRad(45 - this.minDirectionalAlignment);
 
     this.minimalAlignmentCosine = Math.cos(alignmentRadians);
-    this.minimalCornerAlignmentCosine = Math.cos(cornerAreaRadians);
   }
 
   public updateGestureConfig({ enabled = true, ...props }: Config): void {
@@ -62,7 +59,7 @@ export default class FlingGestureHandler extends GestureHandler {
     const velocityVector = Vector.fromVelocity(this.tracker, this.keyPointer);
 
     const getAlignment = (
-      direction: Directions | CompositeDirections,
+      direction: Directions,
       minimalAlignmentCosine: number
     ) => {
       return (
@@ -79,12 +76,7 @@ export default class FlingGestureHandler extends GestureHandler {
       getAlignment(direction, this.minimalAlignmentCosine)
     );
 
-    const cornerFillAlignmentList = Object.values(CompositeDirections).map(
-      (direction) => getAlignment(direction, this.minimalCornerAlignmentCosine)
-    );
-
-    const isAligned =
-      alignmentList.some(Boolean) || cornerFillAlignmentList.some(Boolean);
+    const isAligned = alignmentList.some(Boolean);
     const isFast = velocityVector.magnitude > this.minVelocity;
 
     if (

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -10,7 +10,6 @@ const DEFAULT_MIN_VELOCITY = 700;
 const DEFAULT_MIN_DIRECTION_ALIGNMENT = 20;
 const DEFAULT_DIRECTION = Directions.RIGHT;
 const DEFAULT_NUMBER_OF_TOUCHES_REQUIRED = 1;
-const DEFAULT_ENABLE_CORNER_ACTIVATION = true;
 
 export default class FlingGestureHandler extends GestureHandler {
   private numberOfPointersRequired = DEFAULT_NUMBER_OF_TOUCHES_REQUIRED;
@@ -19,7 +18,6 @@ export default class FlingGestureHandler extends GestureHandler {
   private maxDurationMs = DEFAULT_MAX_DURATION_MS;
   private minVelocity = DEFAULT_MIN_VELOCITY;
   private minDirectionalAlignment = DEFAULT_MIN_DIRECTION_ALIGNMENT;
-  private enableCornerActivation = DEFAULT_ENABLE_CORNER_ACTIVATION;
   private delayTimeout!: number;
 
   private maxNumberOfPointersSimultaneously = 0;
@@ -77,15 +75,13 @@ export default class FlingGestureHandler extends GestureHandler {
     };
 
     // list of alignments to all activated directions
-    const alignmentList = Object.values(Directions).map((direction) =>
-      getAlignment(direction, this.minimalAlignmentCosine)
+    const alignmentList = Object.values(Directions).map(
+      (direction) => getAlignment(direction, this.minimalAlignmentCosine)
     );
 
-    const cornerFillAlignmentList = this.enableCornerActivation
-      ? Object.values(CornerDirections).map((direction) =>
-          getAlignment(direction, this.minimalCornerAlignmentCosine)
-        )
-      : [];
+    const cornerFillAlignmentList = Object.values(CornerDirections).map(
+      (direction) => getAlignment(direction, this.minimalCornerAlignmentCosine)
+    );
 
     const isAligned =
       alignmentList.some(Boolean) || cornerFillAlignmentList.some(Boolean);
@@ -93,7 +89,7 @@ export default class FlingGestureHandler extends GestureHandler {
 
     if (
       this.maxNumberOfPointersSimultaneously ===
-        this.numberOfPointersRequired &&
+      this.numberOfPointersRequired &&
       isAligned &&
       isFast
     ) {

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -1,10 +1,5 @@
 import { State } from '../../State';
-import {
-  CompositeDirections,
-  Directions,
-  axialDirectionsList,
-  diagonalDirectionsList,
-} from '../../Directions';
+import { DiagonalDirections, Directions } from '../../Directions';
 import { AdaptedEvent, Config } from '../interfaces';
 
 import GestureHandler from './GestureHandler';
@@ -59,7 +54,7 @@ export default class FlingGestureHandler extends GestureHandler {
     const velocityVector = Vector.fromVelocity(this.tracker, this.keyPointer);
 
     const getAlignment = (
-      direction: CompositeDirections,
+      direction: Directions | DiagonalDirections,
       minimalAlignmentCosine: number
     ) => {
       return (
@@ -70,6 +65,9 @@ export default class FlingGestureHandler extends GestureHandler {
         )
       );
     };
+
+    const axialDirectionsList = Object.values(Directions);
+    const diagonalDirectionsList = Object.values(DiagonalDirections);
 
     // list of alignments to all activated directions
     const axialAlignmentList = axialDirectionsList.map((direction) =>

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -75,8 +75,8 @@ export default class FlingGestureHandler extends GestureHandler {
     };
 
     // list of alignments to all activated directions
-    const alignmentList = Object.values(Directions).map(
-      (direction) => getAlignment(direction, this.minimalAlignmentCosine)
+    const alignmentList = Object.values(Directions).map((direction) =>
+      getAlignment(direction, this.minimalAlignmentCosine)
     );
 
     const cornerFillAlignmentList = Object.values(CornerDirections).map(
@@ -89,7 +89,7 @@ export default class FlingGestureHandler extends GestureHandler {
 
     if (
       this.maxNumberOfPointersSimultaneously ===
-      this.numberOfPointersRequired &&
+        this.numberOfPointersRequired &&
       isAligned &&
       isFast
     ) {

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -3,6 +3,7 @@ import {
   CompositeDirections,
   Directions,
   axialDirectionsList,
+  diagonalDirectionsList,
 } from '../../Directions';
 import { AdaptedEvent, Config } from '../interfaces';
 
@@ -75,13 +76,12 @@ export default class FlingGestureHandler extends GestureHandler {
       getAlignment(direction, AXIAL_DEVIATION_COSINE)
     );
 
-    const diagonalAlignmentList = axialDirectionsList.map((direction) =>
+    const diagonalAlignmentList = diagonalDirectionsList.map((direction) =>
       getAlignment(direction, DIAGONAL_DEVIATION_COSINE)
     );
 
-    const isAligned = axialAlignmentList
-      .concat(diagonalAlignmentList)
-      .some(Boolean);
+    const isAligned =
+      axialAlignmentList.some(Boolean) || diagonalAlignmentList.some(Boolean);
 
     const isFast = velocityVector.magnitude > this.minVelocity;
 

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -25,8 +25,8 @@ export default class FlingGestureHandler extends GestureHandler {
   private maxNumberOfPointersSimultaneously = 0;
   private keyPointer = NaN;
 
-  private minimalAlignmentCosine: number = 0;
-  private minimalCornerAlignmentCosine: number = 0;
+  private minimalAlignmentCosine = 0;
+  private minimalCornerAlignmentCosine = 0;
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
@@ -65,13 +65,13 @@ export default class FlingGestureHandler extends GestureHandler {
 
     const getAlignment = (
       direction: Directions | CornerDirections,
-      minimalAlignmentCos: number
+      minimalAlignmentCosine: number
     ) => {
       return (
         (direction & this.direction) === direction &&
         velocityVector.isSimilar(
           Vector.fromDirection(direction),
-          minimalAlignmentCos
+          minimalAlignmentCosine
         )
       );
     };
@@ -80,6 +80,7 @@ export default class FlingGestureHandler extends GestureHandler {
     const alignmentList = Object.values(Directions).map((direction) =>
       getAlignment(direction, this.minimalAlignmentCosine)
     );
+
     const cornerFillAlignmentList = this.enableCornerActivation
       ? Object.values(CornerDirections).map((direction) =>
           getAlignment(direction, this.minimalCornerAlignmentCosine)

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -7,7 +7,7 @@ import Vector from '../tools/Vector';
 
 const DEFAULT_MAX_DURATION_MS = 800;
 const DEFAULT_MIN_VELOCITY = 700;
-const DEFAULT_MIN_DIRECTION_ALIGNMENT = 20;
+const DEFAULT_MIN_DIRECTION_ALIGNMENT = 40;
 const DEFAULT_DIRECTION = Directions.RIGHT;
 const DEFAULT_NUMBER_OF_TOUCHES_REQUIRED = 1;
 
@@ -31,8 +31,9 @@ export default class FlingGestureHandler extends GestureHandler {
     const degToRad = (degrees: number) => (degrees * Math.PI) / 180;
 
     const alignmentRadians = degToRad(this.minDirectionalAlignment);
+    const maxDirectionalDeviation = alignmentRadians / 2;
 
-    this.minimalAlignmentCosine = Math.cos(alignmentRadians);
+    this.minimalAlignmentCosine = Math.cos(maxDirectionalDeviation);
   }
 
   public updateGestureConfig({ enabled = true, ...props }: Config): void {

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -7,7 +7,7 @@ import Vector from '../tools/Vector';
 
 const DEFAULT_MAX_DURATION_MS = 800;
 const DEFAULT_MIN_VELOCITY = 700;
-const DEFAULT_MIN_DIRECTION_ALIGNMENT = 40;
+const DEFAULT_DIRECTIONAL_ALIGNMENT_CONE = 40;
 const DEFAULT_DIRECTION = Directions.RIGHT;
 const DEFAULT_NUMBER_OF_TOUCHES_REQUIRED = 1;
 
@@ -17,7 +17,7 @@ export default class FlingGestureHandler extends GestureHandler {
 
   private maxDurationMs = DEFAULT_MAX_DURATION_MS;
   private minVelocity = DEFAULT_MIN_VELOCITY;
-  private minDirectionalAlignment = DEFAULT_MIN_DIRECTION_ALIGNMENT;
+  private directionalAlignmentCone = DEFAULT_DIRECTIONAL_ALIGNMENT_CONE;
   private delayTimeout!: number;
 
   private maxNumberOfPointersSimultaneously = 0;
@@ -30,7 +30,7 @@ export default class FlingGestureHandler extends GestureHandler {
 
     const degToRad = (degrees: number) => (degrees * Math.PI) / 180;
 
-    const alignmentRadians = degToRad(this.minDirectionalAlignment);
+    const alignmentRadians = degToRad(this.directionalAlignmentCone);
     const maxDirectionalDeviation = alignmentRadians / 2;
 
     this.minimalAlignmentCosine = Math.cos(maxDirectionalDeviation);

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -1,5 +1,5 @@
 import { State } from '../../State';
-import { CornerDirections, Directions } from '../../Directions';
+import { CompositeDirections, Directions } from '../../Directions';
 import { AdaptedEvent, Config } from '../interfaces';
 
 import GestureHandler from './GestureHandler';
@@ -62,7 +62,7 @@ export default class FlingGestureHandler extends GestureHandler {
     const velocityVector = Vector.fromVelocity(this.tracker, this.keyPointer);
 
     const getAlignment = (
-      direction: Directions | CornerDirections,
+      direction: Directions | CompositeDirections,
       minimalAlignmentCosine: number
     ) => {
       return (
@@ -79,7 +79,7 @@ export default class FlingGestureHandler extends GestureHandler {
       getAlignment(direction, this.minimalAlignmentCosine)
     );
 
-    const cornerFillAlignmentList = Object.values(CornerDirections).map(
+    const cornerFillAlignmentList = Object.values(CompositeDirections).map(
       (direction) => getAlignment(direction, this.minimalCornerAlignmentCosine)
     );
 

--- a/src/web/tools/Vector.ts
+++ b/src/web/tools/Vector.ts
@@ -1,4 +1,4 @@
-import { CompositeDirections, Directions } from '../../Directions';
+import { Directions } from '../../Directions';
 import { MINIMAL_FLING_VELOCITY } from '../constants';
 import PointerTracker from './PointerTracker';
 
@@ -20,7 +20,7 @@ export default class Vector {
     this.unitY = isMagnitudeSufficient ? this.y / this._magnitude : 0;
   }
 
-  static fromDirection(direction: Directions | CompositeDirections) {
+  static fromDirection(direction: Directions) {
     return DirectionToVectorMappings.get(direction)!;
   }
 
@@ -44,17 +44,14 @@ export default class Vector {
   }
 }
 
-const DirectionToVectorMappings = new Map<
-  Directions | CompositeDirections,
-  Vector
->([
+const DirectionToVectorMappings = new Map<Directions, Vector>([
   [Directions.LEFT, new Vector(-1, 0)],
   [Directions.RIGHT, new Vector(1, 0)],
   [Directions.UP, new Vector(0, -1)],
   [Directions.DOWN, new Vector(0, 1)],
 
-  [CompositeDirections.UP_RIGHT, new Vector(1, -1)],
-  [CompositeDirections.DOWN_RIGHT, new Vector(1, 1)],
-  [CompositeDirections.UP_LEFT, new Vector(-1, -1)],
-  [CompositeDirections.DOWN_LEFT, new Vector(-1, 1)],
+  [Directions.UP_RIGHT, new Vector(1, -1)],
+  [Directions.DOWN_RIGHT, new Vector(1, 1)],
+  [Directions.UP_LEFT, new Vector(-1, -1)],
+  [Directions.DOWN_LEFT, new Vector(-1, 1)],
 ]);

--- a/src/web/tools/Vector.ts
+++ b/src/web/tools/Vector.ts
@@ -1,0 +1,52 @@
+import { Directions } from '../../Directions';
+import { MINIMAL_FLING_VELOCITY } from '../constants';
+import PointerTracker from './PointerTracker';
+
+export default class Vector {
+  private readonly x;
+  private readonly y;
+  private readonly unitX;
+  private readonly unitY;
+  private readonly _magnitude;
+
+  constructor(x: number, y: number) {
+    this.x = x;
+    this.y = y;
+
+    this._magnitude = Math.hypot(this.x, this.y);
+    const isMagnitudeSufficient = this._magnitude > MINIMAL_FLING_VELOCITY;
+
+    this.unitX = isMagnitudeSufficient ? this.x / this._magnitude : 0;
+    this.unitY = isMagnitudeSufficient ? this.y / this._magnitude : 0;
+  }
+
+  static fromDirection(direction: Directions) {
+    return DirectionToVectorMappings.get(direction)!;
+  }
+
+  static fromVelocity(tracker: PointerTracker, pointerId: number) {
+    return new Vector(
+      tracker.getVelocityX(pointerId),
+      tracker.getVelocityY(pointerId)
+    );
+  }
+
+  get magnitude() {
+    return this._magnitude;
+  }
+
+  computeSimilarity(vector: Vector) {
+    return this.unitX * vector.unitX + this.unitY * vector.unitY;
+  }
+
+  isSimilar(vector: Vector, threshold: number) {
+    return this.computeSimilarity(vector) > threshold;
+  }
+}
+
+const DirectionToVectorMappings = new Map<Directions, Vector>([
+  [Directions.LEFT, new Vector(-1, 0)],
+  [Directions.RIGHT, new Vector(1, 0)],
+  [Directions.UP, new Vector(0, -1)],
+  [Directions.DOWN, new Vector(0, 1)],
+]);

--- a/src/web/tools/Vector.ts
+++ b/src/web/tools/Vector.ts
@@ -44,7 +44,10 @@ export default class Vector {
   }
 }
 
-const DirectionToVectorMappings = new Map<Directions | CornerDirections, Vector>([
+const DirectionToVectorMappings = new Map<
+  Directions | CornerDirections,
+  Vector
+>([
   [Directions.LEFT, new Vector(-1, 0)],
   [Directions.RIGHT, new Vector(1, 0)],
   [Directions.UP, new Vector(0, -1)],

--- a/src/web/tools/Vector.ts
+++ b/src/web/tools/Vector.ts
@@ -1,4 +1,4 @@
-import { Directions } from '../../Directions';
+import { CornerDirections, Directions } from '../../Directions';
 import { MINIMAL_FLING_VELOCITY } from '../constants';
 import PointerTracker from './PointerTracker';
 
@@ -20,7 +20,7 @@ export default class Vector {
     this.unitY = isMagnitudeSufficient ? this.y / this._magnitude : 0;
   }
 
-  static fromDirection(direction: Directions) {
+  static fromDirection(direction: Directions | CornerDirections) {
     return DirectionToVectorMappings.get(direction)!;
   }
 
@@ -44,9 +44,14 @@ export default class Vector {
   }
 }
 
-const DirectionToVectorMappings = new Map<Directions, Vector>([
+const DirectionToVectorMappings = new Map<Directions | CornerDirections, Vector>([
   [Directions.LEFT, new Vector(-1, 0)],
   [Directions.RIGHT, new Vector(1, 0)],
   [Directions.UP, new Vector(0, -1)],
   [Directions.DOWN, new Vector(0, 1)],
+
+  [CornerDirections.UP_RIGHT, new Vector(1, -1)],
+  [CornerDirections.DOWN_RIGHT, new Vector(1, 1)],
+  [CornerDirections.UP_LEFT, new Vector(-1, -1)],
+  [CornerDirections.DOWN_LEFT, new Vector(-1, 1)],
 ]);

--- a/src/web/tools/Vector.ts
+++ b/src/web/tools/Vector.ts
@@ -20,8 +20,8 @@ export default class Vector {
     this.unitY = isMagnitudeSufficient ? this.y / this._magnitude : 0;
   }
 
-  static fromDirection(direction: Directions | CompositeDirections) {
-    return DirectionToVectorMappings.get(direction as CompositeDirections)!;
+  static fromDirection(direction: Directions | CompositeDirections): Vector {
+    return DirectionToVectorMappings.get(direction)!;
   }
 
   static fromVelocity(tracker: PointerTracker, pointerId: number) {

--- a/src/web/tools/Vector.ts
+++ b/src/web/tools/Vector.ts
@@ -1,4 +1,4 @@
-import { Directions } from '../../Directions';
+import { CompositeDirections, Directions } from '../../Directions';
 import { MINIMAL_FLING_VELOCITY } from '../constants';
 import PointerTracker from './PointerTracker';
 
@@ -20,8 +20,8 @@ export default class Vector {
     this.unitY = isMagnitudeSufficient ? this.y / this._magnitude : 0;
   }
 
-  static fromDirection(direction: Directions) {
-    return DirectionToVectorMappings.get(direction)!;
+  static fromDirection(direction: Directions | CompositeDirections) {
+    return DirectionToVectorMappings.get(direction as CompositeDirections)!;
   }
 
   static fromVelocity(tracker: PointerTracker, pointerId: number) {
@@ -44,14 +44,14 @@ export default class Vector {
   }
 }
 
-const DirectionToVectorMappings = new Map<Directions, Vector>([
-  [Directions.LEFT, new Vector(-1, 0)],
-  [Directions.RIGHT, new Vector(1, 0)],
-  [Directions.UP, new Vector(0, -1)],
-  [Directions.DOWN, new Vector(0, 1)],
+const DirectionToVectorMappings = new Map<CompositeDirections, Vector>([
+  [CompositeDirections.LEFT, new Vector(-1, 0)],
+  [CompositeDirections.RIGHT, new Vector(1, 0)],
+  [CompositeDirections.UP, new Vector(0, -1)],
+  [CompositeDirections.DOWN, new Vector(0, 1)],
 
-  [Directions.UP_RIGHT, new Vector(1, -1)],
-  [Directions.DOWN_RIGHT, new Vector(1, 1)],
-  [Directions.UP_LEFT, new Vector(-1, -1)],
-  [Directions.DOWN_LEFT, new Vector(-1, 1)],
+  [CompositeDirections.UP_RIGHT, new Vector(1, -1)],
+  [CompositeDirections.DOWN_RIGHT, new Vector(1, 1)],
+  [CompositeDirections.UP_LEFT, new Vector(-1, -1)],
+  [CompositeDirections.DOWN_LEFT, new Vector(-1, 1)],
 ]);

--- a/src/web/tools/Vector.ts
+++ b/src/web/tools/Vector.ts
@@ -1,4 +1,4 @@
-import { CompositeDirections, Directions } from '../../Directions';
+import { DiagonalDirections, Directions } from '../../Directions';
 import { MINIMAL_FLING_VELOCITY } from '../constants';
 import PointerTracker from './PointerTracker';
 
@@ -20,7 +20,7 @@ export default class Vector {
     this.unitY = isMagnitudeSufficient ? this.y / this._magnitude : 0;
   }
 
-  static fromDirection(direction: Directions | CompositeDirections): Vector {
+  static fromDirection(direction: Directions | DiagonalDirections): Vector {
     return DirectionToVectorMappings.get(direction)!;
   }
 
@@ -44,14 +44,17 @@ export default class Vector {
   }
 }
 
-const DirectionToVectorMappings = new Map<CompositeDirections, Vector>([
-  [CompositeDirections.LEFT, new Vector(-1, 0)],
-  [CompositeDirections.RIGHT, new Vector(1, 0)],
-  [CompositeDirections.UP, new Vector(0, -1)],
-  [CompositeDirections.DOWN, new Vector(0, 1)],
+const DirectionToVectorMappings = new Map<
+  Directions | DiagonalDirections,
+  Vector
+>([
+  [Directions.LEFT, new Vector(-1, 0)],
+  [Directions.RIGHT, new Vector(1, 0)],
+  [Directions.UP, new Vector(0, -1)],
+  [Directions.DOWN, new Vector(0, 1)],
 
-  [CompositeDirections.UP_RIGHT, new Vector(1, -1)],
-  [CompositeDirections.DOWN_RIGHT, new Vector(1, 1)],
-  [CompositeDirections.UP_LEFT, new Vector(-1, -1)],
-  [CompositeDirections.DOWN_LEFT, new Vector(-1, 1)],
+  [DiagonalDirections.UP_RIGHT, new Vector(1, -1)],
+  [DiagonalDirections.DOWN_RIGHT, new Vector(1, 1)],
+  [DiagonalDirections.UP_LEFT, new Vector(-1, -1)],
+  [DiagonalDirections.DOWN_LEFT, new Vector(-1, 1)],
 ]);

--- a/src/web/tools/Vector.ts
+++ b/src/web/tools/Vector.ts
@@ -1,4 +1,4 @@
-import { CornerDirections, Directions } from '../../Directions';
+import { CompositeDirections, Directions } from '../../Directions';
 import { MINIMAL_FLING_VELOCITY } from '../constants';
 import PointerTracker from './PointerTracker';
 
@@ -20,7 +20,7 @@ export default class Vector {
     this.unitY = isMagnitudeSufficient ? this.y / this._magnitude : 0;
   }
 
-  static fromDirection(direction: Directions | CornerDirections) {
+  static fromDirection(direction: Directions | CompositeDirections) {
     return DirectionToVectorMappings.get(direction)!;
   }
 
@@ -45,7 +45,7 @@ export default class Vector {
 }
 
 const DirectionToVectorMappings = new Map<
-  Directions | CornerDirections,
+  Directions | CompositeDirections,
   Vector
 >([
   [Directions.LEFT, new Vector(-1, 0)],
@@ -53,8 +53,8 @@ const DirectionToVectorMappings = new Map<
   [Directions.UP, new Vector(0, -1)],
   [Directions.DOWN, new Vector(0, 1)],
 
-  [CornerDirections.UP_RIGHT, new Vector(1, -1)],
-  [CornerDirections.DOWN_RIGHT, new Vector(1, 1)],
-  [CornerDirections.UP_LEFT, new Vector(-1, -1)],
-  [CornerDirections.DOWN_LEFT, new Vector(-1, 1)],
+  [CompositeDirections.UP_RIGHT, new Vector(1, -1)],
+  [CompositeDirections.DOWN_RIGHT, new Vector(1, 1)],
+  [CompositeDirections.UP_LEFT, new Vector(-1, -1)],
+  [CompositeDirections.DOWN_LEFT, new Vector(-1, 1)],
 ]);

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -21,8 +21,5 @@ export const degToRad = (degrees: number) => (degrees * Math.PI) / 180;
 export const coneToDeviation = (degrees: number) =>
   Math.cos(degToRad(degrees / 2));
 
-export const firstArrayValues = (array: Array<any>, amount: number) =>
-  array.filter((_, index) => index < amount);
-
-export const lastArrayValues = (array: Array<any>, amount: number) =>
+export const lastArrayValues = (array: any[], amount: number) =>
   array.filter((_, index, object) => index > object.length - amount - 1);

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -15,3 +15,14 @@ export const PointerTypeMapping = new Map<string, PointerType>([
   ['pen', PointerType.STYLUS],
   ['none', PointerType.OTHER],
 ]);
+
+export const degToRad = (degrees: number) => (degrees * Math.PI) / 180;
+
+export const coneToDeviation = (degrees: number) =>
+  Math.cos(degToRad(degrees / 2));
+
+export const firstArrayValues = (array: Array<any>, amount: number) =>
+  array.filter((_, index) => index < amount);
+
+export const lastArrayValues = (array: Array<any>, amount: number) =>
+  array.filter((_, index, object) => index > object.length - amount - 1);

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -20,6 +20,3 @@ export const degToRad = (degrees: number) => (degrees * Math.PI) / 180;
 
 export const coneToDeviation = (degrees: number) =>
   Math.cos(degToRad(degrees / 2));
-
-export const lastArrayValues = (array: any[], amount: number) =>
-  array.filter((_, index, object) => index > object.length - amount - 1);


### PR DESCRIPTION
## Description

This PR implements a requested feature to activate fling on corners of two adjacent activated directions.

## Test plan

- In project root run `yarn`
- Go to `example/` and run `yarn`
- Paste Fling example from Gesture Handler docs into EmptyExample.tsx
- Run `yarn web` for Web or `yarn start` for IOS and Android
