### PR TITLE
[tvOS] Fix tvOS not building because of `LongPressGestureHandler`

### DIFF
--- a/apple/Handlers/RNLongPressHandler.m
+++ b/apple/Handlers/RNLongPressHandler.m
@@ -235,7 +235,9 @@
 
   prop = config[@"numberOfPointers"];
   if (prop != nil) {
+#if !TARGET_OS_TV
     recognizer.numberOfTouchesRequired = [RCTConvert CGFloat:prop];
+#endif
   }
 }
 

--- a/apple/Handlers/RNLongPressHandler.m
+++ b/apple/Handlers/RNLongPressHandler.m
@@ -233,12 +233,12 @@
     recognizer.allowableMovement = [RCTConvert CGFloat:prop];
   }
 
+#if !TARGET_OS_TV
   prop = config[@"numberOfPointers"];
   if (prop != nil) {
-#if !TARGET_OS_TV
     recognizer.numberOfTouchesRequired = [RCTConvert CGFloat:prop];
-#endif
   }
+#endif
 }
 
 #if !TARGET_OS_OSX


### PR DESCRIPTION
## Description

When building a React Native app for TvOS, the following error is being thrown:
![image](https://github.com/user-attachments/assets/b7b75b92-90ab-45a5-9c1f-416ed414bd92)

 
This PR fixes this issue by wrapping `numberOfPointersRequired` in a platform specific clause to fix the build error.

closes: #3089

## Test plan

Try building `TvOS` before and after this change