### PR TITLE
Fix scroll view handler state change events

### DIFF
--- a/apple/Handlers/RNNativeViewHandler.mm
+++ b/apple/Handlers/RNNativeViewHandler.mm
@@ -85,7 +85,11 @@
 
 - (BOOL)isScrollView
 {
+#ifdef RCT_NEW_ARCH_ENABLED
+  return [self.view isKindOfClass:[RCTScrollViewComponentView class]];
+#else
   return [self.view isKindOfClass:[RCTScrollView class]];
+#endif
 }
 
 @end

--- a/apple/Handlers/RNNativeViewHandler.mm
+++ b/apple/Handlers/RNNativeViewHandler.mm
@@ -56,7 +56,7 @@
 
   // For now, we are handling only the scroll view case.
   // If more views need special treatment, then we can switch to a delegate pattern
-  if ([_gestureHandler retrieveScrollViewFromRecognizer:self] == nil) {
+  if ([_gestureHandler retrieveScrollView:self.view] == nil) {
     [self reset];
   }
 }
@@ -77,7 +77,7 @@
 
 - (void)updateStateIfScrollView
 {
-  UIScrollView *scrollView = [_gestureHandler retrieveScrollViewFromRecognizer:self];
+  UIScrollView *scrollView = [_gestureHandler retrieveScrollView:self.view];
   if (!scrollView)
     return;
   for (UIGestureRecognizer *scrollViewGestureRecognizer in scrollView.gestureRecognizers) {
@@ -134,20 +134,8 @@
   // We can restore default scrollview behaviour to delay touches to scrollview's children
   // because gesture handler system can handle cancellation of scroll recognizer when JS responder
   // is set
-#ifdef RCT_NEW_ARCH_ENABLED
-  if ([view isKindOfClass:[RCTScrollViewComponentView class]]) {
-    UIScrollView *scrollView = ((RCTScrollViewComponentView *)view).scrollView;
-    scrollView.delaysContentTouches = YES;
-  }
-#else
-  if ([view isKindOfClass:[RCTScrollView class]]) {
-    // This part of the code is coupled with RN implementation of ScrollView native wrapper and
-    // we expect for RCTScrollView component to contain a subclass of UIScrollview as the only
-    // subview
-    UIScrollView *scrollView = [view.subviews objectAtIndex:0];
-    scrollView.delaysContentTouches = YES;
-  }
-#endif // RCT_NEW_ARCH_ENABLED
+  UIScrollView *scrollView = [self retrieveScrollView:view];
+  scrollView.delaysContentTouches = YES;
 }
 
 - (void)handleTouchDown:(UIView *)sender forEvent:(UIEvent *)event

--- a/apple/Handlers/RNNativeViewHandler.mm
+++ b/apple/Handlers/RNNativeViewHandler.mm
@@ -39,14 +39,13 @@
 
 - (void)touchesBegan:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
-  [self setStateIfScrollView:UIGestureRecognizerStatePossible];
   [_gestureHandler setCurrentPointerType:event];
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
-  [self setStateIfScrollView:UIGestureRecognizerStateChanged];
+  [self updateStateIfScrollView];
   [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
 }
 
@@ -57,7 +56,7 @@
 
   // For now, we are handling only the scroll view case.
   // If more views need special treatment, then we can switch to a delegate pattern
-  if (![self isScrollView]) {
+  if ([_gestureHandler retrieveScrollViewFromRecognizer:self] == nil) {
     [self reset];
   }
 }
@@ -76,20 +75,16 @@
   [_gestureHandler reset];
 }
 
-- (void)setStateIfScrollView:(UIGestureRecognizerState)state
+- (void)updateStateIfScrollView
 {
-  if ([self isScrollView]) {
-    self.state = state;
+  UIScrollView *scrollView = [_gestureHandler retrieveScrollViewFromRecognizer:self];
+  if (!scrollView)
+    return;
+  for (UIGestureRecognizer *scrollViewGestureRecognizer in scrollView.gestureRecognizers) {
+    if ([_gestureHandler isUIScrollViewPanGestureRecognizer:scrollViewGestureRecognizer]) {
+      self.state = scrollViewGestureRecognizer.state;
+    }
   }
-}
-
-- (BOOL)isScrollView
-{
-#ifdef RCT_NEW_ARCH_ENABLED
-  return [self.view isKindOfClass:[RCTScrollViewComponentView class]];
-#else
-  return [self.view isKindOfClass:[RCTScrollView class]];
-#endif
 }
 
 @end

--- a/apple/Handlers/RNNativeViewHandler.mm
+++ b/apple/Handlers/RNNativeViewHandler.mm
@@ -39,12 +39,14 @@
 
 - (void)touchesBegan:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
+  [self setStateIfScrollView:UIGestureRecognizerStatePossible];
   [_gestureHandler setCurrentPointerType:event];
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
+  [self setStateIfScrollView:UIGestureRecognizerStateChanged];
   [_gestureHandler.pointerTracker touchesMoved:touches withEvent:event];
 }
 
