### PR TITLE
[Web] Send relative coords in event.

### DIFF
--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -570,12 +570,12 @@ export default abstract class GestureHandler implements IGestureHandler {
 
   protected transformNativeEvent(): Record<string, unknown> {
     // those properties are shared by most handlers and if not this method will be overriden
-    const rect = this.delegate.measureView();
     const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    const lastRelativeCoords = this.tracker.getRelativeCoordsAverage();
 
     return {
-      x: lastCoords.x - rect.pageX,
-      y: lastCoords.y - rect.pageY,
+      x: lastRelativeCoords.x,
+      y: lastRelativeCoords.y,
       absoluteX: lastCoords.x,
       absoluteY: lastCoords.y,
     };


### PR DESCRIPTION
## Description

Changes made in #2938 and #2939 allowed us to calculate `x` and `y` relative to given `View` with the same method on `PointerEvents` and `TouchEvents`. This PR changes logic in `GestureHandler` base class, so that now it sends relative coordinates calculated by tracker.

This change, combined with the one from #2943, makes handlers send correct relative coords.

> [!NOTE]
> New coords may not be correct if the `view` is rotated, or some of its ancestors are scaled. These cases will be handled in different PRs.

## Test plan

Copy snippet below and paste it into `transformNativeEvent` in `GestureHandler.ts`

<details>
<summary> Logs snippet </summary>

```jsx

    const rect = this.delegate.measureView();
    const old = {
      x: lastCoords.x - rect.pageX,
      y: lastCoords.y - rect.pageY,
    };

    console.table({
      oldX: old.x,
      oldY: old.y,
      newX: lastRelativeCoords.x,
      newY: lastRelativeCoords.y,
      dx: old.x - lastRelativeCoords.x,
      dy: old.y - lastRelativeCoords.y,
    });

```

</details>

Here's example video that shows difference between those calculations:


https://github.com/software-mansion/react-native-gesture-handler/assets/63123542/d3a0575c-3821-4d2a-ac96-a0c3a870a1f5

