### PR TITLE
Bump `typescript` version in example

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -55,7 +55,7 @@
     "metro-react-native-babel-preset": "0.76.5",
     "prettier": "^2.2.1",
     "react-test-renderer": "18.2.0",
-    "typescript": "^4.5.5",
+    "typescript": "5.0.4",
     "webpack-dev-server": "3.11.3"
   },
   "resolutions": {

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -16304,10 +16304,10 @@ typedarray@^0.0.6:
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
-typescript@^4.5.5:
-  version "4.5.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.5.tgz#d8c953832d28924a9e3d37c73d729c846c5896f3"
-  integrity sha512-TCTIul70LyWe6IJWT8QSYeA54WQe8EjQFU4wY52Fasj5UKx88LNYKCgBEHcOMOrFF1rKGbD8v/xcNWVUq9SymA==
+typescript@5.0.4:
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.0.4.tgz#b217fd20119bd61a94d4011274e0ab369058da3b"
+  integrity sha512-cW9T5W9xY37cc+jfEnaUvX91foxtHkza3Nw3wkoF4sSlKn0MONdkdEndig/qPBWXNkmplh3NzayQzCiHM4/hqw==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"


### PR DESCRIPTION
## Description

Our latest fails on CI were caused by outdated `typescript` in example app.  #2835 added `moduleSuffixes` into `compilerOptions` in `tsconfig.json`, but this option was added in version 4.7 of `typescript` and our example app currently has version 4.5.5.

This PR updates `typescript` version in our example app to much version in the root.

## Test plan

Check that CI passes.