### PR TITLE
Unify comments and simplify some conditions.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -64,6 +64,7 @@
         "ts-expect-error": "allow-with-description"
       }
     ],
-    "curly": "error"
+    "curly": "error",
+    "spaced-comment": "error"
   }
 }

--- a/src/Directions.ts
+++ b/src/Directions.ts
@@ -3,7 +3,7 @@ const LEFT = 2;
 const UP = 4;
 const DOWN = 8;
 
-// public interface
+// Public interface
 export const Directions = {
   RIGHT: RIGHT,
   LEFT: LEFT,
@@ -11,7 +11,7 @@ export const Directions = {
   DOWN: DOWN,
 } as const;
 
-// internal interface
+// Internal interface
 export const DiagonalDirections = {
   UP_RIGHT: UP | RIGHT,
   DOWN_RIGHT: DOWN | RIGHT,

--- a/src/RNGestureHandlerModule.web.ts
+++ b/src/RNGestureHandlerModule.web.ts
@@ -67,10 +67,10 @@ export default {
     }
 
     if (isNewWebImplementationEnabled()) {
-      //@ts-ignore Types should be HTMLElement or React.Component
+      // @ts-ignore Types should be HTMLElement or React.Component
       NodeManager.getHandler(handlerTag).init(newView, propsRef);
     } else {
-      //@ts-ignore Types should be HTMLElement or React.Component
+      // @ts-ignore Types should be HTMLElement or React.Component
       HammerNodeManager.getHandler(handlerTag).setView(newView, propsRef);
     }
   },

--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -519,7 +519,7 @@ export default class DrawerLayout extends Component<
         this.emitStateChanged(IDLE, willShow);
         this.setState({ drawerOpened: willShow });
         if (this.state.drawerState !== DRAGGING) {
-          // it's possilbe that user started drag while the drawer
+          // It's possilbe that user started drag while the drawer
           // was settling, don't override state in this case
           this.setState({ drawerState: IDLE });
         }
@@ -601,7 +601,7 @@ export default class DrawerLayout extends Component<
     const drawerSlide = drawerType !== 'back';
     const containerSlide = drawerType !== 'front';
 
-    // we rely on row and row-reverse flex directions to position the drawer
+    // We rely on row and row-reverse flex directions to position the drawer
     // properly. Apparently for RTL these are flipped which requires us to use
     // the opposite setting for the drawer to appear from left or right
     // according to the drawerPosition prop

--- a/src/components/DrawerLayout.tsx
+++ b/src/components/DrawerLayout.tsx
@@ -154,7 +154,7 @@ export interface DrawerLayoutProps {
 
   onGestureRef?: (ref: PanGestureHandler) => void;
 
-  // implicit `children` prop has been removed in @types/react^18.0.0
+  // Implicit `children` prop has been removed in @types/react^18.0.0
   children?:
     | React.ReactNode
     | ((openValue?: AnimatedInterpolation) => React.ReactNode);

--- a/src/components/GestureButtons.tsx
+++ b/src/components/GestureButtons.tsx
@@ -73,7 +73,7 @@ class InnerBaseButton extends React.Component<BaseButtonWithRefProps> {
         );
       }
     } else if (
-      // cancel longpress timeout if it's set and the finger moved out of the view
+      // Cancel longpress timeout if it's set and the finger moved out of the view
       state === State.ACTIVE &&
       !pointerInside &&
       this.longPressTimeout !== undefined
@@ -81,7 +81,7 @@ class InnerBaseButton extends React.Component<BaseButtonWithRefProps> {
       clearTimeout(this.longPressTimeout);
       this.longPressTimeout = undefined;
     } else if (
-      // cancel longpress timeout if it's set and the gesture has finished
+      // Cancel longpress timeout if it's set and the gesture has finished
       this.longPressTimeout !== undefined &&
       (state === State.END ||
         state === State.CANCELLED ||

--- a/src/components/GestureComponents.tsx
+++ b/src/components/GestureComponents.tsx
@@ -67,7 +67,7 @@ export const ScrollView = React.forwardRef<
     />
   );
 });
-// backward type compatibility with https://github.com/software-mansion/react-native-gesture-handler/blob/db78d3ca7d48e8ba57482d3fe9b0a15aa79d9932/react-native-gesture-handler.d.ts#L440-L457
+// Backward type compatibility with https://github.com/software-mansion/react-native-gesture-handler/blob/db78d3ca7d48e8ba57482d3fe9b0a15aa79d9932/react-native-gesture-handler.d.ts#L440-L457
 // include methods of wrapped components by creating an intersection type with the RN component instead of duplicating them.
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type ScrollView = typeof GHScrollView & RNScrollView;

