### PR TITLE
Add `jest.useFakeTimers()` in jestSetup.js

### DIFF
--- a/jestSetup.js
+++ b/jestSetup.js
@@ -5,3 +5,5 @@ jest.mock('./lib/commonjs/RNGestureHandlerModule', () =>
 jest.mock('./lib/module/RNGestureHandlerModule', () =>
   require('./lib/module/mocks')
 );
+
+jest.useFakeTimers();


### PR DESCRIPTION
## Description

✅ Success Case
- When we used "react-native-reanimated" package, jest test success.
- Because "react-native-reanimated" jestUtils included `jest.useFakeTimers()`
  - https://github.com/software-mansion/react-native-reanimated/blob/main/src/reanimated2/jestUtils.ts#L155

❌ Fail Case
- When we unused "react-native-reanimated" package, Jest test will be failed. (exit code 1) 
  - Jest Error message: "You are trying to access a property or method of the Jest environment after it has been torn down" (https://github.com/jestjs/jest/blob/d4d1f2b8004b1eb4bf0cf862698dd1142e13278f/packages/jest-runtime/src/index.ts#L2228)


👉 So, I added `jest.useFakeTimers()` in `jestSetup.js`

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

1. Setup project, without "react-native-reanimated" package.
2. Setup Jest
3. Write this simple test code.

```tsx
import { GestureDetector, Gesture } from 'react-native-gesture-handler';
import { Text } from 'react-native';
import { render, screen } from '@testing-library/react-native';

describe('Test', () => {
  it('Success', () => {
      function TestComponent() {
        const gesture = Gesture.Pan().onEnd(() => {});

        return (
          <GestureDetector gesture={gesture}>
              <Text>DummyText</Text>
          </GestureDetector>
      }

      render(<TestComponent />);
      expect(screen.getByText('DummyText')).toBeOnTheScreen();
  });
})
```

<!--
Describe how did you test this change here.
-->
