### PR TITLE
Don't run old arch integrity check on every PR

### DIFF
--- a/.github/workflows/check-paper-integrity.yml
+++ b/.github/workflows/check-paper-integrity.yml
@@ -1,5 +1,14 @@
 name: Test Paper Architecture integrity
-on: [pull_request]
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/check-paper-integrity.yml'
+      - 'src/specs/**'
+      - 'android/paper/**'
+  push:
+    branches:
+      - main
+  workflow_dispatch:
 jobs:
   check:
     if: github.repository == 'software-mansion/react-native-gesture-handler'


### PR DESCRIPTION
## Description

`Test Paper Architecture integrity` action is running on every PR, even when the relevant files aren't modified. This PR changes that.
