### PR TITLE
Fix `lint-staged`

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
   "lint-staged": {
     "./{src,example,FabricExample,MacOSExample}/**/*.{ts,tsx}": "yarn format:js",
     "android/**/*.kt": "yarn format:android",
-    "apple/**/*.{h,m,mm,cpp}": "yarn format:ios",
+    "apple/**/*.{h,m,mm,cpp}": "yarn format:apple",
     "src/specs/*.ts": "yarn sync-architectures"
   },
   "release-it": {


### PR DESCRIPTION
## Description

#3053 changed `format` script. However, I forgot to update `lint-staged` hook, which now fails on commit.

## Test plan

Try to commit changes in `obj-c` files.