### PR TITLE
Use `locationOfTouch:inView` over `locationInView` for focal point

### DIFF
--- a/apple/Handlers/RNPinchHandler.m
+++ b/apple/Handlers/RNPinchHandler.m
@@ -164,12 +164,16 @@
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIPinchGestureRecognizer *)recognizer
 {
   CGPoint accumulatedPoint = CGPointZero;
+
   for (int i = 0; i < recognizer.numberOfTouches; i++) {
     CGPoint location = [recognizer locationOfTouch:i inView:recognizer.view];
     accumulatedPoint.x += location.x;
     accumulatedPoint.y += location.y;
   }
-  CGPoint focalPoint = CGPointMake(accumulatedPoint.x / recognizer.numberOfTouches, accumulatedPoint.y / recognizer.numberOfTouches);
+
+  CGPoint focalPoint =
+      CGPointMake(accumulatedPoint.x / recognizer.numberOfTouches, accumulatedPoint.y / recognizer.numberOfTouches);
+
   return [RNGestureHandlerEventExtraData forPinch:recognizer.scale
                                    withFocalPoint:focalPoint
                                      withVelocity:recognizer.velocity

--- a/apple/Handlers/RNPinchHandler.m
+++ b/apple/Handlers/RNPinchHandler.m
@@ -163,8 +163,15 @@
 #else
 - (RNGestureHandlerEventExtraData *)eventExtraData:(UIPinchGestureRecognizer *)recognizer
 {
+  CGPoint accumulatedPoint = CGPointZero;
+  for (int i = 0; i < recognizer.numberOfTouches; i++) {
+    CGPoint location = [recognizer locationOfTouch:i inView:recognizer.view];
+    accumulatedPoint.x += location.x;
+    accumulatedPoint.y += location.y;
+  }
+  CGPoint focalPoint = CGPointMake(accumulatedPoint.x / recognizer.numberOfTouches, accumulatedPoint.y / recognizer.numberOfTouches);
   return [RNGestureHandlerEventExtraData forPinch:recognizer.scale
-                                   withFocalPoint:[recognizer locationInView:recognizer.view]
+                                   withFocalPoint:focalPoint
                                      withVelocity:recognizer.velocity
                               withNumberOfTouches:recognizer.numberOfTouches
                                   withPointerType:_pointerType];


### PR DESCRIPTION
## Description
Replace `locationInView` with `locationOfTouch:inView:` in Pinch handler to fix truncated focalX and focalY in gesture handler context.

While reading the [docs](https://developer.apple.com/documentation/uikit/uigesturerecognizer?language=objc) I found the following section that suggest there's an alternative.

> Clients of gesture recognizers can also ask for the location of a gesture by calling [locationInView:](https://developer.apple.com/documentation/uikit/uigesturerecognizer/1624219-locationinview?language=objc) or [locationOfTouch:inView:](https://developer.apple.com/documentation/uikit/uigesturerecognizer/1624201-locationoftouch?language=objc).

By calculating the midpoint using `[locationOfTouch:inView:]` we get the same number, but with accuracy of many decimal places

Fixes #2833

## Test plan

Tested on repro example in (#2833).