### PR TITLE
Minor TS changes

### DIFF
--- a/src/handlers/PanGestureHandler.ts
+++ b/src/handlers/PanGestureHandler.ts
@@ -150,7 +150,9 @@ export interface PanGestureHandlerProps
    * to 0. If only one number `p` is given a range of `(-inf, p)` will be used
    * if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
    */
-  activeOffsetY?: number | number[];
+  activeOffsetY?:
+    | number
+    | [activeOffsetYStart: number, activeOffsetYEnd: number];
 
   /**
    * Range along X axis (in points) where fingers travels without activation of
@@ -160,7 +162,9 @@ export interface PanGestureHandlerProps
    * to 0. If only one number `p` is given a range of `(-inf, p)` will be used
    * if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
    */
-  activeOffsetX?: number | number[];
+  activeOffsetX?:
+    | number
+    | [activeOffsetXStart: number, activeOffsetXEnd: number];
 
   /**
    * When the finger moves outside this range (in points) along Y axis and
@@ -170,7 +174,7 @@ export interface PanGestureHandlerProps
    * to 0. If only one number `p` is given a range of `(-inf, p)` will be used
    * if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
    */
-  failOffsetY?: number | number[];
+  failOffsetY?: number | [failOffsetYStart: number, failOffsetYEnd: number];
 
   /**
    * When the finger moves outside this range (in points) along X axis and
@@ -180,7 +184,7 @@ export interface PanGestureHandlerProps
    * to 0. If only one number `p` is given a range of `(-inf, p)` will be used
    * if `p` is higher or equal to 0 and `(-p, inf)` otherwise.
    */
-  failOffsetX?: number | number[];
+  failOffsetX?: number | [failOffsetXStart: number, failOffsetXEnd: number];
 }
 
 export const panHandlerName = 'PanGestureHandler';

--- a/src/handlers/gestures/panGesture.ts
+++ b/src/handlers/gestures/panGesture.ts
@@ -43,7 +43,9 @@ export class PanGesture extends ContinousBaseGesture<
     this.handlerName = 'PanGestureHandler';
   }
 
-  activeOffsetY(offset: number | number[]) {
+  activeOffsetY(
+    offset: number | [activeOffsetYStart: number, activeOffsetYEnd: number]
+  ) {
     if (Array.isArray(offset)) {
       this.config.activeOffsetYStart = offset[0];
       this.config.activeOffsetYEnd = offset[1];
@@ -55,7 +57,9 @@ export class PanGesture extends ContinousBaseGesture<
     return this;
   }
 
-  activeOffsetX(offset: number | number[]) {
+  activeOffsetX(
+    offset: number | [activeOffsetXStart: number, activeOffsetXEnd: number]
+  ) {
     if (Array.isArray(offset)) {
       this.config.activeOffsetXStart = offset[0];
       this.config.activeOffsetXEnd = offset[1];
@@ -67,7 +71,9 @@ export class PanGesture extends ContinousBaseGesture<
     return this;
   }
 
-  failOffsetY(offset: number | number[]) {
+  failOffsetY(
+    offset: number | [failOffsetYStart: number, failOffsetYEnd: number]
+  ) {
     if (Array.isArray(offset)) {
       this.config.failOffsetYStart = offset[0];
       this.config.failOffsetYEnd = offset[1];
@@ -79,7 +85,9 @@ export class PanGesture extends ContinousBaseGesture<
     return this;
   }
 
-  failOffsetX(offset: number | number[]) {
+  failOffsetX(
+    offset: number | [failOffsetXStart: number, failOffsetXEnd: number]
+  ) {
     if (Array.isArray(offset)) {
       this.config.failOffsetXStart = offset[0];
       this.config.failOffsetXEnd = offset[1];

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,6 +18,9 @@ export function withPrevAndCurrent<T, Transformed>(
   const currentArr = [...array];
   const transformedArr: Transformed[] = [];
   currentArr.forEach((current, i) => {
+    // This type cast is fine and solves problem mentioned in https://github.com/software-mansion/react-native-gesture-handler/pull/2867 (namely that `previous` can be undefined).
+    // Unfortunately, linter on our CI does not allow this type of casting as it is unnecessary. To bypass that we use eslint-disable.
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     const previous = previousArr[i] as Transformed | null;
     const transformed = mapFn(previous, current);
     previousArr.push(transformed);

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -18,7 +18,7 @@ export function withPrevAndCurrent<T, Transformed>(
   const currentArr = [...array];
   const transformedArr: Transformed[] = [];
   currentArr.forEach((current, i) => {
-    const previous = previousArr[i];
+    const previous = previousArr[i] as Transformed | null;
     const transformed = mapFn(previous, current);
     previousArr.push(transformed);
     transformedArr.push(transformed);


### PR DESCRIPTION
## Description

This PR is a successor of #2867 - it solves problems that were present in mentioned PR, namely:

1. changes type of offset properties of `Pan` into `number | [number, number]`, so that it is impossible to assign to them something else than number or array with 2 numbers
2. adds type cast in `withPrevAndCurrent` function (used in `jest`)

## Test plan

Try to assign something else than number or array of two numbers to any of changed properties - error should appear.
