### PR TITLE
[web] Fix `NativeViewGestureHandler` style.

### DIFF
--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -27,10 +27,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
 
     const view = this.delegate.getView() as HTMLElement;
 
-    view.style['touchAction'] = 'auto';
-    // @ts-ignore Turns on defualt touch behavior on Safari
-    view.style['WebkitTouchCallout'] = 'auto';
-
+    this.restoreViewStyles(view);
     this.buttonRole = view.getAttribute('role') === 'button';
   }
 
@@ -43,6 +40,19 @@ export default class NativeViewGestureHandler extends GestureHandler {
     if (this.config.disallowInterruption !== undefined) {
       this.disallowInterruption = this.config.disallowInterruption;
     }
+
+    const view = this.delegate.getView() as HTMLElement;
+    this.restoreViewStyles(view);
+  }
+
+  private restoreViewStyles(view: HTMLElement) {
+    if (!view) {
+      return;
+    }
+
+    view.style['touchAction'] = 'auto';
+    // @ts-ignore Turns on defualt touch behavior on Safari
+    view.style['WebkitTouchCallout'] = 'auto';
   }
 
   protected resetConfig(): void {


### PR DESCRIPTION
## Description

#3041 introduced a regression - calling `updateGestureConfig` resulted in `NativeViewGestureHandler` having `touchAction: none;` even though it shouldn't. Because of that our example app didn't scroll.

## Test plan

Check that example app is scrolling.
