### PR TITLE
docs: fix footer on landing

### DIFF
--- a/docs/src/components/FooterBackground/styles.module.css
+++ b/docs/src/components/FooterBackground/styles.module.css
@@ -6,3 +6,30 @@
 [class*='footerLanding'] {
   margin-top: -106px;
 }
+
+@media (max-width: 996px) {
+  .moonContainer {
+    margin-top: 121px;
+  }
+  [class*='footerLanding'] {
+    margin-top: -121px;
+  }
+}
+
+@media (max-width: 700px) {
+  .moonContainer {
+    margin-top: 147px;
+  }
+  [class*='footerLanding'] {
+    margin-top: -147px;
+  }
+}
+
+@media (max-width: 376px) {
+  .moonContainer {
+    margin-top: 173px;
+  }
+  [class*='footerLanding'] {
+    margin-top: -173px;
+  }
+}


### PR DESCRIPTION
On mobile (<996px) the footer margin was broken - this PR fixes that

Before:

<img width="409" alt="image" src="https://github.com/user-attachments/assets/4f508a5f-cf5a-4146-ae70-9d2d3b877585">

After:

<img width="408" alt="image" src="https://github.com/user-attachments/assets/f93fdcab-135f-45c7-a04f-eec4896299a3">
