### PR TITLE
Fix nested pressable's event propagation.

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -132,7 +132,7 @@ const EXAMPLES: ExamplesSection[] = [
         component: NestedTouchables as React.ComponentType,
       },
       {
-        name: 'Nested Pressables',
+        name: 'Nested Pressables - issue #2980',
         component: NestedPressables as React.ComponentType,
       },
       {

--- a/example/src/release_tests/nestedPressables/index.tsx
+++ b/example/src/release_tests/nestedPressables/index.tsx
@@ -23,24 +23,32 @@ export default function Example() {
   );
 }
 
+const BOX_SIZE_COEFFICIENT = 100;
+
+const getBoxStyle = (size: number): StyleProp<ViewStyle> => ({
+  width: size,
+  height: size,
+  borderWidth: 1,
+});
+
 const innerStyle = ({
   pressed,
-}: PressableStateCallbackType): StyleProp<ViewStyle> =>
-  pressed
-    ? { backgroundColor: 'purple', width: 100, height: 100 }
-    : { width: 100, height: 100, borderWidth: 1 };
+}: PressableStateCallbackType): StyleProp<ViewStyle> => [
+  getBoxStyle(BOX_SIZE_COEFFICIENT),
+  pressed ? { backgroundColor: 'purple' } : null,
+];
 const middleStyle = ({
   pressed,
-}: PressableStateCallbackType): StyleProp<ViewStyle> =>
-  pressed
-    ? { backgroundColor: 'green', width: 200, height: 200 }
-    : { width: 200, height: 200, borderWidth: 1 };
+}: PressableStateCallbackType): StyleProp<ViewStyle> => [
+  getBoxStyle(BOX_SIZE_COEFFICIENT * 2),
+  pressed ? { backgroundColor: 'green' } : null,
+];
 const outerStyle = ({
   pressed,
-}: PressableStateCallbackType): StyleProp<ViewStyle> =>
-  pressed
-    ? { backgroundColor: 'yellow', width: 300, height: 300 }
-    : { width: 300, height: 300, borderWidth: 1 };
+}: PressableStateCallbackType): StyleProp<ViewStyle> => [
+  getBoxStyle(BOX_SIZE_COEFFICIENT * 3),
+  pressed ? { backgroundColor: 'yellow' } : null,
+];
 
 function GesturizedBoxes() {
   return (

--- a/example/src/release_tests/nestedPressables/index.tsx
+++ b/example/src/release_tests/nestedPressables/index.tsx
@@ -52,9 +52,9 @@ const outerStyle = ({
 
 function GesturizedBoxes() {
   return (
-    <GesturizedPressable style={outerStyle}>
-      <GesturizedPressable style={middleStyle}>
-        <GesturizedPressable style={innerStyle} />
+    <GesturizedPressable style={outerStyle} testID="outer">
+      <GesturizedPressable style={middleStyle} testID="middle">
+        <GesturizedPressable style={innerStyle} testID="inner" />
       </GesturizedPressable>
     </GesturizedPressable>
   );

--- a/example/src/release_tests/nestedPressables/index.tsx
+++ b/example/src/release_tests/nestedPressables/index.tsx
@@ -5,6 +5,7 @@ import {
   StyleProp,
   StyleSheet,
   Text,
+  View,
   ViewStyle,
 } from 'react-native';
 import {
@@ -15,10 +16,12 @@ import {
 export default function Example() {
   return (
     <ScrollView>
-      <Text style={styles.text}>Gesturized Nested Pressables</Text>
-      <GesturizedBoxes />
-      <Text style={styles.text}>Legacy Nested Pressables</Text>
-      <LegacyBoxes />
+      <View style={styles.centering}>
+        <Text style={styles.text}>Gesturized Nested Pressables</Text>
+        <GesturizedBoxes />
+        <Text style={styles.text}>Legacy Nested Pressables</Text>
+        <LegacyBoxes />
+      </View>
     </ScrollView>
   );
 }
@@ -35,19 +38,22 @@ const innerStyle = ({
   pressed,
 }: PressableStateCallbackType): StyleProp<ViewStyle> => [
   getBoxStyle(BOX_SIZE_COEFFICIENT),
-  pressed ? { backgroundColor: 'purple' } : null,
+  pressed ? { backgroundColor: '#c00' } : { backgroundColor: '#c77' },
+  styles.centering,
 ];
 const middleStyle = ({
   pressed,
 }: PressableStateCallbackType): StyleProp<ViewStyle> => [
   getBoxStyle(BOX_SIZE_COEFFICIENT * 2),
-  pressed ? { backgroundColor: 'green' } : null,
+  pressed ? { backgroundColor: '#0c0' } : { backgroundColor: '#7a7' },
+  styles.centering,
 ];
 const outerStyle = ({
   pressed,
 }: PressableStateCallbackType): StyleProp<ViewStyle> => [
   getBoxStyle(BOX_SIZE_COEFFICIENT * 3),
-  pressed ? { backgroundColor: 'yellow' } : null,
+  pressed ? { backgroundColor: '#00c' } : { backgroundColor: '#88a' },
+  styles.centering,
 ];
 
 function GesturizedBoxes() {
@@ -71,5 +77,13 @@ function LegacyBoxes() {
 }
 
 const styles = StyleSheet.create({
-  text: { fontSize: 20, margin: 20 },
+  text: {
+    fontSize: 20,
+    margin: 20,
+  },
+  centering: {
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 6,
+  },
 });

--- a/example/src/release_tests/nestedPressables/index.tsx
+++ b/example/src/release_tests/nestedPressables/index.tsx
@@ -18,7 +18,7 @@ export default function Example() {
     <ScrollView>
       <LoremIpsum words={40} />
       <Text style={styles.text}>Gesturized Nested Pressables</Text>
-      <ReanimatedBoxes />
+      <GesturizedBoxes />
       <LoremIpsum words={40} />
       <Text style={styles.text}>Legacy Nested Pressables</Text>
       <LegacyBoxes />
@@ -46,7 +46,7 @@ const outerStyle = ({
     ? { backgroundColor: 'yellow', width: 300, height: 300 }
     : { width: 300, height: 300, borderWidth: 1 };
 
-function ReanimatedBoxes() {
+function GesturizedBoxes() {
   return (
     <GesturizedPressable style={outerStyle}>
       <GesturizedPressable style={middleStyle}>

--- a/example/src/release_tests/nestedPressables/index.tsx
+++ b/example/src/release_tests/nestedPressables/index.tsx
@@ -11,18 +11,14 @@ import {
   ScrollView,
   Pressable as GesturizedPressable,
 } from 'react-native-gesture-handler';
-import { LoremIpsum } from '../../common';
 
 export default function Example() {
   return (
     <ScrollView>
-      <LoremIpsum words={40} />
       <Text style={styles.text}>Gesturized Nested Pressables</Text>
       <GesturizedBoxes />
-      <LoremIpsum words={40} />
       <Text style={styles.text}>Legacy Nested Pressables</Text>
       <LegacyBoxes />
-      <LoremIpsum words={40} />
     </ScrollView>
   );
 }

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -102,7 +102,7 @@ export default function Pressable(props: PressableProps) {
         deferredEventPayload.current = event;
       }
 
-      if (isTouchPropagationAllowed.current === false) {
+      if (!isTouchPropagationAllowed.current) {
         return;
       }
 
@@ -164,7 +164,7 @@ export default function Pressable(props: PressableProps) {
 
   const activateLongPress = useCallback(
     (event: GestureTouchEvent) => {
-      if (isTouchPropagationAllowed.current === false) {
+      if (!isTouchPropagationAllowed.current) {
         return;
       }
 

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -57,6 +57,7 @@ export default function Pressable(props: PressableProps) {
   const hoverGesture = useMemo(
     () =>
       Gesture.Hover()
+        .manualActivation(true) // stops Hover from blocking Native gesture activation on web
         .onBegin((event) => {
           if (hoverOutTimeout.current) {
             clearTimeout(hoverOutTimeout.current);
@@ -255,6 +256,9 @@ export default function Pressable(props: PressableProps) {
               }
               propagationGreenLight.current = false;
             }
+          }
+          if (Platform.OS === 'web') {
+            propagationGreenLight.current = true;
           }
         }),
     [pressInHandler, pressOutHandler]

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -91,7 +91,7 @@ export default function Pressable(props: PressableProps) {
   );
 
   const pressDelayTimeoutRef = useRef<number | null>(null);
-  const propagationGreenLight = useRef<boolean>(false);
+  const isTouchPropagationAllowed = useRef<boolean>(false);
 
   // iOS only, propagationGreenLight setting occurs after other checks when in scroll-view
   const awaitingEventPayload = useRef<PressableEvent | null>(null);
@@ -102,7 +102,7 @@ export default function Pressable(props: PressableProps) {
         awaitingEventPayload.current = event;
       }
 
-      if (propagationGreenLight.current === false) {
+      if (isTouchPropagationAllowed.current === false) {
         return;
       }
 
@@ -150,7 +150,7 @@ export default function Pressable(props: PressableProps) {
         longPressTimeoutRef.current = null;
       }
 
-      propagationGreenLight.current = false;
+      isTouchPropagationAllowed.current = false;
       hasPassedBoundsChecks.current = false;
       isPressCallbackEnabled.current = true;
       setPressedState(false);
@@ -164,7 +164,7 @@ export default function Pressable(props: PressableProps) {
 
   const activateLongPress = useCallback(
     (event: GestureTouchEvent) => {
-      if (propagationGreenLight.current === false) {
+      if (isTouchPropagationAllowed.current === false) {
         return;
       }
 
@@ -286,12 +286,12 @@ export default function Pressable(props: PressableProps) {
         .onBegin(() => {
           // Android sets BEGAN state on press down
           if (Platform.OS === 'android') {
-            propagationGreenLight.current = true;
+            isTouchPropagationAllowed.current = true;
           }
         })
         .onStart(() => {
           if (Platform.OS === 'web') {
-            propagationGreenLight.current = true;
+            isTouchPropagationAllowed.current = true;
           }
 
           // iOS sets ACTIVE state on press down
@@ -300,21 +300,21 @@ export default function Pressable(props: PressableProps) {
           }
 
           if (awaitingEventPayload.current) {
-            propagationGreenLight.current = true;
+            isTouchPropagationAllowed.current = true;
 
             if (hasPassedBoundsChecks.current) {
               pressInHandler(awaitingEventPayload.current);
               awaitingEventPayload.current = null;
             } else {
               pressOutHandler(awaitingEventPayload.current);
-              propagationGreenLight.current = false;
+              isTouchPropagationAllowed.current = false;
             }
 
             return;
           }
 
           if (hasPassedBoundsChecks.current) {
-            propagationGreenLight.current = true;
+            isTouchPropagationAllowed.current = true;
             return;
           }
 
@@ -323,7 +323,7 @@ export default function Pressable(props: PressableProps) {
             return;
           }
 
-          propagationGreenLight.current = true;
+          isTouchPropagationAllowed.current = true;
         }),
     [pressInHandler, pressOutHandler]
   );

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -94,19 +94,19 @@ export default function Pressable(props: PressableProps) {
   const isTouchPropagationAllowed = useRef<boolean>(false);
 
   // iOS only: due to varying flow of gestures, events sometimes have to be saved for later use
-  const awaitingEventPayload = useRef<PressableEvent | null>(null);
+  const waitingEventPayload = useRef<PressableEvent | null>(null);
 
   const pressInHandler = useCallback(
     (event: PressableEvent) => {
       if (handlingOnTouchesDown.current) {
-        awaitingEventPayload.current = event;
+        waitingEventPayload.current = event;
       }
 
       if (isTouchPropagationAllowed.current === false) {
         return;
       }
 
-      awaitingEventPayload.current = null;
+      waitingEventPayload.current = null;
 
       props.onPressIn?.(event);
       isPressCallbackEnabled.current = true;
@@ -134,9 +134,9 @@ export default function Pressable(props: PressableProps) {
         pressInHandler(event);
       }
 
-      if (awaitingEventPayload.current) {
-        props.onPressIn?.(awaitingEventPayload.current);
-        awaitingEventPayload.current = null;
+      if (waitingEventPayload.current) {
+        props.onPressIn?.(waitingEventPayload.current);
+        waitingEventPayload.current = null;
       }
 
       props.onPressOut?.(event);
@@ -245,7 +245,7 @@ export default function Pressable(props: PressableProps) {
           }
           // On iOS, short taps will make LongPress gesture call onTouchesUp before Native gesture calls onStart
           // This variable ensures that onStart isn't detected as the first gesture since Pressable is pressed.
-          if (awaitingEventPayload.current !== null) {
+          if (waitingEventPayload.current !== null) {
             preventNativeEffects.current = true;
           }
           pressOutHandler(gestureTouchToPressableEvent(event));
@@ -299,14 +299,14 @@ export default function Pressable(props: PressableProps) {
             return;
           }
 
-          if (awaitingEventPayload.current) {
+          if (waitingEventPayload.current) {
             isTouchPropagationAllowed.current = true;
 
             if (hasPassedBoundsChecks.current) {
-              pressInHandler(awaitingEventPayload.current);
-              awaitingEventPayload.current = null;
+              pressInHandler(waitingEventPayload.current);
+              waitingEventPayload.current = null;
             } else {
-              pressOutHandler(awaitingEventPayload.current);
+              pressOutHandler(waitingEventPayload.current);
               isTouchPropagationAllowed.current = false;
             }
 

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -146,6 +146,11 @@ export default function Pressable(props: PressableProps) {
         props.onPress?.(event);
       }
 
+      if (longPressTimeoutRef.current) {
+        clearTimeout(longPressTimeoutRef.current);
+        longPressTimeoutRef.current = null;
+      }
+
       propagationGreenLight.current = false;
       hasPassedBoundsChecks.current = false;
       isPressCallbackEnabled.current = true;
@@ -168,6 +173,11 @@ export default function Pressable(props: PressableProps) {
       if (hasPassedBoundsChecks.current) {
         props.onLongPress?.(gestureTouchToPressableEvent(event));
         isPressCallbackEnabled.current = false;
+      }
+
+      if (longPressTimeoutRef.current) {
+        clearTimeout(longPressTimeoutRef.current);
+        longPressTimeoutRef.current = null;
       }
     },
     [props]

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -71,7 +71,7 @@ export default function Pressable(props: PressableProps) {
           }
           props.onHoverIn?.(gestureToPressableEvent(event));
         })
-        .onEnd((event) => {
+        .onFinalize((event) => {
           if (hoverInTimeout.current) {
             clearTimeout(hoverInTimeout.current);
           }

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -95,10 +95,11 @@ export default function Pressable(props: PressableProps) {
 
   const pressInHandler = useCallback(
     (event: PressableEvent) => {
+      if (handlingOnTouchesDown.current) {
+        awaitingEventPayload.current = event;
+      }
+
       if (propagationGreenLight.current === false) {
-        if (Platform.OS === 'ios') {
-          awaitingEventPayload.current = event;
-        }
         return;
       }
 
@@ -131,6 +132,11 @@ export default function Pressable(props: PressableProps) {
         // even though we are located at the pressOutHandler
         clearTimeout(pressDelayTimeoutRef.current);
         pressInHandler(event);
+      }
+
+      if (awaitingEventPayload.current) {
+        props.onPressIn?.(awaitingEventPayload.current);
+        awaitingEventPayload.current = null;
       }
 
       props.onPressOut?.(event);

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -159,6 +159,7 @@ export default function Pressable(props: PressableProps) {
   const pressAndTouchGesture = useMemo(
     () =>
       Gesture.LongPress()
+        .maxDistance(Number.MAX_SAFE_INTEGER)
         .onStart((event) => {
           if (isPressedDown.current) {
             props.onLongPress?.(gestureToPressableEvent(event));

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -142,6 +142,8 @@ export default function Pressable(props: PressableProps) {
 
       propagationGreenLight.current = false;
       isPressedDown.current = false;
+      isPressCallbackEnabled.current = true;
+
       setPressedState(false);
     },
     [pressInHandler, props]

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -284,6 +284,7 @@ export default function Pressable(props: PressableProps) {
     gesture.enabled(isPressableEnabled);
     gesture.runOnJS(true);
     gesture.hitSlop(appliedHitSlop);
+    gesture.shouldCancelWhenOutside(false);
 
     if (Platform.OS !== 'web') {
       gesture.shouldCancelWhenOutside(true);

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -93,7 +93,7 @@ export default function Pressable(props: PressableProps) {
   const pressDelayTimeoutRef = useRef<number | null>(null);
   const isTouchPropagationAllowed = useRef<boolean>(false);
 
-  // iOS only, propagationGreenLight setting occurs after other checks when in scroll-view
+  // iOS only: due to varying flow of gestures, events sometimes have to be saved for later use
   const awaitingEventPayload = useRef<PressableEvent | null>(null);
 
   const pressInHandler = useCallback(

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -191,8 +191,8 @@ export default function Pressable(props: PressableProps) {
   const pressAndTouchGesture = useMemo(
     () =>
       Gesture.LongPress()
-        .minDuration(Number.MAX_SAFE_INTEGER)
-        .maxDistance(Number.MAX_SAFE_INTEGER)
+        .minDuration(Number.MAX_SAFE_INTEGER) // stops long press from blocking native gesture
+        .maxDistance(Number.MAX_SAFE_INTEGER) // stops long press from cancelling after set distance
         .cancelsTouchesInView(false)
         .onTouchesDown((event) => {
           handlingOnTouchesDown.current = true;

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -113,11 +113,6 @@ export default function Pressable(props: PressableProps) {
 
   const pressOutHandler = useCallback(
     (event: PressableEvent) => {
-      if (Platform.OS === 'ios' && !awaitingEventPayload.current) {
-        awaitingEventPayload.current = event;
-        return;
-      }
-
       if (
         !isPressedDown.current ||
         event.nativeEvent.touches.length >
@@ -136,7 +131,7 @@ export default function Pressable(props: PressableProps) {
 
       // Similarily to pressDelay, on IOS the flow of methods is reversed due to
       // asynchronous behaviour of Native Buttons.
-      if (Platform.OS === 'ios') {
+      if (Platform.OS === 'ios' && awaitingEventPayload.current) {
         propagationGreenLight.current = true;
         pressInHandler(event);
         propagationGreenLight.current = false;
@@ -254,6 +249,7 @@ export default function Pressable(props: PressableProps) {
               propagationGreenLight.current = true;
               if (isPressedDown.current) {
                 pressInHandler(awaitingEventPayload.current);
+                awaitingEventPayload.current = null;
               } else {
                 pressOutHandler(awaitingEventPayload.current);
               }

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -257,8 +257,6 @@ export default function Pressable(props: PressableProps) {
                 pressOutHandler(awaitingEventPayload.current);
               }
               propagationGreenLight.current = false;
-            } else {
-              propagationGreenLight.current = true;
             }
           }
           if (Platform.OS === 'web') {

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -97,12 +97,15 @@ export default function Pressable(props: PressableProps) {
     (event: PressableEvent) => {
       if (Platform.OS === 'ios' && !awaitingEventPayload.current) {
         awaitingEventPayload.current = event;
-        return;
       }
 
       if (propagationGreenLight.current === false) {
         return;
       }
+
+      // if ios passes the propagationGreenLight by here,
+      // awaitingEventPayload would trigger a double press-in callback when pressing out
+      awaitingEventPayload.current = null;
 
       props.onPressIn?.(event);
       isPressCallbackEnabled.current = true;

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -103,7 +103,7 @@ export default function Pressable(props: PressableProps) {
         return;
       }
 
-      // if ios passes the propagationGreenLight by here,
+      // If ios passes the propagationGreenLight by here,
       // awaitingEventPayload would trigger a double press-in callback when pressing out
       awaitingEventPayload.current = null;
 
@@ -234,7 +234,7 @@ export default function Pressable(props: PressableProps) {
     [normalizedHitSlop, pressInHandler, pressOutHandler, props]
   );
 
-  // buttonGesture lives inside RNButton to enable android's ripple and to capture non-propagating events
+  // ButtonGesture lives inside RNButton to enable android's ripple and to capture non-propagating events
   const buttonGesture = useMemo(
     () =>
       Gesture.Native()

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -119,8 +119,8 @@ export default function Pressable(props: PressableProps) {
   const pressOutHandler = useCallback(
     (event: GestureTouchEvent) => {
       if (
-        !isPressedDown.current
-        // || event.allTouches.length > event.changedTouches.length
+        !isPressedDown.current ||
+        event.allTouches.length > event.changedTouches.length
       ) {
         return;
       }

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -95,22 +95,17 @@ export default function Pressable(props: PressableProps) {
   const pressInHandler = useCallback(
     (event: PressableEvent) => {
       if (Platform.OS === 'ios' && !awaitingEventPayload.current) {
-        console.log('IOS_SETTING_PAYLOAD');
         awaitingEventPayload.current = event;
         return;
       }
 
       if (propagationGreenLight.current === false) {
-        console.log('PRESS_IN_HANDLER NO_GREEN_LIGHT');
         return;
       }
-
-      console.log('PRESS_IN_HANDLER SUCCESS');
 
       props.onPressIn?.(event);
       isPressCallbackEnabled.current = true;
       pressDelayTimeoutRef.current = null;
-      console.log('PRESSED_STATE true');
       setPressedState(true);
     },
     [props]
@@ -118,9 +113,7 @@ export default function Pressable(props: PressableProps) {
 
   const pressOutHandler = useCallback(
     (event: PressableEvent) => {
-      console.log('PRESS_OUT_HANDLER');
       if (Platform.OS === 'ios' && !awaitingEventPayload.current) {
-        console.log('IOS_SETTING_PAYLOAD');
         awaitingEventPayload.current = event;
         return;
       }
@@ -144,15 +137,12 @@ export default function Pressable(props: PressableProps) {
       // Similarily to pressDelay, on IOS the flow of methods is reversed due to
       // asynchronous behaviour of Native Buttons.
       if (Platform.OS === 'ios') {
-        console.log('IOS_EXECUTING_PAYLOAD');
         propagationGreenLight.current = true;
         pressInHandler(event);
         propagationGreenLight.current = false;
-        console.log('IOS_RESETTING_PAYLOAD');
         awaitingEventPayload.current = null;
       }
 
-      console.log('PRESS_OUT_HANDLER SUCCESS');
       props.onPressOut?.(event);
       propagationGreenLight.current = false;
 
@@ -161,7 +151,6 @@ export default function Pressable(props: PressableProps) {
       }
 
       isPressedDown.current = false;
-      console.log('PRESSED_STATE false');
       setPressedState(false);
     },
     [pressInHandler, props]
@@ -176,17 +165,13 @@ export default function Pressable(props: PressableProps) {
       Gesture.LongPress()
         .onStart((event) => {
           if (isPressedDown.current) {
-            console.log('PRESS ACTIVATED');
             props.onLongPress?.(gestureToPressableEvent(event));
             isPressCallbackEnabled.current = false;
           }
         })
         .onTouchesDown((event) => {
-          console.log('TOUCHES DOWN');
           handlingOnTouchesDown.current = true;
           pressableRef.current?.measure((_x, _y, width, height) => {
-            console.log('TOUCHES DOWN (start-routine)');
-
             if (
               !isTouchWithinInset(
                 {
@@ -221,7 +206,6 @@ export default function Pressable(props: PressableProps) {
           });
         })
         .onTouchesUp((event) => {
-          console.log('TOUCHES UP');
           if (handlingOnTouchesDown.current) {
             onEndHandlingTouchesDown.current = () =>
               pressOutHandler(gestureTouchToPressableEvent(event));
@@ -231,7 +215,6 @@ export default function Pressable(props: PressableProps) {
           pressOutHandler(gestureTouchToPressableEvent(event));
         })
         .onTouchesCancelled((event) => {
-          console.log('TOUCHES CANCEL');
           if (handlingOnTouchesDown.current) {
             cancelledMidPress.current = true;
             onEndHandlingTouchesDown.current = () =>
@@ -258,22 +241,16 @@ export default function Pressable(props: PressableProps) {
         .onBegin(() => {
           // Android sets BEGAN state on press down
           if (Platform.OS === 'android') {
-            console.log('EXCLUSIVITY STATED (android)');
             propagationGreenLight.current = true;
           }
         })
         .onStart(() => {
           // IOS sets ACTIVE state on press down
           if (Platform.OS === 'ios') {
-            console.log('EXCLUSIVITY STATED (ios)');
             // While on Android, NativeButton press detection is one of the first recognized events,
             // On IOS it is one of the last if the click occurs quickly - around 200ms between press in & out.
             // Thus pressInHandler has to be invoked through a mechanism similar to that dealing with delayed presses.
             if (awaitingEventPayload.current) {
-              console.log(
-                'EXCLUSIVITY HANDLING:',
-                isPressedDown.current ? 'NORMAL' : 'REVERSED'
-              );
               propagationGreenLight.current = true;
               if (isPressedDown.current) {
                 pressInHandler(awaitingEventPayload.current);

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -110,6 +110,7 @@ export default function Pressable(props: PressableProps) {
       props.onPressIn?.(event);
       isPressCallbackEnabled.current = true;
       pressDelayTimeoutRef.current = null;
+      propagationGreenLight.current = false;
       setPressedState(true);
     },
     [props]
@@ -138,12 +139,10 @@ export default function Pressable(props: PressableProps) {
       if (Platform.OS === 'ios' && awaitingEventPayload.current) {
         propagationGreenLight.current = true;
         pressInHandler(event);
-        propagationGreenLight.current = false;
         awaitingEventPayload.current = null;
       }
 
       props.onPressOut?.(event);
-      propagationGreenLight.current = false;
 
       if (isPressCallbackEnabled.current) {
         props.onPress?.(event);

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -22,7 +22,6 @@ import {
   nativeTouchToPressableEvent,
 } from './utils';
 import { PressabilityDebugView } from '../../handlers/PressabilityDebugView';
-import { GestureTouchEvent } from '../../handlers/gestureHandlerCommon';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;
 
@@ -117,10 +116,11 @@ export default function Pressable(props: PressableProps) {
   );
 
   const pressOutHandler = useCallback(
-    (event: GestureTouchEvent) => {
+    (event: PressableEvent) => {
       if (
         !isPressedDown.current ||
-        event.allTouches.length > event.changedTouches.length
+        event.nativeEvent.touches.length >
+          event.nativeEvent.changedTouches.length
       ) {
         return;
       }
@@ -130,14 +130,14 @@ export default function Pressable(props: PressableProps) {
         // we want to immediately activate it's effects - pressInHandler,
         // even though we are located at the pressOutHandler
         clearTimeout(pressDelayTimeoutRef.current);
-        pressInHandler(gestureTouchToPressableEvent(event));
+        pressInHandler(event);
       }
 
-      props.onPressOut?.(gestureTouchToPressableEvent(event));
+      props.onPressOut?.(event);
       propagationGreenLight.current = false;
 
       if (isPressCallbackEnabled.current) {
-        props.onPress?.(gestureTouchToPressableEvent(event));
+        props.onPress?.(event);
       }
 
       isPressedDown.current = false;
@@ -191,16 +191,18 @@ export default function Pressable(props: PressableProps) {
         })
         .onTouchesUp((event) => {
           if (handlingOnTouchesDown.current) {
-            onEndHandlingTouchesDown.current = () => pressOutHandler(event);
+            onEndHandlingTouchesDown.current = () =>
+              pressOutHandler(gestureTouchToPressableEvent(event));
             return;
           }
 
-          pressOutHandler(event);
+          pressOutHandler(gestureTouchToPressableEvent(event));
         })
         .onTouchesCancelled((event) => {
           if (handlingOnTouchesDown.current) {
             cancelledMidPress.current = true;
-            onEndHandlingTouchesDown.current = () => pressOutHandler(event);
+            onEndHandlingTouchesDown.current = () =>
+              pressOutHandler(gestureTouchToPressableEvent(event));
             return;
           }
 
@@ -211,7 +213,7 @@ export default function Pressable(props: PressableProps) {
             return;
           }
 
-          pressOutHandler(event);
+          pressOutHandler(gestureTouchToPressableEvent(event));
         }),
     [
       normalizedHitSlop,

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -226,9 +226,15 @@ export default function Pressable(props: PressableProps) {
   const rippleGesture = useMemo(
     () =>
       Gesture.Native()
-        .onBegin(() => console.log('BEGIN'))
-        .onStart(() => console.log('START'))
-        .onEnd(() => console.log('END')),
+        .onBegin(() => {
+          propagationGreenLight.current = true;
+        })
+        .onStart(() => {
+          propagationGreenLight.current = true;
+        })
+        .onEnd(() => {
+          propagationGreenLight.current = false;
+        }),
     []
   );
 

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -90,7 +90,7 @@ export default function Pressable(props: PressableProps) {
   const pressDelayTimeoutRef = useRef<number | null>(null);
   const propagationGreenLight = useRef<boolean>(false);
 
-  // IOS only, propagationGreenLight setting occurs after other checks when in scroll-view
+  // iOS only, propagationGreenLight setting occurs after other checks when in scroll-view
   const awaitingEventPayload = useRef<PressableEvent | null>(null);
 
   const pressInHandler = useCallback(
@@ -103,7 +103,7 @@ export default function Pressable(props: PressableProps) {
         return;
       }
 
-      // If ios passes the propagationGreenLight by here,
+      // If iOS passes the propagationGreenLight by here,
       // awaitingEventPayload would trigger a double press-in callback when pressing out
       awaitingEventPayload.current = null;
 
@@ -134,7 +134,7 @@ export default function Pressable(props: PressableProps) {
         pressInHandler(event);
       }
 
-      // Similarily to pressDelay, on IOS the flow of methods is reversed due to
+      // Similarily to pressDelay, on iOS the flow of methods is reversed due to
       // asynchronous behaviour of Native buttons when inside Native scollable areas.
       if (Platform.OS === 'ios' && awaitingEventPayload.current) {
         propagationGreenLight.current = true;
@@ -244,7 +244,7 @@ export default function Pressable(props: PressableProps) {
           }
         })
         .onStart(() => {
-          // IOS sets ACTIVE state on press down
+          // iOS sets ACTIVE state on press down
           if (Platform.OS === 'ios') {
             if (awaitingEventPayload.current) {
               propagationGreenLight.current = true;
@@ -298,7 +298,7 @@ export default function Pressable(props: PressableProps) {
 
   const defaultRippleColor = props.android_ripple ? undefined : 'transparent';
 
-  // `cursor: 'pointer'` on `RNButton` crashes IOS
+  // `cursor: 'pointer'` on `RNButton` crashes iOS
   const pointerStyle: StyleProp<ViewStyle> =
     Platform.OS === 'web' ? { cursor: 'pointer' } : {};
 

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -148,6 +148,7 @@ export default function Pressable(props: PressableProps) {
         props.onPress?.(event);
       }
 
+      propagationGreenLight.current = false;
       isPressedDown.current = false;
       setPressedState(false);
     },

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -35,6 +35,7 @@ export default function Pressable(props: PressableProps) {
   // Disabled when onLongPress has been called
   const isPressCallbackEnabled = useRef<boolean>(true);
   const hasPassedBoundsChecks = useRef<boolean>(false);
+  const isBoundsCheckNecessary = useRef<boolean>(true);
 
   const normalizedHitSlop: Insets = useMemo(
     () =>
@@ -154,7 +155,7 @@ export default function Pressable(props: PressableProps) {
       propagationGreenLight.current = false;
       hasPassedBoundsChecks.current = false;
       isPressCallbackEnabled.current = true;
-
+      isBoundsCheckNecessary.current = true;
       setPressedState(false);
     },
     [pressInHandler, props]
@@ -302,6 +303,12 @@ export default function Pressable(props: PressableProps) {
             } else {
               if (hasPassedBoundsChecks.current) {
                 propagationGreenLight.current = true;
+              } else {
+                // In case Native Start is the very first gesture on iOS to launch
+                // that means we are in a no-scroll, no-nesting situation
+                // and native start may be trated as a replacement to the measure function.
+                propagationGreenLight.current = true;
+                isBoundsCheckNecessary.current = false;
               }
             }
           }

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -14,12 +14,12 @@ import {
 import NativeButton from '../GestureHandlerButton';
 import {
   numberAsInset,
-  adaptStateChangeEvent,
+  gestureToPressableEvent,
   isTouchWithinInset,
-  adaptTouchEvent,
+  gestureTouchToPressableEvent,
   addInsets,
   splitStyles,
-  adaptNativeTouchEvent,
+  nativeTouchToPressableEvent,
 } from './utils';
 import { PressabilityDebugView } from '../../handlers/PressabilityDebugView';
 import { GestureTouchEvent } from '../../handlers/gestureHandlerCommon';
@@ -57,7 +57,7 @@ export default function Pressable(props: PressableProps) {
     () =>
       Gesture.LongPress().onStart((event) => {
         if (isPressedDown.current) {
-          props.onLongPress?.(adaptStateChangeEvent(event));
+          props.onLongPress?.(gestureToPressableEvent(event));
           isPressCallbackEnabled.current = false;
         }
       }),
@@ -76,12 +76,12 @@ export default function Pressable(props: PressableProps) {
           }
           if (props.delayHoverIn) {
             hoverInTimeout.current = setTimeout(
-              () => props.onHoverIn?.(adaptStateChangeEvent(event)),
+              () => props.onHoverIn?.(gestureToPressableEvent(event)),
               props.delayHoverIn
             );
             return;
           }
-          props.onHoverIn?.(adaptStateChangeEvent(event));
+          props.onHoverIn?.(gestureToPressableEvent(event));
         })
         .onEnd((event) => {
           if (hoverInTimeout.current) {
@@ -89,12 +89,12 @@ export default function Pressable(props: PressableProps) {
           }
           if (props.delayHoverOut) {
             hoverOutTimeout.current = setTimeout(
-              () => props.onHoverOut?.(adaptStateChangeEvent(event)),
+              () => props.onHoverOut?.(gestureToPressableEvent(event)),
               props.delayHoverOut
             );
             return;
           }
-          props.onHoverOut?.(adaptStateChangeEvent(event));
+          props.onHoverOut?.(gestureToPressableEvent(event));
         }),
     [props]
   );
@@ -130,14 +130,14 @@ export default function Pressable(props: PressableProps) {
         // we want to immediately activate it's effects - pressInHandler,
         // even though we are located at the pressOutHandler
         clearTimeout(pressDelayTimeoutRef.current);
-        pressInHandler(adaptTouchEvent(event));
+        pressInHandler(gestureTouchToPressableEvent(event));
       }
 
-      props.onPressOut?.(adaptTouchEvent(event));
+      props.onPressOut?.(gestureTouchToPressableEvent(event));
       propagationGreenLight.current = false;
 
       if (isPressCallbackEnabled.current) {
-        props.onPress?.(adaptTouchEvent(event));
+        props.onPress?.(gestureTouchToPressableEvent(event));
       }
 
       isPressedDown.current = false;
@@ -178,10 +178,10 @@ export default function Pressable(props: PressableProps) {
 
             if (props.unstable_pressDelay) {
               pressDelayTimeoutRef.current = setTimeout(() => {
-                pressInHandler(adaptTouchEvent(event));
+                pressInHandler(gestureTouchToPressableEvent(event));
               }, props.unstable_pressDelay);
             } else {
-              pressInHandler(adaptTouchEvent(event));
+              pressInHandler(gestureTouchToPressableEvent(event));
             }
 
             onEndHandlingTouchesDown.current?.();
@@ -281,7 +281,7 @@ export default function Pressable(props: PressableProps) {
         console.log('touch start');
         event.stopPropagation();
         propagationGreenLight.current = true;
-        pressInHandler(adaptNativeTouchEvent(event));
+        pressInHandler(nativeTouchToPressableEvent(event));
       }}>
       <GestureDetector gesture={gesture}>
         <NativeButton

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -90,7 +90,7 @@ export default function Pressable(props: PressableProps) {
   const pressDelayTimeoutRef = useRef<number | null>(null);
   const propagationGreenLight = useRef<boolean>(false);
 
-  // IOS only, propagationGreenLight setting occurs after it's checking
+  // IOS only, propagationGreenLight setting occurs after other checks when in scroll-view
   const awaitingEventPayload = useRef<PressableEvent | null>(null);
 
   const pressInHandler = useCallback(
@@ -134,7 +134,7 @@ export default function Pressable(props: PressableProps) {
       }
 
       // Similarily to pressDelay, on IOS the flow of methods is reversed due to
-      // asynchronous behaviour of Native Buttons.
+      // asynchronous behaviour of Native buttons when inside Native scollable areas.
       if (Platform.OS === 'ios' && awaitingEventPayload.current) {
         propagationGreenLight.current = true;
         pressInHandler(event);
@@ -247,9 +247,6 @@ export default function Pressable(props: PressableProps) {
         .onStart(() => {
           // IOS sets ACTIVE state on press down
           if (Platform.OS === 'ios') {
-            // While on Android, NativeButton press detection is one of the first recognized events,
-            // On IOS it is one of the last if the click occurs quickly - around 200ms between press in & out.
-            // Thus pressInHandler has to be invoked through a mechanism similar to that dealing with delayed presses.
             if (awaitingEventPayload.current) {
               propagationGreenLight.current = true;
               if (isPressedDown.current) {

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -134,14 +134,6 @@ export default function Pressable(props: PressableProps) {
         pressInHandler(event);
       }
 
-      // Similarily to pressDelay, on iOS the flow of methods is reversed due to
-      // asynchronous behaviour of Native buttons when inside Native scollable areas.
-      if (Platform.OS === 'ios' && awaitingEventPayload.current) {
-        propagationGreenLight.current = true;
-        pressInHandler(event);
-        awaitingEventPayload.current = null;
-      }
-
       props.onPressOut?.(event);
 
       if (isPressCallbackEnabled.current) {

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -259,6 +259,8 @@ export default function Pressable(props: PressableProps) {
                 pressOutHandler(awaitingEventPayload.current);
               }
               propagationGreenLight.current = false;
+            } else {
+              propagationGreenLight.current = true;
             }
           }
           if (Platform.OS === 'web') {

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -57,7 +57,7 @@ export default function Pressable(props: PressableProps) {
   const hoverGesture = useMemo(
     () =>
       Gesture.Hover()
-        .manualActivation(true) // stops Hover from blocking Native gesture activation on web
+        .manualActivation(true) // Stops Hover from blocking Native gesture activation on web
         .onBegin((event) => {
           if (hoverOutTimeout.current) {
             clearTimeout(hoverOutTimeout.current);

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -207,6 +207,8 @@ export default function Pressable(props: PressableProps) {
           pressOutHandler(gestureTouchToPressableEvent(event));
         })
         .onTouchesCancelled((event) => {
+          isPressCallbackEnabled.current = false;
+
           if (handlingOnTouchesDown.current) {
             cancelledMidPress.current = true;
             onEndHandlingTouchesDown.current = () =>

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -19,7 +19,6 @@ import {
   gestureTouchToPressableEvent,
   addInsets,
   splitStyles,
-  nativeTouchToPressableEvent,
 } from './utils';
 import { PressabilityDebugView } from '../../handlers/PressabilityDebugView';
 
@@ -224,7 +223,14 @@ export default function Pressable(props: PressableProps) {
   );
 
   // rippleGesture lives inside RNButton to enable android's ripple
-  const rippleGesture = useMemo(() => Gesture.Native(), []);
+  const rippleGesture = useMemo(
+    () =>
+      Gesture.Native()
+        .onBegin(() => console.log('BEGIN'))
+        .onStart(() => console.log('START'))
+        .onEnd(() => console.log('END')),
+    []
+  );
 
   pressGesture.minDuration(
     (props.delayLongPress ?? DEFAULT_LONG_PRESS_DURATION) +
@@ -276,13 +282,7 @@ export default function Pressable(props: PressableProps) {
   const [innerStyles, outerStyles] = splitStyles(flattenedStyles);
 
   return (
-    <View
-      style={outerStyles}
-      hitSlop={appliedHitSlop}
-      onTouchStart={(event) => {
-        propagationGreenLight.current = true;
-        pressInHandler(nativeTouchToPressableEvent(event));
-      }}>
+    <View style={outerStyles}>
       <GestureDetector gesture={gesture}>
         <NativeButton
           ref={pressableRef}

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -280,8 +280,6 @@ export default function Pressable(props: PressableProps) {
       style={outerStyles}
       hitSlop={appliedHitSlop}
       onTouchStart={(event) => {
-        console.log('touch start');
-        event.stopPropagation();
         propagationGreenLight.current = true;
         pressInHandler(nativeTouchToPressableEvent(event));
       }}>

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -35,7 +35,7 @@ export default function Pressable(props: PressableProps) {
   // Disabled when onLongPress has been called
   const isPressCallbackEnabled = useRef<boolean>(true);
   const hasPassedBoundsChecks = useRef<boolean>(false);
-  const preventNativeEffects = useRef<boolean>(false);
+  const shouldPreventNativeEffects = useRef<boolean>(false);
 
   const normalizedHitSlop: Insets = useMemo(
     () =>
@@ -246,7 +246,7 @@ export default function Pressable(props: PressableProps) {
           // On iOS, short taps will make LongPress gesture call onTouchesUp before Native gesture calls onStart
           // This variable ensures that onStart isn't detected as the first gesture since Pressable is pressed.
           if (deferredEventPayload.current !== null) {
-            preventNativeEffects.current = true;
+            shouldPreventNativeEffects.current = true;
           }
           pressOutHandler(gestureTouchToPressableEvent(event));
         })
@@ -318,8 +318,8 @@ export default function Pressable(props: PressableProps) {
             return;
           }
 
-          if (preventNativeEffects.current) {
-            preventNativeEffects.current = false;
+          if (shouldPreventNativeEffects.current) {
+            shouldPreventNativeEffects.current = false;
             return;
           }
 

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -107,8 +107,6 @@ export default function Pressable(props: PressableProps) {
         return;
       }
 
-      // If iOS passes the propagationGreenLight by here,
-      // awaitingEventPayload would trigger a double press-in callback when pressing out
       awaitingEventPayload.current = null;
 
       props.onPressIn?.(event);
@@ -283,7 +281,7 @@ export default function Pressable(props: PressableProps) {
     ]
   );
 
-  // ButtonGesture lives inside RNButton to enable android's ripple and to capture non-propagating events
+  // RNButton is placed inside ButtonGesture to enable Android's ripple and to capture non-propagating events
   const buttonGesture = useMemo(
     () =>
       Gesture.Native()

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -243,8 +243,8 @@ export default function Pressable(props: PressableProps) {
               pressOutHandler(gestureTouchToPressableEvent(event));
             return;
           }
-          // On iOS, when pressed out before Native gesture pressed in,
-          // without setting this variable Native gesture would think it's the first one to be launched
+          // On iOS, short taps will make LongPress gesture call onTouchesUp before Native gesture calls onStart
+          // This variable ensures that onStart isn't detected as the first gesture since Pressable is pressed.
           if (awaitingEventPayload.current !== null) {
             preventNativeEffects.current = true;
           }

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -152,7 +152,7 @@ export default function Pressable(props: PressableProps) {
 
       setPressedState(false);
     },
-    [pressInHandler, pressedState, props]
+    [pressInHandler, props]
   );
 
   const handlingOnTouchesDown = useRef<boolean>(false);

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -95,11 +95,10 @@ export default function Pressable(props: PressableProps) {
 
   const pressInHandler = useCallback(
     (event: PressableEvent) => {
-      if (Platform.OS === 'ios' && !awaitingEventPayload.current) {
-        awaitingEventPayload.current = event;
-      }
-
       if (propagationGreenLight.current === false) {
+        if (Platform.OS === 'ios') {
+          awaitingEventPayload.current = event;
+        }
         return;
       }
 

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -111,7 +111,6 @@ export default function Pressable(props: PressableProps) {
       props.onPressIn?.(event);
       isPressCallbackEnabled.current = true;
       pressDelayTimeoutRef.current = null;
-      propagationGreenLight.current = false;
       setPressedState(true);
     },
     [props]
@@ -165,6 +164,11 @@ export default function Pressable(props: PressableProps) {
         .maxDistance(Number.MAX_SAFE_INTEGER)
         .cancelsTouchesInView(false)
         .onStart((event) => {
+          console.log('LPS', props.testID);
+          if (propagationGreenLight.current === false) {
+            console.log('caught exception');
+          }
+
           if (hasPassedBoundsChecks.current) {
             props.onLongPress?.(gestureToPressableEvent(event));
             isPressCallbackEnabled.current = false;

--- a/src/components/Pressable/PressableProps.tsx
+++ b/src/components/Pressable/PressableProps.tsx
@@ -18,8 +18,8 @@ export interface PressableAndroidRippleConfig {
   foreground?: null | boolean | undefined;
 }
 
-export type PressEvent = {
-  changedTouches: PressEvent[];
+export type InnerPressableEvent = {
+  changedTouches: InnerPressableEvent[];
   identifier: number;
   locationX: number;
   locationY: number;
@@ -27,11 +27,11 @@ export type PressEvent = {
   pageY: number;
   target: number;
   timestamp: number;
-  touches: PressEvent[];
+  touches: InnerPressableEvent[];
   force?: number;
 };
 
-export type PressableEvent = { nativeEvent: PressEvent };
+export type PressableEvent = { nativeEvent: InnerPressableEvent };
 
 export interface PressableProps
   extends AccessibilityProps,

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -192,7 +192,7 @@ const innerStyleKeys = new Set([
   'paddingVertical',
   'start',
   'end',
-  'direction', // IOS only
+  'direction', // iOS only
 ] as StylePropKeys);
 
 const splitStyles = (from: ViewStyle): [ViewStyle, ViewStyle] => {

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -130,15 +130,20 @@ const gestureTouchToPressableEvent = (
   };
 };
 
-const nativeTouchToPressInnerPressableEvent = (
-  event: NativeTouchEvent
+const nativeTouchToInnerPressableEvent = (
+  event: NativeTouchEvent,
+  isRecursive = true
 ): InnerPressableEvent => {
-  const touchesList = event.touches.map((touch: NativeTouchEvent) =>
-    nativeTouchToPressInnerPressableEvent(touch)
-  );
-  const changedTouchesList = event.changedTouches.map(
-    (touch: NativeTouchEvent) => nativeTouchToPressInnerPressableEvent(touch)
-  );
+  const touchesList = isRecursive
+    ? event.touches.map((touch: NativeTouchEvent) =>
+        nativeTouchToInnerPressableEvent(touch, false)
+      )
+    : [];
+  const changedTouchesList = isRecursive
+    ? event.changedTouches.map((touch: NativeTouchEvent) =>
+        nativeTouchToInnerPressableEvent(touch, false)
+      )
+    : [];
 
   return {
     identifier: 0,
@@ -149,15 +154,15 @@ const nativeTouchToPressInnerPressableEvent = (
     target: 0,
     timestamp: event.timestamp,
     force: undefined,
-    touches: touchesList, // Always empty - legacy compatibility
-    changedTouches: changedTouchesList, // Always empty - legacy compatibility
+    touches: touchesList,
+    changedTouches: changedTouchesList,
   };
 };
 
 const nativeTouchToPressableEvent = (
   event: GestureResponderEvent
 ): PressableEvent => ({
-  nativeEvent: nativeTouchToPressInnerPressableEvent(event.nativeEvent),
+  nativeEvent: nativeTouchToInnerPressableEvent(event.nativeEvent),
 });
 
 type StylePropKeys = (keyof ViewStyle)[];

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -130,13 +130,20 @@ const gestureTouchToPressableEvent = (
   };
 };
 
-const nativeEventToTouchData = (event: NativeTouchEvent): TouchData => {
+const nativeTouchToPressInnerPressableEvent = (
+  event: NativeTouchEvent
+): InnerPressableEvent => {
   return {
-    id: 0,
-    x: event.touches.at(0)?.locationX ?? -1,
-    y: event.touches.at(0)?.locationY ?? -1,
-    absoluteX: event.touches.at(0)?.pageX ?? -1,
-    absoluteY: event.touches.at(0)?.pageY ?? -1,
+    identifier: 0,
+    locationX: event.locationX,
+    locationY: event.locationY,
+    pageX: event.pageX,
+    pageY: event.pageY,
+    target: 0,
+    timestamp: event.timestamp,
+    force: undefined,
+    touches: [], // Always empty - legacy compatibility
+    changedTouches: [], // Always empty - legacy compatibility
   };
 };
 
@@ -144,14 +151,12 @@ const nativeTouchToPressableEvent = (
   event: GestureResponderEvent
 ): PressableEvent => {
   const timestamp = event.nativeEvent.timestamp;
-  const targetId = 0;
 
   const touchesList = event.nativeEvent.touches.map((touch: NativeTouchEvent) =>
-    touchDataToPressEvent(nativeEventToTouchData(touch), timestamp, targetId)
+    nativeTouchToPressInnerPressableEvent(touch)
   );
   const changedTouchesList = event.nativeEvent.changedTouches.map(
-    (touch: NativeTouchEvent) =>
-      touchDataToPressEvent(nativeEventToTouchData(touch), timestamp, targetId)
+    (touch: NativeTouchEvent) => nativeTouchToPressInnerPressableEvent(touch)
   );
 
   return {

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -43,16 +43,22 @@ const touchDataToPressEvent = (
   changedTouches: [], // Always empty - legacy compatibility
 });
 
-const gestureToTouchData = (
+const gestureToPressEvent = (
   event: GestureStateChangeEvent<
     HoverGestureHandlerEventPayload | LongPressGestureHandlerEventPayload
-  >
-): TouchData => ({
-  id: event.handlerTag,
-  x: event.x,
-  y: event.y,
-  absoluteX: event.absoluteX,
-  absoluteY: event.absoluteY,
+  >,
+  timestamp: number,
+  targetId: number
+): PressEvent => ({
+  identifier: event.handlerTag,
+  locationX: event.x,
+  locationY: event.y,
+  pageX: event.absoluteX,
+  pageY: event.absoluteY,
+  target: targetId,
+  timestamp: timestamp,
+  touches: [], // Always empty - legacy compatibility
+  changedTouches: [], // Always empty - legacy compatibility
 });
 
 const isTouchWithinInset = (
@@ -75,9 +81,7 @@ const gestureToPressableEvent = (
   // As far as I can see, there isn't a conventional way of getting targetId with the data we get
   const targetId = 0;
 
-  const touchData = gestureToTouchData(event);
-
-  const pressEvent = touchDataToPressEvent(touchData, timestamp, targetId);
+  const pressEvent = gestureToPressEvent(event, timestamp, targetId);
 
   return {
     nativeEvent: {

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -133,6 +133,13 @@ const gestureTouchToPressableEvent = (
 const nativeTouchToPressInnerPressableEvent = (
   event: NativeTouchEvent
 ): InnerPressableEvent => {
+  const touchesList = event.touches.map((touch: NativeTouchEvent) =>
+    nativeTouchToPressInnerPressableEvent(touch)
+  );
+  const changedTouchesList = event.changedTouches.map(
+    (touch: NativeTouchEvent) => nativeTouchToPressInnerPressableEvent(touch)
+  );
+
   return {
     identifier: 0,
     locationX: event.locationX,
@@ -142,38 +149,16 @@ const nativeTouchToPressInnerPressableEvent = (
     target: 0,
     timestamp: event.timestamp,
     force: undefined,
-    touches: [], // Always empty - legacy compatibility
-    changedTouches: [], // Always empty - legacy compatibility
+    touches: touchesList, // Always empty - legacy compatibility
+    changedTouches: changedTouchesList, // Always empty - legacy compatibility
   };
 };
 
 const nativeTouchToPressableEvent = (
   event: GestureResponderEvent
-): PressableEvent => {
-  const timestamp = event.nativeEvent.timestamp;
-
-  const touchesList = event.nativeEvent.touches.map((touch: NativeTouchEvent) =>
-    nativeTouchToPressInnerPressableEvent(touch)
-  );
-  const changedTouchesList = event.nativeEvent.changedTouches.map(
-    (touch: NativeTouchEvent) => nativeTouchToPressInnerPressableEvent(touch)
-  );
-
-  return {
-    nativeEvent: {
-      touches: touchesList,
-      changedTouches: changedTouchesList,
-      identifier: 0,
-      locationX: event.nativeEvent.locationX,
-      locationY: event.nativeEvent.locationY,
-      pageX: event.nativeEvent.pageX,
-      pageY: event.nativeEvent.pageX,
-      target: 0,
-      timestamp: timestamp,
-      force: undefined,
-    },
-  };
-};
+): PressableEvent => ({
+  nativeEvent: nativeTouchToPressInnerPressableEvent(event.nativeEvent),
+});
 
 type StylePropKeys = (keyof ViewStyle)[];
 

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -1,4 +1,9 @@
-import { Insets, ViewStyle } from 'react-native';
+import {
+  GestureResponderEvent,
+  Insets,
+  NativeTouchEvent,
+  ViewStyle,
+} from 'react-native';
 import { LongPressGestureHandlerEventPayload } from '../../handlers/GestureHandlerEventPayload';
 import {
   TouchData,
@@ -119,6 +124,47 @@ const adaptTouchEvent = (event: GestureTouchEvent): PressableEvent => {
   };
 };
 
+const nativeToTouchData = (event: NativeTouchEvent): TouchData => {
+  return {
+    id: 0,
+    x: event.touches.at(0)?.locationX ?? -1,
+    y: event.touches.at(0)?.locationY ?? -1,
+    absoluteX: event.touches.at(0)?.pageX ?? -1,
+    absoluteY: event.touches.at(0)?.pageY ?? -1,
+  };
+};
+
+const adaptNativeTouchEvent = (
+  event: GestureResponderEvent
+): PressableEvent => {
+  const timestamp = event.nativeEvent.timestamp;
+  const targetId = 0;
+
+  const nativeTouches = event.nativeEvent.touches.map(
+    (touch: NativeTouchEvent) =>
+      touchToPressEvent(nativeToTouchData(touch), timestamp, targetId)
+  );
+  const nativeChangedTouches = event.nativeEvent.changedTouches.map(
+    (touch: NativeTouchEvent) =>
+      touchToPressEvent(nativeToTouchData(touch), timestamp, targetId)
+  );
+
+  return {
+    nativeEvent: {
+      touches: nativeTouches,
+      changedTouches: nativeChangedTouches,
+      identifier: 0,
+      locationX: event.nativeEvent.locationX,
+      locationY: event.nativeEvent.locationY,
+      pageX: event.nativeEvent.pageX,
+      pageY: event.nativeEvent.pageX,
+      target: 0,
+      timestamp: timestamp,
+      force: undefined,
+    },
+  };
+};
+
 type StylePropKeys = (keyof ViewStyle)[];
 
 // Source:
@@ -172,5 +218,6 @@ export {
   isTouchWithinInset,
   adaptStateChangeEvent,
   adaptTouchEvent,
+  adaptNativeTouchEvent,
   splitStyles,
 };

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -27,7 +27,7 @@ const addInsets = (a: Insets, b: Insets): Insets => ({
   bottom: (a.bottom ?? 0) + (b.bottom ?? 0),
 });
 
-const touchToPressEvent = (
+const touchDataToPressEvent = (
   data: TouchData,
   timestamp: number,
   targetId: number
@@ -43,7 +43,7 @@ const touchToPressEvent = (
   changedTouches: [], // Always empty - legacy compatibility
 });
 
-const changeToTouchData = (
+const gestureToTouchData = (
   event: GestureStateChangeEvent<
     HoverGestureHandlerEventPayload | LongPressGestureHandlerEventPayload
   >
@@ -65,7 +65,7 @@ const isTouchWithinInset = (
   (touch?.x ?? 0) > -(inset.left ?? 0) &&
   (touch?.y ?? 0) > -(inset.top ?? 0);
 
-const adaptStateChangeEvent = (
+const gestureToPressableEvent = (
   event: GestureStateChangeEvent<
     HoverGestureHandlerEventPayload | LongPressGestureHandlerEventPayload
   >
@@ -75,9 +75,9 @@ const adaptStateChangeEvent = (
   // As far as I can see, there isn't a conventional way of getting targetId with the data we get
   const targetId = 0;
 
-  const touchData = changeToTouchData(event);
+  const touchData = gestureToTouchData(event);
 
-  const pressEvent = touchToPressEvent(touchData, timestamp, targetId);
+  const pressEvent = touchDataToPressEvent(touchData, timestamp, targetId);
 
   return {
     nativeEvent: {
@@ -95,17 +95,19 @@ const adaptStateChangeEvent = (
   };
 };
 
-const adaptTouchEvent = (event: GestureTouchEvent): PressableEvent => {
+const gestureTouchToPressableEvent = (
+  event: GestureTouchEvent
+): PressableEvent => {
   const timestamp = Date.now();
 
   // As far as I can see, there isn't a conventional way of getting targetId with the data we get
   const targetId = 0;
 
   const nativeTouches = event.allTouches.map((touch: TouchData) =>
-    touchToPressEvent(touch, timestamp, targetId)
+    touchDataToPressEvent(touch, timestamp, targetId)
   );
   const nativeChangedTouches = event.changedTouches.map((touch: TouchData) =>
-    touchToPressEvent(touch, timestamp, targetId)
+    touchDataToPressEvent(touch, timestamp, targetId)
   );
 
   return {
@@ -134,7 +136,7 @@ const nativeToTouchData = (event: NativeTouchEvent): TouchData => {
   };
 };
 
-const adaptNativeTouchEvent = (
+const nativeTouchToPressableEvent = (
   event: GestureResponderEvent
 ): PressableEvent => {
   const timestamp = event.nativeEvent.timestamp;
@@ -142,11 +144,11 @@ const adaptNativeTouchEvent = (
 
   const nativeTouches = event.nativeEvent.touches.map(
     (touch: NativeTouchEvent) =>
-      touchToPressEvent(nativeToTouchData(touch), timestamp, targetId)
+      touchDataToPressEvent(nativeToTouchData(touch), timestamp, targetId)
   );
   const nativeChangedTouches = event.nativeEvent.changedTouches.map(
     (touch: NativeTouchEvent) =>
-      touchToPressEvent(nativeToTouchData(touch), timestamp, targetId)
+      touchDataToPressEvent(nativeToTouchData(touch), timestamp, targetId)
   );
 
   return {
@@ -213,11 +215,9 @@ const splitStyles = (from: ViewStyle): [ViewStyle, ViewStyle] => {
 export {
   numberAsInset,
   addInsets,
-  touchToPressEvent,
-  changeToTouchData,
   isTouchWithinInset,
-  adaptStateChangeEvent,
-  adaptTouchEvent,
-  adaptNativeTouchEvent,
+  gestureToPressableEvent,
+  gestureTouchToPressableEvent,
+  nativeTouchToPressableEvent,
   splitStyles,
 };

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -192,7 +192,7 @@ const innerStyleKeys = new Set([
   'paddingVertical',
   'start',
   'end',
-  'direction', // iOS only
+  'direction', // IOS only
 ] as StylePropKeys);
 
 const splitStyles = (from: ViewStyle): [ViewStyle, ViewStyle] => {

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -132,14 +132,14 @@ const gestureTouchToPressableEvent = (
 
 const nativeTouchToInnerPressableEvent = (
   event: NativeTouchEvent,
-  isRecursive = true
+  isParent = true
 ): InnerPressableEvent => {
-  const touchesList = isRecursive
+  const touchesList = isParent
     ? event.touches.map((touch: NativeTouchEvent) =>
         nativeTouchToInnerPressableEvent(touch, false)
       )
     : [];
-  const changedTouchesList = isRecursive
+  const changedTouchesList = isParent
     ? event.changedTouches.map((touch: NativeTouchEvent) =>
         nativeTouchToInnerPressableEvent(touch, false)
       )

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -107,17 +107,17 @@ const gestureTouchToPressableEvent = (
   // As far as I can see, there isn't a conventional way of getting targetId with the data we get
   const targetId = 0;
 
-  const nativeTouches = event.allTouches.map((touch: TouchData) =>
+  const touchesList = event.allTouches.map((touch: TouchData) =>
     touchDataToPressEvent(touch, timestamp, targetId)
   );
-  const nativeChangedTouches = event.changedTouches.map((touch: TouchData) =>
+  const changedTouchesList = event.changedTouches.map((touch: TouchData) =>
     touchDataToPressEvent(touch, timestamp, targetId)
   );
 
   return {
     nativeEvent: {
-      touches: nativeTouches,
-      changedTouches: nativeChangedTouches,
+      touches: touchesList,
+      changedTouches: changedTouchesList,
       identifier: event.handlerTag,
       locationX: event.allTouches.at(0)?.x ?? -1,
       locationY: event.allTouches.at(0)?.y ?? -1,
@@ -130,7 +130,7 @@ const gestureTouchToPressableEvent = (
   };
 };
 
-const nativeToTouchData = (event: NativeTouchEvent): TouchData => {
+const nativeEventToTouchData = (event: NativeTouchEvent): TouchData => {
   return {
     id: 0,
     x: event.touches.at(0)?.locationX ?? -1,
@@ -146,19 +146,18 @@ const nativeTouchToPressableEvent = (
   const timestamp = event.nativeEvent.timestamp;
   const targetId = 0;
 
-  const nativeTouches = event.nativeEvent.touches.map(
-    (touch: NativeTouchEvent) =>
-      touchDataToPressEvent(nativeToTouchData(touch), timestamp, targetId)
+  const touchesList = event.nativeEvent.touches.map((touch: NativeTouchEvent) =>
+    touchDataToPressEvent(nativeEventToTouchData(touch), timestamp, targetId)
   );
-  const nativeChangedTouches = event.nativeEvent.changedTouches.map(
+  const changedTouchesList = event.nativeEvent.changedTouches.map(
     (touch: NativeTouchEvent) =>
-      touchDataToPressEvent(nativeToTouchData(touch), timestamp, targetId)
+      touchDataToPressEvent(nativeEventToTouchData(touch), timestamp, targetId)
   );
 
   return {
     nativeEvent: {
-      touches: nativeTouches,
-      changedTouches: nativeChangedTouches,
+      touches: touchesList,
+      changedTouches: changedTouchesList,
       identifier: 0,
       locationX: event.nativeEvent.locationX,
       locationY: event.nativeEvent.locationY,

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -11,7 +11,7 @@ import {
   GestureTouchEvent,
 } from '../../handlers/gestureHandlerCommon';
 import { HoverGestureHandlerEventPayload } from '../../handlers/gestures/hoverGesture';
-import { PressEvent, PressableEvent } from './PressableProps';
+import { InnerPressableEvent, PressableEvent } from './PressableProps';
 
 const numberAsInset = (value: number): Insets => ({
   left: value,
@@ -31,7 +31,7 @@ const touchDataToPressEvent = (
   data: TouchData,
   timestamp: number,
   targetId: number
-): PressEvent => ({
+): InnerPressableEvent => ({
   identifier: data.id,
   locationX: data.x,
   locationY: data.y,
@@ -49,7 +49,7 @@ const gestureToPressEvent = (
   >,
   timestamp: number,
   targetId: number
-): PressEvent => ({
+): InnerPressableEvent => ({
   identifier: event.handlerTag,
   locationX: event.x,
   locationY: event.y,

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -1,9 +1,4 @@
-import {
-  GestureResponderEvent,
-  Insets,
-  NativeTouchEvent,
-  ViewStyle,
-} from 'react-native';
+import { Insets, ViewStyle } from 'react-native';
 import { LongPressGestureHandlerEventPayload } from '../../handlers/GestureHandlerEventPayload';
 import {
   TouchData,
@@ -130,41 +125,6 @@ const gestureTouchToPressableEvent = (
   };
 };
 
-const nativeTouchToInnerPressableEvent = (
-  event: NativeTouchEvent,
-  isParent = true
-): InnerPressableEvent => {
-  const touchesList = isParent
-    ? event.touches.map((touch: NativeTouchEvent) =>
-        nativeTouchToInnerPressableEvent(touch, false)
-      )
-    : [];
-  const changedTouchesList = isParent
-    ? event.changedTouches.map((touch: NativeTouchEvent) =>
-        nativeTouchToInnerPressableEvent(touch, false)
-      )
-    : [];
-
-  return {
-    identifier: 0,
-    locationX: event.locationX,
-    locationY: event.locationY,
-    pageX: event.pageX,
-    pageY: event.pageY,
-    target: 0,
-    timestamp: event.timestamp,
-    force: undefined,
-    touches: touchesList,
-    changedTouches: changedTouchesList,
-  };
-};
-
-const nativeTouchToPressableEvent = (
-  event: GestureResponderEvent
-): PressableEvent => ({
-  nativeEvent: nativeTouchToInnerPressableEvent(event.nativeEvent),
-});
-
 type StylePropKeys = (keyof ViewStyle)[];
 
 // Source:
@@ -216,6 +176,5 @@ export {
   isTouchWithinInset,
   gestureToPressableEvent,
   gestureTouchToPressableEvent,
-  nativeTouchToPressableEvent,
   splitStyles,
 };


### PR DESCRIPTION
### Issue:
`Test case`: `3` nested pressables
`Actions`: `click`, `press for <500ms`, `press for >500ms`
`Expected behaviour`: No propagation
`Observed behaviour`: Propagation for `500ms` (until long press activates), then no propagation.

### Cause:
Touch and non-active events disregard component's layer,
only state respecting component's level is `ACTIVE`.

### Solution:
Create a component which activates immediately after pressing `Pressable`, capture that event and use it for state setting and callback calling.

### Important:
This PR also performs a lot of de-cluttering work in the `utils.ts` file.
This is necessary due to the convoluted nature of the handled problem, it was especially important to me in this PR to be dealing with clearly labelled functions.

closes: #2980