### PR TITLE
Disable flipper on CI

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -21,6 +21,8 @@ jobs:
     concurrency:
       group: ios-${{ matrix.working-directory }}-${{ github.ref }}
       cancel-in-progress: true
+    env:
+      NO_FLIPPER: 1
     steps:
       - name: checkout
         uses: actions/checkout@v2

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -21,8 +21,6 @@ jobs:
     concurrency:
       group: ios-${{ matrix.working-directory }}-${{ github.ref }}
       cancel-in-progress: true
-    env:
-      NO_FLIPPER: 1
     steps:
       - name: checkout
         uses: actions/checkout@v2
@@ -40,7 +38,7 @@ jobs:
         run: yarn
       - name: Install pods
         working-directory: ${{ matrix.working-directory }}/ios
-        run: bundle install && bundle exec pod install
+        run: bundle install && NO_FLIPPER=1 bundle exec pod install
       - name: Build app
         working-directory: ${{ matrix.working-directory }}
         run: yarn ios --simulator=\"iPhone 14\" --mode Debug --verbose --terminal /bin/zsh


### PR DESCRIPTION
## Description

Currently our iOS build fails on Flipper build. This PR adds `NO_FLIPPER` flag since it is no longer required.

## Test plan

Check that CI passes.
