### PR TITLE
Add keyboard support to gesture handler

### DIFF
--- a/src/PointerType.ts
+++ b/src/PointerType.ts
@@ -3,4 +3,5 @@ export enum PointerType {
   STYLUS,
   MOUSE,
   OTHER,
+  KEY,
 }

--- a/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/src/web/tools/GestureHandlerWebDelegate.ts
@@ -11,6 +11,7 @@ import { isPointerInBounds } from '../utils';
 import EventManager from './EventManager';
 import { Config } from '../interfaces';
 import { MouseButton } from '../../handlers/gestureHandlerCommon';
+import KeyEventManager from './KeyEventManager';
 
 export class GestureHandlerWebDelegate
   implements GestureHandlerDelegate<HTMLElement, IGestureHandler>
@@ -46,6 +47,7 @@ export class GestureHandlerWebDelegate
 
     this.eventManagers.push(new PointerEventManager(this.view));
     this.eventManagers.push(new TouchEventManager(this.view));
+    this.eventManagers.push(new KeyEventManager(this.view));
 
     this.eventManagers.forEach((manager) =>
       this.gestureHandler.attachEventManager(manager)

--- a/src/web/tools/KeyEventManager.ts
+++ b/src/web/tools/KeyEventManager.ts
@@ -1,0 +1,38 @@
+import { AdaptedEvent, EventTypes } from '../interfaces';
+import EventManager from './EventManager';
+import { PointerType } from '../../PointerType';
+
+export default class KeyEventManager extends EventManager<HTMLElement> {
+  private keyDownCallback = (event: unknown): void => {
+    const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.DOWN);
+    this.onPointerDown(adaptedEvent);
+  };
+  private keyUpCallback = (event: unknown): void => {
+    const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.UP);
+    this.onPointerUp(adaptedEvent);
+  };
+
+  public registerListeners(): void {
+    this.view.addEventListener('keydown', this.keyDownCallback);
+    this.view.addEventListener('keyup', this.keyUpCallback);
+  }
+
+  public unregisterListeners(): void {
+    this.view.addEventListener('keydown', this.keyDownCallback);
+    this.view.addEventListener('keyup', this.keyUpCallback);
+  }
+
+  protected mapEvent(event: unknown, eventType: EventTypes): AdaptedEvent {
+    console.log(event);
+    return {
+      x: 0,
+      y: 0,
+      offsetX: 0,
+      offsetY: 0,
+      pointerId: 0,
+      eventType: eventType,
+      pointerType: PointerType.KEY,
+      time: 0,
+    };
+  }
+}

--- a/src/web/tools/KeyEventManager.ts
+++ b/src/web/tools/KeyEventManager.ts
@@ -3,11 +3,22 @@ import EventManager from './EventManager';
 import { PointerType } from '../../PointerType';
 
 export default class KeyEventManager extends EventManager<HTMLElement> {
-  private keyDownCallback = (event: unknown): void => {
+  private activationKeys = ['Enter', 'Space'];
+
+  private keyDownCallback = (event: KeyboardEvent): void => {
+    if (this.activationKeys.indexOf(event.code) === -1) {
+      return;
+    }
+
     const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.DOWN);
     this.onPointerDown(adaptedEvent);
   };
-  private keyUpCallback = (event: unknown): void => {
+
+  private keyUpCallback = (event: KeyboardEvent): void => {
+    if (this.activationKeys.indexOf(event.code) === -1) {
+      return;
+    }
+
     const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.UP);
     this.onPointerUp(adaptedEvent);
   };
@@ -22,17 +33,24 @@ export default class KeyEventManager extends EventManager<HTMLElement> {
     this.view.addEventListener('keyup', this.keyUpCallback);
   }
 
-  protected mapEvent(event: unknown, eventType: EventTypes): AdaptedEvent {
-    console.log(event);
+  protected mapEvent(
+    event: KeyboardEvent,
+    eventType: EventTypes
+  ): AdaptedEvent {
+    const relativeX = this.view.offsetLeft + this.view.offsetWidth / 2;
+    const relativeY = this.view.offsetTop + this.view.offsetHeight / 2;
+    const viewportX = (event.view?.screenX ?? 0) + this.view.offsetWidth / 2;
+    const viewportY = (event.view?.screenY ?? 0) + this.view.offsetHeight / 2;
+
     return {
-      x: 0,
-      y: 0,
-      offsetX: 0,
-      offsetY: 0,
+      x: viewportX,
+      y: viewportY,
+      offsetX: relativeX,
+      offsetY: relativeY,
       pointerId: 0,
       eventType: eventType,
       pointerType: PointerType.KEY,
-      time: 0,
+      time: event.timeStamp,
     };
   }
 }


### PR DESCRIPTION
## Description

By default, all native android and web components support keyboard navigation and option to press elements with `Enter` or `Spacebar` keys.

Gestures and components provided by Gesture Handler lack the latter option.

This PR adds keyboard support to the entirety of gesture handler, allowing it to replace mouse or finger navigation.

## Test plan

- try navigating around the example app using just the following keys: `Tab`, `Shift-Tab`, `Space`, `Enter`