### PR TITLE
`PointerTracker` refactor.

### DIFF
--- a/src/web/detectors/RotationGestureDetector.ts
+++ b/src/web/detectors/RotationGestureDetector.ts
@@ -39,16 +39,14 @@ export default class RotationGestureDetector
 
     const [firstPointerID, secondPointerID] = this.keyPointers;
 
-    const firstPointerX: number = tracker.getLastX(firstPointerID);
-    const firstPointerY: number = tracker.getLastY(firstPointerID);
-    const secondPointerX: number = tracker.getLastX(secondPointerID);
-    const secondPointerY: number = tracker.getLastY(secondPointerID);
+    const firstPointerCoords = tracker.getLastAbsoluteCoords(firstPointerID);
+    const secondPointerCoords = tracker.getLastAbsoluteCoords(secondPointerID);
 
-    const vectorX: number = secondPointerX - firstPointerX;
-    const vectorY: number = secondPointerY - firstPointerY;
+    const vectorX: number = secondPointerCoords.x - firstPointerCoords.x;
+    const vectorY: number = secondPointerCoords.y - firstPointerCoords.y;
 
-    this.anchorX = (firstPointerX + secondPointerX) / 2;
-    this.anchorY = (firstPointerY + secondPointerY) / 2;
+    this.anchorX = (firstPointerCoords.x + secondPointerCoords.x) / 2;
+    this.anchorY = (firstPointerCoords.y + secondPointerCoords.y) / 2;
 
     //Angle diff should be positive when rotating in clockwise direction
     const angle: number = -Math.atan2(vectorY, vectorX);

--- a/src/web/detectors/ScaleGestureDetector.ts
+++ b/src/web/detectors/ScaleGestureDetector.ts
@@ -76,10 +76,10 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
 
     const div: number = pointerUp ? numOfPointers - 1 : numOfPointers;
 
-    const { totalX, totalY } = tracker.getAbsoluteCoordsSum();
+    const coordsSum = tracker.getAbsoluteCoordsSum();
 
-    const focusX = totalX / div;
-    const focusY = totalY / div;
+    const focusX = coordsSum.x / div;
+    const focusY = coordsSum.y / div;
 
     //Determine average deviation from focal point
 

--- a/src/web/detectors/ScaleGestureDetector.ts
+++ b/src/web/detectors/ScaleGestureDetector.ts
@@ -76,11 +76,10 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
 
     const div: number = pointerUp ? numOfPointers - 1 : numOfPointers;
 
-    const sumX = tracker.getSumX(ignoredPointer);
-    const sumY = tracker.getSumY(ignoredPointer);
+    const { totalX, totalY } = tracker.getAbsoluteCoordsSum();
 
-    const focusX = sumX / div;
-    const focusY = sumY / div;
+    const focusX = totalX / div;
+    const focusY = totalY / div;
 
     //Determine average deviation from focal point
 
@@ -92,8 +91,8 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
         return;
       }
 
-      devSumX += Math.abs(value.lastX - focusX);
-      devSumY += Math.abs(value.lastY - focusY);
+      devSumX += Math.abs(value.abosoluteCoords.x - focusX);
+      devSumY += Math.abs(value.abosoluteCoords.y - focusY);
     });
 
     const devX: number = devSumX / div;

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -405,10 +405,9 @@ export default abstract class GestureHandler implements IGestureHandler {
       nativeEvent: {
         numberOfPointers: this.tracker.getTrackedPointersCount(),
         state: newState,
-        pointerInside: this.delegate.isPointerInBounds({
-          x: this.tracker.getLastAvgX(),
-          y: this.tracker.getLastAvgY(),
-        }),
+        pointerInside: this.delegate.isPointerInBounds(
+          this.tracker.getAbsoluteCoordsAverage()
+        ),
         ...this.transformNativeEvent(),
         handlerTag: this.handlerTag,
         target: this.viewRef,
@@ -442,10 +441,10 @@ export default abstract class GestureHandler implements IGestureHandler {
 
       all.push({
         id: id,
-        x: element.lastX - rect.pageX,
-        y: element.lastY - rect.pageY,
-        absoluteX: element.lastX,
-        absoluteY: element.lastY,
+        x: element.abosoluteCoords.x - rect.pageX,
+        y: element.abosoluteCoords.y - rect.pageY,
+        absoluteX: element.abosoluteCoords.x,
+        absoluteY: element.abosoluteCoords.y,
       });
     });
 
@@ -465,10 +464,10 @@ export default abstract class GestureHandler implements IGestureHandler {
 
         changed.push({
           id: id,
-          x: element.lastX - rect.pageX,
-          y: element.lastY - rect.pageY,
-          absoluteX: element.lastX,
-          absoluteY: element.lastY,
+          x: element.abosoluteCoords.x - rect.pageX,
+          y: element.abosoluteCoords.y - rect.pageY,
+          absoluteX: element.abosoluteCoords.x,
+          absoluteY: element.abosoluteCoords.y,
         });
       });
     }
