### PR TITLE
docs: Update Expo installation instructions

### DIFF
--- a/docs/docs/fundamentals/installation.md
+++ b/docs/docs/fundamentals/installation.md
@@ -31,7 +31,7 @@ The Expo SDK incorporates the latest version of react-native-gesture-handler ava
 
 ### Bare [React Native](https://reactnative.dev/)
 
-Since the library uses native support for handling gestures, it requires an extended installation to the norm. If you are starting a new project, initialize it with [`npx create-expo-app@latest`](https://docs.expo.dev/more/create-expo/) since it comes pre-installed with react-native-gesture-handler.
+Since the library uses native support for handling gestures, it requires an extended installation to the norm. If you are starting a new project, initialize it with [`npx create-expo-app@latest`](https://docs.expo.dev/get-started/create-a-project/) since it comes pre-installed with react-native-gesture-handler.
 
 ## JS
 

--- a/docs/docs/fundamentals/installation.md
+++ b/docs/docs/fundamentals/installation.md
@@ -23,17 +23,15 @@ Note that if you wish to use [`React.createRef()`](https://reactjs.org/docs/refs
 
 In order to fully utilize the [touch events](/docs/gestures/touch-events/) you also need to use `react-native-reanimated` 2.3.0-beta.4 or newer.
 
-## Expo
+## [Expo](https://expo.dev)
 
-### Managed [Expo](https://expo.io)
+To use the version of react-native-gesture-handler that is compatible with your Expo project, run `npx expo install react-native-gesture-handler`.
 
-To use the version of react-native-gesture-handler that is compatible with your managed Expo project, run `expo install react-native-gesture-handler`.
+The Expo SDK incorporates the latest version of react-native-gesture-handler available at the time of each SDK release, so Expo apps might not always support all our latest features as soon as they are available.
 
-The Expo SDK incorporates the latest version of react-native-gesture-handler available at the time of each SDK release, so managed Expo apps might not always support all our latest features as soon as they are available.
+### Bare [React Native](https://reactnative.dev/)
 
-### Bare [React Native](http://reactnative.dev/)
-
-Since the library uses native support for handling gestures, it requires an extended installation to the norm. If you are starting a new project, you may want to initialize it with [expo-cli](https://docs.expo.io/versions/latest/workflow/expo-cli/) and use a bare template, they come pre-installed with react-native-gesture-handler.
+Since the library uses native support for handling gestures, it requires an extended installation to the norm. If you are starting a new project, initialize it with [`npx create-expo-app@latest`](https://docs.expo.dev/more/create-expo/) since it comes pre-installed with react-native-gesture-handler.
 
 ## JS
 


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

Going through the Expo section on the Installation page, I found installation instructions were outdated. The managed term is deprecated since only Expo Go and development builds are currently reliable terminologies when it comes to starting a new Expo project. To reflect this, this PR makes the following changes:
- Remove use of managed as a term and section heading
- Add link to H2 heading for Expo
- Change `expo install ...` command to `npx expo install ...` since `expo-cli` is deprecated and now local Expo CLI is used inside an Expo project to install a new library when running `expo install`.
- Update Expo link to expo.dev since expo.io is no longer a working domain
- Update Bare section about initializing a new project with `create-expo-app` whose default template now comes with `react-native-gesture-handler` library installed. The bare template which has been updated since `expo-cli` was deprecated has now become `bare-minimum` and doesn't include this library. I've also added a link to the Create a project page in Expo docs.
- Fix React Native link in the sub section heading to use `https` protocol.
- Remove `expo-cli` reference and link.

## Test plan

<!--
Describe how did you test this change here.
-->

By going through the changes manually and ensuring all links are working.
