### PR TITLE
Add `enabled` prop support to swipeable

### DIFF
--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -580,6 +580,8 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       swipeableMethods,
     ]);
 
+    panGesture.enabled(props.enabled !== false);
+
     const animatedStyle = useAnimatedStyle(
       () => ({
         transform: [{ translateX: appliedTranslation.value }],


### PR DESCRIPTION
## Description

This issue fixes `enabled` prop having no effect on the new Swipeable.

Reported [here](https://github.com/software-mansion/react-native-gesture-handler/pull/2936#issuecomment-2252874472) by @jackstudd

## Test plan

- open `release_tests` > `Swipeable Reanimation` example in both an emulator and an editor
- add `enabled={false}` prop to both the swipeables
- legacy `swipeable` is now immovable
- new `swipeable` used to be unaffected, with this fix it should be immovable as well

I added the `enabled` usage only for the `Pan` gesture and not the `Tap` gesture intentionally.
The `Tap` gesture should remain active even when the rest of `swipeable` is disabled, 
as I found when testing the legacy `swipeable` 