@@ -534,18 +533,18 @@ export default abstract class GestureHandler implements IGestureHandler {
 
       all.push({
         id: id,
-        x: element.lastX - rect.pageX,
-        y: element.lastY - rect.pageY,
-        absoluteX: element.lastX,
-        absoluteY: element.lastY,
+        x: element.abosoluteCoords.x - rect.pageX,
+        y: element.abosoluteCoords.y - rect.pageY,
+        absoluteX: element.abosoluteCoords.x,
+        absoluteY: element.abosoluteCoords.y,
       });
 
       changed.push({
         id: id,
-        x: element.lastX - rect.pageX,
-        y: element.lastY - rect.pageY,
-        absoluteX: element.lastX,
-        absoluteY: element.lastY,
+        x: element.abosoluteCoords.x - rect.pageX,
+        y: element.abosoluteCoords.y - rect.pageY,
+        absoluteX: element.abosoluteCoords.x,
+        absoluteY: element.abosoluteCoords.y,
       });
     });
 
@@ -570,12 +569,13 @@ export default abstract class GestureHandler implements IGestureHandler {
   protected transformNativeEvent(): Record<string, unknown> {
     // those properties are shared by most handlers and if not this method will be overriden
     const rect = this.delegate.measureView();
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
 
     return {
-      x: this.tracker.getLastAvgX() - rect.pageX,
-      y: this.tracker.getLastAvgY() - rect.pageY,
-      absoluteX: this.tracker.getLastAvgX(),
-      absoluteY: this.tracker.getLastAvgY(),
+      x: lastCoords.x - rect.pageX,
+      y: lastCoords.y - rect.pageY,
+      absoluteX: lastCoords.x,
+      absoluteY: lastCoords.y,
     };
   }
 
@@ -720,8 +720,9 @@ export default abstract class GestureHandler implements IGestureHandler {
     }
 
     const rect = this.delegate.measureView();
-    const offsetX: number = this.tracker.getLastX() - rect.pageX;
-    const offsetY: number = this.tracker.getLastY() - rect.pageY;
+    const { x, y } = this.tracker.getLastAbsoluteCoords();
+    const offsetX: number = x - rect.pageX;
+    const offsetY: number = y - rect.pageY;
 
     if (
       offsetX >= left &&

--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -64,8 +64,9 @@ export default class NativeViewGestureHandler extends GestureHandler {
   }
 
   private newPointerAction(): void {
-    this.startX = this.tracker.getLastAvgX();
-    this.startY = this.tracker.getLastAvgY();
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.startX = lastCoords.x;
+    this.startY = lastCoords.y;
 
     if (this.currentState !== State.UNDETERMINED) {
       return;
@@ -80,8 +81,9 @@ export default class NativeViewGestureHandler extends GestureHandler {
   protected onPointerMove(event: AdaptedEvent): void {
     this.tracker.track(event);
 
-    const dx = this.startX - this.tracker.getLastAvgX();
-    const dy = this.startY - this.tracker.getLastAvgY();
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    const dx = this.startX - lastCoords.x;
+    const dy = this.startY - lastCoords.y;
     const distSq = dx * dx + dy * dy;
 
     if (distSq >= this.minDistSq) {

--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -219,8 +219,9 @@ export default class PanGestureHandler extends GestureHandler {
     this.tracker.addToTracker(event);
     super.onPointerDown(event);
 
-    this.lastX = this.tracker.getLastAvgX();
-    this.lastY = this.tracker.getLastAvgY();
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.lastX = lastCoords.x;
+    this.lastY = lastCoords.y;
 
     this.startX = this.lastX;
     this.startY = this.lastY;
@@ -239,8 +240,9 @@ export default class PanGestureHandler extends GestureHandler {
     this.offsetX += this.lastX - this.startX;
     this.offsetY += this.lastY - this.startY;
 
-    this.lastX = this.tracker.getLastAvgX();
-    this.lastY = this.tracker.getLastAvgY();
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.lastX = lastCoords.x;
+    this.lastY = lastCoords.y;
 
     this.startX = this.lastX;
     this.startY = this.lastY;
@@ -259,8 +261,9 @@ export default class PanGestureHandler extends GestureHandler {
   protected onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
     if (this.currentState === State.ACTIVE) {
-      this.lastX = this.tracker.getLastAvgX();
-      this.lastY = this.tracker.getLastAvgY();
+      const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+      this.lastX = lastCoords.x;
+      this.lastY = lastCoords.y;
     }
 
     this.tracker.removeFromTracker(event.pointerId);
@@ -280,8 +283,9 @@ export default class PanGestureHandler extends GestureHandler {
     this.offsetX += this.lastX - this.startX;
     this.offsetY += this.lastY - this.startY;
 
-    this.lastX = this.tracker.getLastAvgX();
-    this.lastY = this.tracker.getLastAvgY();
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.lastX = lastCoords.x;
+    this.lastY = lastCoords.y;
 
     this.startX = this.lastX;
     this.startY = this.lastY;
@@ -299,10 +303,13 @@ export default class PanGestureHandler extends GestureHandler {
   protected onPointerMove(event: AdaptedEvent): void {
     this.tracker.track(event);
 
-    this.lastX = this.tracker.getLastAvgX();
-    this.lastY = this.tracker.getLastAvgY();
-    this.velocityX = this.tracker.getVelocityX(event.pointerId);
-    this.velocityY = this.tracker.getVelocityY(event.pointerId);
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.lastX = lastCoords.x;
+    this.lastY = lastCoords.y;
+
+    const velocity = this.tracker.getVelocity(event.pointerId);
+    this.velocityX = velocity.x;
+    this.velocityY = velocity.y;
 
     this.checkBegan();
 
@@ -316,10 +323,13 @@ export default class PanGestureHandler extends GestureHandler {
 
     this.tracker.track(event);
 
-    this.lastX = this.tracker.getLastAvgX();
-    this.lastY = this.tracker.getLastAvgY();
-    this.velocityX = this.tracker.getVelocityX(event.pointerId);
-    this.velocityY = this.tracker.getVelocityY(event.pointerId);
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.lastX = lastCoords.x;
+    this.lastY = lastCoords.y;
+
+    const velocity = this.tracker.getVelocity(event.pointerId);
+    this.velocityX = velocity.x;
+    this.velocityY = velocity.y;
 
     this.checkBegan();
 
@@ -453,8 +463,9 @@ export default class PanGestureHandler extends GestureHandler {
         }, this.activateAfterLongPress);
       }
     } else {
-      this.velocityX = this.tracker.getVelocityX(event.pointerId);
-      this.velocityY = this.tracker.getVelocityY(event.pointerId);
+      const velocity = this.tracker.getVelocity(event.pointerId);
+      this.velocityX = velocity.x;
+      this.velocityY = velocity.y;
     }
   }
 

--- a/src/web/handlers/TapGestureHandler.ts
+++ b/src/web/handlers/TapGestureHandler.ts
@@ -133,19 +133,22 @@ export default class TapGestureHandler extends GestureHandler {
     this.offsetX += this.lastX - this.startX;
     this.offsetY += this.lastY - this.startY;
 
-    this.lastX = this.tracker.getLastAvgX();
-    this.lastY = this.tracker.getLastAvgY();
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.lastX = lastCoords.x;
+    this.lastY = lastCoords.y;
 
-    this.startX = this.tracker.getLastAvgX();
-    this.startY = this.tracker.getLastAvgY();
+    this.startX = lastCoords.x;
+    this.startY = lastCoords.y;
 
     this.updateState(event);
   }
 
   protected onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
-    this.lastX = this.tracker.getLastAvgX();
-    this.lastY = this.tracker.getLastAvgY();
+
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.lastX = lastCoords.x;
+    this.lastY = lastCoords.y;
 
     this.tracker.removeFromTracker(event.pointerId);
 
@@ -159,8 +162,9 @@ export default class TapGestureHandler extends GestureHandler {
     this.offsetX += this.lastX - this.startX;
     this.offsetY += this.lastY = this.startY;
 
-    this.lastX = this.tracker.getLastAvgX();
-    this.lastY = this.tracker.getLastAvgY();
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.lastX = lastCoords.x;
+    this.lastY = lastCoords.y;
 
     this.startX = this.lastX;
     this.startY = this.lastY;
@@ -172,8 +176,9 @@ export default class TapGestureHandler extends GestureHandler {
     this.trySettingPosition(event);
     this.tracker.track(event);
 
-    this.lastX = this.tracker.getLastAvgX();
-    this.lastY = this.tracker.getLastAvgY();
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.lastX = lastCoords.x;
+    this.lastY = lastCoords.y;
 
     this.updateState(event);
 
@@ -184,8 +189,9 @@ export default class TapGestureHandler extends GestureHandler {
     this.trySettingPosition(event);
     this.tracker.track(event);
 
-    this.lastX = this.tracker.getLastAvgX();
-    this.lastY = this.tracker.getLastAvgY();
+    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    this.lastX = lastCoords.x;
+    this.lastY = lastCoords.y;
 
     this.updateState(event);
 

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -335,13 +335,7 @@ export default class GestureHandlerOrchestrator {
     // TODO: Find better way to handle that issue, for example by activation order and handler cancelling
 
     const isPointerWithinBothBounds = (pointer: number) => {
-      const handlerX: number = handler.getTracker().getLastX(pointer);
-      const handlerY: number = handler.getTracker().getLastY(pointer);
-
-      const point = {
-        x: handlerX,
-        y: handlerY,
-      };
+      const point = handler.getTracker().getLastAbsoluteCoords(pointer);
 
       return (
         handler.getDelegate().isPointerInBounds(point) &&

--- a/src/web/tools/PointerTracker.ts
+++ b/src/web/tools/PointerTracker.ts
@@ -3,7 +3,7 @@ import VelocityTracker from './VelocityTracker';
 
 export interface TrackerElement {
   abosoluteCoords: Point;
-  viewRelativeCoords: Point;
+  relativeCoords: Point;
   timestamp: number;
   velocityX: number;
   velocityY: number;
@@ -41,7 +41,7 @@ export default class PointerTracker {
 
     const newElement: TrackerElement = {
       abosoluteCoords: { x: event.x, y: event.y },
-      viewRelativeCoords: { x: event.offsetX, y: event.offsetY },
+      relativeCoords: { x: event.offsetX, y: event.offsetY },
       timestamp: event.time,
       velocityX: 0,
       velocityY: 0,
@@ -76,7 +76,7 @@ export default class PointerTracker {
     element.velocityY = velocityY;
 
     element.abosoluteCoords = { x: event.x, y: event.y };
-    element.viewRelativeCoords = { x: event.offsetX, y: event.offsetY };
+    element.relativeCoords = { x: event.offsetX, y: event.offsetY };
 
     this.trackedPointers.set(event.pointerId, element);
 
@@ -133,17 +133,17 @@ export default class PointerTracker {
     }
   }
 
-  public getLastViewRelativeCoords(pointerId?: number) {
+  public getLastRelativeCoords(pointerId?: number) {
     if (pointerId !== undefined) {
       return {
-        x: this.trackedPointers.get(pointerId)?.viewRelativeCoords.x as number,
-        y: this.trackedPointers.get(pointerId)?.viewRelativeCoords.y as number,
+        x: this.trackedPointers.get(pointerId)?.relativeCoords.x as number,
+        y: this.trackedPointers.get(pointerId)?.relativeCoords.y as number,
       };
     } else {
       return {
-        x: this.trackedPointers.get(this.lastMovedPointerId)?.viewRelativeCoords
+        x: this.trackedPointers.get(this.lastMovedPointerId)?.relativeCoords
           .x as number,
-        y: this.trackedPointers.get(this.lastMovedPointerId)?.viewRelativeCoords
+        y: this.trackedPointers.get(this.lastMovedPointerId)?.relativeCoords
           .y as number,
       };
     }
@@ -180,13 +180,13 @@ export default class PointerTracker {
     return sum;
   }
 
-  public getViewRelativeCoordsSum(ignoredPointer?: number) {
+  public getRelativeCoordsSum(ignoredPointer?: number) {
     const sum = { x: 0, y: 0 };
 
     this.trackedPointers.forEach((value, key) => {
       if (key !== ignoredPointer) {
-        sum.x += value.viewRelativeCoords.x;
-        sum.y += value.viewRelativeCoords.y;
+        sum.x += value.relativeCoords.x;
+        sum.y += value.relativeCoords.y;
       }
     });
 

--- a/src/web/tools/PointerTracker.ts
+++ b/src/web/tools/PointerTracker.ts
@@ -40,14 +40,8 @@ export default class PointerTracker {
     this.lastMovedPointerId = event.pointerId;
 
     const newElement: TrackerElement = {
-      abosoluteCoords: {
-        x: event.x,
-        y: event.y,
-      },
-      viewRelativeCoords: {
-        x: event.offsetX,
-        y: event.offsetY,
-      },
+      abosoluteCoords: { x: event.x, y: event.y },
+      viewRelativeCoords: { x: event.offsetX, y: event.offsetY },
       timestamp: event.time,
       velocityX: 0,
       velocityY: 0,
@@ -81,15 +75,8 @@ export default class PointerTracker {
     element.velocityX = velocityX;
     element.velocityY = velocityY;
 
-    element.abosoluteCoords = {
-      x: event.x,
-      y: event.y,
-    };
-
-    element.viewRelativeCoords = {
-      x: event.offsetX,
-      y: event.offsetY,
-    };
+    element.abosoluteCoords = { x: event.x, y: event.y };
+    element.viewRelativeCoords = { x: event.offsetX, y: event.offsetY };
 
     this.trackedPointers.set(event.pointerId, element);
 
@@ -146,15 +133,31 @@ export default class PointerTracker {
     }
   }
 
+  public getLastViewRelativeCoords(pointerId?: number) {
+    if (pointerId !== undefined) {
+      return {
+        x: this.trackedPointers.get(pointerId)?.viewRelativeCoords.x as number,
+        y: this.trackedPointers.get(pointerId)?.viewRelativeCoords.y as number,
+      };
+    } else {
+      return {
+        x: this.trackedPointers.get(this.lastMovedPointerId)?.viewRelativeCoords
+          .x as number,
+        y: this.trackedPointers.get(this.lastMovedPointerId)?.viewRelativeCoords
+          .y as number,
+      };
+    }
+  }
+
   // Some handlers use these methods to send average values in native event.
   // This may happen when pointers have already been removed from tracker (i.e. pointerup event).
   // In situation when NaN would be sent as a response, we return cached value.
   // That prevents handlers from crashing
   public getAbsoluteCoordsAverage() {
-    const { totalX, totalY } = this.getAbsoluteCoordsSum();
+    const coordsSum = this.getAbsoluteCoordsSum();
 
-    const avgX = totalX / this.trackedPointers.size;
-    const avgY = totalY / this.trackedPointers.size;
+    const avgX = coordsSum.x / this.trackedPointers.size;
+    const avgY = coordsSum.y / this.trackedPointers.size;
 
     const averages = {
       x: isNaN(avgX) ? this.cachedAverages.x : avgX,
@@ -165,23 +168,35 @@ export default class PointerTracker {
   }
 
   public getAbsoluteCoordsSum(ignoredPointer?: number) {
-    const sum = {
-      totalX: 0,
-      totalY: 0,
-    };
+    const sum = { x: 0, y: 0 };
 
     this.trackedPointers.forEach((value, key) => {
       if (key !== ignoredPointer) {
-        sum.totalX += value.abosoluteCoords.x;
-        sum.totalY += value.abosoluteCoords.y;
+        sum.x += value.abosoluteCoords.x;
+        sum.y += value.abosoluteCoords.y;
       }
     });
 
     return sum;
   }
+
+  public getViewRelativeCoordsSum(ignoredPointer?: number) {
+    const sum = { x: 0, y: 0 };
+
+    this.trackedPointers.forEach((value, key) => {
+      if (key !== ignoredPointer) {
+        sum.x += value.viewRelativeCoords.x;
+        sum.y += value.viewRelativeCoords.y;
+      }
+    });
+
+    return sum;
+  }
+
   public getTrackedPointersCount(): number {
     return this.trackedPointers.size;
   }
+
   public getTrackedPointersID(): number[] {
     const keys: number[] = [];
 

--- a/src/web/tools/PointerTracker.ts
+++ b/src/web/tools/PointerTracker.ts
@@ -1,12 +1,10 @@
-import { AdaptedEvent } from '../interfaces';
+import { AdaptedEvent, Point } from '../interfaces';
 import VelocityTracker from './VelocityTracker';
 
 export interface TrackerElement {
-  lastX: number;
-  lastY: number;
-
-  timeStamp: number;
-
+  abosoluteCoords: Point;
+  viewRelativeCoords: Point;
+  timestamp: number;
   velocityX: number;
   velocityY: number;
 }
@@ -42,9 +40,15 @@ export default class PointerTracker {
     this.lastMovedPointerId = event.pointerId;
 
     const newElement: TrackerElement = {
-      lastX: event.x,
-      lastY: event.y,
-      timeStamp: event.time,
+      abosoluteCoords: {
+        x: event.x,
+        y: event.y,
+      },
+      viewRelativeCoords: {
+        x: event.offsetX,
+        y: event.offsetY,
+      },
+      timestamp: event.time,
       velocityX: 0,
       velocityY: 0,
     };
@@ -52,10 +56,7 @@ export default class PointerTracker {
     this.trackedPointers.set(event.pointerId, newElement);
     this.mapTouchEventId(event.pointerId);
 
-    this.cachedAverages = {
-      x: this.getLastAvgX(),
-      y: this.getLastAvgY(),
-    };
+    this.cachedAverages = this.getAbsoluteCoordsAverage();
   }
 
   public removeFromTracker(pointerId: number): void {
@@ -80,18 +81,19 @@ export default class PointerTracker {
     element.velocityX = velocityX;
     element.velocityY = velocityY;
 
-    element.lastX = event.x;
-    element.lastY = event.y;
+    element.abosoluteCoords = {
+      x: event.x,
+      y: event.y,
+    };
+
+    element.viewRelativeCoords = {
+      x: event.offsetX,
+      y: event.offsetY,
+    };
 
     this.trackedPointers.set(event.pointerId, element);
 
-    const avgX: number = this.getLastAvgX();
-    const avgY: number = this.getLastAvgY();
-
-    this.cachedAverages = {
-      x: avgX,
-      y: avgY,
-    };
+    this.cachedAverages = this.getAbsoluteCoordsAverage();
   }
 
   //Mapping TouchEvents ID
@@ -121,52 +123,26 @@ export default class PointerTracker {
     return NaN;
   }
 
-  public getVelocityX(pointerId: number): number {
-    return this.trackedPointers.get(pointerId)?.velocityX as number;
+  public getVelocity(pointerId: number) {
+    return {
+      x: this.trackedPointers.get(pointerId)?.velocityX as number,
+      y: this.trackedPointers.get(pointerId)?.velocityY as number,
+    };
   }
-  public getVelocityY(pointerId: number): number {
-    return this.trackedPointers.get(pointerId)?.velocityY as number;
-  }
 
-  /**
-   * Returns X coordinate of last moved pointer
-   */
-  public getLastX(): number;
-
-  /**
-   *
-   * @param pointerId
-   * Returns X coordinate of given pointer
-   */
-  // eslint-disable-next-line @typescript-eslint/unified-signatures
-  public getLastX(pointerId: number): number;
-
-  public getLastX(pointerId?: number): number {
+  public getLastAbsoluteCoords(pointerId?: number) {
     if (pointerId !== undefined) {
-      return this.trackedPointers.get(pointerId)?.lastX as number;
+      return {
+        x: this.trackedPointers.get(pointerId)?.abosoluteCoords.x as number,
+        y: this.trackedPointers.get(pointerId)?.abosoluteCoords.y as number,
+      };
     } else {
-      return this.trackedPointers.get(this.lastMovedPointerId)?.lastX as number;
-    }
-  }
-
-  /**
-   * Returns Y coordinate of last moved pointer
-   */
-  public getLastY(): number;
-
-  /**
-   *
-   * @param pointerId
-   * Returns Y coordinate of given pointer
-   */
-  // eslint-disable-next-line @typescript-eslint/unified-signatures
-  public getLastY(pointerId: number): number;
-
-  public getLastY(pointerId?: number): number {
-    if (pointerId !== undefined) {
-      return this.trackedPointers.get(pointerId)?.lastY as number;
-    } else {
-      return this.trackedPointers.get(this.lastMovedPointerId)?.lastY as number;
+      return {
+        x: this.trackedPointers.get(this.lastMovedPointerId)?.abosoluteCoords
+          .x as number,
+        y: this.trackedPointers.get(this.lastMovedPointerId)?.abosoluteCoords
+          .y as number,
+      };
     }
   }
 
@@ -174,35 +150,34 @@ export default class PointerTracker {
   // This may happen when pointers have already been removed from tracker (i.e. pointerup event).
   // In situation when NaN would be sent as a response, we return cached value.
   // That prevents handlers from crashing
-  public getLastAvgX(): number {
-    const avgX: number = this.getSumX() / this.trackedPointers.size;
-    return isNaN(avgX) ? this.cachedAverages.x : avgX;
+  public getAbsoluteCoordsAverage() {
+    const { totalX, totalY } = this.getAbsoluteCoordsSum();
+
+    const avgX = totalX / this.trackedPointers.size;
+    const avgY = totalY / this.trackedPointers.size;
+
+    const averages = {
+      x: isNaN(avgX) ? this.cachedAverages.x : avgX,
+      y: isNaN(avgY) ? this.cachedAverages.y : avgY,
+    };
+
+    return averages;
   }
-  public getLastAvgY(): number {
-    const avgY: number = this.getSumY() / this.trackedPointers.size;
-    return isNaN(avgY) ? this.cachedAverages.y : avgY;
-  }
-  public getSumX(ignoredPointer?: number): number {
-    let sumX = 0;
+
+  public getAbsoluteCoordsSum(ignoredPointer?: number) {
+    const sum = {
+      totalX: 0,
+      totalY: 0,
+    };
 
     this.trackedPointers.forEach((value, key) => {
       if (key !== ignoredPointer) {
-        sumX += value.lastX;
+        sum.totalX += value.abosoluteCoords.x;
+        sum.totalY += value.abosoluteCoords.y;
       }
     });
 
-    return sumX;
-  }
-  public getSumY(ignoredPointer?: number): number {
-    let sumY = 0;
-
-    this.trackedPointers.forEach((value, key) => {
-      if (key !== ignoredPointer) {
-        sumY += value.lastY;
-      }
-    });
-
-    return sumY;
+    return sum;
   }
   public getTrackedPointersCount(): number {
     return this.trackedPointers.size;

--- a/src/web/tools/Vector.ts
+++ b/src/web/tools/Vector.ts
@@ -25,10 +25,8 @@ export default class Vector {
   }
 
   static fromVelocity(tracker: PointerTracker, pointerId: number) {
-    return new Vector(
-      tracker.getVelocityX(pointerId),
-      tracker.getVelocityY(pointerId)
-    );
+    const velocity = tracker.getVelocity(pointerId);
+    return new Vector(velocity.x, velocity.y);
   }
 
   get magnitude() {


### PR DESCRIPTION
## Description

Fixing #2929 required adding additional information to `TrackerElement`. If we were to leave current structure of `PointerTracker`, we would have to add few more methods. After refactoring, there are only 2 that were not present before:

- `getLastViewRelativeCoords`
- `getViewRelativeCoordsSum`

I'd like to make similar changes to our handlers in the future (i.e. use `coords` object instead of `lastX` and `lastY` variables).

## Test plan

Tested on example app.