### PR TITLE
[macOS] Fix handlers not responding after opening context menu

### DIFF
--- a/apple/RNRootViewGestureRecognizer.m
+++ b/apple/RNRootViewGestureRecognizer.m
@@ -113,6 +113,11 @@
 {
   [super rightMouseDown:event];
   [self interactionsBegan:[NSSet setWithObject:event] withEvent:event];
+
+  // This line fixes issue in which handlers couldn't react to mouse clicks after right click.
+  // Right click opens context menu, which prevents RootView from receiving rightMouseUp. This leads
+  // to a situation where RootView is left in Possible state, instead of Failed, thus blocking other handlers.
+  self.state = NSGestureRecognizerStateFailed;
 }
 
 - (void)mouseDragged:(NSEvent *)event


### PR DESCRIPTION
## Description

Right now if you open context menu on `macOS`, handlers do not respond to gestures immediately. This issue also affects components out of Gesture Handler, for example `Pressable` from `react-native`.

RootView is used to cancel other gestures. It blocks them when it is in `Possible` state. This state is changed to `Failed`  inside `interactionEnded` function, which on `macOS` is called inside `mouseUp` and `rightMouseUp`.

The problem is that when context menu gets opened, we no longer receive `rightMouseUp`, thus state of the recognizer is not set to `Failed`. This results in recognizer blocking other gestures.

### Other approaches

I've also tried to create context menu listener, in order to avoid setting state to `Failed` directly in `rightMouseDown`. However, it didn't work. I wasn't able to set listener on neither of `view` or `window` 😞 

Closes #2700

## Test plan

Tested on example App (also with `Pressable` from `react-native`)

### Before

https://github.com/user-attachments/assets/842cf758-a003-423b-9ca9-e53fdf9b8cb8

### After

https://github.com/user-attachments/assets/77e09156-d1f0-4d30-9260-00213068103f