--- a/src/components/GestureHandlerRootView.android.tsx
+++ b/src/components/GestureHandlerRootView.android.tsx
@@ -12,7 +12,7 @@ export default function GestureHandlerRootView({
   style,
   ...rest
 }: GestureHandlerRootViewProps) {
-  // try initialize fabric on the first render, at this point we can
+  // Try initialize fabric on the first render, at this point we can
   // reliably check if fabric is enabled (the function contains a flag
   // to make sure it's called only once)
   maybeInitializeFabric();

--- a/src/components/GestureHandlerRootView.tsx
+++ b/src/components/GestureHandlerRootView.tsx
@@ -11,7 +11,7 @@ export default function GestureHandlerRootView({
   style,
   ...rest
 }: GestureHandlerRootViewProps) {
-  // try initialize fabric on the first render, at this point we can
+  // Try initialize fabric on the first render, at this point we can
   // reliably check if fabric is enabled (the function contains a flag
   // to make sure it's called only once)
   maybeInitializeFabric();

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -31,7 +31,7 @@ export default function Pressable(props: PressableProps) {
 
   const pressableRef = useRef<View>(null);
 
-  // disabled when onLongPress has been called
+  // Disabled when onLongPress has been called
   const isPressCallbackEnabled = useRef<boolean>(true);
   const isPressedDown = useRef<boolean>(false);
 
@@ -107,7 +107,7 @@ export default function Pressable(props: PressableProps) {
     }
 
     if (props.unstable_pressDelay && pressDelayTimeoutRef.current !== null) {
-      // legacy Pressable behaviour - if pressDelay is set, we want to call onPressIn on touch up
+      // Legacy Pressable behaviour - if pressDelay is set, we want to call onPressIn on touch up
       clearTimeout(pressDelayTimeoutRef.current);
       pressInHandler(event);
     }
@@ -228,7 +228,7 @@ export default function Pressable(props: PressableProps) {
     }
   }
 
-  // uses different hitSlop, to activate on hitSlop area instead of pressRetentionOffset area
+  // Uses different hitSlop, to activate on hitSlop area instead of pressRetentionOffset area
   rippleGesture.hitSlop(normalizedHitSlop);
 
   const gesture = Gesture.Simultaneous(

--- a/src/components/Pressable/utils.ts
+++ b/src/components/Pressable/utils.ts
@@ -34,8 +34,8 @@ const touchToPressEvent = (
   pageY: data.absoluteY,
   target: targetId,
   timestamp: timestamp,
-  touches: [], // always empty - legacy compatibility
-  changedTouches: [], // always empty - legacy compatibility
+  touches: [], // Always empty - legacy compatibility
+  changedTouches: [], // Always empty - legacy compatibility
 });
 
 const changeToTouchData = (

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -376,7 +376,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
         const progressTarget = toValue === 0 ? 0 : 1;
 
-        // velocity is in px, while progress is in %
+        // Velocity is in px, while progress is in %
         springConfig.velocity = 0;
 
         showLeftProgress.value =
@@ -510,12 +510,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           toValue = -rightWidth.value;
         }
       } else if (rowState.value === 1) {
-        // swiped to left
+        // Swiped to left
         if (translationX > -leftThreshold) {
           toValue = leftWidth.value;
         }
       } else {
-        // swiped to right
+        // Swiped to right
         if (translationX < rightThreshold) {
           toValue = -rightWidth.value;
         }

--- a/src/components/Swipeable.tsx
+++ b/src/components/Swipeable.tsx
@@ -393,12 +393,12 @@ export default class Swipeable extends Component<
         toValue = -rightWidth;
       }
     } else if (rowState === 1) {
-      // swiped to left
+      // Swiped to left
       if (translationX > -leftThreshold) {
         toValue = leftWidth;
       }
     } else {
-      // swiped to right
+      // Swiped to right
       if (translationX < rightThreshold) {
         toValue = -rightWidth;
       }
@@ -509,7 +509,7 @@ export default class Swipeable extends Component<
       <Animated.View
         style={[
           styles.leftActions,
-          // all those and below parameters can have ! since they are all
+          // All those and below parameters can have ! since they are all
           // asigned in constructor in `updateAnimatedEvent` but TS cannot spot
           // it for some reason
           { transform: [{ translateX: this.leftActionTranslate! }] },

--- a/src/components/touchables/GenericTouchable.tsx
+++ b/src/components/touchables/GenericTouchable.tsx
@@ -53,7 +53,7 @@ export default class GenericTouchable extends Component<
     },
   };
 
-  // timeout handlers
+  // Timeout handlers
   pressInTimeout: Timeout;
   pressOutTimeout: Timeout;
   longPressTimeout: Timeout;
@@ -120,7 +120,7 @@ export default class GenericTouchable extends Component<
   componentDidMount() {
     this.reset();
   }
-  // reset timeout to prevent memory leaks.
+  // Reset timeout to prevent memory leaks.
   reset() {
     this.longPressDetected = false;
     this.pointerInside = true;
@@ -202,12 +202,12 @@ export default class GenericTouchable extends Component<
 
   onLongPressDetected = () => {
     this.longPressDetected = true;
-    // checked for in the caller of `onLongPressDetected`, but better to check twice
+    // Checked for in the caller of `onLongPressDetected`, but better to check twice
     this.props.onLongPress?.();
   };
 
   componentWillUnmount() {
-    // to prevent memory leaks
+    // To prevent memory leaks
     this.reset();
   }
 
@@ -219,7 +219,7 @@ export default class GenericTouchable extends Component<
   }
 
   onMoveOut() {
-    // long press should no longer be detected
+    // Long press should no longer be detected
     clearTimeout(this.longPressTimeout!);
     this.longPressTimeout = null;
     if (this.STATE === TOUCHABLE_STATE.BEGAN) {

--- a/src/components/touchables/TouchableNativeFeedback.android.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.android.tsx
@@ -23,7 +23,7 @@ export default class TouchableNativeFeedback extends Component<TouchableNativeFe
     },
   };
 
-  // could be taken as RNTouchableNativeFeedback.SelectableBackground etc. but the API may change
+  // Could be taken as RNTouchableNativeFeedback.SelectableBackground etc. but the API may change
   static SelectableBackground = (rippleRadius?: number) => ({
     type: 'ThemeAttrAndroid',
     // I added `attribute` prop to clone the implementation of RN and be able to use only 2 types

--- a/src/components/touchables/TouchableOpacity.tsx
+++ b/src/components/touchables/TouchableOpacity.tsx
@@ -24,7 +24,7 @@ export default class TouchableOpacity extends Component<TouchableOpacityProps> {
     activeOpacity: 0.2,
   };
 
-  // opacity is 1 one by default but could be overwritten
+  // Opacity is 1 one by default but could be overwritten
   getChildStyleOpacityWithDefault = () => {
     const childStyle = StyleSheet.flatten(this.props.style) || {};
     return childStyle.opacity == null

--- a/src/getShadowNodeFromRef.ts
+++ b/src/getShadowNodeFromRef.ts
@@ -8,7 +8,7 @@ let getInternalInstanceHandleFromPublicInstance: (ref: unknown) => {
 };
 
 export function getShadowNodeFromRef(ref: unknown) {
-  // load findHostInstance_DEPRECATED lazily because it may not be available before render
+  // Load findHostInstance_DEPRECATED lazily because it may not be available before render
   if (findHostInstance_DEPRECATED === undefined) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -20,7 +20,7 @@ export function getShadowNodeFromRef(ref: unknown) {
     }
   }
 
-  // load findHostInstance_DEPRECATED lazily because it may not be available before render
+  // Load findHostInstance_DEPRECATED lazily because it may not be available before render
   if (getInternalInstanceHandleFromPublicInstance === undefined) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment

--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -81,10 +81,10 @@ if (UIManagerConstants) {
 // Wrap JS responder calls and notify gesture handler manager
 const {
   setJSResponder: oldSetJSResponder = () => {
-    //no operation
+    // no-op
   },
   clearJSResponder: oldClearJSResponder = () => {
-    //no operation
+    // no-op
   },
 } = UIManagerAny;
 UIManagerAny.setJSResponder = (tag: number, blockNativeResponder: boolean) => {
@@ -318,7 +318,7 @@ export default function createHandler<
       this.viewTag = newViewTag;
 
       if (Platform.OS === 'web') {
-        // typecast due to dynamic resolution, attachGestureHandler should have web version signature in this branch
+        // Typecast due to dynamic resolution, attachGestureHandler should have web version signature in this branch
         (
           RNGestureHandlerModule.attachGestureHandler as AttachGestureHandlerWeb
         )(

--- a/src/handlers/createNativeWrapper.tsx
+++ b/src/handlers/createNativeWrapper.tsx
@@ -28,7 +28,7 @@ export default function createNativeWrapper<P>(
     React.ComponentType<any>,
     P & NativeViewGestureHandlerProps
   >((props, ref) => {
-    // filter out props that should be passed to gesture handler wrapper
+    // Filter out props that should be passed to gesture handler wrapper
     const gestureHandlerProps = Object.keys(props).reduce(
       (res, key) => {
         // TS being overly protective with it's types, see https://github.com/microsoft/TypeScript/issues/26255#issuecomment-458013731 for more info
@@ -39,7 +39,7 @@ export default function createNativeWrapper<P>(
         }
         return res;
       },
-      { ...config } // watch out not to modify config
+      { ...config } // Watch out not to modify config
     );
     const _ref = useRef<React.ComponentType<P>>();
     const _gestureHandlerRef = useRef<React.ComponentType<P>>();
@@ -48,7 +48,7 @@ export default function createNativeWrapper<P>(
       // @ts-ignore TODO(TS) decide how nulls work in this context
       () => {
         const node = _gestureHandlerRef.current;
-        // add handlerTag for relations config
+        // Add handlerTag for relations config
         if (_ref.current && node) {
           // @ts-ignore FIXME(TS) think about createHandler return type
           _ref.current.handlerTag = node.handlerTag;

--- a/src/handlers/gestureHandlerCommon.ts
+++ b/src/handlers/gestureHandlerCommon.ts
@@ -136,7 +136,7 @@ export type TouchAction =
   | 'revert-layer'
   | 'unset';
 
-//TODO(TS) events in handlers
+// TODO(TS) events in handlers
 
 export interface GestureEvent<ExtraEventPayloadT = Record<string, unknown>> {
   nativeEvent: Readonly<GestureEventPayload & ExtraEventPayloadT>;
@@ -201,11 +201,11 @@ export type BaseGestureHandlerProps<
   onActivated?: (event: HandlerStateChangeEvent) => void;
   onEnded?: (event: HandlerStateChangeEvent) => void;
 
-  //TODO(TS) consider using NativeSyntheticEvent
+  // TODO(TS) consider using NativeSyntheticEvent
   onGestureEvent?: (event: GestureEvent<ExtraEventPayloadT>) => void;
   onHandlerStateChange?: (
     event: HandlerStateChangeEvent<ExtraEventPayloadT>
   ) => void;
-  // implicit `children` prop has been removed in @types/react^18.0.0
+  // Implicit `children` prop has been removed in @types/react^18.0.0
   children?: React.ReactNode;
 };

--- a/src/handlers/gestureHandlerTypesCompat.ts
+++ b/src/handlers/gestureHandlerTypesCompat.ts
@@ -29,13 +29,13 @@ import type { RotationGestureHandlerProps } from './RotationGestureHandler';
 import type { TapGestureHandlerProps } from './TapGestureHandler';
 import type { NativeViewGestureHandlerProps } from './NativeViewGestureHandler';
 
-// events
+// Events
 export type GestureHandlerGestureEventNativeEvent = GestureEventPayload;
 export type GestureHandlerStateChangeNativeEvent =
   HandlerStateChangeEventPayload;
 export type GestureHandlerGestureEvent = GestureEvent;
 export type GestureHandlerStateChangeEvent = HandlerStateChangeEvent;
-// gesture handlers events
+// Gesture handlers events
 export type NativeViewGestureHandlerGestureEvent =
   GestureEvent<NativeViewGestureHandlerPayload>;
 export type NativeViewGestureHandlerStateChangeEvent =
@@ -76,7 +76,7 @@ export type FlingGestureHandlerGestureEvent =
 export type FlingGestureHandlerStateChangeEvent =
   HandlerStateChangeEvent<FlingGestureHandlerEventPayload>;
 
-// handlers properties
+// Handlers properties
 export type NativeViewGestureHandlerProperties = NativeViewGestureHandlerProps;
 export type TapGestureHandlerProperties = TapGestureHandlerProps;
 export type LongPressGestureHandlerProperties = LongPressGestureHandlerProps;
@@ -85,7 +85,7 @@ export type PinchGestureHandlerProperties = PinchGestureHandlerProps;
 export type RotationGestureHandlerProperties = RotationGestureHandlerProps;
 export type FlingGestureHandlerProperties = FlingGestureHandlerProps;
 export type ForceTouchGestureHandlerProperties = ForceTouchGestureHandlerProps;
-// button props
+// Button props
 export type RawButtonProperties = RawButtonProps;
 export type BaseButtonProperties = BaseButtonProps;
 export type RectButtonProperties = RectButtonProps;

--- a/src/handlers/gestures/GestureDetector/Wrap.tsx
+++ b/src/handlers/gestures/GestureDetector/Wrap.tsx
@@ -4,7 +4,7 @@ import { tagMessage } from '../../../utils';
 
 export class Wrap extends React.Component<{
   onGestureHandlerEvent?: unknown;
-  // implicit `children` prop has been removed in @types/react^18.0.0
+  // Implicit `children` prop has been removed in @types/react^18.0.0
   children?: React.ReactNode;
 }> {
   render() {

--- a/src/handlers/gestures/GestureDetector/attachHandlers.ts
+++ b/src/handlers/gestures/GestureDetector/attachHandlers.ts
@@ -32,7 +32,7 @@ export function attachHandlers({
 }: AttachHandlersConfig) {
   gestureConfig.initialize();
 
-  // use queueMicrotask to extract handlerTags, because all refs should be initialized
+  // Use queueMicrotask to extract handlerTags, because all refs should be initialized
   // when it's ran
   ghQueueMicrotask(() => {
     if (!preparedGesture.isMounted) {
@@ -52,7 +52,7 @@ export function attachHandlers({
     registerHandler(handler.handlerTag, handler, handler.config.testId);
   }
 
-  // use queueMicrotask to extract handlerTags, because all refs should be initialized
+  // Use queueMicrotask to extract handlerTags, because all refs should be initialized
   // when it's ran
   ghQueueMicrotask(() => {
     if (!preparedGesture.isMounted) {
@@ -83,7 +83,7 @@ export function attachHandlers({
       )(
         gesture.handlerTag,
         viewTag,
-        ActionType.JS_FUNCTION_OLD_API, // ignored on web
+        ActionType.JS_FUNCTION_OLD_API, // Ignored on web
         webEventHandlersRef
       );
     } else {

--- a/src/handlers/gestures/GestureDetector/index.tsx
+++ b/src/handlers/gestures/GestureDetector/index.tsx
@@ -111,7 +111,7 @@ export const GestureDetector = (props: GestureDetectorProps) => {
   );
 
   const webEventHandlersRef = useWebEventHandlers();
-  // store state in ref to prevent unnecessary renders
+  // Store state in ref to prevent unnecessary renders
   const state = useRef<GestureDetectorState>({
     firstRender: true,
     viewRef: null,

--- a/src/handlers/gestures/GestureDetector/updateHandlers.ts
+++ b/src/handlers/gestures/GestureDetector/updateHandlers.ts
@@ -22,7 +22,7 @@ export function updateHandlers(
     const handler = preparedGesture.attachedGestures[i];
     checkGestureCallbacksForWorklets(handler);
 
-    // only update handlerTag when it's actually different, it may be the same
+    // Only update handlerTag when it's actually different, it may be the same
     // if gesture config object is wrapped with useMemo
     if (newGestures[i].handlerTag !== handler.handlerTag) {
       newGestures[i].handlerTag = handler.handlerTag;
@@ -30,7 +30,7 @@ export function updateHandlers(
     }
   }
 
-  // use queueMicrotask to extract handlerTags, because when it's ran, all refs should be updated
+  // Use queueMicrotask to extract handlerTags, because when it's ran, all refs should be updated
   // and handlerTags in BaseGesture references should be updated in the loop above (we need to wait
   // in case of external relations)
   ghQueueMicrotask(() => {
@@ -38,14 +38,14 @@ export function updateHandlers(
       return;
     }
 
-    // if amount of gesture configs changes, we need to update the callbacks in shared value
+    // If amount of gesture configs changes, we need to update the callbacks in shared value
     let shouldUpdateSharedValueIfUsed =
       preparedGesture.attachedGestures.length !== newGestures.length;
 
     for (let i = 0; i < newGestures.length; i++) {
       const handler = preparedGesture.attachedGestures[i];
 
-      // if the gestureId is different (gesture isn't wrapped with useMemo or its dependencies changed),
+      // If the gestureId is different (gesture isn't wrapped with useMemo or its dependencies changed),
       // we need to update the shared value, assuming the gesture runs on UI thread or the thread changed
       if (
         handler.handlers.gestureId !== newGestures[i].handlers.gestureId &&
@@ -71,7 +71,7 @@ export function updateHandlers(
 
     if (preparedGesture.animatedHandlers && shouldUpdateSharedValueIfUsed) {
       const newHandlersValue = preparedGesture.attachedGestures
-        .filter((g) => g.shouldUseReanimated) // ignore gestures that shouldn't run on UI
+        .filter((g) => g.shouldUseReanimated) // Ignore gestures that shouldn't run on UI
         .map((g) => g.handlers) as unknown as HandlerCallbacks<
         Record<string, unknown>
       >[];

--- a/src/handlers/gestures/GestureDetector/useDetectorUpdater.ts
+++ b/src/handlers/gestures/GestureDetector/useDetectorUpdater.ts
@@ -28,7 +28,7 @@ export function useDetectorUpdater(
   const updateAttachedGestures = useCallback(
     // skipConfigUpdate is used to prevent unnecessary updates when only checking if the view has changed
     (skipConfigUpdate?: boolean) => {
-      // if the underlying view has changed we need to reattach handlers to the new view
+      // If the underlying view has changed we need to reattach handlers to the new view
       const viewTag = findNodeHandle(state.viewRef) as number;
       const didUnderlyingViewChange = viewTag !== state.previousViewTag;
 

--- a/src/handlers/gestures/GestureDetector/utils.ts
+++ b/src/handlers/gestures/GestureDetector/utils.ts
@@ -111,7 +111,7 @@ export function checkGestureCallbacksForWorklets(gesture: GestureType) {
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function validateDetectorChildren(ref: any) {
-  // finds the first native view under the Wrap component and traverses the fiber tree upwards
+  // Finds the first native view under the Wrap component and traverses the fiber tree upwards
   // to check whether there is more than one native view as a pseudo-direct child of GestureDetector
   // i.e. this is not ok:
   //            Wrap

--- a/src/handlers/gestures/GestureDetector/utils.ts
+++ b/src/handlers/gestures/GestureDetector/utils.ts
@@ -73,7 +73,7 @@ export function checkGestureCallbacksForWorklets(gesture: GestureType) {
   if (!__DEV__) {
     return;
   }
-  // if a gesture is explicitly marked to run on the JS thread there is no need to check
+  // If a gesture is explicitly marked to run on the JS thread there is no need to check
   // if callbacks are worklets as the user is aware they will be ran on the JS thread
   if (gesture.config.runOnJS) {
     return;
@@ -82,7 +82,7 @@ export function checkGestureCallbacksForWorklets(gesture: GestureType) {
   const areSomeNotWorklets = gesture.handlers.isWorklet.includes(false);
   const areSomeWorklets = gesture.handlers.isWorklet.includes(true);
 
-  // if some of the callbacks are worklets and some are not, and the gesture is not
+  // If some of the callbacks are worklets and some are not, and the gesture is not
   // explicitly marked with `.runOnJS(true)` show an error
   if (areSomeNotWorklets && areSomeWorklets) {
     console.error(
@@ -93,12 +93,12 @@ export function checkGestureCallbacksForWorklets(gesture: GestureType) {
   }
 
   if (Reanimated === undefined) {
-    // if Reanimated is not available, we can't run worklets, so we shouldn't show the warning
+    // If Reanimated is not available, we can't run worklets, so we shouldn't show the warning
     return;
   }
 
   const areAllNotWorklets = !areSomeWorklets && areSomeNotWorklets;
-  // if none of the callbacks are worklets and the gesture is not explicitly marked with
+  // If none of the callbacks are worklets and the gesture is not explicitly marked with
   // `.runOnJS(true)` show a warning
   if (areAllNotWorklets) {
     console.warn(

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -37,7 +37,7 @@ export type GestureRef =
   | number
   | GestureType
   | React.RefObject<GestureType | undefined>
-  | React.RefObject<React.ComponentType | undefined>; // allow adding a ref to a gesture handler
+  | React.RefObject<React.ComponentType | undefined>; // Allow adding a ref to a gesture handler
 export interface BaseGestureConfig
   extends CommonGestureConfig,
     Record<string, unknown> {
@@ -418,8 +418,8 @@ export abstract class BaseGesture<
   prepare() {}
 
   get shouldUseReanimated(): boolean {
-    // use Reanimated when runOnJS isn't set explicitly,
-    // and all defined callbacks are worklets,
+    // Use Reanimated when runOnJS isn't set explicitly,
+    // all defined callbacks are worklets
     // and remote debugging is disabled
     return (
       this.config.runOnJS !== true &&

--- a/src/handlers/gestures/gesture.ts
+++ b/src/handlers/gestures/gesture.ts
@@ -168,7 +168,7 @@ export abstract class BaseGesture<
 
   // eslint-disable-next-line @typescript-eslint/ban-types
   protected isWorklet(callback: Function) {
-    //@ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
+    // @ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
     return callback.__workletHash !== undefined;
   }
 
@@ -205,7 +205,7 @@ export abstract class BaseGesture<
     ) => void
   ) {
     this.handlers.onEnd = callback;
-    //@ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
+    // @ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
     this.handlers.isWorklet[CALLBACK_TYPE.END] = this.isWorklet(callback);
     return this;
   }
@@ -221,7 +221,7 @@ export abstract class BaseGesture<
     ) => void
   ) {
     this.handlers.onFinalize = callback;
-    //@ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
+    // @ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
     this.handlers.isWorklet[CALLBACK_TYPE.FINALIZE] = this.isWorklet(callback);
     return this;
   }

--- a/src/handlers/gestures/gestureComposition.ts
+++ b/src/handlers/gestures/gestureComposition.ts
@@ -29,8 +29,8 @@ export class ComposedGesture extends Gesture {
     if (gesture instanceof BaseGesture) {
       const newConfig = { ...gesture.config };
 
-      // no need to extend `blocksHandlers` here, because it's not changed in composition
-      // the same effect is achieved by reversing the order of 2 gestures in `Exclusive`
+      // No need to extend `blocksHandlers` here, because it's not changed in composition.
+      // The same effect is achieved by reversing the order of 2 gestures in `Exclusive`
       newConfig.simultaneousWith = extendRelation(
         newConfig.simultaneousWith,
         simultaneousGestures
@@ -71,7 +71,7 @@ export class ComposedGesture extends Gesture {
 
 export class SimultaneousGesture extends ComposedGesture {
   prepare() {
-    // this piece of magic works something like this:
+    // This piece of magic works something like this:
     // for every gesture in the array
     const simultaneousArrays = this.gestures.map((gesture) =>
       // we take the array it's in
@@ -97,7 +97,7 @@ export class SimultaneousGesture extends ComposedGesture {
 
 export class ExclusiveGesture extends ComposedGesture {
   prepare() {
-    // transforms the array of gestures into array of grouped raw (not composed) gestures
+    // Transforms the array of gestures into array of grouped raw (not composed) gestures
     // i.e. [gesture1, gesture2, ComposedGesture(gesture3, gesture4)] -> [[gesture1], [gesture2], [gesture3, gesture4]]
     const gestureArrays = this.gestures.map((gesture) =>
       gesture.toGestureArray()
@@ -112,7 +112,7 @@ export class ExclusiveGesture extends ComposedGesture {
         this.requireGesturesToFail.concat(requireToFail)
       );
 
-      // every group gets to wait for all groups before it
+      // Every group gets to wait for all groups before it
       requireToFail = requireToFail.concat(gestureArrays[i]);
     }
   }

--- a/src/handlers/gestures/gestureStateManager.ts
+++ b/src/handlers/gestures/gestureStateManager.ts
@@ -13,7 +13,7 @@ const warningMessage = tagMessage(
   'react-native-reanimated is required in order to use synchronous state management'
 );
 
-// check if reanimated module is available, but look for useSharedValue as conditional
+// Check if reanimated module is available, but look for useSharedValue as conditional
 // require of reanimated can sometimes return content of `utils.ts` file (?)
 const REANIMATED_AVAILABLE = Reanimated?.useSharedValue !== undefined;
 const setGestureState = Reanimated?.setGestureState;

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,16 +6,16 @@ export { PointerType } from './PointerType';
 export { default as gestureHandlerRootHOC } from './components/gestureHandlerRootHOC';
 export { default as GestureHandlerRootView } from './components/GestureHandlerRootView';
 export type {
-  // event types
+  // Event types
   GestureEvent,
   HandlerStateChangeEvent,
-  // event payloads types
+  // Event payloads types
   GestureEventPayload,
   HandlerStateChangeEventPayload,
-  // pointer events
+  // Pointer events
   GestureTouchEvent,
   TouchData,
-  // new api event types
+  // New api event types
   GestureUpdateEvent,
   GestureStateChangeEvent,
 } from './handlers/gestureHandlerCommon';
@@ -104,10 +104,10 @@ export {
 } from './components/GestureComponents';
 export { HoverEffect } from './handlers/gestures/hoverGesture';
 export type {
-  //events
+  // Events
   GestureHandlerGestureEvent,
   GestureHandlerStateChangeEvent,
-  //event payloads
+  // Event payloads
   GestureHandlerGestureEventNativeEvent,
   GestureHandlerStateChangeNativeEvent,
   NativeViewGestureHandlerGestureEvent,
@@ -126,7 +126,7 @@ export type {
   RotationGestureHandlerStateChangeEvent,
   FlingGestureHandlerGestureEvent,
   FlingGestureHandlerStateChangeEvent,
-  // handlers props
+  // Handlers props
   NativeViewGestureHandlerProperties,
   TapGestureHandlerProperties,
   LongPressGestureHandlerProperties,
@@ -135,7 +135,7 @@ export type {
   RotationGestureHandlerProperties,
   FlingGestureHandlerProperties,
   ForceTouchGestureHandlerProperties,
-  // buttons props
+  // Buttons props
   RawButtonProperties,
   BaseButtonProperties,
   RectButtonProperties,

--- a/src/init.ts
+++ b/src/init.ts
@@ -8,7 +8,7 @@ export function initialize() {
   startListening();
 }
 
-// since isFabric() may give wrong results before the first render, we call this
+// Since isFabric() may give wrong results before the first render, we call this
 // method during render of GestureHandlerRootView
 export function maybeInitializeFabric() {
   if (isFabric() && !fabricInitialized) {

--- a/src/jestUtils/jestUtils.ts
+++ b/src/jestUtils/jestUtils.ts
@@ -61,7 +61,7 @@ import {
 import { State } from '../State';
 import { hasProperty, withPrevAndCurrent } from '../utils';
 
-// load fireEvent conditionally, so RNGH may be used in setups without testing-library
+// Load fireEvent conditionally, so RNGH may be used in setups without testing-library
 let fireEvent = (
   _element: ReactTestInstance,
   _name: string,
@@ -74,7 +74,7 @@ try {
   // eslint-disable-next-line @typescript-eslint/no-var-requires
   fireEvent = require('@testing-library/react-native').fireEvent;
 } catch (_e) {
-  // do nothing if not available
+  // Do nothing if not available
 }
 
 type GestureHandlerTestEvent<

--- a/src/mocks.ts
+++ b/src/mocks.ts
@@ -14,7 +14,7 @@ import { State } from './State';
 import { Directions } from './Directions';
 
 const NOOP = () => {
-  // do nothing
+  // Do nothing
 };
 const PanGestureHandler = View;
 const attachGestureHandler = NOOP;
@@ -63,7 +63,7 @@ export default {
   updateGestureHandler,
   flushOperations,
   install,
-  // probably can be removed
+  // Probably can be removed
   Directions,
   State,
 } as const;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -43,7 +43,7 @@ export function tagMessage(msg: string) {
   return `[react-native-gesture-handler] ${msg}`;
 }
 
-// helper method to check whether Fabric is enabled, however global.nativeFabricUIManager
+// Helper method to check whether Fabric is enabled, however global.nativeFabricUIManager
 // may not be initialized before the first render
 export function isFabric(): boolean {
   // @ts-expect-error nativeFabricUIManager is not yet included in the RN types

--- a/src/web/detectors/RotationGestureDetector.ts
+++ b/src/web/detectors/RotationGestureDetector.ts
@@ -48,7 +48,7 @@ export default class RotationGestureDetector
     this.anchorX = (firstPointerCoords.x + secondPointerCoords.x) / 2;
     this.anchorY = (firstPointerCoords.y + secondPointerCoords.y) / 2;
 
-    //Angle diff should be positive when rotating in clockwise direction
+    // Angle diff should be positive when rotating in clockwise direction
     const angle: number = -Math.atan2(vectorY, vectorX);
 
     this.rotation = Number.isNaN(this.previousAngle)

--- a/src/web/detectors/ScaleGestureDetector.ts
+++ b/src/web/detectors/ScaleGestureDetector.ts
@@ -72,7 +72,7 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
       ? event.pointerId
       : undefined;
 
-    //Determine focal point
+    // Determine focal point
 
     const div: number = pointerUp ? numOfPointers - 1 : numOfPointers;
 
@@ -81,7 +81,7 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
     const focusX = coordsSum.x / div;
     const focusY = coordsSum.y / div;
 
-    //Determine average deviation from focal point
+    // Determine average deviation from focal point
 
     let devSumX = 0;
     let devSumY = 0;
@@ -103,7 +103,7 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
 
     const span = Math.hypot(spanX, spanY);
 
-    //Begin/end events
+    // Begin/end events
     const wasInProgress: boolean = this.inProgress;
     this.focusX = focusX;
     this.focusY = focusY;
@@ -128,7 +128,7 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
       this.inProgress = this.onScaleBegin(this);
     }
 
-    //Handle motion
+    // Handle motion
     if (action !== EventTypes.MOVE) {
       return true;
     }

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -69,7 +69,7 @@ export default class FlingGestureHandler extends GestureHandler {
     const axialDirectionsList = Object.values(Directions);
     const diagonalDirectionsList = Object.values(DiagonalDirections);
 
-    // list of alignments to all activated directions
+    // List of alignments to all activated directions
     const axialAlignmentList = axialDirectionsList.map((direction) =>
       getAlignment(direction, AXIAL_DEVIATION_COSINE)
     );

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -726,15 +726,9 @@ export default abstract class GestureHandler implements IGestureHandler {
     const offsetX: number = x - rect.pageX;
     const offsetY: number = y - rect.pageY;
 
-    if (
-      offsetX >= left &&
-      offsetX <= right &&
-      offsetY >= top &&
-      offsetY <= bottom
-    ) {
-      return true;
-    }
-    return false;
+    return (
+      offsetX >= left && offsetX <= right && offsetY >= top && offsetY <= bottom
+    );
   }
 
   public isButtonInConfig(mouseButton: MouseButton | undefined) {

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -843,7 +843,7 @@ function invokeNullableMethod(
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     if (value?.setValue) {
-      //Reanimated API
+      // Reanimated API
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       value.setValue(nativeValue);
     } else {

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -333,10 +333,10 @@ export default abstract class GestureHandler implements IGestureHandler {
     this.tryToSendMoveEvent(true, event);
   }
   protected onPointerMoveOver(_event: AdaptedEvent): void {
-    // used only by hover gesture handler atm
+    // Used only by hover gesture handler atm
   }
   protected onPointerMoveOut(_event: AdaptedEvent): void {
-    // used only by hover gesture handler atm
+    // Used only by hover gesture handler atm
   }
   private tryToSendMoveEvent(out: boolean, event: AdaptedEvent): void {
     if ((out && this.shouldCancelWhenOutside) || !this.enabled) {
@@ -569,7 +569,7 @@ export default abstract class GestureHandler implements IGestureHandler {
   }
 
   protected transformNativeEvent(): Record<string, unknown> {
-    // those properties are shared by most handlers and if not this method will be overriden
+    // Those properties are shared by most handlers and if not this method will be overriden
     const lastCoords = this.tracker.getAbsoluteCoordsAverage();
     const lastRelativeCoords = this.tracker.getRelativeCoordsAverage();
 
@@ -853,7 +853,7 @@ function invokeNullableMethod(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
       value.setValue(nativeValue);
     } else {
-      //RN Animated API
+      // RN Animated API
       method.__nodeConfig.argMapping[index] = [key, nativeValue];
     }
   }

--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -7,8 +7,8 @@ import GestureHandler from './GestureHandler';
 export default class NativeViewGestureHandler extends GestureHandler {
   private buttonRole!: boolean;
 
-  //TODO: Implement logic for activation on start
-  //@ts-ignore Logic yet to be implemented
+  // TODO: Implement logic for activation on start
+  // @ts-ignore Logic yet to be implemented
   private shouldActivateOnStart = false;
   private disallowInterruption = false;
 
@@ -28,7 +28,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
     const view = this.delegate.getView() as HTMLElement;
 
     view.style['touchAction'] = 'auto';
-    //@ts-ignore Turns on defualt touch behavior on Safari
+    // @ts-ignore Turns on defualt touch behavior on Safari
     view.style['WebkitTouchCallout'] = 'auto';
 
     this.buttonRole = view.getAttribute('role') === 'button';

--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -210,7 +210,7 @@ export default class PanGestureHandler extends GestureHandler {
     clearTimeout(this.activationTimeout);
   }
 
-  //EventsHandling
+  // Events Handling
   protected onPointerDown(event: AdaptedEvent): void {
     if (!this.isButtonInConfig(event.button)) {
       return;

--- a/src/web/handlers/TapGestureHandler.ts
+++ b/src/web/handlers/TapGestureHandler.ts
@@ -103,7 +103,7 @@ export default class TapGestureHandler extends GestureHandler {
     }
   }
 
-  //Handling Events
+  // Handling Events
   protected onPointerDown(event: AdaptedEvent): void {
     if (!this.isButtonInConfig(event.button)) {
       return;

--- a/src/web/tools/EventManager.ts
+++ b/src/web/tools/EventManager.ts
@@ -28,8 +28,8 @@ export default abstract class EventManager<T> {
   protected onPointerUp(_event: AdaptedEvent): void {}
   protected onPointerRemove(_event: AdaptedEvent): void {}
   protected onPointerMove(_event: AdaptedEvent): void {}
-  protected onPointerLeave(_event: AdaptedEvent): void {} // called only when pointer is pressed (or touching)
-  protected onPointerEnter(_event: AdaptedEvent): void {} // called only when pointer is pressed (or touching)
+  protected onPointerLeave(_event: AdaptedEvent): void {} // Called only when pointer is pressed (or touching)
+  protected onPointerEnter(_event: AdaptedEvent): void {} // Called only when pointer is pressed (or touching)
   protected onPointerCancel(_event: AdaptedEvent): void {
     // When pointer cancel is triggered and there are more pointers on the view, only one pointer is cancelled
     // Because we want all pointers to be cancelled by that event, we are doing it manually by reseting handler and changing activePointersCounter to 0

--- a/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/src/web/tools/GestureHandlerWebDelegate.ts
@@ -37,13 +37,8 @@ export class GestureHandlerWebDelegate
 
     this.addContextMenuListeners(config);
 
-    if (!config.userSelect) {
-      this.view.style['webkitUserSelect'] = 'none';
-      this.view.style['userSelect'] = 'none';
-    } else {
-      this.view.style['webkitUserSelect'] = config.userSelect;
-      this.view.style['userSelect'] = config.userSelect;
-    }
+    this.view.style['userSelect'] = config.userSelect ?? 'none';
+    this.view.style['webkitUserSelect'] = config.userSelect ?? 'none';
 
     this.view.style['touchAction'] = config.touchAction ?? 'none';
     //@ts-ignore This one disables default events on Safari

--- a/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/src/web/tools/GestureHandlerWebDelegate.ts
@@ -41,7 +41,7 @@ export class GestureHandlerWebDelegate
     this.view.style['webkitUserSelect'] = config.userSelect ?? 'none';
 
     this.view.style['touchAction'] = config.touchAction ?? 'none';
-    //@ts-ignore This one disables default events on Safari
+    // @ts-ignore This one disables default events on Safari
     this.view.style['WebkitTouchCallout'] = 'none';
 
     this.eventManagers.push(new PointerEventManager(this.view));

--- a/src/web/tools/LeastSquareSolver.ts
+++ b/src/web/tools/LeastSquareSolver.ts
@@ -69,17 +69,17 @@ class Matrix {
   }
 }
 
-/// An nth degree polynomial fit to a dataset.
+// An nth degree polynomial fit to a dataset.
 class PolynomialFit {
-  /// The polynomial coefficients of the fit.
-  ///
-  /// For each `i`, the element `coefficients[i]` is the coefficient of
-  /// the `i`-th power of the variable.
+  // The polynomial coefficients of the fit.
+  //
+  // For each `i`, the element `coefficients[i]` is the coefficient of
+  // the `i`-th power of the variable.
   public coefficients: number[];
 
-  /// Creates a polynomial fit of the given degree.
-  ///
-  /// There are n + 1 coefficients in a fit of degree n.
+  // Creates a polynomial fit of the given degree.
+  //
+  // There are n + 1 coefficients in a fit of degree n.
   constructor(degree: number) {
     this.coefficients = new Array<number>(degree + 1);
   }
@@ -87,27 +87,27 @@ class PolynomialFit {
 
 const precisionErrorTolerance = 1e-10;
 
-/// Uses the least-squares algorithm to fit a polynomial to a set of data.
+// Uses the least-squares algorithm to fit a polynomial to a set of data.
 export default class LeastSquareSolver {
-  /// The x-coordinates of each data point.
+  // The x-coordinates of each data point.
   private x: number[];
-  /// The y-coordinates of each data point.
+  // The y-coordinates of each data point.
   private y: number[];
-  /// The weight to use for each data point.
+  // The weight to use for each data point.
   private w: number[];
 
-  /// Creates a least-squares solver.
-  ///
-  /// The [x], [y], and [w] arguments must not be null.
+  // Creates a least-squares solver.
+  //
+  // The [x], [y], and [w] arguments must not be null.
   constructor(x: number[], y: number[], w: number[]) {
     this.x = x;
     this.y = y;
     this.w = w;
   }
 
-  /// Fits a polynomial of the given degree to the data points.
-  ///
-  /// When there is not enough data to fit a curve null is returned.
+  // Fits a polynomial of the given degree to the data points.
+  //
+  // When there is not enough data to fit a curve null is returned.
   public solve(degree: number): PolynomialFit | null {
     if (degree > this.x.length) {
       // Not enough data to fit a curve.

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -197,8 +197,8 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.CANCEL);
 
     if (this.trackedPointers.has(adaptedEvent.pointerId)) {
-      // in some cases the `pointerup` event is not fired, but `lostpointercapture` is
-      // we simulate the `pointercancel` event here to make sure the gesture handler stops tracking it
+      // In some cases the `pointerup` event is not fired, but `lostpointercapture` is.
+      // Here we simulate the `pointercancel` event to make sure the gesture handler stops tracking it.
       this.onPointerCancel(adaptedEvent);
 
       this.activePointersCounter = 0;

--- a/src/web/tools/PointerTracker.ts
+++ b/src/web/tools/PointerTracker.ts
@@ -86,7 +86,7 @@ export default class PointerTracker {
     this.cachedRelativeAverages = this.getRelativeCoordsAverage();
   }
 
-  //Mapping TouchEvents ID
+  // Mapping TouchEvents ID
   private mapTouchEventId(id: number): void {
     for (const [mappedId, touchId] of this.touchEventsIds) {
       if (isNaN(touchId)) {
@@ -156,6 +156,7 @@ export default class PointerTracker {
   // This may happen when pointers have already been removed from tracker (i.e. pointerup event).
   // In situation when NaN would be sent as a response, we return cached value.
   // That prevents handlers from crashing
+
   public getAbsoluteCoordsAverage() {
     const coordsSum = this.getAbsoluteCoordsSum();
 

--- a/src/web/tools/TouchEventManager.ts
+++ b/src/web/tools/TouchEventManager.ts
@@ -20,7 +20,7 @@ export default class TouchEventManager extends EventManager<HTMLElement> {
           x: adaptedEvent.x,
           y: adaptedEvent.y,
         }) ||
-        //@ts-ignore touchType field does exist
+        // @ts-ignore touchType field does exist
         event.changedTouches[i].touchType === 'stylus'
       ) {
         continue;
@@ -45,7 +45,7 @@ export default class TouchEventManager extends EventManager<HTMLElement> {
         i,
         TouchEventType.MOVE
       );
-      //@ts-ignore touchType field does exist
+      // @ts-ignore touchType field does exist
       if (event.changedTouches[i].touchType === 'stylus') {
         continue;
       }
@@ -89,7 +89,7 @@ export default class TouchEventManager extends EventManager<HTMLElement> {
         break;
       }
 
-      //@ts-ignore touchType field does exist
+      // @ts-ignore touchType field does exist
       if (event.changedTouches[i].touchType === 'stylus') {
         continue;
       }
@@ -121,7 +121,7 @@ export default class TouchEventManager extends EventManager<HTMLElement> {
         TouchEventType.CANCELLED
       );
 
-      //@ts-ignore touchType field does exist
+      // @ts-ignore touchType field does exist
       if (event.changedTouches[i].touchType === 'stylus') {
         continue;
       }

--- a/src/web/tools/VelocityTracker.ts
+++ b/src/web/tools/VelocityTracker.ts
@@ -18,12 +18,12 @@ export default class VelocityTracker {
     this.samples.push(event);
   }
 
-  /// Returns an estimate of the velocity of the object being tracked by the
-  /// tracker given the current information available to the tracker.
-  ///
-  /// Information is added using [addPosition].
-  ///
-  /// Returns null if there is no data on which to base an estimate.
+  // Returns an estimate of the velocity of the object being tracked by the
+  // tracker given the current information available to the tracker.
+  //
+  // Information is added using [addPosition].
+  //
+  // Returns null if there is no data on which to base an estimate.
   private getVelocityEstimate(): [number, number] | null {
     const x = [];
     const y = [];


### PR DESCRIPTION
## Description

This PR changes 3 things:

1. Unifies comments convention across `ts`/`tsx` files.
2. Simplifies one `return` statement in `GestureHandler` on `web`
3. Simplifies `userSelect` assignment in `GestureHandlerWebDelegate`

1. leads to many changed files, so if you think that 2. and 3. deserve their own PRs I'll open them 😅 

### Comments

Changed things:

- start with capital letter
- use `//` instead of `///`
- insert space between `//` and actual comment 

It also adds `ESlint` rule `spaced-comment`, which enforces spaces between `//` and comment content.

### `return`

I've removed `if` condition and moved it right to `return` statement

<details>
<summary> Before </summary>

```tsx
if (
  offsetX >= left &&
  offsetX <= right &&
  offsetY >= top &&
  offsetY <= bottom
) {
  return true;
}
return false;
```

</details>

<details>
<summary> After </summary>

```tsx
return (
  offsetX >= left && offsetX <= right && offsetY >= top && offsetY <= bottom
);
```

</details>

### `userSelect` assignment

I've changed `userSelect` assignment in `GestureHandlerWebDelegate` to use `??` operator

<details>
<summary> Before </summary>

```tsx
if (!config.userSelect) {
  this.view.style['webkitUserSelect'] = 'none';
  this.view.style['userSelect'] = 'none';
} else {
  this.view.style['webkitUserSelect'] = config.userSelect;
  this.view.style['userSelect'] = config.userSelect;
}
```

</details>

<details>
<summary> After </summary>

```tsx
this.view.style['userSelect'] = config.userSelect ?? 'none';
this.view.style['webkitUserSelect'] = config.userSelect ?? 'none';
```

</details>


## Test plan

Verified that example app works as it used to.
