### PR TITLE
Fix `ScrollView` intercepting touches through out-of-bounds children

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNViewConfigurationHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNViewConfigurationHelper.kt
@@ -4,6 +4,8 @@ import android.view.View
 import android.view.ViewGroup
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
+import com.facebook.react.views.scroll.ReactHorizontalScrollView
+import com.facebook.react.views.scroll.ReactScrollView
 import com.facebook.react.views.view.ReactViewGroup
 import com.swmansion.gesturehandler.core.PointerEventsConfig
 import com.swmansion.gesturehandler.core.ViewConfigurationHelper
@@ -40,12 +42,11 @@ class RNViewConfigurationHelper : ViewConfigurationHelper {
     } else parent.getChildAt(index)
   }
 
-  override fun isViewClippingChildren(view: ViewGroup): Boolean {
-    if (view.clipChildren) {
-      return true
-    }
-    return if (view is ReactViewGroup) {
-      "hidden" == view.overflow
-    } else false
+  override fun isViewClippingChildren(view: ViewGroup) = when {
+    view.clipChildren -> true
+    view is ReactScrollView -> view.overflow != "visible"
+    view is ReactHorizontalScrollView -> view.overflow != "visible"
+    view is ReactViewGroup -> view.overflow == "hidden"
+    else -> false
   }
 }


### PR DESCRIPTION
## Description

In https://github.com/facebook/react-native/pull/43464 `clipChildren` started being set to false on scrollviews, which caused `isViewClippingChildren` to return false. Because of this, gesture handler would traverse the children of the scrollview even when touch was out of bounds:

https://github.com/user-attachments/assets/6d108b55-6e06-4202-bc77-9d9dd2825456

This PR adds special cases for scroll views that have `overflow` set to `visible` so that scrolling works on all of its children.

## Test plan

Test components sample on FabricExample app
