### PR TITLE
docs: bump `@swmansion/t-rex-ui` to 0.0.12

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -29,7 +29,7 @@
     "@emotion/styled": "^11.10.6",
     "@mdx-js/react": "^1.6.22",
     "@mui/material": "^5.12.0",
-    "@swmansion/t-rex-ui": "^0.0.9",
+    "@swmansion/t-rex-ui": "^0.0.12",
     "@vercel/og": "^0.6.2",
     "babel-polyfill": "^6.26.0",
     "babel-preset-expo": "^9.2.2",

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -3204,10 +3204,10 @@
     "@svgr/plugin-jsx" "^6.5.1"
     "@svgr/plugin-svgo" "^6.5.1"
 
-"@swmansion/t-rex-ui@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.npmjs.org/@swmansion/t-rex-ui/-/t-rex-ui-0.0.9.tgz#192c8e6beabcbb885b37e485157b610e2b8599b9"
-  integrity sha512-4FoJP/7RFeDB36YEvRd0dvqZ7jbq9xipbyOFk0uM7Dpc9xgkO3ZVhPuS6lbHOvN3L8/rvBE/d6nDRZH3yd8Y9g==
+"@swmansion/t-rex-ui@^0.0.12":
+  version "0.0.12"
+  resolved "https://registry.npmjs.org/@swmansion/t-rex-ui/-/t-rex-ui-0.0.12.tgz#fffdc8a222773fb77019d188a60dd60decbe8ddf"
+  integrity sha512-l2gtWH6Z9CVl1GoZoypkcMM0mYBShOBvE13ct40sKc7LwqKtFv+PCrdYwMbGcd2kj95fhG7dTyueZW2pMP6R1w==
   dependencies:
     "@docsearch/react" "^3.6.0"
     "@docusaurus/core" "^2.4.3"


### PR DESCRIPTION
Important changes from 0.0.12:
* [navbar_links ](https://github.com/software-mansion-labs/t-rex-ui/commit/cab20427bf28d8325e6cc97dc7ac329927edb019) - not visible in this docs (lack of links by default)
* [search modal style fix](https://github.com/software-mansion-labs/t-rex-ui/commit/c1a69ac4fd81458b9bd24314aaa74a0d30b0f2bf)
* [hire us links](https://github.com/software-mansion-labs/t-rex-ui/commit/8ef15757524a395d3f12b57c85c9f561a3398120)

<img width="1094" alt="image" src="https://github.com/software-mansion/react-native-gesture-handler/assets/59940332/8b6b8c5d-a903-466a-bd3b-6621cea467f2">

<img width="212" alt="image" src="https://github.com/software-mansion/react-native-gesture-handler/assets/59940332/656f72d3-2271-486b-a4a5-e068057b01a0">
