### PR TITLE
chore(types): add missing pointerType to GestureTouchEvent

### DIFF
--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -167,6 +167,7 @@ export type GestureTouchEvent = {
   eventType: TouchEventType;
   allTouches: TouchData[];
   changedTouches: TouchData[];
+  pointerType: PointerType;
 };
 
 export type GestureUpdateEvent<GestureEventPayloadT = Record<string, unknown>> =


### PR DESCRIPTION
## Description

Using `Gesture.Tap().onTouchesDown((event) => {})` event is a `GestureTouchEvent` that is missing the `pointerType` key while it does exist in the actual object.

