### PR TITLE
[web] Fix `scale`

### DIFF
--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -27,28 +27,30 @@ export function calculateViewScale(view: HTMLElement) {
     scaleY: 1,
   };
 
-  const scales = styles.scale.split(' ');
+  // Get scales from scale property
+  if (styles.scale !== undefined && styles.scale !== 'none') {
+    const scales = styles.scale.split(' ');
 
-  if (scales[0] !== 'none') {
-    resultScales.scaleX = parseFloat(scales[0]);
+    if (scales[0]) {
+      resultScales.scaleX = parseFloat(scales[0]);
+    }
+
+    resultScales.scaleY = scales[1]
+      ? parseFloat(scales[1])
+      : parseFloat(scales[0]);
   }
 
-  if (scales[1]) {
-    resultScales.scaleY = parseFloat(scales[1]);
-  }
-
+  // Get scales from transform property
   const matrixElements = new RegExp(/matrix\((.+)\)/).exec(
     styles.transform
   )?.[1];
 
-  if (!matrixElements) {
-    return resultScales;
+  if (matrixElements) {
+    const matrixElementsArray = matrixElements.split(', ');
+
+    resultScales.scaleX *= parseFloat(matrixElementsArray[0]);
+    resultScales.scaleY *= parseFloat(matrixElementsArray[3]);
   }
-
-  const matrixElementsArray = matrixElements.split(', ');
-
-  resultScales.scaleX *= parseFloat(matrixElementsArray[0]);
-  resultScales.scaleY *= parseFloat(matrixElementsArray[3]);
 
   return resultScales;
 }


### PR DESCRIPTION
## Description

This PR does 2 things:

1. Adds check if `style.scale` is defined in order to avoid crash when trying to call `split` method
2. Fixes incorrect `scaleY` if only one value was present in `style.scale`

>[!NOTE]
>While I'm not sure why `style.scale` was `undefined` when it should be `none`, I suspect that this may be caused by `NativeWind`

## Test plan

Using code below I've verified that scale is calculated correctly by manipulating `element.style` in `inspector`.

<details>
<summary>Test code</summary>

```tsx
import React from 'react';
import { StyleSheet, Text, View } from 'react-native';
import { Gesture, GestureDetector } from 'react-native-gesture-handler';

export default function EmptyExample() {
  const g = Gesture.Pan();
  return (
    <View style={styles.container}>
      <GestureDetector gesture={g}>
        <View style={styles.box} />
      </GestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },

  box: {
    width: 100,
    height: 100,
    backgroundColor: 'plum',
    borderRadius: 10,
  },
});

```

</details>



Style            |  Logs
:-------------------------:|:-------------------------:
<img width="356" alt="image" src="https://github.com/user-attachments/assets/ea2bb143-d9e6-4ffb-bbfa-307171e9f7b4">  |   <img width="583" alt="image" src="https://github.com/user-attachments/assets/eed07df2-3d88-4d5d-8c0f-897336f8715c">
