### PR TITLE
Fix old Gesture Handler API integration with Reaniamted

### DIFF
--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -343,9 +343,9 @@ export default function createHandler<
         const actionType = (() => {
           if (
             (this.props?.onGestureEvent &&
-              'current' in this.props.onGestureEvent) ||
+              'workletEventHandler' in this.props.onGestureEvent) ||
             (this.props?.onHandlerStateChange &&
-              'current' in this.props.onHandlerStateChange)
+              'workletEventHandler' in this.props.onHandlerStateChange)
           ) {
             // Reanimated worklet
             return ActionType.REANIMATED_WORKLET;

--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -347,12 +347,12 @@ export default function createHandler<
             ('current' in onGestureEvent ||
               'workletEventHandler' in onGestureEvent);
           const onHandlerStateChange = this.props?.onHandlerStateChange;
-          const isStateChangeWorklet =
+          const isStateChangeHandlerWorklet =
             onHandlerStateChange &&
             ('current' in onHandlerStateChange ||
               'workletEventHandler' in onHandlerStateChange);
           const isReanimatedHandler =
-            isGestureHandlerWorklet || isStateChangeWorklet;
+            isGestureHandlerWorklet || isStateChangeHandlerWorklet;
           if (isReanimatedHandler) {
             // Reanimated worklet
             return ActionType.REANIMATED_WORKLET;

--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -341,18 +341,22 @@ export default function createHandler<
         });
 
         const actionType = (() => {
-          if (
-            (this.props?.onGestureEvent &&
-              'workletEventHandler' in this.props.onGestureEvent) ||
-            (this.props?.onHandlerStateChange &&
-              'workletEventHandler' in this.props.onHandlerStateChange)
-          ) {
+          const onGestureEvent = this.props?.onGestureEvent;
+          const isGestureHandlerWorklet =
+            onGestureEvent &&
+            ('current' in onGestureEvent ||
+              'workletEventHandler' in onGestureEvent);
+          const onHandlerStateChange = this.props?.onHandlerStateChange;
+          const isStateChangeWorklet =
+            onHandlerStateChange &&
+            ('current' in onHandlerStateChange ||
+              'workletEventHandler' in onHandlerStateChange);
+          const isReanimatedHandler =
+            isGestureHandlerWorklet || isStateChangeWorklet;
+          if (isReanimatedHandler) {
             // Reanimated worklet
             return ActionType.REANIMATED_WORKLET;
-          } else if (
-            this.props?.onGestureEvent &&
-            '__isNative' in this.props.onGestureEvent
-          ) {
+          } else if (onGestureEvent && '__isNative' in onGestureEvent) {
             // Animated.event with useNativeDriver: true
             return ActionType.NATIVE_ANIMATED_EVENT;
           } else {


### PR DESCRIPTION
## Description

This PR resolves the recognition issue of the Reanimated Event handler for the previous Gesture Handler API. This adjustment was necessary due to a modification in the internal property name that was utilized to identify the Reanimated event handler (as seen here: https://github.com/software-mansion/react-native-reanimated/pull/5743).

## Test plan

Run this example - https://github.com/software-mansion/react-native-reanimated/blob/main/app/src/examples/DragAndSnapExample.tsx
