### PR TITLE
Fix cancelling manual activation gestures blocking interactivity on iOS

### DIFF
--- a/apple/Handlers/RNFlingHandler.m
+++ b/apple/Handlers/RNFlingHandler.m
@@ -60,6 +60,7 @@
   _lastPoint = [[[touches allObjects] objectAtIndex:0] locationInView:_gestureHandler.recognizer.view];
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [self reset];
 }
 
 - (void)triggerAction

--- a/apple/Handlers/RNForceTouchHandler.m
+++ b/apple/Handlers/RNForceTouchHandler.m
@@ -115,6 +115,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
 {
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [self reset];
 }
 
 - (void)handleForceWithTouches:(NSSet<RNGHUITouch *> *)touches

--- a/apple/Handlers/RNLongPressHandler.m
+++ b/apple/Handlers/RNLongPressHandler.m
@@ -91,6 +91,7 @@
 {
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [self reset];
 }
 
 - (void)reset

--- a/apple/Handlers/RNManualHandler.m
+++ b/apple/Handlers/RNManualHandler.m
@@ -57,6 +57,7 @@
 {
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [self reset];
 }
 
 - (void)reset

--- a/apple/Handlers/RNPanHandler.m
+++ b/apple/Handlers/RNPanHandler.m
@@ -161,6 +161,7 @@
 - (void)interactionsCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [self reset];
 }
 
 #if TARGET_OS_OSX

--- a/apple/Handlers/RNPinchHandler.m
+++ b/apple/Handlers/RNPinchHandler.m
@@ -73,6 +73,7 @@
 - (void)interactionsCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [self reset];
 }
 
 #if TARGET_OS_OSX

--- a/apple/Handlers/RNRotationHandler.m
+++ b/apple/Handlers/RNRotationHandler.m
@@ -67,6 +67,7 @@
 - (void)interactionsCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+  [self reset];
 }
 
 #if TARGET_OS_OSX

--- a/apple/Handlers/RNRotationHandler.m
+++ b/apple/Handlers/RNRotationHandler.m
@@ -62,7 +62,6 @@
 - (void)interactionsEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
-  [self reset];
 }
 
 - (void)interactionsCancelled:(NSSet *)touches withEvent:(UIEvent *)event

--- a/apple/Handlers/RNRotationHandler.m
+++ b/apple/Handlers/RNRotationHandler.m
@@ -62,6 +62,7 @@
 - (void)interactionsEnded:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+  [self reset];
 }
 
 - (void)interactionsCancelled:(NSSet *)touches withEvent:(UIEvent *)event

--- a/apple/Handlers/RNTapHandler.m
+++ b/apple/Handlers/RNTapHandler.m
@@ -206,6 +206,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [super touchesCancelled:touches withEvent:event];
   [self interactionsCancelled:touches withEvent:event];
+  [self reset];
 }
 
 #endif

--- a/apple/RNGestureHandler.m
+++ b/apple/RNGestureHandler.m
@@ -501,7 +501,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   // might be called after some pointers are down, and after state manipulation by the user.
   // Pointer tracker calls this method when it resets, and in that case it no longer tracks
   // any pointers, thus entering this if
-  if (YES) {
+  if (!_needsPointerData || _pointerTracker.trackedPointersCount == 0) {
     _lastState = RNGestureHandlerStateUndetermined;
     _state = RNGestureHandlerStateBegan;
   }

--- a/apple/RNGestureHandler.m
+++ b/apple/RNGestureHandler.m
@@ -501,7 +501,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   // might be called after some pointers are down, and after state manipulation by the user.
   // Pointer tracker calls this method when it resets, and in that case it no longer tracks
   // any pointers, thus entering this if
-  if (!_needsPointerData || _pointerTracker.trackedPointersCount == 0) {
+  if (YES) {
     _lastState = RNGestureHandlerStateUndetermined;
     _state = RNGestureHandlerStateBegan;
   }


### PR DESCRIPTION
## Description

Having a `gesture` with `manualActivation` set to `true` freezes interactions globally when such gesture gets cancelled. If a touch or palm cancellation is triggered by the device, all touchable elements, both the native and the gesturized ones in the app become disabled.
This state is fixed when the cancelled gesture is triggered again.

closes #2885
## Test plan

Using the attached example on iOS iPad, perform the following sequence:
- tap the `OUTSIDE PRESSABLE` - see how it turns red
- press the grey area with an entire palm so that a cancellation notification dispatches to the console
- now try tapping the `OUTSIDE PRESSABLE` yet again
- on the `main` branch, you will see no red indicator, on this branch you should see one, which is the intended behaviour

## Code:
```js
import React from 'react-native';
import { TouchableHighlight, View, Text, StyleSheet } from 'react-native';
import {
  Gesture,
  GestureHandlerRootView,
  GestureDetector,
} from 'react-native-gesture-handler';

export default function EmptyExample() {
  const pan = Gesture.Pinch()
    .manualActivation(true)
    .onTouchesDown((event) => {
      console.log('down', event);
    })
    .onTouchesCancelled((event) => {
      console.log('cancelled', event);
    })
    .onStart(() => console.log('started'));

  return (
    <GestureHandlerRootView style={exampleStyles.root}>
      <TouchableHighlight
        onPress={() => console.log(2)}
        underlayColor={'red'}
        style={[exampleStyles.button, { backgroundColor: '#21da1a' }]}>
        <Text>OUTSIDE DETECTOR</Text>
      </TouchableHighlight>
      <GestureDetector gesture={pan}>
        <View style={[exampleStyles.area, { backgroundColor: '#5e5e5e' }]}>
          <TouchableHighlight
            onPress={() => console.log(1)}
            underlayColor={'red'}
            style={[exampleStyles.button, { backgroundColor: '#dad41a' }]}>
            <Text>INSIDE DETECTOR</Text>
          </TouchableHighlight>
        </View>
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

const exampleStyles = StyleSheet.create({
  root: {
    flex: 1,
  },
  area: { flex: 1, marginTop: 100 },
  button: {
    width: 100,
    height: 100,
    zIndex: 100,
    position: 'absolute',
  },
});
```