### PR TITLE
Add check when removing handlers from orchestrator

### DIFF
--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -32,9 +32,14 @@ export default class GestureHandlerOrchestrator {
   }
 
   public removeHandlerFromOrchestrator(handler: IGestureHandler): void {
-    this.gestureHandlers.splice(this.gestureHandlers.indexOf(handler), 1);
-    this.awaitingHandlers.splice(this.awaitingHandlers.indexOf(handler), 1);
-    this.awaitingHandlersTags.delete(handler.getTag());
+    if (this.gestureHandlers.includes(handler)) {
+      this.gestureHandlers.splice(this.gestureHandlers.indexOf(handler), 1);
+    }
+
+    if (this.awaitingHandlers.includes(handler)) {
+      this.awaitingHandlers.splice(this.awaitingHandlers.indexOf(handler), 1);
+      this.awaitingHandlersTags.delete(handler.getTag());
+    }
   }
 
   private cleanupFinishedHandlers(): void {


### PR DESCRIPTION
## Description

#2819 removed changes made in #2802. After further investigation we found out that `removeHandlerFromOrchestrator` didn't check if handlers were present in orchestrator, therefore in some situation calling this function ended up in removing wrong handler. Calling `indexOf` returned `-1` and, as you can read in [docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/splice):

> Negative index counts back from the end of the array

So instead of ignoring that, we simply removed wrong handler.

## Test plan

Tested on example app (mostly on swipeable example) and example code from #2819