### PR TITLE
[macOS] Add `ForceTouch` warning

### DIFF
--- a/apple/Handlers/RNForceTouchHandler.m
+++ b/apple/Handlers/RNForceTouchHandler.m
@@ -184,6 +184,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
 
 - (instancetype)initWithTag:(NSNumber *)tag
 {
+  RCTLogWarn(@"ForceTouchHandler is not supported on macOS");
   if ((self = [super initWithTag:tag])) {
     _recognizer = [NSGestureRecognizer alloc];
   }


### PR DESCRIPTION
## Description

This PR adds warning that `ForceTouchGestureHandler` is not implemented on `macOS`. As stated in #2701:

>(...) This leads to some inconvenience, as we still have JS warning about not supporting Force Touch. It should be moved to native files as well.  

This is not true. Warning mentioned in quote above says that `ForceTouch` is not available on given platform. However, this is generic warning that will be thrown also for example on Android or web (if given platform doesn't support `ForceTouch`). This is something different from not supporting `ForceTouchGestureHandler` and it should not be removed. 

The other thing is that warning about `ForceTouch` availability is currently missing on new API. We will add it soon.

Closes #2701 

## Test plan

Place the following code inside any example in `MacOSExample`:

<details>
<summary> Test code </summary>

```tsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import { Gesture, GestureDetector } from 'react-native-gesture-handler';

export default function App() {
  const ft = Gesture.ForceTouch();

  return (
    <GestureDetector gesture={ft}>
      <View style={styles.container} />
    </GestureDetector>
  );
}

const styles = StyleSheet.create({
  container: {
    width: 100,
    height: 100,
    backgroundColor: 'crimson',
  },
});

```

</details>
