### PR TITLE
Use newer constructor for all Gesture Handler events on Android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.kt
@@ -9,6 +9,7 @@ package com.swmansion.gesturehandler.react
 import androidx.core.util.Pools
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
 import com.swmansion.gesturehandler.core.GestureHandler
 import com.swmansion.gesturehandler.react.eventbuilders.GestureHandlerEventDataBuilder
@@ -29,7 +30,8 @@ class RNGestureHandlerEvent private constructor() : Event<RNGestureHandlerEvent>
     dataBuilder: GestureHandlerEventDataBuilder<T>,
     useNativeAnimatedName: Boolean
   ) {
-    super.init(handler.view!!.id)
+    val view = handler.view!!
+    super.init(UIManagerHelper.getSurfaceId(view), view.id)
     this.dataBuilder = dataBuilder
     this.useTopPrefixedName = useNativeAnimatedName
     coalescingKey = handler.eventCoalescingKey

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.kt
@@ -9,6 +9,7 @@ package com.swmansion.gesturehandler.react
 import androidx.core.util.Pools
 import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.events.Event
 import com.swmansion.gesturehandler.core.GestureHandler
 import com.swmansion.gesturehandler.react.eventbuilders.GestureHandlerEventDataBuilder
@@ -24,7 +25,8 @@ class RNGestureHandlerStateChangeEvent private constructor() : Event<RNGestureHa
     oldState: Int,
     dataBuilder: GestureHandlerEventDataBuilder<T>,
   ) {
-    super.init(handler.view!!.id)
+    val view = handler.view!!
+    super.init(UIManagerHelper.getSurfaceId(view), view.id)
     this.dataBuilder = dataBuilder
     this.newState = newState
     this.oldState = oldState

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
@@ -11,7 +11,8 @@ class RNGestureHandlerTouchEvent private constructor() : Event<RNGestureHandlerT
   private var extraData: WritableMap? = null
   private var coalescingKey: Short = 0
   private fun <T : GestureHandler<T>> init(handler: T) {
-    super.init(UIManagerHelper.getSurfaceId(handler.view), handler.view!!.id)
+    val view = handler.view!!
+    super.init(UIManagerHelper.getSurfaceId(view), view.id)
     extraData = createEventData(handler)
     coalescingKey = handler.eventCoalescingKey
   }


### PR DESCRIPTION
## Description

Updates events to use the newer constructor with `surfaceId`.

## Test plan

Check the example app
