### PR TITLE
Add touchType to touchEvent

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
@@ -49,6 +49,7 @@ class RNGestureHandlerTouchEvent private constructor() : Event<RNGestureHandlerT
       putInt("state", handler.state)
       putInt("numberOfTouches", handler.trackedPointersCount)
       putInt("eventType", handler.touchEventType)
+      putInt("touchType", handler.pointerType)
 
       handler.consumeChangedTouchesPayload()?.let {
         putArray("changedTouches", it)

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
@@ -49,7 +49,7 @@ class RNGestureHandlerTouchEvent private constructor() : Event<RNGestureHandlerT
       putInt("state", handler.state)
       putInt("numberOfTouches", handler.trackedPointersCount)
       putInt("eventType", handler.touchEventType)
-      putInt("touchType", handler.pointerType)
+      putInt("pointerType", handler.pointerType)
 
       handler.consumeChangedTouchesPayload()?.let {
         putArray("changedTouches", it)

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -167,6 +167,7 @@ export type GestureTouchEvent = {
   eventType: TouchEventType;
   allTouches: TouchData[];
   changedTouches: TouchData[];
+  pointerType: number;
 };
 
 export type GestureUpdateEvent<GestureEventPayloadT = Record<string, unknown>> =

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -167,7 +167,7 @@ export type GestureTouchEvent = {
   eventType: TouchEventType;
   allTouches: TouchData[];
   changedTouches: TouchData[];
-  pointerType: number;
+  pointerType: PointerType;
 };
 
 export type GestureUpdateEvent<GestureEventPayloadT = Record<string, unknown>> =

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -511,6 +511,7 @@ export default abstract class GestureHandler implements IGestureHandler {
         changedTouches: changed,
         allTouches: all,
         numberOfTouches: numberOfTouches,
+        pointerType: this.pointerType,
       },
       timeStamp: Date.now(),
     };
@@ -556,6 +557,7 @@ export default abstract class GestureHandler implements IGestureHandler {
         changedTouches: changed,
         allTouches: all,
         numberOfTouches: all.length,
+        pointerType: this.pointerType,
       },
       timeStamp: Date.now(),
     };

--- a/src/web/interfaces.ts
+++ b/src/web/interfaces.ts
@@ -113,7 +113,7 @@ interface NativeTouchEvent extends Record<string, TouchNativeArgs> {
   changedTouches: PointerData[];
   allTouches: PointerData[];
   numberOfTouches: number;
-  pointerType: number;
+  pointerType: PointerType;
 }
 
 export interface ResultEvent extends Record<string, NativeEvent | number> {

--- a/src/web/interfaces.ts
+++ b/src/web/interfaces.ts
@@ -113,6 +113,7 @@ interface NativeTouchEvent extends Record<string, TouchNativeArgs> {
   changedTouches: PointerData[];
   allTouches: PointerData[];
   numberOfTouches: number;
+  pointerType: number;
 }
 
 export interface ResultEvent extends Record<string, NativeEvent | number> {


### PR DESCRIPTION
This PR adds pointerType to touchEvent on android and web.
This propet is already present on ios but it's missing from web and android.
