### PR TITLE
Fix Detector creating and attaching all gestures twice on first mount

### DIFF
--- a/src/handlers/gestures/GestureDetector/index.tsx
+++ b/src/handlers/gestures/GestureDetector/index.tsx
@@ -164,10 +164,10 @@ export const GestureDetector = (props: GestureDetectorProps) => {
   }, []);
 
   useEffect(() => {
-    if (!state.firstRender) {
-      updateAttachedGestures();
-    } else {
+    if (state.firstRender) {
       state.firstRender = false;
+    } else {
+      updateAttachedGestures();
     }
   }, [props]);
 

--- a/src/handlers/gestures/GestureDetector/useViewRefHandler.ts
+++ b/src/handlers/gestures/GestureDetector/useViewRefHandler.ts
@@ -32,7 +32,9 @@ export function useViewRefHandler(
 
       // Pass true as `skipConfigUpdate`. Here we only want to trigger the eventual reattaching of handlers
       // in case the view has changed. If the view doesn't change, the update will be handled by detector.
-      updateAttachedGestures(true);
+      if (!state.firstRender) {
+        updateAttachedGestures(true);
+      }
 
       if (__DEV__ && isFabric() && global.isFormsStackingContext) {
         const node = getShadowNodeFromRef(ref);


### PR DESCRIPTION
## Description

After refactoring, the Detector would create and attach all gestures twice on the first mount. This made gestures effectively not work on Android, since two gestures would be attached to the view. JS side would listen to the events of only the second one, while on the native side, the second one would always be canceled by the second one.

Note that the gestures don't work when the children of the detector change, which is probably caused by the Reanimated upgrade with the new example app.

## Test plan

Check any of the new API examples on Android
