### PR TITLE
Use correct origin point for calculating the absolute position on Android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -4,14 +4,13 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.graphics.PointF
-import android.graphics.Rect
 import android.os.Build
 import android.view.MotionEvent
 import android.view.MotionEvent.PointerCoords
 import android.view.MotionEvent.PointerProperties
 import android.view.View
-import android.view.Window
 import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.UiThreadUtil
 import com.facebook.react.bridge.WritableArray
 import com.facebook.react.uimanager.PixelUtil
@@ -176,12 +175,9 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     this.view = view
     this.orchestrator = orchestrator
 
-    val decorView = getWindow(view?.context)?.decorView
-    if (decorView != null) {
-      val frame = Rect()
-      decorView.getWindowVisibleDisplayFrame(frame)
-      windowOffset[0] = frame.left
-      windowOffset[1] = frame.top
+    val content = getActivity(view?.context)?.findViewById<View>(android.R.id.content)
+    if (content != null) {
+      content.getLocationOnScreen(windowOffset)
     } else {
       windowOffset[0] = 0
       windowOffset[1] = 0
@@ -192,10 +188,11 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
 
   protected open fun onPrepare() {}
 
-  private fun getWindow(context: Context?): Window? {
+  private fun getActivity(context: Context?): Activity? {
     if (context == null) return null
-    if (context is Activity) return context.window
-    if (context is ContextWrapper) return getWindow(context.baseContext)
+    if (context is ReactContext) return context.currentActivity
+    if (context is Activity) return context
+    if (context is ContextWrapper) return getActivity(context.baseContext)
 
     return null
   }


### PR DESCRIPTION
## Description

In https://github.com/software-mansion/react-native-gesture-handler/pull/1812 I changed how absolute position is calculated to be relative to the window instead of the screen, but there were two things wrong with it:
- It used [getWindowVisibleDisplayFrame](https://developer.android.com/reference/android/view/View#getWindowVisibleDisplayFrame(android.graphics.Rect)) which `tells you the available area where content can be placed and remain visible to users`. This was always taking status bar height into account, even if the app could be drawn behind it.
- It was calling this method on the `decorView`, which is drawn under system bars anyway

This PR changes it to use `contentView` of the current activity and [getLocationOnScreen](https://developer.android.com/reference/android/view/View#getLocationOnScreen(int[])) which `gets the coordinates of this view in the coordinate space of the device screen, irrespective of system decorations and whether the system is in multi-window mode`.

In a nutshell, after this PR the absolute position will take into account whether the app is displayed behind the status bar.

## Test plan

Tested on the example app:

https://github.com/software-mansion/react-native-gesture-handler/assets/21055725/c3230a2d-7bba-483b-b160-1c9fb32b0da1

https://github.com/software-mansion/react-native-gesture-handler/assets/21055725/701d9fa0-0c9f-4126-af58-f80c6a0a6526
