### PR TITLE
Fix `FlatList` type

### DIFF
--- a/src/components/GestureComponents.tsx
+++ b/src/components/GestureComponents.tsx
@@ -91,6 +91,12 @@ export const DrawerLayoutAndroid = createNativeWrapper<
 export type DrawerLayoutAndroid = typeof DrawerLayoutAndroid &
   RNDrawerLayoutAndroid;
 
+interface FlatListProps {
+  // since we are using `renderScrollComponent` to wrap the ScrollView,
+  // we need to remove the `refreshing` prop from the FlatList API
+  renderScrollComponent?: never;
+}
+
 export const FlatList = React.forwardRef((props, ref) => {
   const refreshControlGestureRef = React.useRef<RefreshControl>(null);
 
@@ -140,7 +146,8 @@ export const FlatList = React.forwardRef((props, ref) => {
   props: PropsWithChildren<
     RNFlatListProps<ItemT> &
       RefAttributes<FlatList<ItemT>> &
-      NativeViewGestureHandlerProps
+      NativeViewGestureHandlerProps &
+      FlatListProps
   >,
   ref: ForwardedRef<FlatList<ItemT>>
 ) => ReactElement | null;

--- a/src/components/GestureComponents.tsx
+++ b/src/components/GestureComponents.tsx
@@ -91,12 +91,6 @@ export const DrawerLayoutAndroid = createNativeWrapper<
 export type DrawerLayoutAndroid = typeof DrawerLayoutAndroid &
   RNDrawerLayoutAndroid;
 
-interface FlatListProps {
-  // since we are using `renderScrollComponent` to wrap the ScrollView,
-  // we need to remove the `refreshing` prop from the FlatList API
-  renderScrollComponent?: never;
-}
-
 export const FlatList = React.forwardRef((props, ref) => {
   const refreshControlGestureRef = React.useRef<RefreshControl>(null);
 
@@ -144,10 +138,9 @@ export const FlatList = React.forwardRef((props, ref) => {
   );
 }) as <ItemT = any>(
   props: PropsWithChildren<
-    RNFlatListProps<ItemT> &
+    Omit<RNFlatListProps<ItemT>, 'renderScrollComponent'> &
       RefAttributes<FlatList<ItemT>> &
-      NativeViewGestureHandlerProps &
-      FlatListProps
+      NativeViewGestureHandlerProps
   >,
   ref: ForwardedRef<FlatList<ItemT>>
 ) => ReactElement | null;


### PR DESCRIPTION
## Description

Closes https://github.com/software-mansion/react-native-gesture-handler/issues/2990

Removes `renderScrollComponent` from the public API of FlatList exported by Gesture Handler, as its being overwritten with Gesture Handler's scroll view anyway.

## Test plan

Verify that `renderScrollComponent` causes a TypeScript error on FlatList exported from RNGH.
