### PR TITLE
Fix Pressable props export

### DIFF
--- a/src/components/Pressable/index.ts
+++ b/src/components/Pressable/index.ts
@@ -1,2 +1,2 @@
-export { PressableProps } from './PressableProps';
+export type { PressableProps } from './PressableProps';
 export { default } from './Pressable';


### PR DESCRIPTION
## Description

The current output for `commonjs` is
```js
"use strict";

Object.defineProperty(exports, "__esModule", {
  value: true
});
Object.defineProperty(exports, "PressableProps", {
  enumerable: true,
  get: function () {
    return _PressableProps.PressableProps;
  }
});
Object.defineProperty(exports, "default", {
  enumerable: true,
  get: function () {
    return _Pressable.default;
  }
});

var _PressableProps = require("./PressableProps");

var _Pressable = _interopRequireDefault(require("./Pressable"));

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
//# sourceMappingURL=index.js.map
```

While `PressableProps` doesn't exist as it only exports types. This may be causing problems ([like in Expensify atm](https://github.com/Expensify/App/actions/runs/10198945150/job/28214919841?pr=45289)).

This PR changes it to only export types, which are stripped resulting in 

```js
"use strict";

Object.defineProperty(exports, "__esModule", {
  value: true
});
Object.defineProperty(exports, "default", {
  enumerable: true,
  get: function () {
    return _Pressable.default;
  }
});

var _Pressable = _interopRequireDefault(require("./Pressable"));

function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
//# sourceMappingURL=index.js.map
```

## Test plan

Build the library and check generated files
