### PR TITLE
Fix duplicate `libreactnative.so` and `libjsi.so`

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -146,6 +146,8 @@ android {
         // only the ones that make the build fail (ideally we should only include libgesturehandler but we
         // are only allowed to specify exclude patterns)
         exclude "**/libreact_render*.so"
+        exclude "**/libreactnative.so"
+        exclude "**/libjsi.so"
     }
 
     sourceSets.main {


### PR DESCRIPTION
## Description

I've started seeing these errors on 0.76.0-rc.1.

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeDebugNativeLibs'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeNativeLibsTask$MergeNativeLibsTaskWorkAction
   > 2 files found with path 'lib/arm64-v8a/libjsi.so' from inputs:
      - /Users/tomekzaw/RNOS/Reanimated76/react-native-reanimated/node_modules/react-native-gesture-handler/android/build/intermediates/library_jni/debug/copyDebugJniLibsProjectOnly/jni/arm64-v8a/libjsi.so
      - /Users/tomekzaw/.gradle/caches/8.10/transforms/e363f8ea49fe13fc78e6ed35173e9914/transformed/react-android-0.76.0-rc.1-debug/jni/arm64-v8a/libjsi.so
     If you are using jniLibs and CMake IMPORTED targets, see
     https://developer.android.com/r/tools/jniLibs-vs-imported-targets
```

```
FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':app:mergeDebugNativeLibs'.
> A failure occurred while executing com.android.build.gradle.internal.tasks.MergeNativeLibsTask$MergeNativeLibsTaskWorkAction
   > 2 files found with path 'lib/arm64-v8a/libreactnative.so' from inputs:
      - /Users/tomekzaw/RNOS/Reanimated76/react-native-reanimated/node_modules/react-native-gesture-handler/android/build/intermediates/library_jni/debug/copyDebugJniLibsProjectOnly/jni/arm64-v8a/libreactnative.so
      - /Users/tomekzaw/.gradle/caches/8.10/transforms/e363f8ea49fe13fc78e6ed35173e9914/transformed/react-android-0.76.0-rc.1-debug/jni/arm64-v8a/libreactnative.so
     If you are using jniLibs and CMake IMPORTED targets, see
     https://developer.android.com/r/tools/jniLibs-vs-imported-targets
```

## Test plan

<!--
Describe how did you test this change here.
-->
