### PR TITLE
Make handler comparator work only on non-null objects

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -615,7 +615,7 @@ class GestureHandlerOrchestrator(
     private val matrixTransformCoords = FloatArray(2)
     private val inverseMatrix = Matrix()
     private val tempCoords = FloatArray(2)
-    private val handlersComparator = Comparator<GestureHandler<*>?> { a, b ->
+    private val handlersComparator = Comparator<GestureHandler<*>> { a, b ->
       return@Comparator if (a.isActive && b.isActive || a.isAwaiting && b.isAwaiting) {
         // both A and B are either active or awaiting activation, in which case we prefer one that
         // has activated (or turned into "awaiting" state) earlier


### PR DESCRIPTION
## Description

Should close https://github.com/software-mansion/react-native-gesture-handler/issues/2960

Changes the comparator type to work only with non-null objects, since it's only used in this way. It was probably a leftover from migration to Kotlin.

## Test plan

Build the app
