### PR TITLE
Web `Orchestrator` refactor.

### DIFF
--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -122,7 +122,7 @@ export default abstract class GestureHandler implements IGestureHandler {
 
     this.onStateChange(newState, oldState);
 
-    if (this.isFinished()) {
+    if (!this.enabled && this.isFinished()) {
       this.currentState = State.UNDETERMINED;
     }
   }

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -133,8 +133,8 @@ export default class GestureHandlerOrchestrator {
       }
     }
 
-    this.awaitingHandlers = this.awaitingHandlers.filter(
-      (otherHandler) => !shouldWait(otherHandler)
+    this.awaitingHandlers = this.awaitingHandlers.filter((otherHandler) =>
+      this.awaitingHandlersTags.has(otherHandler.getTag())
     );
   }
 

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -207,12 +207,11 @@ export default class GestureHandlerOrchestrator {
       }
     }
 
-    this.awaitingHandlers.forEach((otherHandler) => {
+    for (const otherHandler of this.awaitingHandlers) {
       if (this.shouldHandlerBeCancelledBy(otherHandler, handler)) {
-        otherHandler?.cancel();
-        otherHandler?.setAwaiting(true);
+        otherHandler.setAwaiting(true);
       }
-    });
+    }
 
     handler.sendEvent(State.ACTIVE, State.BEGAN);
 
@@ -223,14 +222,13 @@ export default class GestureHandlerOrchestrator {
       }
     }
 
