### PR TITLE
Remove event listeners on handler drop

### DIFF
--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -74,7 +74,8 @@ export default abstract class GestureHandler implements IGestureHandler {
     manager.setOnPointerOutOfBounds(this.onPointerOutOfBounds.bind(this));
     manager.setOnPointerMoveOver(this.onPointerMoveOver.bind(this));
     manager.setOnPointerMoveOut(this.onPointerMoveOut.bind(this));
-    manager.setListeners();
+
+    manager.registerListeners();
   }
 
   //

--- a/src/web/interfaces.ts
+++ b/src/web/interfaces.ts
@@ -90,6 +90,11 @@ interface NativeEvent extends Record<string, NativeEventArgs> {
   pointerType: PointerType;
 }
 
+export interface Point {
+  x: number;
+  y: number;
+}
+
 export interface PointerData {
   id: number;
   x: number;

--- a/src/web/tools/EventManager.ts
+++ b/src/web/tools/EventManager.ts
@@ -1,6 +1,8 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
 import { AdaptedEvent, EventTypes, TouchEventType } from '../interfaces';
 
+type PointerEventCallback = (event: AdaptedEvent) => void;
+
 export default abstract class EventManager<T> {
   protected readonly view: T;
   protected pointersInBounds: number[] = [];
@@ -11,7 +13,9 @@ export default abstract class EventManager<T> {
     this.activePointersCounter = 0;
   }
 
-  public abstract setListeners(): void;
+  public abstract registerListeners(): void;
+  public abstract unregisterListeners(): void;
+
   protected abstract mapEvent(
     event: Event,
     eventType: EventTypes,
@@ -36,39 +40,37 @@ export default abstract class EventManager<T> {
   protected onPointerMoveOver(_event: AdaptedEvent): void {}
   protected onPointerMoveOut(_event: AdaptedEvent): void {}
 
-  public setOnPointerDown(callback: (event: AdaptedEvent) => void): void {
+  public setOnPointerDown(callback: PointerEventCallback): void {
     this.onPointerDown = callback;
   }
-  public setOnPointerAdd(callback: (event: AdaptedEvent) => void): void {
+  public setOnPointerAdd(callback: PointerEventCallback): void {
     this.onPointerAdd = callback;
   }
-  public setOnPointerUp(callback: (event: AdaptedEvent) => void): void {
+  public setOnPointerUp(callback: PointerEventCallback): void {
     this.onPointerUp = callback;
   }
-  public setOnPointerRemove(callback: (event: AdaptedEvent) => void): void {
+  public setOnPointerRemove(callback: PointerEventCallback): void {
     this.onPointerRemove = callback;
   }
-  public setOnPointerMove(callback: (event: AdaptedEvent) => void): void {
+  public setOnPointerMove(callback: PointerEventCallback): void {
     this.onPointerMove = callback;
   }
-  public setOnPointerLeave(callback: (event: AdaptedEvent) => void): void {
+  public setOnPointerLeave(callback: PointerEventCallback): void {
     this.onPointerLeave = callback;
   }
-  public setOnPointerEnter(callback: (event: AdaptedEvent) => void): void {
+  public setOnPointerEnter(callback: PointerEventCallback): void {
     this.onPointerEnter = callback;
   }
-  public setOnPointerCancel(callback: (event: AdaptedEvent) => void): void {
+  public setOnPointerCancel(callback: PointerEventCallback): void {
     this.onPointerCancel = callback;
   }
-  public setOnPointerOutOfBounds(
-    callback: (event: AdaptedEvent) => void
-  ): void {
+  public setOnPointerOutOfBounds(callback: PointerEventCallback): void {
     this.onPointerOutOfBounds = callback;
   }
-  public setOnPointerMoveOver(callback: (event: AdaptedEvent) => void): void {
+  public setOnPointerMoveOver(callback: PointerEventCallback): void {
     this.onPointerMoveOver = callback;
   }
-  public setOnPointerMoveOut(callback: (event: AdaptedEvent) => void): void {
+  public setOnPointerMoveOut(callback: PointerEventCallback): void {
     this.onPointerMoveOut = callback;
   }
 

--- a/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/src/web/tools/GestureHandlerWebDelegate.ts
@@ -151,5 +151,9 @@ export class GestureHandlerWebDelegate
 
   public destroy(config: Config): void {
     this.removeContextMenuListeners(config);
+
+    this.eventManagers.forEach((manager) => {
+      manager.unregisterListeners();
+    });
   }
 }

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -10,10 +10,19 @@ const PointerTypes = {
   Stylus: 'pen',
 };
 
+type PointerEventCallback = (event: PointerEvent) => void;
 export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();
   private readonly mouseButtonsMapper = new Map<number, MouseButton>();
   private lastPosition: Point;
+
+  private boundPointerDownCallback: PointerEventCallback;
+  private boundPointerUpCallback: PointerEventCallback;
+  private boundPointerMoveCallback: PointerEventCallback;
+  private boundPointerCancelCallback: PointerEventCallback;
+  private boundPointerEnterCallback: PointerEventCallback;
+  private boundPointerLeaveCallback: PointerEventCallback;
+  private boundLostPointerCaptureCallback: PointerEventCallback;
 
   constructor(view: HTMLElement) {
     super(view);
@@ -23,6 +32,15 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     this.mouseButtonsMapper.set(2, MouseButton.RIGHT);
     this.mouseButtonsMapper.set(3, MouseButton.BUTTON_4);
     this.mouseButtonsMapper.set(4, MouseButton.BUTTON_5);
+
+    this.boundPointerDownCallback = this.pointerDownCallback.bind(this);
+    this.boundPointerUpCallback = this.pointerUpCallback.bind(this);
+    this.boundPointerMoveCallback = this.pointerMoveCallback.bind(this);
+    this.boundPointerCancelCallback = this.pointerCancelCallback.bind(this);
+    this.boundPointerEnterCallback = this.pointerEnterCallback.bind(this);
+    this.boundPointerLeaveCallback = this.pointerLeaveCallback.bind(this);
+    this.boundLostPointerCaptureCallback =
+      this.lostPointerCaptureCallback.bind(this);
 
     this.lastPosition = {
       x: -Infinity,
@@ -203,54 +221,45 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
   }
 
   public registerListeners(): void {
-    this.view.addEventListener(
-      'pointerdown',
-      this.pointerDownCallback.bind(this)
-    );
-
-    this.view.addEventListener('pointerup', this.pointerUpCallback.bind(this));
-
-    this.view.addEventListener(
-      'pointermove',
-      this.pointerMoveCallback.bind(this)
-    );
-
+    this.view.addEventListener('pointerdown', this.boundPointerDownCallback);
+    this.view.addEventListener('pointerup', this.boundPointerUpCallback);
+    this.view.addEventListener('pointermove', this.boundPointerMoveCallback);
     this.view.addEventListener(
       'pointercancel',
-      this.pointerCancelCallback.bind(this)
+      this.boundPointerCancelCallback
     );
 
     // onPointerEnter and onPointerLeave are triggered by a custom logic responsible for
     // handling shouldCancelWhenOutside flag, and are unreliable unless the pointer is down.
     // We therefore use pointerenter and pointerleave events to handle the hover gesture,
     // mapping them to onPointerMoveOver and onPointerMoveOut respectively.
-
-    this.view.addEventListener(
-      'pointerenter',
-      this.pointerEnterCallback.bind(this)
-    );
-
-    this.view.addEventListener(
-      'pointerleave',
-      this.pointerLeaveCallback.bind(this)
-    );
-
+    this.view.addEventListener('pointerenter', this.boundPointerEnterCallback);
+    this.view.addEventListener('pointerleave', this.boundPointerLeaveCallback);
     this.view.addEventListener(
       'lostpointercapture',
-      this.lostPointerCaptureCallback.bind(this)
+      this.boundLostPointerCaptureCallback
     );
   }
 
   public unregisterListeners(): void {
-    this.view.removeEventListener('pointerdown', this.pointerDownCallback);
-    this.view.removeEventListener('pointerup', this.pointerUpCallback);
-    this.view.removeEventListener('pointermove', this.pointerMoveCallback);
-    this.view.removeEventListener('pointercancel', this.pointerCancelCallback);
-    this.view.removeEventListener('pointerenter', this.pointerEnterCallback);
-    this.view.removeEventListener('pointerleave', this.pointerLeaveCallback);
+    this.view.removeEventListener('pointerdown', this.boundPointerDownCallback);
+    this.view.removeEventListener('pointerup', this.boundPointerUpCallback);
+    this.view.removeEventListener('pointermove', this.boundPointerMoveCallback);
+    this.view.removeEventListener(
+      'pointercancel',
+      this.boundPointerCancelCallback
+    );
+    this.view.removeEventListener(
+      'pointerenter',
+      this.boundPointerEnterCallback
+    );
+    this.view.removeEventListener(
+      'pointerleave',
+      this.boundPointerLeaveCallback
+    );
     this.view.removeEventListener(
       'lostpointercapture',
-      this.lostPointerCaptureCallback
+      this.boundLostPointerCaptureCallback
     );
   }
 

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -1,6 +1,6 @@
 import EventManager from './EventManager';
 import { MouseButton } from '../../handlers/gestureHandlerCommon';
-import { AdaptedEvent, EventTypes } from '../interfaces';
+import { AdaptedEvent, EventTypes, Point } from '../interfaces';
 import { PointerTypeMapping, isPointerInBounds } from '../utils';
 import { PointerType } from '../../PointerType';
 
@@ -13,6 +13,7 @@ const PointerTypes = {
 export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();
   private readonly mouseButtonsMapper = new Map<number, MouseButton>();
+  private lastPosition: Point;
 
   constructor(view: HTMLElement) {
     super(view);
@@ -22,200 +23,234 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     this.mouseButtonsMapper.set(2, MouseButton.RIGHT);
     this.mouseButtonsMapper.set(3, MouseButton.BUTTON_4);
     this.mouseButtonsMapper.set(4, MouseButton.BUTTON_5);
+
+    this.lastPosition = {
+      x: -Infinity,
+      y: -Infinity,
+    };
   }
 
-  public setListeners(): void {
-    this.view.addEventListener('pointerdown', (event: PointerEvent): void => {
-      if (event.pointerType === PointerTypes.Touch) {
-        return;
-      }
-      if (
-        !isPointerInBounds(this.view, { x: event.clientX, y: event.clientY })
-      ) {
-        return;
-      }
+  private pointerDownCallback(event: PointerEvent) {
+    if (event.pointerType === PointerTypes.Touch) {
+      return;
+    }
+    if (!isPointerInBounds(this.view, { x: event.clientX, y: event.clientY })) {
+      return;
+    }
 
-      const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.DOWN);
-      const target = event.target as HTMLElement;
+    const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.DOWN);
+    const target = event.target as HTMLElement;
 
-      if (!POINTER_CAPTURE_EXCLUDE_LIST.has(target.tagName)) {
-        target.setPointerCapture(adaptedEvent.pointerId);
-      }
+    if (!POINTER_CAPTURE_EXCLUDE_LIST.has(target.tagName)) {
+      target.setPointerCapture(adaptedEvent.pointerId);
+    }
 
-      this.markAsInBounds(adaptedEvent.pointerId);
-      this.trackedPointers.add(adaptedEvent.pointerId);
+    this.markAsInBounds(adaptedEvent.pointerId);
+    this.trackedPointers.add(adaptedEvent.pointerId);
 
-      if (++this.activePointersCounter > 1) {
-        adaptedEvent.eventType = EventTypes.ADDITIONAL_POINTER_DOWN;
-        this.onPointerAdd(adaptedEvent);
-      } else {
-        this.onPointerDown(adaptedEvent);
-      }
+    if (++this.activePointersCounter > 1) {
+      adaptedEvent.eventType = EventTypes.ADDITIONAL_POINTER_DOWN;
+      this.onPointerAdd(adaptedEvent);
+    } else {
+      this.onPointerDown(adaptedEvent);
+    }
+  }
+
+  private pointerUpCallback(event: PointerEvent) {
+    if (event.pointerType === PointerTypes.Touch) {
+      return;
+    }
+
+    // When we call reset on gesture handlers, it also resets their event managers
+    // In some handlers (like RotationGestureHandler) reset is called before all pointers leave view
+    // This means, that activePointersCounter will be set to 0, while there are still remaining pointers on view
+    // Removing them will end in activePointersCounter going below 0, therefore handlers won't behave properly
+    if (this.activePointersCounter === 0) {
+      return;
+    }
+
+    const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.UP);
+    const target = event.target as HTMLElement;
+
+    if (!POINTER_CAPTURE_EXCLUDE_LIST.has(target.tagName)) {
+      target.releasePointerCapture(adaptedEvent.pointerId);
+    }
+
+    this.markAsOutOfBounds(adaptedEvent.pointerId);
+    this.trackedPointers.delete(adaptedEvent.pointerId);
+
+    if (--this.activePointersCounter > 0) {
+      adaptedEvent.eventType = EventTypes.ADDITIONAL_POINTER_UP;
+      this.onPointerRemove(adaptedEvent);
+    } else {
+      this.onPointerUp(adaptedEvent);
+    }
+  }
+
+  private pointerMoveCallback(event: PointerEvent) {
+    if (event.pointerType === PointerTypes.Touch) {
+      return;
+    }
+
+    // Stylus triggers `pointermove` event when it detects changes in pressure. Since it is very sensitive to those changes,
+    // it constantly sends events, even though there was no change in position. To fix that we check whether
+    // pointer has actually moved and if not, we do not send event.
+    if (
+      event.pointerType === PointerTypes.Stylus &&
+      event.x === this.lastPosition.x &&
+      event.y === this.lastPosition.y
+    ) {
+      return;
+    }
+
+    const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.MOVE);
+    const target = event.target as HTMLElement;
+
+    // You may be wondering why are we setting pointer capture here, when we
+    // already set it in `pointerdown` handler. Well, that's a great question,
+    // for which I don't have an answer. Specification (https://www.w3.org/TR/pointerevents2/#dom-element-setpointercapture)
+    // says that the requirement for `setPointerCapture` to work is that pointer
+    // must be in 'active buttons state`, otherwise it will fail silently, which
+    // is lovely. Obviously, when `pointerdown` is fired, one of the buttons
+    // (when using mouse) is pressed, but that doesn't mean that `setPointerCapture`
+    // will succeed, for some reason. Since it fails silently, we don't actually know
+    // if it worked or not (there's `gotpointercapture` event, but the complexity of
+    // incorporating it here seems stupid), so we just call it again here, every time
+    // pointer moves until it succeeds.
+    // God, I do love web development.
+    if (
+      !target.hasPointerCapture(event.pointerId) &&
+      !POINTER_CAPTURE_EXCLUDE_LIST.has(target.tagName)
+    ) {
+      target.setPointerCapture(event.pointerId);
+    }
+
+    const inBounds: boolean = isPointerInBounds(this.view, {
+      x: adaptedEvent.x,
+      y: adaptedEvent.y,
     });
 
-    this.view.addEventListener('pointerup', (event: PointerEvent): void => {
-      if (event.pointerType === PointerTypes.Touch) {
-        return;
-      }
+    const pointerIndex: number = this.pointersInBounds.indexOf(
+      adaptedEvent.pointerId
+    );
 
-      // When we call reset on gesture handlers, it also resets their event managers
-      // In some handlers (like RotationGestureHandler) reset is called before all pointers leave view
-      // This means, that activePointersCounter will be set to 0, while there are still remaining pointers on view
-      // Removing them will end in activePointersCounter going below 0, therefore handlers won't behave properly
-      if (this.activePointersCounter === 0) {
-        return;
-      }
-
-      const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.UP);
-      const target = event.target as HTMLElement;
-
-      if (!POINTER_CAPTURE_EXCLUDE_LIST.has(target.tagName)) {
-        target.releasePointerCapture(adaptedEvent.pointerId);
-      }
-
-      this.markAsOutOfBounds(adaptedEvent.pointerId);
-      this.trackedPointers.delete(adaptedEvent.pointerId);
-
-      if (--this.activePointersCounter > 0) {
-        adaptedEvent.eventType = EventTypes.ADDITIONAL_POINTER_UP;
-        this.onPointerRemove(adaptedEvent);
+    if (inBounds) {
+      if (pointerIndex < 0) {
+        adaptedEvent.eventType = EventTypes.ENTER;
+        this.onPointerEnter(adaptedEvent);
+        this.markAsInBounds(adaptedEvent.pointerId);
       } else {
-        this.onPointerUp(adaptedEvent);
+        this.onPointerMove(adaptedEvent);
       }
-    });
-
-    const lastPosition: { x: number | null; y: number | null } = {
-      x: null,
-      y: null,
-    };
-
-    this.view.addEventListener('pointermove', (event: PointerEvent): void => {
-      if (event.pointerType === PointerTypes.Touch) {
-        return;
-      }
-
-      // Stylus triggers `pointermove` event when it detects changes in pressure. Since it is very sensitive to those changes,
-      // it constantly sends events, even though there was no change in position. To fix that we check whether
-      // pointer has actually moved and if not, we do not send event.
-      if (
-        event.pointerType === PointerTypes.Stylus &&
-        event.x === lastPosition.x &&
-        event.y === lastPosition.y
-      ) {
-        return;
-      }
-
-      const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.MOVE);
-      const target = event.target as HTMLElement;
-
-      // You may be wondering why are we setting pointer capture here, when we
-      // already set it in `pointerdown` handler. Well, that's a great question,
-      // for which I don't have an answer. Specification (https://www.w3.org/TR/pointerevents2/#dom-element-setpointercapture)
-      // says that the requirement for `setPointerCapture` to work is that pointer
-      // must be in 'active buttons state`, otherwise it will fail silently, which
-      // is lovely. Obviously, when `pointerdown` is fired, one of the buttons
-      // (when using mouse) is pressed, but that doesn't mean that `setPointerCapture`
-      // will succeed, for some reason. Since it fails silently, we don't actually know
-      // if it worked or not (there's `gotpointercapture` event, but the complexity of
-      // incorporating it here seems stupid), so we just call it again here, every time
-      // pointer moves until it succeeds.
-      // God, I do love web development.
-      if (
-        !target.hasPointerCapture(event.pointerId) &&
-        !POINTER_CAPTURE_EXCLUDE_LIST.has(target.tagName)
-      ) {
-        target.setPointerCapture(event.pointerId);
-      }
-
-      const inBounds: boolean = isPointerInBounds(this.view, {
-        x: adaptedEvent.x,
-        y: adaptedEvent.y,
-      });
-
-      const pointerIndex: number = this.pointersInBounds.indexOf(
-        adaptedEvent.pointerId
-      );
-
-      if (inBounds) {
-        if (pointerIndex < 0) {
-          adaptedEvent.eventType = EventTypes.ENTER;
-          this.onPointerEnter(adaptedEvent);
-          this.markAsInBounds(adaptedEvent.pointerId);
-        } else {
-          this.onPointerMove(adaptedEvent);
-        }
+    } else {
+      if (pointerIndex >= 0) {
+        adaptedEvent.eventType = EventTypes.LEAVE;
+        this.onPointerLeave(adaptedEvent);
+        this.markAsOutOfBounds(adaptedEvent.pointerId);
       } else {
-        if (pointerIndex >= 0) {
-          adaptedEvent.eventType = EventTypes.LEAVE;
-          this.onPointerLeave(adaptedEvent);
-          this.markAsOutOfBounds(adaptedEvent.pointerId);
-        } else {
-          this.onPointerOutOfBounds(adaptedEvent);
-        }
+        this.onPointerOutOfBounds(adaptedEvent);
       }
+    }
 
-      lastPosition.x = event.x;
-      lastPosition.y = event.y;
-    });
+    this.lastPosition.x = event.x;
+    this.lastPosition.y = event.y;
+  }
 
-    this.view.addEventListener('pointercancel', (event: PointerEvent): void => {
-      if (event.pointerType === PointerTypes.Touch) {
-        return;
-      }
+  private pointerCancelCallback(event: PointerEvent) {
+    if (event.pointerType === PointerTypes.Touch) {
+      return;
+    }
 
-      const adaptedEvent: AdaptedEvent = this.mapEvent(
-        event,
-        EventTypes.CANCEL
-      );
+    const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.CANCEL);
 
+    this.onPointerCancel(adaptedEvent);
+    this.markAsOutOfBounds(adaptedEvent.pointerId);
+    this.activePointersCounter = 0;
+    this.trackedPointers.clear();
+  }
+
+  private pointerEnterCallback(event: PointerEvent) {
+    if (event.pointerType === PointerTypes.Touch) {
+      return;
+    }
+
+    const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.ENTER);
+
+    this.onPointerMoveOver(adaptedEvent);
+  }
+
+  private pointerLeaveCallback(event: PointerEvent) {
+    if (event.pointerType === PointerTypes.Touch) {
+      return;
+    }
+
+    const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.LEAVE);
+
+    this.onPointerMoveOut(adaptedEvent);
+  }
+
+  private lostPointerCaptureCallback(event: PointerEvent) {
+    const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.CANCEL);
+
+    if (this.trackedPointers.has(adaptedEvent.pointerId)) {
+      // in some cases the `pointerup` event is not fired, but `lostpointercapture` is
+      // we simulate the `pointercancel` event here to make sure the gesture handler stops tracking it
       this.onPointerCancel(adaptedEvent);
-      this.markAsOutOfBounds(adaptedEvent.pointerId);
+
       this.activePointersCounter = 0;
       this.trackedPointers.clear();
-    });
+    }
+  }
+
+  public registerListeners(): void {
+    this.view.addEventListener(
+      'pointerdown',
+      this.pointerDownCallback.bind(this)
+    );
+
+    this.view.addEventListener('pointerup', this.pointerUpCallback.bind(this));
+
+    this.view.addEventListener(
+      'pointermove',
+      this.pointerMoveCallback.bind(this)
+    );
+
+    this.view.addEventListener(
+      'pointercancel',
+      this.pointerCancelCallback.bind(this)
+    );
 
     // onPointerEnter and onPointerLeave are triggered by a custom logic responsible for
     // handling shouldCancelWhenOutside flag, and are unreliable unless the pointer is down.
     // We therefore use pointerenter and pointerleave events to handle the hover gesture,
     // mapping them to onPointerMoveOver and onPointerMoveOut respectively.
 
-    this.view.addEventListener('pointerenter', (event: PointerEvent): void => {
-      if (event.pointerType === PointerTypes.Touch) {
-        return;
-      }
+    this.view.addEventListener(
+      'pointerenter',
+      this.pointerEnterCallback.bind(this)
+    );
 
-      const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.ENTER);
-
-      this.onPointerMoveOver(adaptedEvent);
-    });
-
-    this.view.addEventListener('pointerleave', (event: PointerEvent): void => {
-      if (event.pointerType === PointerTypes.Touch) {
-        return;
-      }
-
-      const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.LEAVE);
-
-      this.onPointerMoveOut(adaptedEvent);
-    });
+    this.view.addEventListener(
+      'pointerleave',
+      this.pointerLeaveCallback.bind(this)
+    );
 
     this.view.addEventListener(
       'lostpointercapture',
-      (event: PointerEvent): void => {
-        const adaptedEvent: AdaptedEvent = this.mapEvent(
-          event,
-          EventTypes.CANCEL
-        );
+      this.lostPointerCaptureCallback.bind(this)
+    );
+  }
 
-        if (this.trackedPointers.has(adaptedEvent.pointerId)) {
-          // in some cases the `pointerup` event is not fired, but `lostpointercapture` is
-          // we simulate the `pointercancel` event here to make sure the gesture handler stops tracking it
-          this.onPointerCancel(adaptedEvent);
-
-          this.activePointersCounter = 0;
-          this.trackedPointers.clear();
-        }
-      }
+  public unregisterListeners(): void {
+    this.view.removeEventListener('pointerdown', this.pointerDownCallback);
+    this.view.removeEventListener('pointerup', this.pointerUpCallback);
+    this.view.removeEventListener('pointermove', this.pointerMoveCallback);
+    this.view.removeEventListener('pointercancel', this.pointerCancelCallback);
+    this.view.removeEventListener('pointerenter', this.pointerEnterCallback);
+    this.view.removeEventListener('pointerleave', this.pointerLeaveCallback);
+    this.view.removeEventListener(
+      'lostpointercapture',
+      this.lostPointerCaptureCallback
     );
   }
 

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -10,19 +10,10 @@ const PointerTypes = {
   Stylus: 'pen',
 };
 
-type PointerEventCallback = (event: PointerEvent) => void;
 export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();
   private readonly mouseButtonsMapper = new Map<number, MouseButton>();
   private lastPosition: Point;
-
-  private boundPointerDownCallback: PointerEventCallback;
-  private boundPointerUpCallback: PointerEventCallback;
-  private boundPointerMoveCallback: PointerEventCallback;
-  private boundPointerCancelCallback: PointerEventCallback;
-  private boundPointerEnterCallback: PointerEventCallback;
-  private boundPointerLeaveCallback: PointerEventCallback;
-  private boundLostPointerCaptureCallback: PointerEventCallback;
 
   constructor(view: HTMLElement) {
     super(view);
@@ -33,22 +24,13 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     this.mouseButtonsMapper.set(3, MouseButton.BUTTON_4);
     this.mouseButtonsMapper.set(4, MouseButton.BUTTON_5);
 
-    this.boundPointerDownCallback = this.pointerDownCallback.bind(this);
-    this.boundPointerUpCallback = this.pointerUpCallback.bind(this);
-    this.boundPointerMoveCallback = this.pointerMoveCallback.bind(this);
-    this.boundPointerCancelCallback = this.pointerCancelCallback.bind(this);
-    this.boundPointerEnterCallback = this.pointerEnterCallback.bind(this);
-    this.boundPointerLeaveCallback = this.pointerLeaveCallback.bind(this);
-    this.boundLostPointerCaptureCallback =
-      this.lostPointerCaptureCallback.bind(this);
-
     this.lastPosition = {
       x: -Infinity,
       y: -Infinity,
     };
   }
 
-  private pointerDownCallback(event: PointerEvent) {
+  private pointerDownCallback = (event: PointerEvent) => {
     if (event.pointerType === PointerTypes.Touch) {
       return;
     }
@@ -72,9 +54,9 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     } else {
       this.onPointerDown(adaptedEvent);
     }
-  }
+  };
 
-  private pointerUpCallback(event: PointerEvent) {
+  private pointerUpCallback = (event: PointerEvent) => {
     if (event.pointerType === PointerTypes.Touch) {
       return;
     }
@@ -103,9 +85,9 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     } else {
       this.onPointerUp(adaptedEvent);
     }
-  }
+  };
 
-  private pointerMoveCallback(event: PointerEvent) {
+  private pointerMoveCallback = (event: PointerEvent) => {
     if (event.pointerType === PointerTypes.Touch) {
       return;
     }
@@ -172,9 +154,9 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
 
     this.lastPosition.x = event.x;
     this.lastPosition.y = event.y;
-  }
+  };
 
-  private pointerCancelCallback(event: PointerEvent) {
+  private pointerCancelCallback = (event: PointerEvent) => {
     if (event.pointerType === PointerTypes.Touch) {
       return;
     }
@@ -185,9 +167,9 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     this.markAsOutOfBounds(adaptedEvent.pointerId);
     this.activePointersCounter = 0;
     this.trackedPointers.clear();
-  }
+  };
 
-  private pointerEnterCallback(event: PointerEvent) {
+  private pointerEnterCallback = (event: PointerEvent) => {
     if (event.pointerType === PointerTypes.Touch) {
       return;
     }
@@ -195,9 +177,9 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.ENTER);
 
     this.onPointerMoveOver(adaptedEvent);
-  }
+  };
 
-  private pointerLeaveCallback(event: PointerEvent) {
+  private pointerLeaveCallback = (event: PointerEvent) => {
     if (event.pointerType === PointerTypes.Touch) {
       return;
     }
@@ -205,9 +187,9 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.LEAVE);
 
     this.onPointerMoveOut(adaptedEvent);
-  }
+  };
 
-  private lostPointerCaptureCallback(event: PointerEvent) {
+  private lostPointerCaptureCallback = (event: PointerEvent) => {
     const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.CANCEL);
 
     if (this.trackedPointers.has(adaptedEvent.pointerId)) {
@@ -218,48 +200,36 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       this.activePointersCounter = 0;
       this.trackedPointers.clear();
     }
-  }
+  };
 
   public registerListeners(): void {
-    this.view.addEventListener('pointerdown', this.boundPointerDownCallback);
-    this.view.addEventListener('pointerup', this.boundPointerUpCallback);
-    this.view.addEventListener('pointermove', this.boundPointerMoveCallback);
-    this.view.addEventListener(
-      'pointercancel',
-      this.boundPointerCancelCallback
-    );
+    this.view.addEventListener('pointerdown', this.pointerDownCallback);
+    this.view.addEventListener('pointerup', this.pointerUpCallback);
+    this.view.addEventListener('pointermove', this.pointerMoveCallback);
+    this.view.addEventListener('pointercancel', this.pointerCancelCallback);
 
     // onPointerEnter and onPointerLeave are triggered by a custom logic responsible for
     // handling shouldCancelWhenOutside flag, and are unreliable unless the pointer is down.
     // We therefore use pointerenter and pointerleave events to handle the hover gesture,
     // mapping them to onPointerMoveOver and onPointerMoveOut respectively.
-    this.view.addEventListener('pointerenter', this.boundPointerEnterCallback);
-    this.view.addEventListener('pointerleave', this.boundPointerLeaveCallback);
+    this.view.addEventListener('pointerenter', this.pointerEnterCallback);
+    this.view.addEventListener('pointerleave', this.pointerLeaveCallback);
     this.view.addEventListener(
       'lostpointercapture',
-      this.boundLostPointerCaptureCallback
+      this.lostPointerCaptureCallback
     );
   }
 
   public unregisterListeners(): void {
-    this.view.removeEventListener('pointerdown', this.boundPointerDownCallback);
-    this.view.removeEventListener('pointerup', this.boundPointerUpCallback);
-    this.view.removeEventListener('pointermove', this.boundPointerMoveCallback);
-    this.view.removeEventListener(
-      'pointercancel',
-      this.boundPointerCancelCallback
-    );
-    this.view.removeEventListener(
-      'pointerenter',
-      this.boundPointerEnterCallback
-    );
-    this.view.removeEventListener(
-      'pointerleave',
-      this.boundPointerLeaveCallback
-    );
+    this.view.removeEventListener('pointerdown', this.pointerDownCallback);
+    this.view.removeEventListener('pointerup', this.pointerUpCallback);
+    this.view.removeEventListener('pointermove', this.pointerMoveCallback);
+    this.view.removeEventListener('pointercancel', this.pointerCancelCallback);
+    this.view.removeEventListener('pointerenter', this.pointerEnterCallback);
+    this.view.removeEventListener('pointerleave', this.pointerLeaveCallback);
     this.view.removeEventListener(
       'lostpointercapture',
-      this.boundLostPointerCaptureCallback
+      this.lostPointerCaptureCallback
     );
   }
 

--- a/src/web/tools/TouchEventManager.ts
+++ b/src/web/tools/TouchEventManager.ts
@@ -4,10 +4,6 @@ import { isPointerInBounds } from '../utils';
 import { PointerType } from '../../PointerType';
 
 export default class TouchEventManager extends EventManager<HTMLElement> {
-  constructor(view: HTMLElement) {
-    super(view);
-  }
-
   private touchStartCallback = (event: TouchEvent): void => {
     for (let i = 0; i < event.changedTouches.length; ++i) {
       const adaptedEvent: AdaptedEvent = this.mapEvent(

--- a/src/web/tools/TouchEventManager.ts
+++ b/src/web/tools/TouchEventManager.ts
@@ -4,134 +4,152 @@ import { isPointerInBounds } from '../utils';
 import { PointerType } from '../../PointerType';
 
 export default class TouchEventManager extends EventManager<HTMLElement> {
-  public setListeners(): void {
-    this.view.addEventListener('touchstart', (event: TouchEvent) => {
-      for (let i = 0; i < event.changedTouches.length; ++i) {
-        const adaptedEvent: AdaptedEvent = this.mapEvent(
-          event,
-          EventTypes.DOWN,
-          i,
-          TouchEventType.DOWN
-        );
+  private touchStartCallback(event: TouchEvent): void {
+    for (let i = 0; i < event.changedTouches.length; ++i) {
+      const adaptedEvent: AdaptedEvent = this.mapEvent(
+        event,
+        EventTypes.DOWN,
+        i,
+        TouchEventType.DOWN
+      );
 
-        // Here we skip stylus, because in case of anything different than touch we want to handle it by using PointerEvents
-        // If we leave stylus to send touch events, handlers will receive every action twice
-        if (
-          !isPointerInBounds(this.view, {
-            x: adaptedEvent.x,
-            y: adaptedEvent.y,
-          }) ||
-          //@ts-ignore touchType field does exist
-          event.changedTouches[i].touchType === 'stylus'
-        ) {
-          continue;
-        }
-
-        this.markAsInBounds(adaptedEvent.pointerId);
-
-        if (++this.activePointersCounter > 1) {
-          adaptedEvent.eventType = EventTypes.ADDITIONAL_POINTER_DOWN;
-          this.onPointerAdd(adaptedEvent);
-        } else {
-          this.onPointerDown(adaptedEvent);
-        }
-      }
-    });
-
-    this.view.addEventListener('touchmove', (event: TouchEvent) => {
-      for (let i = 0; i < event.changedTouches.length; ++i) {
-        const adaptedEvent: AdaptedEvent = this.mapEvent(
-          event,
-          EventTypes.MOVE,
-          i,
-          TouchEventType.MOVE
-        );
-        //@ts-ignore touchType field does exist
-        if (event.changedTouches[i].touchType === 'stylus') {
-          continue;
-        }
-
-        const inBounds: boolean = isPointerInBounds(this.view, {
+      // Here we skip stylus, because in case of anything different than touch we want to handle it by using PointerEvents
+      // If we leave stylus to send touch events, handlers will receive every action twice
+      if (
+        !isPointerInBounds(this.view, {
           x: adaptedEvent.x,
           y: adaptedEvent.y,
-        });
-
-        const pointerIndex: number = this.pointersInBounds.indexOf(
-          adaptedEvent.pointerId
-        );
-
-        if (inBounds) {
-          if (pointerIndex < 0) {
-            adaptedEvent.eventType = EventTypes.ENTER;
-            this.onPointerEnter(adaptedEvent);
-            this.markAsInBounds(adaptedEvent.pointerId);
-          } else {
-            this.onPointerMove(adaptedEvent);
-          }
-        } else {
-          if (pointerIndex >= 0) {
-            adaptedEvent.eventType = EventTypes.LEAVE;
-            this.onPointerLeave(adaptedEvent);
-            this.markAsOutOfBounds(adaptedEvent.pointerId);
-          } else {
-            this.onPointerOutOfBounds(adaptedEvent);
-          }
-        }
-      }
-    });
-
-    this.view.addEventListener('touchend', (event: TouchEvent) => {
-      for (let i = 0; i < event.changedTouches.length; ++i) {
-        // When we call reset on gesture handlers, it also resets their event managers
-        // In some handlers (like RotationGestureHandler) reset is called before all pointers leave view
-        // This means, that activePointersCounter will be set to 0, while there are still remaining pointers on view
-        // Removing them will end in activePointersCounter going below 0, therefore handlers won't behave properly
-        if (this.activePointersCounter === 0) {
-          break;
-        }
-
+        }) ||
         //@ts-ignore touchType field does exist
-        if (event.changedTouches[i].touchType === 'stylus') {
-          continue;
-        }
+        event.changedTouches[i].touchType === 'stylus'
+      ) {
+        continue;
+      }
 
-        const adaptedEvent: AdaptedEvent = this.mapEvent(
-          event,
-          EventTypes.UP,
-          i,
-          TouchEventType.UP
-        );
+      this.markAsInBounds(adaptedEvent.pointerId);
 
-        this.markAsOutOfBounds(adaptedEvent.pointerId);
+      if (++this.activePointersCounter > 1) {
+        adaptedEvent.eventType = EventTypes.ADDITIONAL_POINTER_DOWN;
+        this.onPointerAdd(adaptedEvent);
+      } else {
+        this.onPointerDown(adaptedEvent);
+      }
+    }
+  }
 
-        if (--this.activePointersCounter > 0) {
-          adaptedEvent.eventType = EventTypes.ADDITIONAL_POINTER_UP;
-          this.onPointerRemove(adaptedEvent);
+  private touchMoveCallback(event: TouchEvent): void {
+    for (let i = 0; i < event.changedTouches.length; ++i) {
+      const adaptedEvent: AdaptedEvent = this.mapEvent(
+        event,
+        EventTypes.MOVE,
+        i,
+        TouchEventType.MOVE
+      );
+      //@ts-ignore touchType field does exist
+      if (event.changedTouches[i].touchType === 'stylus') {
+        continue;
+      }
+
+      const inBounds: boolean = isPointerInBounds(this.view, {
+        x: adaptedEvent.x,
+        y: adaptedEvent.y,
+      });
+
+      const pointerIndex: number = this.pointersInBounds.indexOf(
+        adaptedEvent.pointerId
+      );
+
+      if (inBounds) {
+        if (pointerIndex < 0) {
+          adaptedEvent.eventType = EventTypes.ENTER;
+          this.onPointerEnter(adaptedEvent);
+          this.markAsInBounds(adaptedEvent.pointerId);
         } else {
-          this.onPointerUp(adaptedEvent);
+          this.onPointerMove(adaptedEvent);
+        }
+      } else {
+        if (pointerIndex >= 0) {
+          adaptedEvent.eventType = EventTypes.LEAVE;
+          this.onPointerLeave(adaptedEvent);
+          this.markAsOutOfBounds(adaptedEvent.pointerId);
+        } else {
+          this.onPointerOutOfBounds(adaptedEvent);
         }
       }
-    });
+    }
+  }
 
-    this.view.addEventListener('touchcancel', (event: TouchEvent) => {
-      for (let i = 0; i < event.changedTouches.length; ++i) {
-        const adaptedEvent: AdaptedEvent = this.mapEvent(
-          event,
-          EventTypes.CANCEL,
-          i,
-          TouchEventType.CANCELLED
-        );
-
-        //@ts-ignore touchType field does exist
-        if (event.changedTouches[i].touchType === 'stylus') {
-          continue;
-        }
-
-        this.onPointerCancel(adaptedEvent);
-        this.markAsOutOfBounds(adaptedEvent.pointerId);
-        this.activePointersCounter = 0;
+  private touchEndCallback(event: TouchEvent): void {
+    for (let i = 0; i < event.changedTouches.length; ++i) {
+      // When we call reset on gesture handlers, it also resets their event managers
+      // In some handlers (like RotationGestureHandler) reset is called before all pointers leave view
+      // This means, that activePointersCounter will be set to 0, while there are still remaining pointers on view
+      // Removing them will end in activePointersCounter going below 0, therefore handlers won't behave properly
+      if (this.activePointersCounter === 0) {
+        break;
       }
-    });
+
+      //@ts-ignore touchType field does exist
+      if (event.changedTouches[i].touchType === 'stylus') {
+        continue;
+      }
+
+      const adaptedEvent: AdaptedEvent = this.mapEvent(
+        event,
+        EventTypes.UP,
+        i,
+        TouchEventType.UP
+      );
+
+      this.markAsOutOfBounds(adaptedEvent.pointerId);
+
+      if (--this.activePointersCounter > 0) {
+        adaptedEvent.eventType = EventTypes.ADDITIONAL_POINTER_UP;
+        this.onPointerRemove(adaptedEvent);
+      } else {
+        this.onPointerUp(adaptedEvent);
+      }
+    }
+  }
+
+  private touchCancelCallback(event: TouchEvent): void {
+    for (let i = 0; i < event.changedTouches.length; ++i) {
+      const adaptedEvent: AdaptedEvent = this.mapEvent(
+        event,
+        EventTypes.CANCEL,
+        i,
+        TouchEventType.CANCELLED
+      );
+
+      //@ts-ignore touchType field does exist
+      if (event.changedTouches[i].touchType === 'stylus') {
+        continue;
+      }
+
+      this.onPointerCancel(adaptedEvent);
+      this.markAsOutOfBounds(adaptedEvent.pointerId);
+      this.activePointersCounter = 0;
+    }
+  }
+
+  public registerListeners(): void {
+    this.view.addEventListener(
+      'touchstart',
+      this.touchStartCallback.bind(this)
+    );
+    this.view.addEventListener('touchmove', this.touchMoveCallback.bind(this));
+    this.view.addEventListener('touchend', this.touchEndCallback.bind(this));
+    this.view.addEventListener(
+      'touchcancel',
+      this.touchCancelCallback.bind(this)
+    );
+  }
+
+  public unregisterListeners(): void {
+    this.view.removeEventListener('touchstart', this.touchStartCallback);
+    this.view.removeEventListener('touchmove', this.touchMoveCallback);
+    this.view.removeEventListener('touchend', this.touchEndCallback);
+    this.view.removeEventListener('touchcancel', this.touchCancelCallback);
   }
 
   protected mapEvent(

--- a/src/web/tools/TouchEventManager.ts
+++ b/src/web/tools/TouchEventManager.ts
@@ -3,24 +3,12 @@ import EventManager from './EventManager';
 import { isPointerInBounds } from '../utils';
 import { PointerType } from '../../PointerType';
 
-type TouchEventCallback = (event: TouchEvent) => void;
-
 export default class TouchEventManager extends EventManager<HTMLElement> {
-  private boundTouchStartCallback: TouchEventCallback;
-  private boundTouchMoveCallback: TouchEventCallback;
-  private boundTouchEndCallback: TouchEventCallback;
-  private boundTouchCancelCallback: TouchEventCallback;
-
   constructor(view: HTMLElement) {
     super(view);
-
-    this.boundTouchStartCallback = this.touchStartCallback.bind(this);
-    this.boundTouchMoveCallback = this.touchMoveCallback.bind(this);
-    this.boundTouchEndCallback = this.touchEndCallback.bind(this);
-    this.boundTouchCancelCallback = this.touchCancelCallback.bind(this);
   }
 
-  private touchStartCallback(event: TouchEvent): void {
+  private touchStartCallback = (event: TouchEvent): void => {
     for (let i = 0; i < event.changedTouches.length; ++i) {
       const adaptedEvent: AdaptedEvent = this.mapEvent(
         event,
@@ -51,9 +39,9 @@ export default class TouchEventManager extends EventManager<HTMLElement> {
         this.onPointerDown(adaptedEvent);
       }
     }
-  }
+  };
 
-  private touchMoveCallback(event: TouchEvent): void {
+  private touchMoveCallback = (event: TouchEvent): void => {
     for (let i = 0; i < event.changedTouches.length; ++i) {
       const adaptedEvent: AdaptedEvent = this.mapEvent(
         event,
@@ -93,9 +81,9 @@ export default class TouchEventManager extends EventManager<HTMLElement> {
         }
       }
     }
-  }
+  };
 
-  private touchEndCallback(event: TouchEvent): void {
+  private touchEndCallback = (event: TouchEvent): void => {
     for (let i = 0; i < event.changedTouches.length; ++i) {
       // When we call reset on gesture handlers, it also resets their event managers
       // In some handlers (like RotationGestureHandler) reset is called before all pointers leave view
@@ -126,9 +114,9 @@ export default class TouchEventManager extends EventManager<HTMLElement> {
         this.onPointerUp(adaptedEvent);
       }
     }
-  }
+  };
 
-  private touchCancelCallback(event: TouchEvent): void {
+  private touchCancelCallback = (event: TouchEvent): void => {
     for (let i = 0; i < event.changedTouches.length; ++i) {
       const adaptedEvent: AdaptedEvent = this.mapEvent(
         event,
@@ -146,20 +134,20 @@ export default class TouchEventManager extends EventManager<HTMLElement> {
       this.markAsOutOfBounds(adaptedEvent.pointerId);
       this.activePointersCounter = 0;
     }
-  }
+  };
 
   public registerListeners(): void {
-    this.view.addEventListener('touchstart', this.boundTouchStartCallback);
-    this.view.addEventListener('touchmove', this.boundTouchMoveCallback);
-    this.view.addEventListener('touchend', this.boundTouchEndCallback);
-    this.view.addEventListener('touchcancel', this.boundTouchCancelCallback);
+    this.view.addEventListener('touchstart', this.touchStartCallback);
+    this.view.addEventListener('touchmove', this.touchMoveCallback);
+    this.view.addEventListener('touchend', this.touchEndCallback);
+    this.view.addEventListener('touchcancel', this.touchCancelCallback);
   }
 
   public unregisterListeners(): void {
-    this.view.removeEventListener('touchstart', this.boundTouchStartCallback);
-    this.view.removeEventListener('touchmove', this.boundTouchMoveCallback);
-    this.view.removeEventListener('touchend', this.boundTouchEndCallback);
-    this.view.removeEventListener('touchcancel', this.boundTouchCancelCallback);
+    this.view.removeEventListener('touchstart', this.touchStartCallback);
+    this.view.removeEventListener('touchmove', this.touchMoveCallback);
+    this.view.removeEventListener('touchend', this.touchEndCallback);
+    this.view.removeEventListener('touchcancel', this.touchCancelCallback);
   }
 
   protected mapEvent(

--- a/src/web/tools/TouchEventManager.ts
+++ b/src/web/tools/TouchEventManager.ts
@@ -3,7 +3,23 @@ import EventManager from './EventManager';
 import { isPointerInBounds } from '../utils';
 import { PointerType } from '../../PointerType';
 
+type TouchEventCallback = (event: TouchEvent) => void;
+
 export default class TouchEventManager extends EventManager<HTMLElement> {
+  private boundTouchStartCallback: TouchEventCallback;
+  private boundTouchMoveCallback: TouchEventCallback;
+  private boundTouchEndCallback: TouchEventCallback;
+  private boundTouchCancelCallback: TouchEventCallback;
+
+  constructor(view: HTMLElement) {
+    super(view);
+
+    this.boundTouchStartCallback = this.touchStartCallback.bind(this);
+    this.boundTouchMoveCallback = this.touchMoveCallback.bind(this);
+    this.boundTouchEndCallback = this.touchEndCallback.bind(this);
+    this.boundTouchCancelCallback = this.touchCancelCallback.bind(this);
+  }
+
   private touchStartCallback(event: TouchEvent): void {
     for (let i = 0; i < event.changedTouches.length; ++i) {
       const adaptedEvent: AdaptedEvent = this.mapEvent(
@@ -133,23 +149,17 @@ export default class TouchEventManager extends EventManager<HTMLElement> {
   }
 
   public registerListeners(): void {
-    this.view.addEventListener(
-      'touchstart',
-      this.touchStartCallback.bind(this)
-    );
-    this.view.addEventListener('touchmove', this.touchMoveCallback.bind(this));
-    this.view.addEventListener('touchend', this.touchEndCallback.bind(this));
-    this.view.addEventListener(
-      'touchcancel',
-      this.touchCancelCallback.bind(this)
-    );
+    this.view.addEventListener('touchstart', this.boundTouchStartCallback);
+    this.view.addEventListener('touchmove', this.boundTouchMoveCallback);
+    this.view.addEventListener('touchend', this.boundTouchEndCallback);
+    this.view.addEventListener('touchcancel', this.boundTouchCancelCallback);
   }
 
   public unregisterListeners(): void {
-    this.view.removeEventListener('touchstart', this.touchStartCallback);
-    this.view.removeEventListener('touchmove', this.touchMoveCallback);
-    this.view.removeEventListener('touchend', this.touchEndCallback);
-    this.view.removeEventListener('touchcancel', this.touchCancelCallback);
+    this.view.removeEventListener('touchstart', this.boundTouchStartCallback);
+    this.view.removeEventListener('touchmove', this.boundTouchMoveCallback);
+    this.view.removeEventListener('touchend', this.boundTouchEndCallback);
+    this.view.removeEventListener('touchcancel', this.boundTouchCancelCallback);
   }
 
   protected mapEvent(

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -1,9 +1,7 @@
 import { PointerType } from '../PointerType';
+import { Point } from './interfaces';
 
-export function isPointerInBounds(
-  view: HTMLElement,
-  { x, y }: { x: number; y: number }
-): boolean {
+export function isPointerInBounds(view: HTMLElement, { x, y }: Point): boolean {
   const rect: DOMRect = view.getBoundingClientRect();
 
   return x >= rect.left && x <= rect.right && y >= rect.top && y <= rect.bottom;


### PR DESCRIPTION
## Description

Right now when handlers are dropped, event listeners are not removed from view. I think this might cause problems with SSR. With this PR, listeners are properly removed from underlying view.

### Before

https://github.com/software-mansion/react-native-gesture-handler/assets/63123542/e676a513-d505-41db-b302-96538d585c70

### After

https://github.com/software-mansion/react-native-gesture-handler/assets/63123542/5aa8a319-17c4-4ca5-9f44-bbc60b6d0fe3

## Test plan

1. Run the following code:

<details>
<summary>Test code</summary>

```jsx
import React, { useState } from 'react';
import { StyleSheet, View } from 'react-native';
import { Gesture, GestureDetector } from 'react-native-gesture-handler';

export default function EmptyExample() {
  const fling = Gesture.Fling();
  const tap = Gesture.Tap();

  const [g, setG] = useState<any>(fling);

  setTimeout(() => {
    setG(tap);
    console.log('Switching gesture to tap');
  }, 1500);

  return (
    <View style={styles.container}>
      <GestureDetector gesture={g}>
        <View style={[styles.circle, { backgroundColor: 'crimson' }]} />
      </GestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },

  circle: {
    width: 150,
    height: 150,
    borderRadius: 75,
  },
});

```

</details>

2. Select red circle with inspector and navigate to `Event Listeners`
3. Check that only one listener is present after `Gesture` was changed