### PR TITLE
[Web] Remove hovering pointer from tracker.

### DIFF
--- a/src/web/handlers/HoverGestureHandler.ts
+++ b/src/web/handlers/HoverGestureHandler.ts
@@ -35,7 +35,7 @@ export default class HoverGestureHandler extends GestureHandler {
   }
 
   protected onPointerMoveOut(event: AdaptedEvent): void {
-    this.tracker.addToTracker(event);
+    this.tracker.removeFromTracker(event.pointerId);
     this.stylusData = event.stylusData;
 
     super.onPointerMoveOut(event);


### PR DESCRIPTION
## Description

I've noticed that in `Hover` inside `onPointerMoveOut` method we add pointer to tracker instead of removing it. While it doesn't make much difference, since tracker is reset in [this line](https://github.com/software-mansion/react-native-gesture-handler/blob/b79223de5a47773a464543018b7231113c1ade68/src/web/tools/GestureHandlerOrchestrator.ts#L28), I think it will be better to change it into removing pointer.

## Test plan

Tested on `hover` example.