### PR TITLE
docs: update Hire us links to directly lead to contact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ This project has been build and is maintained thanks to the support from [Shopif
 
 ## Gesture Handler is created by Software Mansion
 
-Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps. We are Core React Native Contributors and experts in dealing with all kinds of React Native issues. We can help you build your next dream product – [Hire us](https://swmansion.com/contact#contact-form).
+Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps. We are Core React Native Contributors and experts in dealing with all kinds of React Native issues. We can help you build your next dream product – [Hire us](https://swmansion.com/contact/projects?utm_source=gesture-handler).

--- a/README.md
+++ b/README.md
@@ -66,4 +66,4 @@ This project has been build and is maintained thanks to the support from [Shopif
 
 ## Gesture Handler is created by Software Mansion
 
-Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps. We are Core React Native Contributors and experts in dealing with all kinds of React Native issues. We can help you build your next dream product – [Hire us](https://swmansion.com/contact/projects?utm_source=gesture-handler).
+Since 2012 [Software Mansion](https://swmansion.com) is a software agency with experience in building web and mobile apps. We are Core React Native Contributors and experts in dealing with all kinds of React Native issues. We can help you build your next dream product – [Hire us](https://swmansion.com/contact/projects?utm_source=gesture-handler&utm_medium=readme).

--- a/docs/src/components/HireUsSection/index.tsx
+++ b/docs/src/components/HireUsSection/index.tsx
@@ -18,7 +18,7 @@ const HireUsSection = () => {
         <HomepageButton
           backgroundStyling={styles.buttonNavyStyling}
           borderStyling={styles.buttonNavyBorderStyling}
-          href="https://swmansion.com/contact#contact-form"
+          href="https://swmansion.com/contact/projects?utm_source=gesture-handler"
           title="Hire us"
         />
       </div>

--- a/docs/src/components/HireUsSection/index.tsx
+++ b/docs/src/components/HireUsSection/index.tsx
@@ -18,7 +18,7 @@ const HireUsSection = () => {
         <HomepageButton
           backgroundStyling={styles.buttonNavyStyling}
           borderStyling={styles.buttonNavyBorderStyling}
-          href="https://swmansion.com/contact/projects?utm_source=gesture-handler&utm_medium=landing-page"
+          href="https://swmansion.com/contact/projects?utm_source=gesture-handler&utm_medium=docs"
           title="Hire us"
         />
       </div>

--- a/docs/src/components/HireUsSection/index.tsx
+++ b/docs/src/components/HireUsSection/index.tsx
@@ -18,7 +18,7 @@ const HireUsSection = () => {
         <HomepageButton
           backgroundStyling={styles.buttonNavyStyling}
           borderStyling={styles.buttonNavyBorderStyling}
-          href="https://swmansion.com/contact/projects?utm_source=gesture-handler"
+          href="https://swmansion.com/contact/projects?utm_source=gesture-handler&utm_medium=landing-page"
           title="Hire us"
         />
       </div>


### PR DESCRIPTION
This PR changes the Hire us links in the documentation and README to directly lead to the opened project contact form. Previously it led to the whole Contact page.