-    if (handler.isAwaiting()) {
-      handler.setAwaiting(false);
-      for (let i = 0; i < this.awaitingHandlers.length; ++i) {
-        if (this.awaitingHandlers[i] === handler) {
-          this.awaitingHandlers.splice(i, 1);
-        }
-      }
+    if (!handler.isAwaiting()) {
+      return;
     }
+
+    handler.setAwaiting(false);
+
+    this.awaitingHandlers.filter((otherHandler) => otherHandler !== handler);
   }
 
   private addAwaitingHandler(handler: IGestureHandler): void {

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -111,11 +111,11 @@ export default class GestureHandlerOrchestrator {
   }
 
   private shouldActivate(handler: IGestureHandler): boolean {
-    const shouldBeCancelled = (otherHandler: IGestureHandler) => {
+    const shouldBeCancelledBy = (otherHandler: IGestureHandler) => {
       return this.shouldHandlerBeCancelledBy(handler, otherHandler);
     };
 
-    return !this.gestureHandlers.some(shouldBeCancelled);
+    return !this.gestureHandlers.some(shouldBeCancelledBy);
   }
 
   private cleanupAwaitingHandlers(handler: IGestureHandler): void {

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -312,38 +312,28 @@ export default class GestureHandlerOrchestrator {
 
     // TODO: Find better way to handle that issue, for example by activation order and handler cancelling
 
-    const handlerPointers: number[] = handler.getTrackedPointersID();
-    const otherPointers: number[] = otherHandler.getTrackedPointersID();
-
-    let overlap = false;
-
-    handlerPointers.forEach((pointer: number) => {
+    const isPointerWithinBothBounds = (pointer: number) => {
       const handlerX: number = handler.getTracker().getLastX(pointer);
       const handlerY: number = handler.getTracker().getLastY(pointer);
 
-      if (
-        handler.getDelegate().isPointerInBounds({ x: handlerX, y: handlerY }) &&
-        otherHandler
-          .getDelegate()
-          .isPointerInBounds({ x: handlerX, y: handlerY })
-      ) {
-        overlap = true;
-      }
-    });
+      const point = {
+        x: handlerX,
+        y: handlerY,
+      };
 
-    otherPointers.forEach((pointer: number) => {
-      const otherX: number = otherHandler.getTracker().getLastX(pointer);
-      const otherY: number = otherHandler.getTracker().getLastY(pointer);
+      return (
+        handler.getDelegate().isPointerInBounds(point) &&
+        otherHandler.getDelegate().isPointerInBounds(point)
+      );
+    };
 
-      if (
-        handler.getDelegate().isPointerInBounds({ x: otherX, y: otherY }) &&
-        otherHandler.getDelegate().isPointerInBounds({ x: otherX, y: otherY })
-      ) {
-        overlap = true;
-      }
-    });
+    const handlerPointers: number[] = handler.getTrackedPointersID();
+    const otherPointers: number[] = otherHandler.getTrackedPointersID();
 
-    return overlap;
+    return (
+      handlerPointers.some(isPointerWithinBothBounds) ||
+      otherPointers.some(isPointerWithinBothBounds)
+    );
   }
 
   private isFinished(state: State): boolean {

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -63,11 +63,14 @@ export default class GestureHandlerOrchestrator {
   private shouldBeCancelledByFinishedHandler(
     handler: IGestureHandler
   ): boolean {
-    return this.gestureHandlers.some(
-      (otherHandler) =>
+    const shouldBeCancelled = (otherHandler: IGestureHandler) => {
+      return (
         this.shouldHandlerWaitForOther(handler, otherHandler) &&
         otherHandler.getState() === State.END
-    );
+      );
+    };
+
+    return this.gestureHandlers.some(shouldBeCancelled);
   }
 
   private tryActivate(handler: IGestureHandler): void {

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -232,16 +232,7 @@ export default class GestureHandlerOrchestrator {
   }
 
   private addAwaitingHandler(handler: IGestureHandler): void {
-    let alreadyExists = false;
-
-    this.awaitingHandlers.forEach((otherHandler) => {
-      if (otherHandler === handler) {
-        alreadyExists = true;
-        return;
-      }
-    });
-
-    if (alreadyExists) {
+    if (this.awaitingHandlers.includes(handler)) {
       return;
     }
 

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -50,19 +50,14 @@ export default class GestureHandlerOrchestrator {
   }
 
   private hasOtherHandlerToWaitFor(handler: IGestureHandler): boolean {
-    let hasToWait = false;
-    this.gestureHandlers.forEach((otherHandler) => {
-      if (
-        otherHandler &&
+    const hasToWaitFor = (otherHandler: IGestureHandler) => {
+      return (
         !this.isFinished(otherHandler.getState()) &&
         this.shouldHandlerWaitForOther(handler, otherHandler)
-      ) {
-        hasToWait = true;
-        return;
-      }
-    });
+      );
+    };
 
-    return hasToWait;
+    return this.gestureHandlers.some(hasToWaitFor);
   }
 
   private shouldBeCancelledByFinishedHandler(

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -220,7 +220,7 @@ export default class GestureHandlerOrchestrator {
 
     for (const otherHandler of this.awaitingHandlers) {
       if (this.shouldHandlerBeCancelledBy(otherHandler, handler)) {
-        otherHandler.setAwaiting(true);
+        otherHandler.setAwaiting(false);
       }
     }
 

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -81,21 +81,27 @@ export default class GestureHandlerOrchestrator {
 
     if (this.hasOtherHandlerToWaitFor(handler)) {
       this.addAwaitingHandler(handler);
-    } else if (
-      handler.getState() !== State.CANCELLED &&
-      handler.getState() !== State.FAILED
-    ) {
-      if (this.shouldActivate(handler)) {
-        this.makeActive(handler);
-      } else {
-        switch (handler.getState()) {
-          case State.ACTIVE:
-            handler.fail();
-            break;
-          case State.BEGAN:
-            handler.cancel();
-        }
-      }
+      return;
+    }
+
+    const handlerState = handler.getState();
+
+    if (handlerState === State.CANCELLED || handlerState === State.FAILED) {
+      return;
+    }
+
+    if (this.shouldActivate(handler)) {
+      this.makeActive(handler);
+      return;
+    }
+
+    if (handlerState === State.ACTIVE) {
+      handler.fail();
+      return;
+    }
+
+    if (handlerState === State.BEGAN) {
+      handler.cancel();
     }
   }
 

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -243,16 +243,7 @@ export default class GestureHandlerOrchestrator {
   }
 
   public recordHandlerIfNotPresent(handler: IGestureHandler): void {
-    let alreadyExists = false;
-
-    this.gestureHandlers.forEach((otherHandler) => {
-      if (otherHandler === handler) {
-        alreadyExists = true;
-        return;
-      }
-    });
-
-    if (alreadyExists) {
+    if (this.gestureHandlers.includes(handler)) {
       return;
     }
 

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -106,13 +106,11 @@ export default class GestureHandlerOrchestrator {
   }
 
   private shouldActivate(handler: IGestureHandler): boolean {
-    for (const otherHandler of this.gestureHandlers) {
-      if (this.shouldHandlerBeCancelledBy(handler, otherHandler)) {
-        return false;
-      }
-    }
+    const shouldBeCancelled = (otherHandler: IGestureHandler) => {
+      return this.shouldHandlerBeCancelledBy(handler, otherHandler);
+    };
 
-    return true;
+    return !this.gestureHandlers.some(shouldBeCancelled);
   }
 
   private cleanupAwaitingHandlers(handler: IGestureHandler): void {

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -284,10 +284,7 @@ export default class GestureHandlerOrchestrator {
       return false;
     }
 
-    if (
-      handler !== otherHandler &&
-      (handler.isAwaiting() || handler.getState() === State.ACTIVE)
-    ) {
+    if (handler.isAwaiting() || handler.getState() === State.ACTIVE) {
       // For now it always returns false
       return handler.shouldBeCancelledByOther(otherHandler);
     }

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -114,15 +114,20 @@ export default class GestureHandlerOrchestrator {
   }
 
   private cleanupAwaitingHandlers(handler: IGestureHandler): void {
-    for (let i = 0; i < this.awaitingHandlers.length; ++i) {
-      if (
-        !this.awaitingHandlers[i].isAwaiting() &&
-        this.shouldHandlerWaitForOther(this.awaitingHandlers[i], handler)
-      ) {
-        this.cleanHandler(this.awaitingHandlers[i]);
-        this.awaitingHandlers.splice(i, 1);
+    const shouldWait = (otherHandler: IGestureHandler) => {
+      return (
+        !otherHandler.isAwaiting() &&
+        this.shouldHandlerWaitForOther(otherHandler, handler)
+      );
+    };
+
+    for (const handler of this.awaitingHandlers) {
+      if (shouldWait(handler)) {
+        this.cleanHandler(handler);
       }
     }
+
+    this.awaitingHandlers.filter((handler) => !shouldWait(handler));
   }
 
   public onHandlerStateChange(

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -36,18 +36,17 @@ export default class GestureHandlerOrchestrator {
   }
 
   private cleanupFinishedHandlers(): void {
+    const isHandlerDone = (handler: IGestureHandler) => {
+      return this.isFinished(handler.getState()) && !handler.isAwaiting();
+    };
+
     for (let i = this.gestureHandlers.length - 1; i >= 0; --i) {
-      const handler = this.gestureHandlers[i];
-
-      if (!handler) {
-        continue;
-      }
-      if (this.isFinished(handler.getState()) && !handler.isAwaiting()) {
-        this.gestureHandlers.splice(i, 1);
-
-        this.cleanHandler(handler);
+      if (isHandlerDone(this.gestureHandlers[i])) {
+        this.cleanHandler(this.gestureHandlers[i]);
       }
     }
+
+    this.gestureHandlers.filter((handler) => !isHandlerDone(handler));
   }
 
   private hasOtherHandlerToWaitFor(handler: IGestureHandler): boolean {


### PR DESCRIPTION
## Description

While working on #2759 I've decided that it will be good idea to also introduce some changes into web version of `orchestrator`. 

While this PR is mostly a refactor, it also brings other changes, for example it adds `awaitingHandlersTags` `set` which is used on android (current implementation was unsafe).

Unfortunately change made in `GestureHandler.ts` reverts #2802, but it is necessary for orchestration process to work. We will find better way to solve this problem in follow-up PR.

## Test plan

<details>
<summary> Tested on the following code: </summary>

```jsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import { Gesture, GestureDetector } from 'react-native-gesture-handler';
import Animated from 'react-native-reanimated';

const log = (e: any, handler: string) =>
  console.log(`[${e.handlerTag}][${handler}]: ${e.state}`);

const orangeTapGesture = Gesture.Tap()
  .runOnJS(true)
  .maxDeltaX(5)
  .onBegin((e) => log(e, 'Orange tap'))
  .onStart((e) => log(e, 'Orange tap'))
  .onFinalize((e, success) => {
    log(e, 'Orange tap');
    if (success) {
      console.log('---> Orange Tap <---');
    }
  });

const orangeDoubleTapGesture = Gesture.Tap()
  .numberOfTaps(2)
  .runOnJS(true)
  .onBegin((e) => log(e, 'Orange Double Tap'))
  .onStart((e) => log(e, 'Orange Double Tap'))
  .onFinalize((e, success) => {
    log(e, 'Orange Double Tap');
    if (success) {
      console.log('---> Orange Double Tap <---');
    }
  });

const blueTapGesture = Gesture.Tap()
  .runOnJS(true)
  .requireExternalGestureToFail(orangeTapGesture, orangeDoubleTapGesture)
  .onBegin((e) => log(e, 'Blue Tap'))
  .onStart((e) => log(e, 'Blue Tap'))
  .onFinalize((e, success) => {
    log(e, 'Blue Tap');
    if (success) {
      console.log('---> Blue Tap <---');
    }
  });

const blueDoubleTapGesture = Gesture.Tap()
  .numberOfTaps(2)
  .runOnJS(true)
  .onBegin((e) => log(e, 'Blue Double Tap'))
  .onStart((e) => log(e, 'Blue Double Tap'))
  .onFinalize((e, success) => {
    log(e, 'Blue Double Tap');
    if (success) {
      console.log('---> Blue Double Tap <---');
    }
  });

const redLongPressGesture = Gesture.LongPress()
  .runOnJS(true)
  .onBegin((e) => log(e, 'Red Longpress'))
  .onStart((e) => log(e, 'Red Longpress'))
  .onFinalize((e, success) => {
    log(e, 'Red Longpress');
    if (success) {
      console.log('---> Red Longpress <---');
    }
  });

const redDoubleTapGesture = Gesture.Tap()
  .numberOfTaps(2)
  .runOnJS(true)
  .onBegin((e) => log(e, 'Red Double Tap'))
  .onStart((e) => log(e, 'Red Double Tap'))
  .onFinalize((e, success) => {
    log(e, 'Red Double Tap');
    if (success) {
      console.log('---> Red Double Tap <---');
    }
  });

const Showcase = () => {
  const gesture = Gesture.Race(redDoubleTapGesture, redLongPressGesture);

  return (
    <View style={[styles.center, { flex: 1, backgroundColor: 'white' }]}>
      <GestureDetector gesture={gesture}>
        <Animated.View style={[styles.outer, styles.center]}>
          <Blue />
        </Animated.View>
      </GestureDetector>
    </View>
  );
};

export default Showcase;

const Blue = () => {
  const composedGesture = Gesture.Exclusive(
    blueDoubleTapGesture,
    blueTapGesture
  );

  return (
    <GestureDetector gesture={composedGesture}>
      <Animated.View style={[styles.blue, styles.center]}>
        <Orange />
      </Animated.View>
    </GestureDetector>
  );
};

const Orange = () => {
  const composedGesture = Gesture.Exclusive(
    orangeDoubleTapGesture,
    orangeTapGesture
  );

  return (
    <GestureDetector gesture={composedGesture}>
      <Animated.View style={styles.orange} />
    </GestureDetector>
  );
};

const styles = StyleSheet.create({
  center: {
    display: 'flex',
    justifyContent: 'space-around',
    alignItems: 'center',
  },

  outer: {
    backgroundColor: 'red',
    width: 400,
    height: 400,
    borderRadius: 200,
  },
  blue: {
    width: 250,
    height: 250,
    backgroundColor: 'blue',

    borderRadius: 175,
  },
  orange: {
    width: 100,
    height: 100,
    backgroundColor: 'orange',
    borderRadius: 50,
  },
});

```

</details>