### PR TITLE
[iOS] Prevent crash when setting `cursor` style

### DIFF
--- a/src/components/GestureButtons.tsx
+++ b/src/components/GestureButtons.tsx
@@ -120,12 +120,13 @@ class InnerBaseButton extends React.Component<BaseButtonWithRefProps> {
   };
 
   render() {
-    const { rippleColor, ...rest } = this.props;
+    const { rippleColor, style, ...rest } = this.props;
 
     return (
       <RawButton
         ref={this.props.innerRef}
         rippleColor={processColor(rippleColor)}
+        style={[style, Platform.OS === 'ios' && { cursor: undefined }]}
         {...rest}
         onGestureEvent={this.onGestureEvent}
         onHandlerStateChange={this.onHandlerStateChange}


### PR DESCRIPTION
## Description

If you try to set `cursor` style in our buttons on `iOS` you'll get `unrecognized selector` error. This PR sets `cursor` value to be undefined on `iOS`, so apps no longer crash.

Fixes #3081 

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import React from 'react';
import { StyleSheet, Text, View } from 'react-native';
import { RectButton } from 'react-native-gesture-handler';

export default function EmptyExample() {
  return (
    <View style={styles.container}>
      <Text>Hello World!</Text>

      <RectButton
        style={{
          width: 100,
          height: 20,
          backgroundColor: 'blue',
          cursor: 'grab',
        }}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
});
```

</details>
