### PR TITLE
Call `getEventDispatcher` in ReactContextExtensions.kt

### DIFF
--- a/android/paper/src/main/java/com/swmansion/gesturehandler/ReactContextExtensions.kt
+++ b/android/paper/src/main/java/com/swmansion/gesturehandler/ReactContextExtensions.kt
@@ -6,7 +6,7 @@ import com.facebook.react.uimanager.events.Event
 
 fun ReactContext.dispatchEvent(event: Event<*>) {
   try {
-    this.getNativeModule(UIManagerModule::class.java)!!.eventDispatcher.dispatchEvent(event)
+    this.getNativeModule(UIManagerModule::class.java)!!.getEventDispatcher().dispatchEvent(event)
   } catch (e: NullPointerException) {
     throw Exception("Couldn't get an instance of UIManagerModule. Gesture Handler is unable to send an event.", e)
   }


### PR DESCRIPTION
## Description

`react-native-gesture-handler` fails to compile on RN 0.76.0-rc.1 with new arch disabled.

<img width="1624" alt="Screenshot 2024-09-23 at 13 05 09" src="https://github.com/user-attachments/assets/67ace3a7-a08c-4b9f-bfd8-ed782610c236">

## Test plan

<!--
Describe how did you test this change here.
-->
