### PR TITLE
[macOS] Switch `hasPointerInside` to `containsPointInView`

### DIFF
--- a/apple/Handlers/RNNativeViewHandler.mm
+++ b/apple/Handlers/RNNativeViewHandler.mm
@@ -62,11 +62,6 @@
 }
 
 #else
-- (BOOL)hasPointerInside
-{
-  return NSPointInRect([self locationInView:self.view], self.view.bounds);
-}
-
 - (void)mouseDown:(NSEvent *)event
 {
   [_gestureHandler setCurrentPointerTypeToMouse];
@@ -231,7 +226,7 @@
 
 - (RNGestureHandlerEventExtraData *)eventExtraData:(RNDummyGestureRecognizer *)recognizer
 {
-  return [RNGestureHandlerEventExtraData forPointerInside:[recognizer hasPointerInside]
+  return [RNGestureHandlerEventExtraData forPointerInside:[self containsPointInView]
                                           withPointerType:RNGestureHandlerMouse];
 }
 

--- a/apple/RNGestureHandler.m
+++ b/apple/RNGestureHandler.m
@@ -509,13 +509,9 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 - (BOOL)containsPointInView
 {
-#if !TARGET_OS_OSX
   CGPoint pt = [_recognizer locationInView:_recognizer.view];
   CGRect hitFrame = RNGHHitSlopInsetRect(_recognizer.view.bounds, _hitSlop);
   return CGRectContainsPoint(hitFrame, pt);
-#else
-  return NSPointInRect([_recognizer locationInView:_recognizer.view], _recognizer.view.bounds);
-#endif
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer

--- a/apple/RNGestureHandler.m
+++ b/apple/RNGestureHandler.m
@@ -509,9 +509,13 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 - (BOOL)containsPointInView
 {
+#if !TARGET_OS_OSX
   CGPoint pt = [_recognizer locationInView:_recognizer.view];
   CGRect hitFrame = RNGHHitSlopInsetRect(_recognizer.view.bounds, _hitSlop);
   return CGRectContainsPoint(hitFrame, pt);
+#else
+  return NSPointInRect([_recognizer locationInView:_recognizer.view], _recognizer.view.bounds);
+#endif
 }
 
 - (BOOL)gestureRecognizerShouldBegin:(UIGestureRecognizer *)gestureRecognizer


### PR DESCRIPTION
## Description

While working on `LongPress` I've noticed that currently check if pointer is inside view is implemented inside `NativeViewGestureHandler`. I've decided to move it to `GestureHandler` to be able to use it in other places.

### `HitSlop`

Current implementation of `containsPointInView` also takes into consideration `HitSlop` property. The only problem is that on `macOS` we cannot detect clicks outside of view using `mouseDown`.  This means that `HitSlop` will work only if click was started inside view - clicking on `HitSlop` area won't activate handlers.

## Test plan

Tested on example app. You can simply see that `RectButtons` navigate to examples - it doesn't work if `pointerInside` is `false`.

<details>
<summary>Also tested on the following code:</summary>

```tsx
export default function App() {
  return (
    <GestureHandlerRootView style={styles.container}>
      <RectButton style={styles.button} hitSlop={10} onPress={console.log} />
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'space-around',
    alignItems: 'center',
  },
  button: {
    width: 100,
    height: 30,
    borderRadius: 15,
    backgroundColor: 'crimson',
  },
});
```

</details>