### PR TITLE
[iOS | macOS] Fix translation calculation in `LongPress`

### DIFF
--- a/apple/Handlers/RNLongPressHandler.m
+++ b/apple/Handlers/RNLongPressHandler.m
@@ -75,7 +75,7 @@
   CGPoint trans = [self translationInView];
   if ((_gestureHandler.shouldCancelWhenOutside && ![_gestureHandler containsPointInView]) ||
       (TEST_MAX_IF_NOT_NAN(
-          fabs(trans.y * trans.y + trans.x + trans.x), self.allowableMovement * self.allowableMovement))) {
+          fabs(trans.y * trans.y + trans.x * trans.x), self.allowableMovement * self.allowableMovement))) {
     self.enabled = NO;
     self.enabled = YES;
   }


### PR DESCRIPTION
## Description

While working on `LongPress` gesture on `macOS` I've found out that translation is calculated incorrectly. This PR fixes that. 

## Test plan

Is it necessary? 🤔 
