### PR TITLE
Set consistent prettier version across all package.jsons

### DIFF
--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -37,7 +37,7 @@
     "babel-jest": "^29.2.1",
     "eslint": "^8.19.0",
     "jest": "^29.2.1",
-    "prettier": "^2.4.1",
+    "prettier": "2.7.1",
     "react-test-renderer": "18.2.0",
     "typescript": "5.0.4"
   },

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -6221,10 +6221,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.4.1:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.0.tgz#c7df58393c9ba77d6fba3921ae01faf994fb9dc9"
-  integrity sha512-9Lmg8hTFZKG0Asr/kW9Bp8tJjRVluO8EJQVfY2T7FMw9T5jy4I/Uvx0Rca/XWf50QQ1/SS48+6IJWnrb+2yemA==
+prettier@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-format@^26.5.2, pretty-format@^26.6.2:
   version "26.6.2"
@@ -6334,12 +6334,8 @@ react-is@^17.0.1:
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 "react-native-gesture-handler@link:..":
-  version "2.17.1"
-  dependencies:
-    "@egjs/hammerjs" "^2.0.17"
-    hoist-non-react-statics "^3.3.0"
-    invariant "^2.2.4"
-    prop-types "^15.7.2"
+  version "0.0.0"
+  uid ""
 
 react-native@0.74.0:
   version "0.74.0"

--- a/MacOSExample/package.json
+++ b/MacOSExample/package.json
@@ -38,7 +38,7 @@
     "glob-to-regexp": "^0.4.1",
     "jest": "^29.2.1",
     "metro-react-native-babel-preset": "0.76.8",
-    "prettier": "^2.4.1",
+    "prettier": "2.7.1",
     "react-test-renderer": "18.2.0",
     "typescript": "4.8.4"
   },

--- a/MacOSExample/yarn.lock
+++ b/MacOSExample/yarn.lock
@@ -5917,10 +5917,10 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.4.1:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
-  integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
+prettier@2.7.1:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
+  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
 
 pretty-format@^26.5.2, pretty-format@^26.6.2:
   version "26.6.2"
@@ -6036,12 +6036,8 @@ react-is@^17.0.1:
   integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 "react-native-gesture-handler@link:..":
-  version "2.17.1"
-  dependencies:
-    "@egjs/hammerjs" "^2.0.17"
-    hoist-non-react-statics "^3.3.0"
-    invariant "^2.2.4"
-    prop-types "^15.7.2"
+  version "0.0.0"
+  uid ""
 
 react-native-macos@^0.72.0:
   version "0.72.4"

--- a/package.json
+++ b/package.json
@@ -100,7 +100,7 @@
     "jest": "^26.6.3",
     "lint-staged": "^12.3.2",
     "madge": "^6.1.0",
-    "prettier": "^2.7.1",
+    "prettier": "2.7.1",
     "react": "18.2.0",
     "react-dom": "^16.12.0",
     "react-native": "0.74.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10560,7 +10560,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.7.1:
+prettier@2.7.1:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
   integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==


### PR DESCRIPTION
Due to inconsistent `prettier` versions across packages, I encountered conflicting `prettier` formatting rules.

This PR bumps the version of `prettier` to `2.7.1` all across the board, which matches what is present in `example/`.

I'm leaving `package.json` in `docs/` alone, as it uses a different, higher `prettier` version than other packages, changing it to `2.7.1` causes too many changes.