### PR TITLE
Change `offsetX` and `offsetY` calculations in `PointerEventManager`

### DIFF
--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -234,11 +234,13 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
   }
 
   protected mapEvent(event: PointerEvent, eventType: EventTypes): AdaptedEvent {
+    const rect = this.view.getBoundingClientRect();
+
     return {
       x: event.clientX,
       y: event.clientY,
-      offsetX: event.offsetX,
-      offsetY: event.offsetY,
+      offsetX: event.clientX - rect.left,
+      offsetY: event.clientY - rect.top,
       pointerId: event.pointerId,
       eventType: eventType,
       pointerType:


### PR DESCRIPTION
## Description

While working on `PointerTracker` refactor and adding `relativeCoords` to it, I've noticed that `offsetX`/`offsetY` in `PointerEventManager` use `PointerEvent.offsetX` (and `offsetY` respectively) while `TouchEventManager` calculates this property by calculating the difference between `clientX` and bounding box (`event.clientX - rect.left`). I've decided to unify this behavior so that `offset` is now calculated in `PointerEventManager` the same way as in `TouchEventManager`.

As. you can see in the videos below, those 2 values may have different results - that is the main reason behind unifying them. `offset` property is used only in `relativeCoords` which have been recently introduced, so it won't be a breaking change.

## Test plan

Tested by adding `console.table` in `onPointerMove` inside `PanGestureHandler`

### `div` with `Pan`

<img width="834" alt="image" src="https://github.com/software-mansion/react-native-gesture-handler/assets/63123542/d1ab88df-b982-4bdc-9dfa-9ccb18284efb">

### Before

https://github.com/software-mansion/react-native-gesture-handler/assets/63123542/61918493-b667-49c5-88c5-bf5205336dae

### After 

https://github.com/software-mansion/react-native-gesture-handler/assets/63123542/a499a69e-52aa-4ed5-a4a4-826b9dc28a7e

