### PR TITLE
Replace `queueMicrotask` with `requestAnimationFrame`

### DIFF
--- a/src/ghQueueMicrotask.ts
+++ b/src/ghQueueMicrotask.ts
@@ -1,5 +1,5 @@
-// `queueMicrotask` was introduced to react-native in version 0.66 (https://github.com/react-native-community/releases/blob/master/CHANGELOG.md#v0660)
-// Because Gesture Handler supports versions 0.64+, we have to handle situations where someone uses older version of react native.
-// That's why if `queueMicrotask` doesn't exist, we use `setImmediate` instead, since it was used before we switched to `queueMicrotask` in version 2.11.0
+// We check for typeof requestAnimationFrame because of SSR
 export const ghQueueMicrotask =
-  typeof queueMicrotask === 'function' ? queueMicrotask : setImmediate;
+  typeof requestAnimationFrame === 'function'
+    ? requestAnimationFrame
+    : queueMicrotask;


### PR DESCRIPTION
## Description

This PR replaces `queueMicrotask` with `requestAnimationFrame`. Turns out that introducing `useLayoutEffect` (which was introduced in #2925) ended up in gestures being attached in wrong order in some cases. 

This can be observed in #2963 (it is highly recommended to look into repro structure):

1. 3 handlers from `ZoomView` where attached - they have correct `tags`
2. Re-render happens, handlers' `tags` are now `-1`
3. `Pan` from `SVGMask` is attached - all handlers marked as `simultaneous` have `tag` `-1`, therefore relations are not set up
4. Handlers from 1. are attached again, so they get back their original `tags`

In this scenario, `simultaneous handlers` array in `Pan` in `SVGMask` was empty, effectively disabling this relation. Switching to `requestAnimationFrame` solves this problem. 

## Test plan

Verify that examples work as they used to (`draggable`, `multitap`, `transformations`)

Also tested on code from #2963 .