@@ -52,7 +54,12 @@
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
   self.state = UIGestureRecognizerStateFailed;
-  [self reset];
+
+  // For now, we are handling only the scroll view case.
+  // If more views need special treatment, then we can switch to a delegate pattern
+  if (![self isScrollView]) {
+    [self reset];
+  }
 }
 
 - (void)touchesCancelled:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
@@ -67,6 +74,18 @@
   [_gestureHandler.pointerTracker reset];
   [super reset];
   [_gestureHandler reset];
+}
+
+- (void)setStateIfScrollView:(UIGestureRecognizerState)state
+{
+  if ([self isScrollView]) {
+    self.state = state;
+  }
+}
+
+- (BOOL)isScrollView
+{
+  return [self.view isKindOfClass:[RCTScrollView class]];
 }
 
 @end

--- a/apple/Handlers/RNNativeViewHandler.mm
+++ b/apple/Handlers/RNNativeViewHandler.mm
@@ -78,8 +78,9 @@
 - (void)updateStateIfScrollView
 {
   UIScrollView *scrollView = [_gestureHandler retrieveScrollView:self.view];
-  if (!scrollView)
+  if (!scrollView) {
     return;
+  }
   for (UIGestureRecognizer *scrollViewGestureRecognizer in scrollView.gestureRecognizers) {
     if ([_gestureHandler isUIScrollViewPanGestureRecognizer:scrollViewGestureRecognizer]) {
       self.state = scrollViewGestureRecognizer.state;

--- a/apple/RNGestureHandler.h
+++ b/apple/RNGestureHandler.h
@@ -9,6 +9,12 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTConvert.h>
 
+#if TARGET_OS_OSX
+#define TargetScrollView NSScrollView
+#else
+#define TargetScrollView UIScrollView
+#endif
+
 #define VEC_LEN_SQ(pt) (pt.x * pt.x + pt.y * pt.y)
 #define TEST_MIN_IF_NOT_NAN(value, limit) \
   (!isnan(limit) && ((limit < 0 && value <= limit) || (limit >= 0 && value >= limit)))
@@ -89,8 +95,13 @@
             withExtraData:(nonnull RNGestureHandlerEventExtraData *)extraData;
 - (void)sendEvent:(nonnull RNGestureHandlerStateChange *)event;
 - (void)sendTouchEventInState:(RNGestureHandlerState)state forViewWithTag:(nonnull NSNumber *)reactTag;
-- (nullable UIScrollView *)retrieveScrollView:(nonnull UIView *)view;
+- (nullable TargetScrollView *)retrieveScrollView:(nonnull RNGHUIView *)view;
+
+#if !TARGET_OS_OSX
 - (BOOL)isUIScrollViewPanGestureRecognizer:(nonnull UIGestureRecognizer *)gestureRecognizer;
+#else
+- (BOOL)isUIScrollViewPanGestureRecognizer:(nonnull NSGestureRecognizer *)gestureRecognizer;
+#endif
 
 #if !TARGET_OS_OSX
 - (void)setCurrentPointerType:(nonnull UIEvent *)event;

--- a/apple/RNGestureHandler.h
+++ b/apple/RNGestureHandler.h
@@ -89,6 +89,8 @@
             withExtraData:(nonnull RNGestureHandlerEventExtraData *)extraData;
 - (void)sendEvent:(nonnull RNGestureHandlerStateChange *)event;
 - (void)sendTouchEventInState:(RNGestureHandlerState)state forViewWithTag:(nonnull NSNumber *)reactTag;
+- (nullable UIScrollView *)retrieveScrollViewFromRecognizer:(nonnull UIGestureRecognizer *)gestureRecognizer;
+- (BOOL)isUIScrollViewPanGestureRecognizer:(nonnull UIGestureRecognizer *)gestureRecognizer;
 
 #if !TARGET_OS_OSX
 - (void)setCurrentPointerType:(nonnull UIEvent *)event;

--- a/apple/RNGestureHandler.h
+++ b/apple/RNGestureHandler.h
@@ -10,9 +10,9 @@
 #import <React/RCTConvert.h>
 
 #if TARGET_OS_OSX
-#define TargetScrollView NSScrollView
+#define RNGHUIScrollView NSScrollView
 #else
-#define TargetScrollView UIScrollView
+#define RNGHUIScrollView UIScrollView
 #endif
 
 #define VEC_LEN_SQ(pt) (pt.x * pt.x + pt.y * pt.y)
@@ -95,7 +95,7 @@
             withExtraData:(nonnull RNGestureHandlerEventExtraData *)extraData;
 - (void)sendEvent:(nonnull RNGestureHandlerStateChange *)event;
 - (void)sendTouchEventInState:(RNGestureHandlerState)state forViewWithTag:(nonnull NSNumber *)reactTag;
-- (nullable TargetScrollView *)retrieveScrollView:(nonnull RNGHUIView *)view;
+- (nullable RNGHUIScrollView *)retrieveScrollView:(nonnull RNGHUIView *)view;
 
 #if !TARGET_OS_OSX
 - (BOOL)isUIScrollViewPanGestureRecognizer:(nonnull UIGestureRecognizer *)gestureRecognizer;

--- a/apple/RNGestureHandler.h
+++ b/apple/RNGestureHandler.h
@@ -89,7 +89,7 @@
             withExtraData:(nonnull RNGestureHandlerEventExtraData *)extraData;
 - (void)sendEvent:(nonnull RNGestureHandlerStateChange *)event;
 - (void)sendTouchEventInState:(RNGestureHandlerState)state forViewWithTag:(nonnull NSNumber *)reactTag;
-- (nullable UIScrollView *)retrieveScrollViewFromRecognizer:(nonnull UIGestureRecognizer *)gestureRecognizer;
+- (nullable UIScrollView *)retrieveScrollView:(nonnull UIView *)view;
 - (BOOL)isUIScrollViewPanGestureRecognizer:(nonnull UIGestureRecognizer *)gestureRecognizer;
 
 #if !TARGET_OS_OSX

--- a/apple/RNGestureHandler.m
+++ b/apple/RNGestureHandler.m
@@ -474,6 +474,11 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     return YES;
   }
 
+  if ([otherGestureRecognizer.view isKindOfClass:[UIScrollView class]] &&
+      [gestureRecognizer isKindOfClass:[RNDummyGestureRecognizer class]]) {
+    return YES;
+  }
+
   RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
   if (handler != nil) {
     if ([_simultaneousHandlers count]) {

--- a/apple/RNGestureHandler.mm
+++ b/apple/RNGestureHandler.mm
@@ -511,7 +511,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 {
   if ([self isUIScrollViewPanGestureRecognizer:otherGestureRecognizer] &&
       [gestureRecognizer isKindOfClass:[RNDummyGestureRecognizer class]]) {
-    UIScrollView *scrollView = [self retrieveScrollViewFromRecognizer:gestureRecognizer];
+    UIScrollView *scrollView = [self retrieveScrollView:gestureRecognizer.view];
     if (scrollView && scrollView == otherGestureRecognizer.view) {
       return YES;
     }
@@ -530,16 +530,19 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   return NO;
 }
 
-- (UIScrollView *)retrieveScrollViewFromRecognizer:(UIGestureRecognizer *)gestureRecognizer
+- (UIScrollView *)retrieveScrollView:(UIView *)view
 {
 #ifdef RCT_NEW_ARCH_ENABLED
-  if ([gestureRecognizer.view isKindOfClass:[RCTScrollViewComponentView class]]) {
-    UIScrollView *scrollView = ((RCTScrollViewComponentView *)gestureRecognizer.view).scrollView;
+  if ([view isKindOfClass:[RCTScrollViewComponentView class]]) {
+    UIScrollView *scrollView = ((RCTScrollViewComponentView *)view).scrollView;
     return scrollView;
   }
 #else
-  if ([gestureRecognizer.view isKindOfClass:[RCTScrollView class]]) {
-    UIScrollView *scrollView = [gestureRecognizer.view.subviews objectAtIndex:0];
+  if ([view isKindOfClass:[RCTScrollView class]]) {
+    // This part of the code is coupled with RN implementation of ScrollView native wrapper and
+    // we expect for RCTScrollView component to contain a subclass of UIScrollview as the only
+    // subview
+    UIScrollView *scrollView = [view.subviews objectAtIndex:0];
     return scrollView;
   }
 #endif

--- a/apple/RNGestureHandler.mm
+++ b/apple/RNGestureHandler.mm
@@ -523,11 +523,8 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 // is UIPanGestureRecognizer and has scrollView property
 - (BOOL)isUIScrollViewPanGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
 {
-  if ([gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] &&
-      [gestureRecognizer respondsToSelector:@selector(scrollView)]) {
-    return YES;
-  }
-  return NO;
+  return [gestureRecognizer isKindOfClass:[UIPanGestureRecognizer class]] &&
+      [gestureRecognizer respondsToSelector:@selector(scrollView)];
 }
 
 - (UIScrollView *)retrieveScrollView:(UIView *)view

--- a/apple/RNGestureHandler.mm
+++ b/apple/RNGestureHandler.mm
@@ -16,6 +16,12 @@
 #import <React/RCTScrollView.h>
 #endif
 
+// #if TARGET_OS_OSX
+// #define TargetScrollView NSScrollView
+// #else
+// #define TargetScrollView UIScrollView
+// #endif
+
 @interface UIGestureRecognizer (GestureHandler)
 @property (nonatomic, readonly) RNGestureHandler *gestureHandler;
 @end
@@ -511,7 +517,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 {
   if ([self isUIScrollViewPanGestureRecognizer:otherGestureRecognizer] &&
       [gestureRecognizer isKindOfClass:[RNDummyGestureRecognizer class]]) {
-    UIScrollView *scrollView = [self retrieveScrollView:gestureRecognizer.view];
+    TargetScrollView *scrollView = [self retrieveScrollView:gestureRecognizer.view];
     if (scrollView && scrollView == otherGestureRecognizer.view) {
       return YES;
     }
@@ -520,6 +526,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   return NO;
 }
 
+#if !TARGET_OS_OSX
 // is UIPanGestureRecognizer and has scrollView property
 - (BOOL)isUIScrollViewPanGestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
 {
@@ -527,11 +534,20 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
       [gestureRecognizer respondsToSelector:@selector(scrollView)];
 }
 
-- (UIScrollView *)retrieveScrollView:(UIView *)view
+#else
+
+- (BOOL)isUIScrollViewPanGestureRecognizer:(NSGestureRecognizer *)gestureRecognizer
+{
+  return NO;
+}
+
+#endif
+
+- (TargetScrollView *)retrieveScrollView:(RNGHUIView *)view
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if ([view isKindOfClass:[RCTScrollViewComponentView class]]) {
-    UIScrollView *scrollView = ((RCTScrollViewComponentView *)view).scrollView;
+    TargetScrollView *scrollView = ((RCTScrollViewComponentView *)view).scrollView;
     return scrollView;
   }
 #else
@@ -539,7 +555,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     // This part of the code is coupled with RN implementation of ScrollView native wrapper and
     // we expect for RCTScrollView component to contain a subclass of UIScrollview as the only
     // subview
-    UIScrollView *scrollView = [view.subviews objectAtIndex:0];
+    TargetScrollView *scrollView = [view.subviews objectAtIndex:0];
     return scrollView;
   }
 #endif

--- a/apple/RNGestureHandler.mm
+++ b/apple/RNGestureHandler.mm
@@ -511,7 +511,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 {
   if ([self isUIScrollViewPanGestureRecognizer:otherGestureRecognizer] &&
       [gestureRecognizer isKindOfClass:[RNDummyGestureRecognizer class]]) {
-    TargetScrollView *scrollView = [self retrieveScrollView:gestureRecognizer.view];
+    RNGHUIScrollView *scrollView = [self retrieveScrollView:gestureRecognizer.view];
     if (scrollView && scrollView == otherGestureRecognizer.view) {
       return YES;
     }
@@ -537,11 +537,11 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 #endif
 
-- (TargetScrollView *)retrieveScrollView:(RNGHUIView *)view
+- (RNGHUIScrollView *)retrieveScrollView:(RNGHUIView *)view
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   if ([view isKindOfClass:[RCTScrollViewComponentView class]]) {
-    TargetScrollView *scrollView = ((RCTScrollViewComponentView *)view).scrollView;
+    RNGHUIScrollView *scrollView = ((RCTScrollViewComponentView *)view).scrollView;
     return scrollView;
   }
 #else
@@ -549,7 +549,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     // This part of the code is coupled with RN implementation of ScrollView native wrapper and
     // we expect for RCTScrollView component to contain a subclass of UIScrollview as the only
     // subview
-    TargetScrollView *scrollView = [view.subviews objectAtIndex:0];
+    RNGHUIScrollView *scrollView = [view.subviews objectAtIndex:0];
     return scrollView;
   }
 #endif

--- a/apple/RNGestureHandler.mm
+++ b/apple/RNGestureHandler.mm
@@ -16,12 +16,6 @@
 #import <React/RCTScrollView.h>
 #endif
 
-// #if TARGET_OS_OSX
-// #define TargetScrollView NSScrollView
-// #else
-// #define TargetScrollView UIScrollView
-// #endif
-
 @interface UIGestureRecognizer (GestureHandler)
 @property (nonatomic, readonly) RNGestureHandler *gestureHandler;
 @end


### PR DESCRIPTION
## Description
  
Regarding this [issue](https://github.com/software-mansion/react-native-gesture-handler/issues/1263), this PR fixes the events that are sent from iOS whenever the state change occurs in a RCTScrollView.  

## Test plan
Tested on simulator and real device.
