### PR TITLE
fix: touch event absolute position

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -397,19 +397,19 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     }
   }
 
-  private fun dispatchTouchDownEvent(event: MotionEvent) {
+  private fun dispatchTouchDownEvent(event: MotionEvent, sourceEvent: MotionEvent) {
     changedTouchesPayload = null
     touchEventType = RNGestureHandlerTouchEvent.EVENT_TOUCH_DOWN
     val pointerId = event.getPointerId(event.actionIndex)
-    val offsetX = event.rawX - event.x
-    val offsetY = event.rawY - event.y
+    val offsetX = sourceEvent.rawX - sourceEvent.x
+    val offsetY = sourceEvent.rawY - sourceEvent.y
 
     trackedPointers[pointerId] = PointerData(
       pointerId,
       event.getX(event.actionIndex),
       event.getY(event.actionIndex),
-      event.getX(event.actionIndex) + offsetX - windowOffset[0],
-      event.getY(event.actionIndex) + offsetY - windowOffset[1],
+      sourceEvent.getX(event.actionIndex) + offsetX - windowOffset[0],
+      sourceEvent.getY(event.actionIndex) + offsetY - windowOffset[1],
     )
     trackedPointersCount++
     addChangedPointer(trackedPointers[pointerId]!!)
@@ -418,20 +418,20 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     dispatchTouchEvent()
   }
 
-  private fun dispatchTouchUpEvent(event: MotionEvent) {
+  private fun dispatchTouchUpEvent(event: MotionEvent, sourceEvent: MotionEvent) {
     extractAllPointersData()
     changedTouchesPayload = null
     touchEventType = RNGestureHandlerTouchEvent.EVENT_TOUCH_UP
     val pointerId = event.getPointerId(event.actionIndex)
-    val offsetX = event.rawX - event.x
-    val offsetY = event.rawY - event.y
+    val offsetX = sourceEvent.rawX - sourceEvent.x
+    val offsetY = sourceEvent.rawY - sourceEvent.y
 
     trackedPointers[pointerId] = PointerData(
       pointerId,
       event.getX(event.actionIndex),
       event.getY(event.actionIndex),
-      event.getX(event.actionIndex) + offsetX - windowOffset[0],
-      event.getY(event.actionIndex) + offsetY - windowOffset[1],
+      sourceEvent.getX(event.actionIndex) + offsetX - windowOffset[0],
+      sourceEvent.getY(event.actionIndex) + offsetY - windowOffset[1],
     )
     addChangedPointer(trackedPointers[pointerId]!!)
     trackedPointers[pointerId] = null
@@ -440,11 +440,11 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     dispatchTouchEvent()
   }
 
-  private fun dispatchTouchMoveEvent(event: MotionEvent) {
+  private fun dispatchTouchMoveEvent(event: MotionEvent, sourceEvent: MotionEvent) {
     changedTouchesPayload = null
     touchEventType = RNGestureHandlerTouchEvent.EVENT_TOUCH_MOVE
-    val offsetX = event.rawX - event.x
-    val offsetY = event.rawY - event.y
+    val offsetX = sourceEvent.rawX - sourceEvent.x
+    val offsetY = sourceEvent.rawY - sourceEvent.y
     var pointersAdded = 0
 
     for (i in 0 until event.pointerCount) {
@@ -454,8 +454,8 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
       if (pointer.x != event.getX(i) || pointer.y != event.getY(i)) {
         pointer.x = event.getX(i)
         pointer.y = event.getY(i)
-        pointer.absoluteX = event.getX(i) + offsetX - windowOffset[0]
-        pointer.absoluteY = event.getY(i) + offsetY - windowOffset[1]
+        pointer.absoluteX = sourceEvent.getX(i) + offsetX - windowOffset[0]
+        pointer.absoluteY = sourceEvent.getY(i) + offsetY - windowOffset[1]
 
         addChangedPointer(pointer)
         pointersAdded++
@@ -471,15 +471,15 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     }
   }
 
-  fun updatePointerData(event: MotionEvent) {
+  fun updatePointerData(event: MotionEvent, sourceEvent: MotionEvent) {
     if (event.actionMasked == MotionEvent.ACTION_DOWN || event.actionMasked == MotionEvent.ACTION_POINTER_DOWN) {
-      dispatchTouchDownEvent(event)
-      dispatchTouchMoveEvent(event)
+      dispatchTouchDownEvent(event, sourceEvent)
+      dispatchTouchMoveEvent(event, sourceEvent)
     } else if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_POINTER_UP) {
-      dispatchTouchMoveEvent(event)
-      dispatchTouchUpEvent(event)
+      dispatchTouchMoveEvent(event, sourceEvent)
+      dispatchTouchUpEvent(event, sourceEvent)
     } else if (event.actionMasked == MotionEvent.ACTION_MOVE) {
-      dispatchTouchMoveEvent(event)
+      dispatchTouchMoveEvent(event, sourceEvent)
     }
   }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -270,7 +270,7 @@ class GestureHandlerOrchestrator(
     // the first `onTouchesDown` event after the handler processes it and changes state
     // to `BEGAN`.
     if (handler.needsPointerData && handler.state != 0) {
-      handler.updatePointerData(event)
+      handler.updatePointerData(event, sourceEvent)
     }
 
     if (!handler.isAwaiting || action != MotionEvent.ACTION_MOVE) {
@@ -292,7 +292,7 @@ class GestureHandlerOrchestrator(
       }
 
       if (handler.needsPointerData && isFirstEvent) {
-        handler.updatePointerData(event)
+        handler.updatePointerData(event, sourceEvent)
       }
 
       // if event was of type UP or POINTER_UP we request handler to stop tracking now that


### PR DESCRIPTION
## Description

The PR fixes the issue mentioned [here](https://github.com/software-mansion/react-native-gesture-handler/issues/3073) about the incorrect absolute positions on touch events. The view transformations should not affect the absolute position of the touch, so the source event should also be passed to gesture handlers and used for calculations. It applies to `ACTION_DOWN`, `ACTION_MOVE`, and `ACTION_UP` motion events.

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

I've checked on android device for repro provided in the above-mentioned issue with some scroll offset. 

<!--
Describe how did you test this change here.
-->
