### PR TITLE
fix: bind scope to null to prevent issues with inline requires

### DIFF
--- a/src/ghQueueMicrotask.ts
+++ b/src/ghQueueMicrotask.ts
@@ -1,6 +1,6 @@
 // We check for typeof requestAnimationFrame because of SSR
 export const ghQueueMicrotask =
-  typeof requestAnimationFrame === "function"
-    // Functions are bound to null to avoid issues with scope when using Metro inline requires.
-    ? requestAnimationFrame.bind(null)
+  typeof requestAnimationFrame === 'function'
+    ? // Functions are bound to null to avoid issues with scope when using Metro inline requires.
+      requestAnimationFrame.bind(null)
     : queueMicrotask.bind(null);

--- a/src/ghQueueMicrotask.ts
+++ b/src/ghQueueMicrotask.ts
@@ -1,5 +1,6 @@
 // We check for typeof requestAnimationFrame because of SSR
 export const ghQueueMicrotask =
-  typeof requestAnimationFrame === 'function'
-    ? requestAnimationFrame
-    : queueMicrotask;
+  typeof requestAnimationFrame === "function"
+    // Functions are bound to null to avoid issues with scope when using Metro inline requires.
+    ? requestAnimationFrame.bind(null)
+    : queueMicrotask.bind(null);


### PR DESCRIPTION
## Description

- I've identified an issue with Metro's inlineRequires + experimentalImportSupport while building tree shaking support for Expo CLI. This issue causes an invalid invocation to be thrown because the scope of the build-in functions is not correct.
- More info can be found here https://github.com/EvanBacon/inline-requires-issue

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

- In my [repro](https://github.com/EvanBacon/inline-requires-issue) the bindings no longer throw. I've raised the issue with Metro team so we can create a system-wide fix, but this should prevent any issues in the meantime. 
