### PR TITLE
Change `onPress` argument in buttons

### DIFF
--- a/src/components/GestureButtons.tsx
+++ b/src/components/GestureButtons.tsx
@@ -56,7 +56,7 @@ class InnerBaseButton extends React.Component<BaseButtonWithRefProps> {
       this.lastActive &&
       this.props.onPress
     ) {
-      this.props.onPress(active);
+      this.props.onPress(pointerInside);
     }
 
     if (


### PR DESCRIPTION
## Description

This PR changes argument passed into `onPress` callback in our Buttons. Previous one was always `false` because of this code:

```tsx
const active = pointerInside && state === State.ACTIVE;
...
if (
  ...
  oldState === State.ACTIVE &&
  ...
) {
  this.props.onPress(active);
}
```

callback was executed when `state` was `END`, so `active` was `false` at this point.

## Test plan

<details>
<summary> Test code </summary>

```tsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import { RectButton } from 'react-native-gesture-handler';

export default function EmptyExample() {
  return (
    <View style={styles.container}>
      <RectButton hitSlop={20} onPress={console.log} style={styles.button} />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'space-around',
  },
  button: {
    width: 300,
    height: 100,
    borderRadius: 25,
    backgroundColor: 'crimson',
  },
});
```

</details>