### PR TITLE
[Android] Drop support for `AGP version <= 7`

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ You will need to have an Android or iOS device or emulator connected.
 
 | version | react-native version |
 | ------- | -------------------- |
+| 2.18.0+ | 0.73.0+              |
 | 2.16.0+ | 0.68.0+              |
 | 2.14.0+ | 0.67.0+              |
 | 2.10.0+ | 0.64.0+              |

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,8 +1,5 @@
 import groovy.json.JsonSlurper
 
-import javax.inject.Inject
-import java.nio.file.Files
-
 buildscript {
     def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNGH_kotlinVersion']
 
@@ -98,15 +95,11 @@ repositories {
 
 android {
     compileSdkVersion safeExtGet("compileSdkVersion", 33)
-    def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
-    if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
-        namespace "com.swmansion.gesturehandler"
-    }
 
-    if (agpVersion.tokenize('.')[0].toInteger() >= 8) {
-        buildFeatures {
-            buildConfig = true
-        }
+    namespace "com.swmansion.gesturehandler"
+    buildFeatures {
+        buildConfig = true
+        prefab true
     }
 
     // Used to override the NDK path/version on internal CI or by allowing
@@ -116,12 +109,6 @@ android {
     }
     if (rootProject.hasProperty("ndkVersion")) {
         ndkVersion rootProject.ext.ndkVersion
-    }
-
-    if (REACT_NATIVE_MINOR_VERSION >= 71) {
-        buildFeatures {
-            prefab true
-        }
     }
 
     defaultConfig {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -99,7 +99,7 @@ android {
     namespace "com.swmansion.gesturehandler"
     buildFeatures {
         buildConfig = true
-        prefab true
+        prefab = true
     }
 
     // Used to override the NDK path/version on internal CI or by allowing

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.swmansion.gesturehandler">
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />


### PR DESCRIPTION
## Description

This PR removes support for Android Gradle Plugin `version <= 7`
`AGP version 7` is unsupported by React Native since `0.73`

Closes: #2725

## Test plan

- build example `Android` app while using `AGP 8.0`
- build example `Android` app while using `AGP 9.0`
- both should run successfully