### PR TITLE
Add chevron to the example app and center labels

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -14,6 +14,7 @@ import {
   StackScreenProps,
 } from '@react-navigation/stack';
 import { NavigationContainer, ParamListBase } from '@react-navigation/native';
+import Entypo from '@expo/vector-icons/Entypo';
 import {
   GestureHandlerRootView,
   RectButton,
@@ -323,6 +324,7 @@ function MainScreenItem({ name, onPressItem }: MainScreenItemProps) {
   return (
     <RectButton style={[styles.button]} onPress={() => onPressItem(name)}>
       <Text>{name}</Text>
+      <Entypo name="chevron-right" size={24} color="#bbb" />
     </RectButton>
   );
 }
@@ -354,7 +356,10 @@ const styles = StyleSheet.create({
     flex: 1,
     height: 50,
     padding: 10,
+    flexDirection: 'row',
     backgroundColor: '#fff',
+    alignItems: 'center',
+    justifyContent: 'space-between',
   },
   buttonContent: {
     flex: 1,


### PR DESCRIPTION
## Description

I noticed the button labels were off-center, so I fixed them and added a chevron at the same time as it was looking kind of empty.

<img width="546" alt="Screenshot 2024-09-17 at 11 27 33" src="https://github.com/user-attachments/assets/d3b65867-5630-4959-b715-82244f423ba5">
