### PR TITLE
[Web] Add `minVelocity` to `Pan` custom activation criteria

### DIFF
--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -20,6 +20,7 @@ export default class PanGestureHandler extends GestureHandler {
     'failOffsetYEnd',
     'minVelocityX',
     'minVelocityY',
+    'minVelocity',
   ];
 
   public velocityX = 0;


### PR DESCRIPTION
## Description

Recently I've discovered that using `.minVelocity()` modifier doesn't affect `Pan` activation on web. After further investigation I've found out that list with custom activation criteria had `minVelocityX` and `minVelocityY`, but `minVelocity` was missing. This PR adds mentioned criterion.

## Test plan

Tested on example app (just add `.minVelocity()` in any example with `Pan`
