### PR TITLE
Add dark mode to button in `Hire us` section

### DIFF
--- a/docs/src/components/HireUsSection/styles.module.css
+++ b/docs/src/components/HireUsSection/styles.module.css
@@ -69,3 +69,9 @@
 .buttonNavyBorderStyling {
   border: 1px solid var(--swm-navy-light-100);
 }
+
+[data-theme='dark'] .buttonNavyStyling:hover,
+[data-theme='dark'] .buttonNavyStyling:hover svg {
+  stroke: var(--swm-landing-button-purple);
+  color: var(--swm-landing-button-purple);
+}


### PR DESCRIPTION
## Description

Normal:
<img width="1482" alt="Screenshot 2024-05-14 at 11 11 23" src="https://github.com/software-mansion/react-native-gesture-handler/assets/59940332/2b452ed9-82a6-477f-b051-4cb6cb2c60b3">

Hovered:
<img width="1482" alt="Screenshot 2024-05-14 at 11 11 26" src="https://github.com/software-mansion/react-native-gesture-handler/assets/59940332/c36e5990-1d01-48bf-8124-cb7ab8431ec0">


## Test plan

```
cd docs/
yarn

# to test development build
yarn start

# to test production build
yarn build
yarn serve
```
