### PR TITLE
Fix failing macOS build

### DIFF
--- a/apple/Handlers/RNNativeViewHandler.mm
+++ b/apple/Handlers/RNNativeViewHandler.mm
@@ -100,7 +100,7 @@
 
 - (void)updateStateIfScrollView
 {
-  UIScrollView *scrollView = [_gestureHandler retrieveScrollView:self.view];
+  RNGHUIScrollView *scrollView = [_gestureHandler retrieveScrollView:self.view];
   if (!scrollView) {
     return;
   }

--- a/apple/RNGHUIKit.h
+++ b/apple/RNGHUIKit.h
@@ -4,6 +4,7 @@
 
 typedef UIView RNGHUIView;
 typedef UITouch RNGHUITouch;
+typedef UIScrollView RNGHUIScrollView;
 
 #define RNGHGestureRecognizerStateFailed UIGestureRecognizerStateFailed;
 #define RNGHGestureRecognizerStatePossible UIGestureRecognizerStatePossible;
@@ -17,6 +18,7 @@ typedef UITouch RNGHUITouch;
 
 typedef RCTUIView RNGHUIView;
 typedef RCTUITouch RNGHUITouch;
+typedef NSScrollView RNGHUIScrollView;
 
 #define RNGHGestureRecognizerStateFailed NSGestureRecognizerStateFailed;
 #define RNGHGestureRecognizerStatePossible NSGestureRecognizerStatePossible;

--- a/apple/RNGestureHandler.h
+++ b/apple/RNGestureHandler.h
@@ -9,12 +9,6 @@
 #import <Foundation/Foundation.h>
 #import <React/RCTConvert.h>
 
-#if TARGET_OS_OSX
-#define RNGHUIScrollView NSScrollView
-#else
-#define RNGHUIScrollView UIScrollView
-#endif
-
 #define VEC_LEN_SQ(pt) (pt.x * pt.x + pt.y * pt.y)
 #define TEST_MIN_IF_NOT_NAN(value, limit) \
   (!isnan(limit) && ((limit < 0 && value <= limit) || (limit >= 0 && value >= limit)))


### PR DESCRIPTION
## Description

In https://github.com/software-mansion/react-native-gesture-handler/pull/2985 some changes were made regarding handling of ScrollViews by the native handler. I have no idea how the build passed on the PR itself but a type only available on iOS was used which causes macOS not to build.

This PR cleans it up.

## Test plan

Build macOS example
