### PR TITLE
Fix Android native buttons emitting 2 press events when talkbalk is enabled

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -1,16 +1,16 @@
 package com.swmansion.gesturehandler.core
 
-import android.content.Context
 import android.os.SystemClock
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
-import android.view.accessibility.AccessibilityManager
 import android.widget.ScrollView
 import com.facebook.react.views.scroll.ReactScrollView
 import com.facebook.react.views.swiperefresh.ReactSwipeRefreshLayout
 import com.facebook.react.views.textinput.ReactEditText
+import com.swmansion.gesturehandler.react.RNGestureHandlerButtonViewManager
+import com.swmansion.gesturehandler.react.isScreenReaderOn
 
 class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   private var shouldActivateOnStart = false
@@ -85,13 +85,9 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
     val view = view!!
 
-    val isTouchExplorationEnabled =
-      (
-        view.context.getSystemService(Context.ACCESSIBILITY_SERVICE)
-          as AccessibilityManager
-        ).isTouchExplorationEnabled
+    val isTouchExplorationEnabled = view.context.isScreenReaderOn()
 
-    if (state == STATE_UNDETERMINED && isTouchExplorationEnabled) {
+    if (view is RNGestureHandlerButtonViewManager.ButtonViewGroup && isTouchExplorationEnabled) {
       // Fix for: https://github.com/software-mansion/react-native-gesture-handler/issues/2808
       // When TalkBack is enabled, two identical press events are sent, while only one is expected.
       // The unexpected one is caught by looking at the state of the current handler,
@@ -123,13 +119,16 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
           view.onTouchEvent(event)
           activate()
         }
+
         tryIntercept(view, event) -> {
           view.onTouchEvent(event)
           activate()
         }
+
         hook.wantsToHandleEventBeforeActivation() -> {
           hook.handleEventBeforeActivation(event)
         }
+
         state != STATE_BEGAN -> {
           if (hook.canBegin(event)) {
             begin()

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -1,10 +1,12 @@
 package com.swmansion.gesturehandler.core
 
+import android.content.Context
 import android.os.SystemClock
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityManager
 import android.widget.ScrollView
 import com.facebook.react.views.scroll.ReactScrollView
 import com.facebook.react.views.swiperefresh.ReactSwipeRefreshLayout
@@ -82,6 +84,16 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
 
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
     val view = view!!
+
+    val isTouchExplorationEnabled = (view.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager).isTouchExplorationEnabled
+
+    if (state == STATE_UNDETERMINED && isTouchExplorationEnabled) {
+      // fix for: https://github.com/software-mansion/react-native-gesture-handler/issues/2808
+      // when talkback is enabled, one real press invokes 2 separate yet identical press events
+      // the invalid ones only differs in that when it's sent, the current handler's state is UNDETERMINED
+      return
+    }
+
     if (event.actionMasked == MotionEvent.ACTION_UP) {
       if (state == STATE_UNDETERMINED && !hook.canBegin(event)) {
         cancel()

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -85,7 +85,9 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
     val view = view!!
 
-    val isTouchExplorationEnabled = (view.context.getSystemService(Context.ACCESSIBILITY_SERVICE) as AccessibilityManager).isTouchExplorationEnabled
+    val isTouchExplorationEnabled =
+      (view.context.getSystemService(Context.ACCESSIBILITY_SERVICE)
+          as AccessibilityManager).isTouchExplorationEnabled
 
     if (state == STATE_UNDETERMINED && isTouchExplorationEnabled) {
       // fix for: https://github.com/software-mansion/react-native-gesture-handler/issues/2808

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -86,12 +86,14 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     val view = view!!
 
     val isTouchExplorationEnabled =
-      (view.context.getSystemService(Context.ACCESSIBILITY_SERVICE)
-          as AccessibilityManager).isTouchExplorationEnabled
+      (
+        view.context.getSystemService(Context.ACCESSIBILITY_SERVICE)
+          as AccessibilityManager
+        ).isTouchExplorationEnabled
 
     if (state == STATE_UNDETERMINED && isTouchExplorationEnabled) {
       // Fix for: https://github.com/software-mansion/react-native-gesture-handler/issues/2808
-      // When TalkBack is enabled, two identical press events are sent, while only one is expected. 
+      // When TalkBack is enabled, two identical press events are sent, while only one is expected.
       // The unexpected one is caught by looking at the state of the current handler,
       // which is UNDETERMINED when receiving the invalid event, and BEGAN when receiving the valid one.
       return

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -89,9 +89,9 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
 
     if (view is RNGestureHandlerButtonViewManager.ButtonViewGroup && isTouchExplorationEnabled) {
       // Fix for: https://github.com/software-mansion/react-native-gesture-handler/issues/2808
-      // When TalkBack is enabled, two identical press events are sent, while only one is expected.
-      // The unexpected one is caught by looking at the state of the current handler,
-      // which is UNDETERMINED when receiving the invalid event, and BEGAN when receiving the valid one.
+      // When TalkBack is enabled, events are often not being sent to the orchestrator for processing.
+      // Instead, states will be changed directly by an alternative mechanism added in this PR:
+      // https://github.com/software-mansion/react-native-gesture-handler/pull/2234
       return
     }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -90,9 +90,10 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
           as AccessibilityManager).isTouchExplorationEnabled
 
     if (state == STATE_UNDETERMINED && isTouchExplorationEnabled) {
-      // fix for: https://github.com/software-mansion/react-native-gesture-handler/issues/2808
-      // when talkback is enabled, one real press invokes 2 separate yet identical press events
-      // the invalid ones only differs in that when it's sent, the current handler's state is UNDETERMINED
+      // Fix for: https://github.com/software-mansion/react-native-gesture-handler/issues/2808
+      // When TalkBack is enabled, two identical press events are sent, while only one is expected. 
+      // The unexpected one is caught by looking at the state of the current handler,
+      // which is UNDETERMINED when receiving the invalid event, and BEGAN when receiving the valid one.
       return
     }
 


### PR DESCRIPTION
## Description

When talkbalk accessability mode is enabled, pressing on any of the buttons provided by gesture handler (`BaseButton`, `RawButton`, `BorderlessButton`, Et Cetera) will cause 2 separate press events to go off.

This PR fixes that invalid behaviour.

Closes: #2808 

## Test plan

- enable talkback mode
- run the attached example
- see how the button labeled `BaseButton` executes twice on `main` and a single time on this branch.

## Attached example

```js
import React from 'react';
import { BaseButton } from 'react-native-gesture-handler';
import { Text, View, StyleSheet } from 'react-native';

const press = () => console.log('JS pressed');
const touch = () => console.log('JS touch');

export default function App() {
  return (
    <View style={styles.root}>
      <BaseButton onPress={press}>
        <View
          accessible
          accessibilityRole="button"
          style={styles.button}
          onTouchStart={touch}>
          <Text>BaseButton</Text>
        </View>
      </BaseButton>
    </View>
  );
}

const styles = StyleSheet.create({
  root: {
    justifyContent: 'center',
    flex: 1,
  },
  button: {
    width: 200,
    height: 100,
    margin: 20,
    backgroundColor: 'cyan',
  },
});
```

## Tests

### Normal behaviour (no talkback, no fix):
![image](https://github.com/user-attachments/assets/74912600-cd97-4347-aae5-8930228a725e)

### Before fix:
![image](https://github.com/user-attachments/assets/b0e1083a-d1ec-4ed6-ab57-7a1236f18ed2)

### With fix:
![image](https://github.com/user-attachments/assets/369c0b68-6c08-4d3b-8f04-5c9701bfd8ac)