### PR TITLE
Remove shared value read on the JS thread during detector update

### DIFF
--- a/src/handlers/gestures/GestureDetector/updateHandlers.ts
+++ b/src/handlers/gestures/GestureDetector/updateHandlers.ts
@@ -40,8 +40,22 @@ export function updateHandlers(
     if (!preparedGesture.isMounted) {
       return;
     }
+
+    // if amount of gesture configs changes, we need to update the callbacks in shared value
+    let shouldUpdateSharedValueIfUsed =
+      preparedGesture.attachedGestures.length !== newGestures.length;
+
     for (let i = 0; i < newGestures.length; i++) {
       const handler = preparedGesture.attachedGestures[i];
+
+      // if the gestureId is different (gesture isn't wrapped with useMemo or its dependencies changed),
+      // we need to update the shared value, assuming the gesture runs on UI thread or the thread changed
+      if (
+        handler.handlers.gestureId !== newGestures[i].handlers.gestureId &&
+        (newGestures[i].shouldUseReanimated || handler.shouldUseReanimated)
+      ) {
+        shouldUpdateSharedValueIfUsed = true;
+      }
 
       handler.config = newGestures[i].config;
       handler.handlers = newGestures[i].handlers;
@@ -59,32 +73,13 @@ export function updateHandlers(
     }
 
     if (preparedGesture.animatedHandlers) {
-      const previousHandlersValue =
-        preparedGesture.animatedHandlers.value ?? [];
       const newHandlersValue = preparedGesture.attachedGestures
         .filter((g) => g.shouldUseReanimated) // ignore gestures that shouldn't run on UI
         .map((g) => g.handlers) as unknown as HandlerCallbacks<
         Record<string, unknown>
       >[];
 
-      // if amount of gesture configs changes, we need to update the callbacks in shared value
-      let shouldUpdateSharedValue =
-        previousHandlersValue.length !== newHandlersValue.length;
-
-      if (!shouldUpdateSharedValue) {
-        // if the amount is the same, we need to check if any of the configs inside has changed
-        for (let i = 0; i < newHandlersValue.length; i++) {
-          if (
-            // we can use the `gestureId` prop as it's unique for every config instance
-            newHandlersValue[i].gestureId !== previousHandlersValue[i].gestureId
-          ) {
-            shouldUpdateSharedValue = true;
-            break;
-          }
-        }
-      }
-
-      if (shouldUpdateSharedValue) {
+      if (shouldUpdateSharedValueIfUsed) {
         preparedGesture.animatedHandlers.value = newHandlersValue;
       }
     }

--- a/src/handlers/gestures/GestureDetector/updateHandlers.ts
+++ b/src/handlers/gestures/GestureDetector/updateHandlers.ts
@@ -72,16 +72,14 @@ export function updateHandlers(
       registerHandler(handler.handlerTag, handler, handler.config.testId);
     }
 
-    if (preparedGesture.animatedHandlers) {
+    if (preparedGesture.animatedHandlers && shouldUpdateSharedValueIfUsed) {
       const newHandlersValue = preparedGesture.attachedGestures
         .filter((g) => g.shouldUseReanimated) // ignore gestures that shouldn't run on UI
         .map((g) => g.handlers) as unknown as HandlerCallbacks<
         Record<string, unknown>
       >[];
 
-      if (shouldUpdateSharedValueIfUsed) {
-        preparedGesture.animatedHandlers.value = newHandlersValue;
-      }
+      preparedGesture.animatedHandlers.value = newHandlersValue;
     }
 
     scheduleFlushOperations();


### PR DESCRIPTION
## Description

In https://github.com/software-mansion/react-native-gesture-handler/pull/2037 support for memoizing gestures was added, which relied on reading the current handlers from the shared value and comparing them to the new ones.

This worked well with Reanimated 2, where shared values kept a copy of their value on JS thread, and the assumption about Reanimated 3, was that even though the read is synchronous, it's quick enough not to cause problems. This assumption was wrong since it can result in JS thread being blocked until the UI thread finishes its current work to allow for SV read.

This PR eliminates the necessity of reading from the shared value by relying on information already available on the JS thread to decide whether the shared value should be updated.

## Test plan

Test on the Example app to make sure nothing breaks, and make sure that memorized gestures don't result in updating the shared value.
