### PR TITLE
Add `TypeDoc` to new API

### DIFF
--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -630,10 +630,32 @@ const applyTouchActionProp = (
 };
 
 interface GestureDetectorProps {
+  /**
+   * A gesture object containing the configuration and callbacks.
+   * Can be any of:
+   * - base gestures (`Tap`, `Pan`, ...)
+   * - `ComposedGesture` (`Race`, `Simultaneous`, `Exclusive`)
+   */
   gesture: ComposedGesture | GestureType;
   children?: React.ReactNode;
+
+  /**
+   * #### Web only
+   * This parameter allows to specify which `userSelect` property should be applied to underlying view.
+   * Possible values are `"none" | "auto" | "text"`. Default value is set to `"none"`.
+   */
   userSelect?: UserSelect;
+  /**
+   * #### Web only
+   * Specifies whether context menu should be enabled after clicking on underlying view with right mouse button.
+   * Default value is set to `false`.
+   */
   enableContextMenu?: boolean;
+  /**
+   * #### Web only
+   * This parameter allows to specify which `touchAction` property should be applied to underlying view.
+   * Supports all CSS touch-action values (e.g. `"none"`, `"pan-y"`). Default value is set to `"none"`.
+   */
   touchAction?: TouchAction;
 }
 interface GestureDetectorState {
@@ -642,6 +664,20 @@ interface GestureDetectorState {
   previousViewTag: number;
   forceReattach: boolean;
 }
+
+/**
+ * `GestureDetector` is responsible for creating and updating native gesture handlers based on the config of provided gesture.
+ *
+ * ### Props
+ * - `gesture`
+ * - `userSelect` (**Web only**)
+ * - `enableContextMenu` (**Web only**)
+ * - `touchAction` (**Web only**)
+ *
+ * ### Remarks
+ * - Gesture Detector will use first native view in its subtree to recognize gestures, however if this view is used only to group its children it may get automatically collapsed.
+ * - Using the same instance of a gesture across multiple Gesture Detectors is not possible.
+ */
 export const GestureDetector = (props: GestureDetectorProps) => {
   const rootViewContext = useContext(GestureHandlerRootViewContext);
   if (__DEV__ && !rootViewContext && !isJestEnv() && Platform.OS !== 'web') {

--- a/src/handlers/gestures/GestureDetector.tsx
+++ b/src/handlers/gestures/GestureDetector.tsx
@@ -677,6 +677,8 @@ interface GestureDetectorState {
  * ### Remarks
  * - Gesture Detector will use first native view in its subtree to recognize gestures, however if this view is used only to group its children it may get automatically collapsed.
  * - Using the same instance of a gesture across multiple Gesture Detectors is not possible.
+ *
+ * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/gesture-detector
  */
 export const GestureDetector = (props: GestureDetectorProps) => {
   const rootViewContext = useContext(GestureHandlerRootViewContext);

--- a/src/handlers/gestures/flingGesture.ts
+++ b/src/handlers/gestures/flingGesture.ts
@@ -13,11 +13,21 @@ export class FlingGesture extends BaseGesture<FlingGestureHandlerEventPayload> {
     this.handlerName = 'FlingGestureHandler';
   }
 
+  /**
+   * Determine exact number of points required to handle the fling gesture.
+   * @param pointers
+   */
   numberOfPointers(pointers: number) {
     this.config.numberOfPointers = pointers;
     return this;
   }
 
+  /**
+   * Expressed allowed direction of movement.
+   * Expected values are exported as constants in the Directions object.
+   * @param direction
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/fling-gesture/#directionvalue-directions
+   */
   direction(direction: number) {
     this.config.direction = direction;
     return this;

--- a/src/handlers/gestures/flingGesture.ts
+++ b/src/handlers/gestures/flingGesture.ts
@@ -25,6 +25,7 @@ export class FlingGesture extends BaseGesture<FlingGestureHandlerEventPayload> {
   /**
    * Expressed allowed direction of movement.
    * Expected values are exported as constants in the Directions object.
+   * Arguments can be combined using `|` operator. Default value is set to `MouseButton.LEFT`.
    * @param direction
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/fling-gesture/#directionvalue-directions
    */

--- a/src/handlers/gestures/forceTouchGesture.ts
+++ b/src/handlers/gestures/forceTouchGesture.ts
@@ -40,16 +40,30 @@ export class ForceTouchGesture extends ContinousBaseGesture<
     this.handlerName = 'ForceTouchGestureHandler';
   }
 
+  /**
+   * A minimal pressure that is required before gesture can activate.
+   * Should be a value from range [0.0, 1.0]. Default is 0.2.
+   * @param force
+   */
   minForce(force: number) {
     this.config.minForce = force;
     return this;
   }
 
+  /**
+   * A maximal pressure that could be applied for gesture.
+   * If the pressure is greater, gesture fails. Should be a value from range [0.0, 1.0].
+   * @param force
+   */
   maxForce(force: number) {
     this.config.maxForce = force;
     return this;
   }
 
+  /**
+   * Value defining if haptic feedback has to be performed on activation.
+   * @param value
+   */
   feedbackOnActivation(value: boolean) {
     this.config.feedbackOnActivation = value;
     return this;

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -155,6 +155,10 @@ export abstract class BaseGesture<
       : [gesture];
   }
 
+  /**
+   * Sets a `ref` to the gesture object, allowing for interoperability with the old API.
+   * @param ref
+   */
   withRef(ref: React.MutableRefObject<GestureType | undefined>) {
     this.config.ref = ref;
     return this;
@@ -166,18 +170,32 @@ export abstract class BaseGesture<
     return callback.__workletHash !== undefined;
   }
 
+  /**
+   * Set the callback that is being called when given gesture handler starts receiving touches.
+   * At the moment of this callback the handler is in `BEGAN` state and we don't know yet if it will recognize the gesture at all.
+   * @param callback
+   */
   onBegin(callback: (event: GestureStateChangeEvent<EventPayloadT>) => void) {
     this.handlers.onBegin = callback;
     this.handlers.isWorklet[CALLBACK_TYPE.BEGAN] = this.isWorklet(callback);
     return this;
   }
 
+  /**
+   * Set the callback that is being called when the gesture is recognized by the handler and it transitions to the `ACTIVE` state.
+   * @param callback
+   */
   onStart(callback: (event: GestureStateChangeEvent<EventPayloadT>) => void) {
     this.handlers.onStart = callback;
     this.handlers.isWorklet[CALLBACK_TYPE.START] = this.isWorklet(callback);
     return this;
   }
 
+  /**
+   * Set the callback that is being called when the gesture that was recognized by the handler finishes and handler reaches `END` state.
+   * It will be called only if the handler was previously in the `ACTIVE` state.
+   * @param callback
+   */
   onEnd(
     callback: (
       event: GestureStateChangeEvent<EventPayloadT>,
@@ -190,6 +208,10 @@ export abstract class BaseGesture<
     return this;
   }
 
+  /**
+   * Set the callback that is being called when the handler finalizes handling gesture - the gesture was recognized and has finished or it failed to recognize.
+   * @param callback
+   */
   onFinalize(
     callback: (
       event: GestureStateChangeEvent<EventPayloadT>,
@@ -202,6 +224,10 @@ export abstract class BaseGesture<
     return this;
   }
 
+  /**
+   * Set the `onTouchesDown` callback which is called every time a finger is placed on the screen.
+   * @param callback
+   */
   onTouchesDown(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
     this.handlers.onTouchesDown = callback;
@@ -211,6 +237,10 @@ export abstract class BaseGesture<
     return this;
   }
 
+  /**
+   * Set the `onTouchesMove` callback which is called every time a finger is moved on the screen.
+   * @param callback
+   */
   onTouchesMove(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
     this.handlers.onTouchesMove = callback;
@@ -220,6 +250,10 @@ export abstract class BaseGesture<
     return this;
   }
 
+  /**
+   * Set the `onTouchesUp` callback which is called every time a finger is lifted from the screen.
+   * @param callback
+   */
   onTouchesUp(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
     this.handlers.onTouchesUp = callback;
@@ -229,6 +263,10 @@ export abstract class BaseGesture<
     return this;
   }
 
+  /**
+   * Set the `onTouchesCancelled` callback which is called every time a finger stops being tracked, for example when the gesture finishes.
+   * @param callback
+   */
   onTouchesCancelled(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
     this.handlers.onTouchesCancelled = callback;
@@ -238,36 +276,77 @@ export abstract class BaseGesture<
     return this;
   }
 
+  /**
+   * Indicates whether the given handler should be analyzing stream of touch events or not.
+   * @param enabled
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture#enabledvalue-boolean
+   */
   enabled(enabled: boolean) {
     this.config.enabled = enabled;
     return this;
   }
 
+  /**
+   * When true the handler will cancel or fail recognition (depending on its current state) whenever the finger leaves the area of the connected view.
+   * @param value
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture#shouldcancelwhenoutsidevalue-boolean
+   */
   shouldCancelWhenOutside(value: boolean) {
     this.config.shouldCancelWhenOutside = value;
     return this;
   }
 
+  /**
+   * This parameter enables control over what part of the connected view area can be used to begin recognizing the gesture.
+   * When a negative number is provided the bounds of the view will reduce the area by the given number of points in each of the sides evenly.
+   * @param hitSlop
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture#hitslopsettings
+   */
   hitSlop(hitSlop: HitSlop) {
     this.config.hitSlop = hitSlop;
     return this;
   }
 
+  /**
+   * #### Web only
+   * This parameter allows to specify which `cursor` should be used when gesture activates.
+   * Supports all CSS cursor values (e.g. `"grab"`, `"zoom-in"`). Default value is set to `"auto"`.
+   * @param activeCursor
+   */
   activeCursor(activeCursor: ActiveCursor) {
     this.config.activeCursor = activeCursor;
     return this;
   }
 
+  /**
+   * #### Web & Android only
+   * Allows users to choose which mouse button should handler respond to.
+   * Arguments can be combined using `|` operator, e.g. `mouseButton(MouseButton.LEFT | MouseButton.RIGHT)`.
+   * Default value is set to `MouseButton.LEFT`.
+   * @param mouseButton
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture#mousebuttonvalue-mousebutton-web--android-only
+   */
   mouseButton(mouseButton: MouseButton) {
     this.config.mouseButton = mouseButton;
     return this;
   }
 
+  /**
+   * When `react-native-reanimated` is installed, the callbacks passed to the gestures are automatically workletized and run on the UI thread when called.
+   * This option allows for changing this behavior: when `true`, all the callbacks will be run on the JS thread instead of the UI thread, regardless of whether they are worklets or not.
+   * Defaults to `false`.
+   * @param runOnJS
+   */
   runOnJS(runOnJS: boolean) {
     this.config.runOnJS = runOnJS;
     return this;
   }
 
+  /**
+   * Allows gestures across different components to be recognized simultaneously.
+   * @param gestures
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition/#simultaneouswithexternalgesture
+   */
   simultaneousWithExternalGesture(...gestures: Exclude<GestureRef, number>[]) {
     for (const gesture of gestures) {
       this.addDependency('simultaneousWith', gesture);
@@ -275,6 +354,11 @@ export abstract class BaseGesture<
     return this;
   }
 
+  /**
+   * Allows to delay activation of the handler until all handlers passed as arguments to this method fail (or don't begin at all).
+   * @param gestures
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition/#requireexternalgesturetofail
+   */
   requireExternalGestureToFail(...gestures: Exclude<GestureRef, number>[]) {
     for (const gesture of gestures) {
       this.addDependency('requireToFail', gesture);
@@ -282,6 +366,11 @@ export abstract class BaseGesture<
     return this;
   }
 
+  /**
+   * Works similarily to `requireExternalGestureToFail` but the direction of the relation is reversed - instead of being one-to-many relation, it's many-to-one.
+   * @param gestures
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition/#blocksexternalgesture
+   */
   blocksExternalGesture(...gestures: Exclude<GestureRef, number>[]) {
     for (const gesture of gestures) {
       this.addDependency('blocksHandlers', gesture);
@@ -289,11 +378,21 @@ export abstract class BaseGesture<
     return this;
   }
 
+  /**
+   * Sets a `testID` property for gesture object, allowing for querying for it in tests.
+   * @param id
+   */
   withTestId(id: string) {
     this.config.testId = id;
     return this;
   }
 
+  /**
+   * #### iOS only
+   * When `true`, the handler will cancel touches for native UI components (`UIButton`, `UISwitch`, etc) it's attached to when it becomes `ACTIVE`.
+   * Default value is `true`.
+   * @param value
+   */
   cancelsTouchesInView(value: boolean) {
     this.config.cancelsTouchesInView = value;
     return this;
@@ -332,12 +431,21 @@ export abstract class ContinousBaseGesture<
   EventPayloadT extends Record<string, unknown>,
   EventChangePayloadT extends Record<string, unknown>
 > extends BaseGesture<EventPayloadT> {
+  /**
+   * Set the callback that is being called every time the gesture receives an update while it's active.
+   * @param callback
+   */
   onUpdate(callback: (event: GestureUpdateEvent<EventPayloadT>) => void) {
     this.handlers.onUpdate = callback;
     this.handlers.isWorklet[CALLBACK_TYPE.UPDATE] = this.isWorklet(callback);
     return this;
   }
 
+  /**
+   * Set the callback that is being called every time the gesture receives an update while it's active.
+   * This callback will receive information about change in value in relation to the last received event.
+   * @param callback
+   */
   onChange(
     callback: (
       event: GestureUpdateEvent<EventPayloadT & EventChangePayloadT>
@@ -348,6 +456,11 @@ export abstract class ContinousBaseGesture<
     return this;
   }
 
+  /**
+   * When `true` the handler will not activate by itself even if its activation criteria are met.
+   * Instead you can manipulate its state using state manager.
+   * @param manualActivation
+   */
   manualActivation(manualActivation: boolean) {
     this.config.manualActivation = manualActivation;
     return this;

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -225,7 +225,7 @@ export abstract class BaseGesture<
   }
 
   /**
-   * Set the `onTouchesDown` callback which is called every time a finger is placed on the screen.
+   * Set the `onTouchesDown` callback which is called every time a pointer is placed on the screen.
    * @param callback
    */
   onTouchesDown(callback: TouchEventHandlerType) {
@@ -238,7 +238,7 @@ export abstract class BaseGesture<
   }
 
   /**
-   * Set the `onTouchesMove` callback which is called every time a finger is moved on the screen.
+   * Set the `onTouchesMove` callback which is called every time a pointer is moved on the screen.
    * @param callback
    */
   onTouchesMove(callback: TouchEventHandlerType) {
@@ -251,7 +251,7 @@ export abstract class BaseGesture<
   }
 
   /**
-   * Set the `onTouchesUp` callback which is called every time a finger is lifted from the screen.
+   * Set the `onTouchesUp` callback which is called every time a pointer is lifted from the screen.
    * @param callback
    */
   onTouchesUp(callback: TouchEventHandlerType) {
@@ -264,7 +264,7 @@ export abstract class BaseGesture<
   }
 
   /**
-   * Set the `onTouchesCancelled` callback which is called every time a finger stops being tracked, for example when the gesture finishes.
+   * Set the `onTouchesCancelled` callback which is called every time a pointer stops being tracked, for example when the gesture finishes.
    * @param callback
    */
   onTouchesCancelled(callback: TouchEventHandlerType) {

--- a/src/handlers/gestures/gestureObjects.ts
+++ b/src/handlers/gestures/gestureObjects.ts
@@ -15,43 +15,97 @@ import { NativeGesture } from './nativeGesture';
 import { ManualGesture } from './manualGesture';
 import { HoverGesture } from './hoverGesture';
 
+/**
+ * `Gesture` is the object that allows you to create and compose gestures.
+ *
+ * ### Remarks
+ * - Consider wrapping your gesture configurations with `useMemo`, as it will reduce the amount of work Gesture Handler has to do under the hood when updating gestures.
+ *
+ * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/gesture
+ */
 export const GestureObjects = {
+  /**
+   * A discrete gesture that recognizes one or many taps.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/tap-gesture
+   */
   Tap: () => {
     return new TapGesture();
   },
 
+  /**
+   * A continuous gesture that can recognize a panning (dragging) gesture and track its movement.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture
+   */
   Pan: () => {
     return new PanGesture();
   },
 
+  /**
+   * A continuous gesture that recognizes pinch gesture. It allows for tracking the distance between two fingers and use that information to scale or zoom your content.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pinch-gesture
+   */
   Pinch: () => {
     return new PinchGesture();
   },
 
+  /**
+   * A continuous gesture that can recognize rotation and track its movement.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/rotation-gesture
+   */
   Rotation: () => {
     return new RotationGesture();
   },
 
+  /**
+   * A discrete gesture that activates when the movement is sufficiently fast.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/fling-gesture
+   */
   Fling: () => {
     return new FlingGesture();
   },
 
+  /**
+   * A discrete gesture that activates when the corresponding view is pressed for a sufficiently long time.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/long-press-gesture
+   */
   LongPress: () => {
     return new LongPressGesture();
   },
 
+  /**
+   * #### iOS only
+   * A continuous gesture that recognizes force of a touch. It allows for tracking pressure of touch on some iOS devices.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/force-touch-gesture
+   */
   ForceTouch: () => {
     return new ForceTouchGesture();
   },
 
+  /**
+   * A gesture that allows other touch handling components to participate in RNGH's gesture system.
+   * When used, the other component should be the direct child of a `GestureDetector`.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/native-gesture
+   */
   Native: () => {
     return new NativeGesture();
   },
 
+  /**
+   * A plain gesture that has no specific activation criteria nor event data set.
+   * Its state has to be controlled manually using a state manager.
+   * It will not fail when all the pointers are lifted from the screen.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/manual-gesture
+   */
   Manual: () => {
     return new ManualGesture();
   },
 
+  /**
+   * A continuous gesture that can recognize hovering above the view it's attached to.
+   * The hover effect may be activated by moving a mouse or a stylus over the view.
+   *
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/hover-gesture
+   */
   Hover: () => {
     return new HoverGesture();
   },
@@ -59,6 +113,7 @@ export const GestureObjects = {
   /**
    * Builds a composed gesture consisting of gestures provided as parameters.
    * The first one that becomes active cancels the rest of gestures.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition/#race
    */
   Race: (...gestures: Gesture[]) => {
     return new ComposedGesture(...gestures);
@@ -66,6 +121,7 @@ export const GestureObjects = {
 
   /**
    * Builds a composed gesture that allows all base gestures to run simultaneously.
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition/#simultaneous
    */
   Simultaneous(...gestures: Gesture[]) {
     return new SimultaneousGesture(...gestures);
@@ -77,6 +133,7 @@ export const GestureObjects = {
    * than the second one, second one has higher priority than the third one, and so on.
    * For example, to make a gesture that recognizes both single and double tap you need
    * to call Exclusive(doubleTap, singleTap).
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition/#exclusive
    */
   Exclusive(...gestures: Gesture[]) {
     return new ExclusiveGesture(...gestures);

--- a/src/handlers/gestures/hoverGesture.ts
+++ b/src/handlers/gestures/hoverGesture.ts
@@ -59,8 +59,8 @@ export class HoverGesture extends ContinousBaseGesture<
   }
 
   /**
+   * #### iOS only
    * Sets the visual hover effect.
-   * iOS only
    */
   effect(effect: HoverEffect) {
     this.config.hoverEffect = effect;

--- a/src/handlers/gestures/longPressGesture.ts
+++ b/src/handlers/gestures/longPressGesture.ts
@@ -14,11 +14,21 @@ export class LongPressGesture extends BaseGesture<LongPressGestureHandlerEventPa
     this.shouldCancelWhenOutside(true);
   }
 
+  /**
+   * Minimum time, expressed in milliseconds, that a finger must remain pressed on the corresponding view.
+   * The default value is 500.
+   * @param duration
+   */
   minDuration(duration: number) {
     this.config.minDurationMs = duration;
     return this;
   }
 
+  /**
+   * Maximum distance, expressed in points, that defines how far the finger is allowed to travel during a long press gesture.
+   * @param distance
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/long-press-gesture#maxdistancevalue-number
+   */
   maxDistance(distance: number) {
     this.config.maxDist = distance;
     return this;

--- a/src/handlers/gestures/nativeGesture.ts
+++ b/src/handlers/gestures/nativeGesture.ts
@@ -13,11 +13,19 @@ export class NativeGesture extends BaseGesture<NativeViewGestureHandlerPayload> 
     this.handlerName = 'NativeViewGestureHandler';
   }
 
+  /**
+   * When true, underlying handler will activate unconditionally when in `BEGAN` or `UNDETERMINED` state.
+   * @param value
+   */
   shouldActivateOnStart(value: boolean) {
     this.config.shouldActivateOnStart = value;
     return this;
   }
 
+  /**
+   * When true, cancels all other gesture handlers when this `NativeViewGestureHandler` receives an `ACTIVE` state event.
+   * @param value
+   */
   disallowInterruption(value: boolean) {
     this.config.disallowInterruption = value;
     return this;

--- a/src/handlers/gestures/panGesture.ts
+++ b/src/handlers/gestures/panGesture.ts
@@ -43,6 +43,11 @@ export class PanGesture extends ContinousBaseGesture<
     this.handlerName = 'PanGestureHandler';
   }
 
+  /**
+   * Range along Y axis (in points) where fingers travels without activation of gesture.
+   * @param offset
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture#activeoffsetyvalue-number--number
+   */
   activeOffsetY(
     offset: number | [activeOffsetYStart: number, activeOffsetYEnd: number]
   ) {
@@ -57,6 +62,11 @@ export class PanGesture extends ContinousBaseGesture<
     return this;
   }
 
+  /**
+   * Range along X axis (in points) where fingers travels without activation of gesture.
+   * @param offset
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture#activeoffsetxvalue-number--number
+   */
   activeOffsetX(
     offset: number | [activeOffsetXStart: number, activeOffsetXEnd: number]
   ) {
@@ -71,6 +81,11 @@ export class PanGesture extends ContinousBaseGesture<
     return this;
   }
 
+  /**
+   * When the finger moves outside this range (in points) along Y axis and gesture hasn't yet activated it will fail recognizing the gesture.
+   * @param offset
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture#failoffsetyvalue-number--number
+   */
   failOffsetY(
     offset: number | [failOffsetYStart: number, failOffsetYEnd: number]
   ) {
@@ -85,6 +100,11 @@ export class PanGesture extends ContinousBaseGesture<
     return this;
   }
 
+  /**
+   * When the finger moves outside this range (in points) along X axis and gesture hasn't yet activated it will fail recognizing the gesture.
+   * @param offset
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture#failoffsetxvalue-number--number
+   */
   failOffsetX(
     offset: number | [failOffsetXStart: number, failOffsetXEnd: number]
   ) {
@@ -99,46 +119,89 @@ export class PanGesture extends ContinousBaseGesture<
     return this;
   }
 
+  /**
+   * A number of fingers that is required to be placed before gesture can activate. Should be a higher or equal to 0 integer.
+   * @param minPointers
+   */
   minPointers(minPointers: number) {
     this.config.minPointers = minPointers;
     return this;
   }
 
+  /**
+   * When the given number of fingers is placed on the screen and gesture hasn't yet activated it will fail recognizing the gesture.
+   * Should be a higher or equal to 0 integer.
+   * @param maxPointers
+   */
   maxPointers(maxPointers: number) {
     this.config.maxPointers = maxPointers;
     return this;
   }
 
+  /**
+   * Minimum distance the finger (or multiple finger) need to travel before the gesture activates.
+   * Expressed in points.
+   * @param distance
+   */
   minDistance(distance: number) {
     this.config.minDist = distance;
     return this;
   }
 
+  /**
+   * Minimum velocity the finger has to reach in order to activate handler.
+   * @param velocity
+   */
   minVelocity(velocity: number) {
     this.config.minVelocity = velocity;
     return this;
   }
 
+  /**
+   * Minimum velocity along X axis the finger has to reach in order to activate handler.
+   * @param velocity
+   */
   minVelocityX(velocity: number) {
     this.config.minVelocityX = velocity;
     return this;
   }
 
+  /**
+   * Minimum velocity along Y axis the finger has to reach in order to activate handler.
+   * @param velocity
+   */
   minVelocityY(velocity: number) {
     this.config.minVelocityY = velocity;
     return this;
   }
 
+  /**
+   * #### Android only
+   * Android, by default, will calculate translation values based on the position of the leading pointer (the first one that was placed on the screen).
+   * This modifier allows that behavior to be changed to the one that is default on iOS - the averaged position of all active pointers will be used to calculate the translation values.
+   * @param value
+   */
   averageTouches(value: boolean) {
     this.config.avgTouches = value;
     return this;
   }
 
+  /**
+   * #### iOS only
+   * Enables two-finger gestures on supported devices, for example iPads with trackpads.
+   * @param value
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture/#enabletrackpadtwofingergesturevalue-boolean-ios-only
+   */
   enableTrackpadTwoFingerGesture(value: boolean) {
     this.config.enableTrackpadTwoFingerGesture = value;
     return this;
   }
 
+  /**
+   * Duration in milliseconds of the LongPress gesture before Pan is allowed to activate.
+   * @param duration
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/pan-gesture/#activateafterlongpressduration-number
+   */
   activateAfterLongPress(duration: number) {
     this.config.activateAfterLongPress = duration;
     return this;

--- a/src/handlers/gestures/tapGesture.ts
+++ b/src/handlers/gestures/tapGesture.ts
@@ -14,36 +14,71 @@ export class TapGesture extends BaseGesture<TapGestureHandlerEventPayload> {
     this.shouldCancelWhenOutside(true);
   }
 
+  /**
+   * Minimum number of pointers (fingers) required to be placed before the gesture activates.
+   * Should be a positive integer. The default value is 1.
+   * @param minPointers
+   */
   minPointers(minPointers: number) {
     this.config.minPointers = minPointers;
     return this;
   }
 
+  /**
+   * Number of tap gestures required to activate the gesture.
+   * The default value is 1.
+   * @param count
+   */
   numberOfTaps(count: number) {
     this.config.numberOfTaps = count;
     return this;
   }
 
+  /**
+   * Maximum distance, expressed in points, that defines how far the finger is allowed to travel during a tap gesture.
+   * @param maxDist
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/tap-gesture#maxdistancevalue-number
+   */
   maxDistance(maxDist: number) {
     this.config.maxDist = maxDist;
     return this;
   }
 
+  /**
+   * Maximum time, expressed in milliseconds, that defines how fast a finger must be released after a touch.
+   * The default value is 500.
+   * @param duration
+   */
   maxDuration(duration: number) {
     this.config.maxDurationMs = duration;
     return this;
   }
 
+  /**
+   * Maximum time, expressed in milliseconds, that can pass before the next tap — if many taps are required.
+   * The default value is 500.
+   * @param delay
+   */
   maxDelay(delay: number) {
     this.config.maxDelayMs = delay;
     return this;
   }
 
+  /**
+   * Maximum distance, expressed in points, that defines how far the finger is allowed to travel along the X axis during a tap gesture.
+   * @param delta
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/tap-gesture#maxdeltaxvalue-number
+   */
   maxDeltaX(delta: number) {
     this.config.maxDeltaX = delta;
     return this;
   }
 
+  /**
+   * Maximum distance, expressed in points, that defines how far the finger is allowed to travel along the Y axis during a tap gesture.
+   * @param delta
+   * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/tap-gesture#maxdeltayvalue-number
+   */
   maxDeltaY(delta: number) {
     this.config.maxDeltaY = delta;
     return this;


### PR DESCRIPTION
## Description

I thought that adding TypeDocs might be a good idea and it could enhance developer experience (I've come up with this idea when I discovered that we have `withRef` modifier). This PR adds TypeDocs to new API (but we can also think of filling missing docs in old API)

## Test plan

Hover functions/components and read docs.
