### PR TITLE
fix: pinch gesture velocity expressed in scale factor per second on android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
@@ -23,7 +23,8 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
     override fun onScale(detector: ScaleGestureDetector): Boolean {
       val prevScaleFactor: Double = scale
       scale *= detector.scaleFactor.toDouble()
-      val delta = detector.timeDelta
+      val delta = detector.timeDeltaSeconds
+
       if (delta > 0) {
         velocity = (scale - prevScaleFactor) / delta
       }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/ScaleGestureDetector.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/ScaleGestureDetector.java
@@ -547,6 +547,10 @@ public class ScaleGestureDetector {
         return mCurrTime - mPrevTime;
     }
 
+    public double getTimeDeltaSeconds() {
+        return (double)this.getTimeDelta() / 1000;
+    }
+
     /**
      * Return the event time of the current event being processed.
      *

--- a/android/src/main/java/com/swmansion/gesturehandler/core/ScaleGestureDetector.java
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/ScaleGestureDetector.java
@@ -547,6 +547,12 @@ public class ScaleGestureDetector {
         return mCurrTime - mPrevTime;
     }
 
+    /**
+     * Return the time difference in seconds between the previous
+     * accepted scaling event and the current scaling event.
+     *
+     * @return Time difference since the last scaling event in seconds.
+     */
     public double getTimeDeltaSeconds() {
         return (double)this.getTimeDelta() / 1000;
     }

--- a/docs/docs/gesture-handlers/pinch-gh.md
+++ b/docs/docs/gesture-handlers/pinch-gh.md
@@ -34,7 +34,7 @@ The scale factor relative to the points of the two touches in screen coordinates
 
 ### `velocity`
 
-Velocity of the pan gesture the current moment. The value is expressed in point units per second.
+Velocity of the pan gesture the current moment. The value is expressed in scale factor per second.
 
 ### `focalX`
 

--- a/docs/docs/gestures/pinch-gesture.md
+++ b/docs/docs/gestures/pinch-gesture.md
@@ -85,7 +85,7 @@ The scale factor relative to the points of the two touches in screen coordinates
 
 ### `velocity`
 
-Velocity of the pan gesture the current moment. The value is expressed in point units per second.
+Velocity of the pan gesture the current moment. The value is expressed in scale factor per second.
 
 ### `focalX`
 


### PR DESCRIPTION
## Description

Pinch gesture velocity should be expressed in scale factor per second on android (just like on iOS [here](https://developer.apple.com/documentation/uikit/uipinchgesturerecognizer/1622233-velocity?language=objc)). I have changed delta to be in seconds instead of ms when calculating the velocity. 

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

I've compared that manually on iOS and android simulator.

<!--
Describe how did you test this change here.
-->
