### PR TITLE
Make `RootViewGestureHandler` handler cancel awaiting gestures

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
@@ -54,6 +54,10 @@ class RNGestureHandlerInteractionManager : GestureHandlerInteractionController {
       return otherHandler.disallowInterruption
     }
 
+    if (otherHandler is RNGestureHandlerRootHelper.RootViewGestureHandler) {
+      return true
+    }
+
     return false
   }
   override fun shouldRecognizeSimultaneously(

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -57,7 +57,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     }
   }
 
-  private inner class RootViewGestureHandler : GestureHandler<RootViewGestureHandler>() {
+  internal inner class RootViewGestureHandler : GestureHandler<RootViewGestureHandler>() {
     override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
       val currentState = state
       // we shouldn't stop intercepting events when there is an active handler already, which could happen when


### PR DESCRIPTION
## Description

Gesture Handler is handling calls to `requestDisallowInterceptTouchEvent` by canceling all gestures: https://github.com/software-mansion/react-native-gesture-handler/blob/5523506c7b64ac5a8a78f5d73dc96adfb13962ba/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt#L90-L94

This is done by activating a root handler that should, in turn, cancel other gestures: https://github.com/software-mansion/react-native-gesture-handler/blob/5523506c7b64ac5a8a78f5d73dc96adfb13962ba/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt#L109-L114

There is a case where this doesn't currently work: when gesture A waits for gesture B and root view is activated, gesture B gets canceled but gesture A is not due to this check: https://github.com/software-mansion/react-native-gesture-handler/blob/5523506c7b64ac5a8a78f5d73dc96adfb13962ba/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt#L692-L698

Since handler A is awaiting, it doesn't get canceled. Gesture B does get canceled, which in turn causes gesture A to activate, effectively making it ignore the cancellation.

This happens because of this method: https://github.com/software-mansion/react-native-gesture-handler/blob/5523506c7b64ac5a8a78f5d73dc96adfb13962ba/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt#L52-L58 which will always return false if the activating gesture is root view.

This PR makes it so that if the activating gesture is the root handler, `shouldHandlerBeCancelledBy` will always return `true`, canceling the waiting gesture.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/2870

## Test plan

Tested on the example app and the reproducer from the issue
