### PR TITLE
[jest] Suppress warning about non-worklet callbacks

### DIFF
--- a/src/handlers/gestures/GestureDetector/utils.ts
+++ b/src/handlers/gestures/GestureDetector/utils.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-import { tagMessage } from '../../../utils';
+import { isJestEnv, tagMessage } from '../../../utils';
 import { GestureRef, BaseGesture, GestureType } from '../gesture';
 
 import { flingGestureHandlerProps } from '../../FlingGestureHandler';
@@ -100,7 +100,7 @@ export function checkGestureCallbacksForWorklets(gesture: GestureType) {
   const areAllNotWorklets = !areSomeWorklets && areSomeNotWorklets;
   // If none of the callbacks are worklets and the gesture is not explicitly marked with
   // `.runOnJS(true)` show a warning
-  if (areAllNotWorklets) {
+  if (areAllNotWorklets && !isJestEnv()) {
     console.warn(
       tagMessage(
         `None of the callbacks in the gesture are worklets. If you wish to run them on the JS thread use '.runOnJS(true)' modifier on the gesture to make this explicit. Otherwise, mark the callbacks as 'worklet' to run them on the UI thread.`


### PR DESCRIPTION
## Description

As mentioned in [this discussion](https://github.com/software-mansion/react-native-gesture-handler/discussions/3047), while testing Gesture Handler with `jest` you can see the following warning:

```
None of the callbacks in the gesture are worklets. If you wish to run them on the JS thread use '.runOnJS(true)' modifier on the gesture to make this explicit. Otherwise, mark the callbacks as 'worklet' to run them on the UI thread.
```

Since `worklets` do not work in `jest`, I believe it is safe to simply suppress this error.

## Test plan

Run tests in our repository
