### PR TITLE
Add information about `GestureHandlerRootView` area and change component name in quick start section in docs. 

### DIFF
--- a/docs/docs/fundamentals/installation.md
+++ b/docs/docs/fundamentals/installation.md
@@ -69,7 +69,7 @@ export default function App() {
 :::info
 If you use props such as `shouldCancelWhenOutside`, `simultaneousHandlers`, `waitFor` etc. with gesture handlers, the handlers need to be mounted under a single `GestureHandlerRootView`. So it's important to keep the `GestureHandlerRootView` as close to the actual root view as possible.
 
-Note that `GestureHandlerRootView` acts like a normal `View`. So if you want it to fill the screen, you will need to pass `{ flex: 1 }` like you'll need to do with a normal `View`. By default, it'll take the size of the content nested inside.
+Note that `GestureHandlerRootView` acts like a normal `View`. Also, gestures will only be recognized within the `GestureHandlerRootView` area. So if you want it to fill the screen, you will need to pass `{ flex: 1 }` like you'll need to do with a normal `View`. By default, it'll take the size of the content nested inside.
 :::
 
 :::tip

--- a/docs/docs/fundamentals/quickstart/_steps/step3.md
+++ b/docs/docs/fundamentals/quickstart/_steps/step3.md
@@ -5,7 +5,7 @@ import {
   withSpring,
 } from 'react-native-reanimated';
 
-function App() {
+function Ball() {
   const isPressed = useSharedValue(false);
   const offset = useSharedValue({ x: 0, y: 0 });
 

--- a/docs/docs/fundamentals/quickstart/_steps/step5.md
+++ b/docs/docs/fundamentals/quickstart/_steps/step5.md
@@ -1,7 +1,7 @@
 ```jsx
 import { Gesture } from 'react-native-gesture-handler';
 
-function App() {
+function Ball() {
   // ...
   const start = useSharedValue({ x: 0, y: 0 });
   const gesture = Gesture.Pan()


### PR DESCRIPTION
## Description

Discussion started in [this comment](https://github.com/software-mansion/react-native-gesture-handler/issues/2837#issuecomment-2082310925) made me think that it will be good idea to mention in our docs, that gestures will be recognized only in the area covered by `GestureHandlerRootView`. 

This PR also changes name of `Ball` component  in "Quick start" section, which for some reason was named `App` in steps 3 and 5.

## Test plan

Run docs