### PR TITLE
Add `userSelect` to TouchableOpacity

### DIFF
--- a/src/components/touchables/GenericTouchable.tsx
+++ b/src/components/touchables/GenericTouchable.tsx
@@ -15,6 +15,7 @@ import { BaseButton } from '../GestureButtons';
 import {
   GestureEvent,
   HandlerStateChangeEvent,
+  UserSelect,
 } from '../../handlers/gestureHandlerCommon';
 import { NativeViewGestureHandlerPayload } from '../../handlers/NativeViewGestureHandler';
 import { TouchableNativeFeedbackExtraProps } from './TouchableNativeFeedback.android';
@@ -51,6 +52,7 @@ export interface GenericTouchableProps
 
   containerStyle?: StyleProp<ViewStyle>;
   hitSlop?: Insets | number;
+  userSelect?: UserSelect;
 }
 
 interface InternalProps {
@@ -286,6 +288,7 @@ export default class GenericTouchable extends Component<
         }
         onGestureEvent={this.onGestureEvent}
         hitSlop={hitSlop}
+        userSelect={this.props.userSelect}
         shouldActivateOnStart={this.props.shouldActivateOnStart}
         disallowInterruption={this.props.disallowInterruption}
         testID={this.props.testID}


### PR DESCRIPTION
## Description

As pointed in [this discussion](https://github.com/software-mansion/react-native-gesture-handler/discussions/2799), it is not possible to set `userSelect` property on `TouchableOpacity` component. This fixes this problem. 

## Test plan

<details>
<summary> Test code </summary>

```jsx
import React from 'react';
import { StyleSheet, View, Text } from 'react-native';
import { TouchableOpacity } from 'react-native-gesture-handler';

export default function EmptyExample() {
  return (
    <View style={styles.container}>
      <TouchableOpacity
        userSelect="auto"
        style={{ width: 100, height: 100, backgroundColor: 'darkgreen' }}>
        <Text>Test</Text>
      </TouchableOpacity>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
});
```

</details>
