### PR TITLE
Fix `onPressOut` not being triggered

### DIFF
--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -94,8 +94,8 @@ export default function Pressable(props: PressableProps) {
   const pressDelayTimeoutRef = useRef<number | null>(null);
   const pressInHandler = useCallback((event: GestureTouchEvent) => {
     props.onPressIn?.(adaptTouchEvent(event));
-    isPressCallbackEnabled.current = true;
     setPressedState(true);
+    isPressCallbackEnabled.current = true;
     pressDelayTimeoutRef.current = null;
   }, []);
   const pressOutHandler = useCallback((event: GestureTouchEvent) => {
@@ -109,7 +109,8 @@ export default function Pressable(props: PressableProps) {
     if (props.unstable_pressDelay && pressDelayTimeoutRef.current !== null) {
       // when delay is preemptively finished by lifting touches,
       // we want to immediately activate it's effects - pressInHandler,
-      // even though we are located at the pressOutHandler      clearTimeout(pressDelayTimeoutRef.current);
+      // even though we are located at the pressOutHandler
+      clearTimeout(pressDelayTimeoutRef.current);
       pressInHandler(event);
     }
 

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -94,9 +94,9 @@ export default function Pressable(props: PressableProps) {
   const pressDelayTimeoutRef = useRef<number | null>(null);
   const pressInHandler = useCallback((event: GestureTouchEvent) => {
     props.onPressIn?.(adaptTouchEvent(event));
-    setPressedState(true);
     isPressCallbackEnabled.current = true;
     pressDelayTimeoutRef.current = null;
+    setPressedState(true);
   }, []);
   const pressOutHandler = useCallback((event: GestureTouchEvent) => {
     if (

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -108,7 +108,7 @@ export default function Pressable(props: PressableProps) {
 
     if (props.unstable_pressDelay && pressDelayTimeoutRef.current !== null) {
       // when delay is preemptively finished by lifting touches,
-      // we want to immidiately activate it's effects - pressInHandler,
+      // we want to immediately activate it's effects - pressInHandler,
       // even though we are located at the pressOutHandler      clearTimeout(pressDelayTimeoutRef.current);
       pressInHandler(event);
     }

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -176,16 +176,16 @@ export default function Pressable(props: PressableProps) {
           pressOutHandler(event);
         })
         .onTouchesCancelled((event) => {
+          if (handlingOnTouchesDown.current) {
+            cancelledMidPress.current = true;
+            onEndHandlingTouchesDown.current = () => pressOutHandler(event);
+            return;
+          }
+
           if (
             !isPressedDown.current ||
             event.allTouches.length > event.changedTouches.length
           ) {
-            return;
-          }
-
-          if (handlingOnTouchesDown.current) {
-            cancelledMidPress.current = true;
-            onEndHandlingTouchesDown.current = () => pressOutHandler(event);
             return;
           }
 

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -107,8 +107,9 @@ export default function Pressable(props: PressableProps) {
     }
 
     if (props.unstable_pressDelay && pressDelayTimeoutRef.current !== null) {
-      // legacy Pressable behaviour - if pressDelay is set, we want to call onPressIn on touch up
-      clearTimeout(pressDelayTimeoutRef.current);
+      // when delay is preemptively finished by lifting touches,
+      // we want to immidiately activate it's effects - pressInHandler,
+      // even though we are located at the pressOutHandler      clearTimeout(pressDelayTimeoutRef.current);
       pressInHandler(event);
     }
 


### PR DESCRIPTION
## Description

An issue was found where `onPressOut` would not be triggered when dragging a `pressedDown` pointer out of the element's bounds, which would cause the element to stay in a `pressedDown` state until the next time it was clicked.
Among other things, this caused issues with styling.
This PR fixes this issue.

https://github.com/software-mansion/react-native-gesture-handler/assets/63123542/3b5d4cf1-d022-49b1-9c11-0a10784a437b

## Test plan
- go to `release_tests > Gesturized Pressable` example
- scroll down to the `Functional styling` example
- interaction with the `Gesturized` square:
  - press on the square.
  - drag outside of it's boundaries
  - stop pressing
- red square switches back to it's original color

All relevant code used for testing is present on both `this` and the `main` branch inside `example/src/release_tests/gesturizedPressable`

closes: #2975 