### PR TITLE
[docs] Improve Reanimated Swipeable documentation.

### DIFF
--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -81,7 +81,8 @@ an argument.
 
 ### `renderLeftActions`
 
-accepts a function which receives the following arguments:
+a function that returns a component which will be rendered under the swipeable after swiping it to the right.
+The function receives the following arguments:
 
 - `progress` value representing swiping progress relative to the width of the returned element.  
   Equals `0` when `swipeable` is closed, `1` when left action is open.  
@@ -95,7 +96,8 @@ To support `rtl` flexbox layouts use `flexDirection` styling.
 
 ### `renderRightActions`
 
-accepts a function which receives the following arguments:
+a function that returns a component which will be rendered under the swipeable after swiping it to the right.
+The function receives the following arguments:
 
 - `progress` value representing swiping progress relative to the width of the returned element.  
   Equals `0` when `swipeable` is closed, `1` when right action is open.  

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -30,7 +30,7 @@ import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
 ### `friction`
 
 a number that specifies how much the visual interaction will be delayed compared to the gesture distance.
-e.g. value of 1 will indicate that the swipeable panel should exactly follow the gesture, 2 means it is going to be two times "slower".
+e.g. value of `1` will indicate that the swipeable panel should exactly follow the gesture, `2` means it is going to be two times "slower".
 
 ### `leftThreshold`
 
@@ -42,11 +42,11 @@ distance from the right edge at which released panel will animate to the open st
 
 ### `dragOffsetFromLeftEdge`
 
-distance that the panel must be dragged from the left edge to be considered a swipe. The default value is 10.
+distance that the panel must be dragged from the left edge to be considered a swipe. The default value is `10`.
 
 ### `dragOffsetFromRightEdge`
 
-distance that the panel must be dragged from the right edge to be considered a swipe. The default value is 10.
+distance that the panel must be dragged from the right edge to be considered a swipe. The default value is `10`.
 
 ### `overshootLeft`
 
@@ -58,7 +58,7 @@ a boolean value indicating if the swipeable panel can be pulled further than the
 
 ### `overshootFriction`
 
-a number that specifies how much the visual interaction will be delayed compared to the gesture distance at overshoot. Default value is 1, it mean no friction, for a native feel, try 8 or above.
+a number that specifies how much the visual interaction will be delayed compared to the gesture distance at overshoot. Default value is `1`, it mean no friction, for a native feel, try `8` or above.
 
 ### `onSwipeableOpen`
 
@@ -112,16 +112,16 @@ To support `rtl` flexbox layouts use `flexDirection` styling.
 
 ### `containerStyle`
 
-style object for the container (Animated.View), for example to override `overflow: 'hidden'`.
+style object for the container (`Animated.View`), for example to override `overflow: 'hidden'`.
 
 ### `childrenContainerStyle`
 
-style object for the children container (Animated.View), for example to apply `flex: 1`.
+style object for the children container (`Animated.View`), for example to apply `flex: 1`.
 
 ### `enableTrackpadTwoFingerGesture` (iOS only)
 
 Enables two-finger gestures on supported devices, for example iPads with trackpads.
-If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
+If not enabled the gesture will require click + drag, with `enableTrackpadTwoFingerGesture` swiping with two fingers will also trigger the gesture.
 
 ### `mouseButton(value: MouseButton)` (Web & Android only)
 

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -85,10 +85,10 @@ a function that returns a component which will be rendered under the swipeable a
 The function receives the following arguments:
 
 - `progress` - a `SharedValue` representing swiping progress relative to the width of the returned element.
-  - Equals `0` when `swipeable` is closed, `1` when left action is open.
-  - Linearly increases to `Infinity` as left action overshoots it's open position.
-- `translation` - a horizontal offset of the `swipeable` relative to its closed position
-- `swipeableMethods` - provides an object exposing the methods listed [here](#methods)
+  - Equals `0` when `swipeable` is closed, `1` when `swipeable` is open.
+  - Linearly increases to `Infinity` as `swipeable` overshoots it's open position.
+- `translation` - a horizontal offset of the `swipeable` relative to its closed position.
+- `swipeableMethods` - provides an object exposing the methods listed [here](#methods).
 
 This function must return a `ReactNode`.
 
@@ -100,10 +100,10 @@ a function that returns a component which will be rendered under the swipeable a
 The function receives the following arguments:
 
 - `progress` - a `SharedValue` representing swiping progress relative to the width of the returned element.
-  - Equals `0` when `swipeable` is closed, `1` when right action is open.
-  - Linearly increases to `Infinity` as right action overshoots it's open position.
-- `translation` - a horizontal offset of the `swipeable` relative to its closed position
-- `swipeableMethods` - provides an object exposing the methods listed [here](#methods)
+  - Equals `0` when `swipeable` is closed, `1` when `swipeable` is open.
+  - Linearly increases to `Infinity` as `swipeable` overshoots it's open position.
+- `translation` - a horizontal offset of the `swipeable` relative to its closed position.
+- `swipeableMethods` - provides an object exposing the methods listed [here](#methods).
 
 This function must return a `ReactNode`.
 

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -86,7 +86,7 @@ accepts a function which receives the following arguments:
 - `progress` value representing swiping progress relative to the width of the returned element.  
   Equals `0` when `swipeable` is closed, `1` when left action is open.  
   Linearly increases to `Infinity` as left action overshoots it's open position.
-- `translation` horizontal translation of `swipeable` in pixels.
+- `translation` horizontal translation of the `swipeable` in pixels.
 - `swipeable` provides an object exposing the methods listed [here](#methods)
 
 This function must return a `ReactNode`.
@@ -100,7 +100,7 @@ accepts a function which receives the following arguments:
 - `progress` value representing swiping progress relative to the width of the returned element.  
   Equals `0` when `swipeable` is closed, `1` when right action is open.  
   Linearly increases to `Infinity` as right action overshoots it's open position.
-- `translation` horizontal translation of `swipeable` in pixels.
+- `translation` horizontal translation of the `swipeable` in pixels.
 - `swipeable` provides an object exposing the methods listed [here](#methods)
 
 This function must return a `ReactNode`.

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -29,7 +29,8 @@ import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
 
 ### `friction`
 
-a number that specifies how much the visual interaction will be delayed compared to the gesture distance. e.g. value of 1 will indicate that the swipeable panel should exactly follow the gesture, 2 means it is going to be two times "slower".
+a number that specifies how much the visual interaction will be delayed compared to the gesture distance.
+e.g. value of 1 will indicate that the swipeable panel should exactly follow the gesture, 2 means it is going to be two times "slower".
 
 ### `leftThreshold`
 
@@ -61,23 +62,19 @@ a number that specifies how much the visual interaction will be delayed compared
 
 ### `onSwipeableOpen`
 
-method that is called when action panel gets open (either right or left). Takes swipe direction as
-an argument.
+method that is called when action panel gets open (either right or left). Takes swipe direction as an argument.
 
 ### `onSwipeableClose`
 
-method that is called when action panel is closed. Takes swipe direction as
-an argument.
+method that is called when action panel is closed. Takes swipe direction as an argument.
 
 ### `onSwipeableWillOpen`
 
-method that is called when action panel starts animating on open (either right or left). Takes swipe direction as
-an argument.
+method that is called when action panel starts animating on open (either right or left). Takes swipe direction as an argument.
 
 ### `onSwipeableWillClose`
 
-method that is called when action panel starts animating on close. Takes swipe direction as
-an argument.
+method that is called when action panel starts animating on close. Takes swipe direction as an argument.
 
 ### `renderLeftActions`
 
@@ -119,7 +116,8 @@ style object for the children container (Animated.View), for example to apply `f
 
 ### `enableTrackpadTwoFingerGesture` (iOS only)
 
-Enables two-finger gestures on supported devices, for example iPads with trackpads. If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
+Enables two-finger gestures on supported devices, for example iPads with trackpads.
+If not enabled the gesture will require click + drag, with enableTrackpadTwoFingerGesture swiping with two fingers will also trigger the gesture.
 
 ### `mouseButton(value: MouseButton)` (Web & Android only)
 
@@ -162,7 +160,8 @@ Unlike method `close`, this method does not trigger any animation.
 
 ### Example:
 
-For a more in-depth presentation of differences between the new and the legacy implementations, see [swipeable example](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example/src/release_tests/swipeableReanimation/index.tsx) from GestureHandler Example App.
+For a more in-depth presentation of differences between the new and the legacy implementations,
+see [swipeable example](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example/src/release_tests/swipeableReanimation/index.tsx) from GestureHandler Example App.
 
 ```jsx
 import React from 'react';

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -86,7 +86,7 @@ a function that returns a component which will be rendered under the swipeable a
 The function receives the following arguments:
 
 - `progress` - a `SharedValue` representing swiping progress relative to the width of the returned element.
-  - Equals `0` when `swipeable` is closed, `1` when `swipeable` is open.
+  - Equals `0` when `swipeable` is closed, `1` when `swipeable` is opened.
   - Linearly increases to `Infinity` as `swipeable` overshoots it's open position.
 - `translation` - a horizontal offset of the `swipeable` relative to its closed position.
 - `swipeableMethods` - provides an object exposing the methods listed [here](#methods).
@@ -101,7 +101,7 @@ a function that returns a component which will be rendered under the swipeable a
 The function receives the following arguments:
 
 - `progress` - a `SharedValue` representing swiping progress relative to the width of the returned element.
-  - Equals `0` when `swipeable` is closed, `1` when `swipeable` is open.
+  - Equals `0` when `swipeable` is closed, `1` when `swipeable` is opened.
   - Linearly increases to `Infinity` as `swipeable` overshoots it's open position.
 - `translation` - a horizontal offset of the `swipeable` relative to its closed position.
 - `swipeableMethods` - provides an object exposing the methods listed [here](#methods).

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -87,7 +87,7 @@ The function receives the following arguments:
 
 - `progress` - a `SharedValue` representing swiping progress relative to the width of the returned element.
   - Equals `0` when `swipeable` is closed, `1` when `swipeable` is opened.
-  - Linearly increases to `Infinity` as `swipeable` overshoots it's open position.
+  - When the element overshoots it's opened position the value tends towards `Infinity`.
 - `translation` - a horizontal offset of the `swipeable` relative to its closed position.
 - `swipeableMethods` - provides an object exposing the methods listed [here](#methods).
 
@@ -102,7 +102,7 @@ The function receives the following arguments:
 
 - `progress` - a `SharedValue` representing swiping progress relative to the width of the returned element.
   - Equals `0` when `swipeable` is closed, `1` when `swipeable` is opened.
-  - Linearly increases to `Infinity` as `swipeable` overshoots it's open position.
+  - When the element overshoots it's opened position the value tends towards `Infinity`.
 - `translation` - a horizontal offset of the `swipeable` relative to its closed position.
 - `swipeableMethods` - provides an object exposing the methods listed [here](#methods).
 

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -158,62 +158,61 @@ Unlike method `close`, this method does not trigger any animation.
 
 ### Example:
 
-See the [swipeable example](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example/src/release_tests/swipeableReanimation/index.tsx) from GestureHandler Example App.
+For a more in-depth presentation of differences between the new and the legacy implementations, see [swipeable example](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example/src/release_tests/swipeableReanimation/index.tsx) from GestureHandler Example App.
 
 ```jsx
-import React, { Component } from 'react';
-import { Animated, StyleSheet, View } from 'react-native';
-import { RectButton } from 'react-native-gesture-handler';
-import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
+import React from 'react';
+import { Text, StyleSheet } from 'react-native';
 
-const LeftAction = ({ dragX, swipeableRef }: LeftActionsProps) => {
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [
-      {
-        translateX: interpolate(
-          dragX.value,
-          [0, 50, 100, 101],
-          [-20, 0, 0, 1],
-          Extrapolation.CLAMP
-        ),
-      },
-    ],
-  }));
-  return (
-    <RectButton
-      style={{
-        flex: 1,
-        backgroundColor: '#497AFC',
-        justifyContent: 'center',
-      }}
-      onPress={() => swipeableRef.current!.close()}>
-      <Animated.Text>
-        Archive
-      </Animated.Text>
-    </RectButton>
-  );
-};
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
+import ReanimatedSwipeable from 'react-native-gesture-handler/ReanimatedSwipeable';
+import Reanimated, {
+  SharedValue,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
 
-const renderLeftActions = (
-  _progress: any,
-  translation: SharedValue<number>,
-  swipeableRef: React.RefObject<SwipeableMethods>
-) => <LeftAction dragX={translation} swipeableRef={swipeableRef} />;
+function RightAction(prog: SharedValue<number>, drag: SharedValue<number>) {
+  const styleAnimation = useAnimatedStyle(() => {
+    console.log('showRightProgress:', prog.value);
+    console.log('appliedTranslation:', drag.value);
 
-function AppleStyleSwipeableRow({ children }: AppleStyleSwipeableRowProps) {
-  const swipeableRow = useRef<SwipeableMethods>(null);
+    return {
+      transform: [{ translateX: drag.value + 50 }],
+    };
+  });
 
   return (
-    <Swipeable
-      ref={swipeableRow}
-      friction={2}
-      enableTrackpadTwoFingerGesture
-      leftThreshold={30}
-      renderLeftActions={(_, progress) =>
-        renderLeftActions(_, progress, swipeableRow)
-      }>
-      <Text>Apple style swipeable</Text>
-    </Swipeable>
+    <Reanimated.View style={styleAnimation}>
+      <Text style={styles.rightAction}>Text</Text>
+    </Reanimated.View>
   );
 }
+
+export default function Example() {
+  return (
+    <GestureHandlerRootView>
+      <ReanimatedSwipeable
+        containerStyle={styles.swipeable}
+        friction={2}
+        enableTrackpadTwoFingerGesture
+        rightThreshold={40}
+        renderRightActions={RightAction}>
+        <Text>Swipe me!</Text>
+      </ReanimatedSwipeable>
+    </GestureHandlerRootView>
+  );
+}
+
+const styles = StyleSheet.create({
+  rightAction: { width: 50, height: 50, backgroundColor: 'purple' },
+  separator: {
+    width: '100%',
+    borderTopWidth: 1,
+  },
+  swipeable: {
+    height: 50,
+    backgroundColor: 'papayawhip',
+    alignItems: 'center',
+  },
+});
 ```

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -84,8 +84,7 @@ an argument.
 a function that returns a component which will be rendered under the swipeable after swiping it to the right.
 The function receives the following arguments:
 
-- `progress`
-  - A `SharedValue` representing swiping progress relative to the width of the returned element.
+- `progress` - a `SharedValue` representing swiping progress relative to the width of the returned element.
   - Equals `0` when `swipeable` is closed, `1` when left action is open.
   - Linearly increases to `Infinity` as left action overshoots it's open position.
 - `translation` - a horizontal offset of the `swipeable` relative to its closed position
@@ -97,13 +96,12 @@ To support `rtl` flexbox layouts use `flexDirection` styling.
 
 ### `renderRightActions`
 
-a function that returns a component which will be rendered under the swipeable after swiping it to the right.
+a function that returns a component which will be rendered under the swipeable after swiping it to the left.
 The function receives the following arguments:
 
-- `progress`
-  - A `SharedValue` representing swiping progress relative to the width of the returned element.
-  - Equals `0` when `swipeable` is closed, `1` when left action is open.
-  - Linearly increases to `Infinity` as left action overshoots it's open position.
+- `progress` - a `SharedValue` representing swiping progress relative to the width of the returned element.
+  - Equals `0` when `swipeable` is closed, `1` when right action is open.
+  - Linearly increases to `Infinity` as right action overshoots it's open position.
 - `translation` - a horizontal offset of the `swipeable` relative to its closed position
 - `swipeableMethods` - provides an object exposing the methods listed [here](#methods)
 

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -81,27 +81,29 @@ an argument.
 
 ### `renderLeftActions`
 
-method that is expected to return an action panel that is going to be revealed from the left side when user swipes right.
-This map describes the values to use as inputRange for extra interpolation:
+accepts a function which receives the following arguments:
 
-SharedValue: [startValue, endValue]
+- `progress` value representing swiping progress relative to the width of the returned element.  
+  Equals `0` when `swipeable` is closed, `1` when left action is open.  
+  Linearly increases to `Infinity` as left action overshoots it's open position.
+- `translation` horizontal translation of `swipeable` in pixels.
+- `swipeable` provides an object exposing the methods listed [here](#methods)
 
-progress: [0, 1]
-
-drag: [0, +]
+This function must return a `ReactNode`.
 
 To support `rtl` flexbox layouts use `flexDirection` styling.
 
 ### `renderRightActions`
 
-method that is expected to return an action panel that is going to be revealed from the right side when user swipes left.
-This map describes the values to use as inputRange for extra interpolation:
+accepts a function which receives the following arguments:
 
-SharedValue: [startValue, endValue]
+- `progress` value representing swiping progress relative to the width of the returned element.  
+  Equals `0` when `swipeable` is closed, `1` when right action is open.  
+  Linearly increases to `Infinity` as right action overshoots it's open position.
+- `translation` horizontal translation of `swipeable` in pixels.
+- `swipeable` provides an object exposing the methods listed [here](#methods)
 
-progress: [0, 1]
-
-drag: [0, -]
+This function must return a `ReactNode`.
 
 To support `rtl` flexbox layouts use `flexDirection` styling.
 

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -50,11 +50,11 @@ distance that the panel must be dragged from the right edge to be considered a s
 
 ### `overshootLeft`
 
-a boolean value indicating if the swipeable panel can be pulled further than the left actions panel's width. It is set to `true` by default as long as the left panel render method is present.
+a boolean value indicating if the swipeable panel can be pulled further than the left actions panel's width. It is set to `true` by default as long as the left panel render function is present.
 
 ### `overshootRight`
 
-a boolean value indicating if the swipeable panel can be pulled further than the right actions panel's width. It is set to `true` by default as long as the right panel render method is present.
+a boolean value indicating if the swipeable panel can be pulled further than the right actions panel's width. It is set to `true` by default as long as the right panel render function is present.
 
 ### `overshootFriction`
 
@@ -62,19 +62,23 @@ a number that specifies how much the visual interaction will be delayed compared
 
 ### `onSwipeableOpen`
 
-method that is called when action panel gets open (either right or left). Takes swipe direction as an argument.
+a function that is called when `swipeable` is opened (either right or left).
+Receives swipe direction as an argument.
 
 ### `onSwipeableClose`
 
-method that is called when action panel is closed. Takes swipe direction as an argument.
+a function that is called when `swipeable` is closed.
+Receives swipe direction as an argument.
 
 ### `onSwipeableWillOpen`
 
-method that is called when action panel starts animating on open (either right or left). Takes swipe direction as an argument.
+a function that is called when `swipeable` starts animating on open (either right or left).
+Receives swipe direction as an argument.
 
 ### `onSwipeableWillClose`
 
-method that is called when action panel starts animating on close. Takes swipe direction as an argument.
+a function that is called when `swipeable` starts animating on close.
+Receives swipe direction as an argument.
 
 ### `renderLeftActions`
 
@@ -142,19 +146,19 @@ Using reference to `Swipeable` it's possible to trigger some actions on it
 
 ### `close`
 
-method that closes component.
+a method that closes component.
 
 ### `openLeft`
 
-method that opens component on left side.
+a method that opens component on left side.
 
 ### `openRight`
 
-method that opens component on right side.
+a method that opens component on right side.
 
 ### `reset`
 
-method that resets the swiping states of this `Swipeable` component.
+a method that resets the swiping states of this `Swipeable` component.
 
 Unlike method `close`, this method does not trigger any animation.
 

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -84,11 +84,12 @@ an argument.
 a function that returns a component which will be rendered under the swipeable after swiping it to the right.
 The function receives the following arguments:
 
-- `progress` value representing swiping progress relative to the width of the returned element.  
-  Equals `0` when `swipeable` is closed, `1` when left action is open.  
-  Linearly increases to `Infinity` as left action overshoots it's open position.
-- `translation` horizontal translation of the `swipeable` in pixels.
-- `swipeable` provides an object exposing the methods listed [here](#methods)
+- `progress`
+  - A `SharedValue` representing swiping progress relative to the width of the returned element.
+  - Equals `0` when `swipeable` is closed, `1` when left action is open.
+  - Linearly increases to `Infinity` as left action overshoots it's open position.
+- `translation` - a horizontal offset of the `swipeable` relative to its closed position
+- `swipeableMethods` - provides an object exposing the methods listed [here](#methods)
 
 This function must return a `ReactNode`.
 
@@ -99,11 +100,12 @@ To support `rtl` flexbox layouts use `flexDirection` styling.
 a function that returns a component which will be rendered under the swipeable after swiping it to the right.
 The function receives the following arguments:
 
-- `progress` value representing swiping progress relative to the width of the returned element.  
-  Equals `0` when `swipeable` is closed, `1` when right action is open.  
-  Linearly increases to `Infinity` as right action overshoots it's open position.
-- `translation` horizontal translation of the `swipeable` in pixels.
-- `swipeable` provides an object exposing the methods listed [here](#methods)
+- `progress`
+  - A `SharedValue` representing swiping progress relative to the width of the returned element.
+  - Equals `0` when `swipeable` is closed, `1` when left action is open.
+  - Linearly increases to `Infinity` as left action overshoots it's open position.
+- `translation` - a horizontal offset of the `swipeable` relative to its closed position
+- `swipeableMethods` - provides an object exposing the methods listed [here](#methods)
 
 This function must return a `ReactNode`.
 

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -145,7 +145,7 @@ export interface SwipeableProps
 
   /**
    * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
-   * `translation`: translation of the `swipeable` in pixels.\
+   * `translation`: a horizontal offset of the `swipeable` relative to its closed position.\
    * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`\
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
@@ -158,7 +158,7 @@ export interface SwipeableProps
 
   /**
    * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
-   * `translation`: translation of the `swipeable` in pixels.\
+   * `translation`: a horizontal offset of the `swipeable` relative to its closed position.\
    * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`\
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -145,28 +145,28 @@ export interface SwipeableProps
 
   /**
    * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
-   * `translation`: translation of the `swipeable` in pixels.
-   * `swipeable` provides an object exposing methods for controlling the `swipeable`
+   * `translation`: translation of the `swipeable` in pixels.\
+   * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`\
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
   renderLeftActions?: (
     progress: SharedValue<number>,
     translation: SharedValue<number>,
-    swipeable: SwipeableMethods
+    swipeableMethods: SwipeableMethods
   ) => React.ReactNode;
 
   /**
    * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
-   * `translation`: translation of the `swipeable` in pixels.
-   * `swipeable` provides an object exposing methods for controlling the `swipeable`
+   * `translation`: translation of the `swipeable` in pixels.\
+   * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`\
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
   renderRightActions?: (
     progress: SharedValue<number>,
     translation: SharedValue<number>,
-    swipeable: SwipeableMethods
+    swipeableMethods: SwipeableMethods
   ) => React.ReactNode;
 
   animationOptions?: Record<string, unknown>;

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -145,7 +145,7 @@ export interface SwipeableProps
 
   /**
    * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
-   * `translation`: translation of swipeable in pixels.
+   * `translation`: translation of the `swipeable` in pixels.
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
@@ -157,7 +157,7 @@ export interface SwipeableProps
 
   /**
    * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
-   * `translation`: translation of swipeable in pixels.
+   * `translation`: translation of the `swipeable` in pixels.
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -144,7 +144,10 @@ export interface SwipeableProps
   onSwipeableCloseStartDrag?: (direction: 'left' | 'right') => void;
 
   /**
-   * `progress`: Equals `0` when action is closed, `1` when action is opened, linearly increases to `Infinity` as `swipeable` overshoots it's open position.\
+   * `progress`: Equals `0` when `swipeable` is closed, `1` when `swipeable` is opened.
+   *  - When the element overshoots it's opened position the value tends towards `Infinity`.
+   *  - Goes back to `1` when `swipeable` is released.
+   *
    * `translation`: a horizontal offset of the `swipeable` relative to its closed position.\
    * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`.
    *
@@ -157,7 +160,10 @@ export interface SwipeableProps
   ) => React.ReactNode;
 
   /**
-   * `progress`: Equals `0` when action is closed, `1` when action is opened, linearly increases to `Infinity` as `swipeable` overshoots it's open position.\
+   * `progress`: Equals `0` when `swipeable` is closed, `1` when `swipeable` is opened.
+   *  - When the element overshoots it's opened position the value tends towards `Infinity`.
+   *  - Goes back to `1` when `swipeable` is released.
+   *
    * `translation`: a horizontal offset of the `swipeable` relative to its closed position.\
    * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`.
    *

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -146,6 +146,7 @@ export interface SwipeableProps
   /**
    * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
    * `translation`: translation of the `swipeable` in pixels.
+   * `swipeable` provides an object exposing methods for controlling the `swipeable`
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
@@ -158,6 +159,7 @@ export interface SwipeableProps
   /**
    * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
    * `translation`: translation of the `swipeable` in pixels.
+   * `swipeable` provides an object exposing methods for controlling the `swipeable`
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -146,7 +146,7 @@ export interface SwipeableProps
   /**
    * `progress`: Equals `0` when action is closed, `1` when action is opened, linearly increases to `Infinity` as `swipeable` overshoots it's open position.\
    * `translation`: a horizontal offset of the `swipeable` relative to its closed position.\
-   * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`.\
+   * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`.
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
@@ -159,7 +159,7 @@ export interface SwipeableProps
   /**
    * `progress`: Equals `0` when action is closed, `1` when action is opened, linearly increases to `Infinity` as `swipeable` overshoots it's open position.\
    * `translation`: a horizontal offset of the `swipeable` relative to its closed position.\
-   * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`.\
+   * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`.
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -144,9 +144,9 @@ export interface SwipeableProps
   onSwipeableCloseStartDrag?: (direction: 'left' | 'right') => void;
 
   /**
-   * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
+   * `progress`: Equals `0` when action is closed, `1` when action is opened, linearly increases to `Infinity` as `swipeable` overshoots it's open position.\
    * `translation`: a horizontal offset of the `swipeable` relative to its closed position.\
-   * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`\
+   * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`.\
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
@@ -157,9 +157,9 @@ export interface SwipeableProps
   ) => React.ReactNode;
 
   /**
-   * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
+   * `progress`: Equals `0` when action is closed, `1` when action is opened, linearly increases to `Infinity` as `swipeable` overshoots it's open position.\
    * `translation`: a horizontal offset of the `swipeable` relative to its closed position.\
-   * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`\
+   * `swipeableMethods`: provides an object exposing methods for controlling the `swipeable`.\
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -144,31 +144,26 @@ export interface SwipeableProps
   onSwipeableCloseStartDrag?: (direction: 'left' | 'right') => void;
 
   /**
-   *
-   * This map describes the values to use as inputRange for extra interpolation:
-   * AnimatedValue: [startValue, endValue]
-   *
-   * progressAnimatedValue: [0, 1] dragAnimatedValue: [0, +]
+   * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
+   * `translation`: translation of swipeable in pixels.
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
   renderLeftActions?: (
-    progressAnimatedValue: SharedValue<number>,
-    dragAnimatedValue: SharedValue<number>,
+    progress: SharedValue<number>,
+    translation: SharedValue<number>,
     swipeable: SwipeableMethods
   ) => React.ReactNode;
+
   /**
-   *
-   * This map describes the values to use as inputRange for extra interpolation:
-   * AnimatedValue: [startValue, endValue]
-   *
-   * progressAnimatedValue: [0, 1] dragAnimatedValue: [0, -]
+   * `progress`: Equals `0` when action is closed, `1` when action is open, linearly increases to `Infinity` as action overshoots it's open position.\
+   * `translation`: translation of swipeable in pixels.
    *
    * To support `rtl` flexbox layouts use `flexDirection` styling.
    * */
   renderRightActions?: (
-    progressAnimatedValue: SharedValue<number>,
-    dragAnimatedValue: SharedValue<number>,
+    progress: SharedValue<number>,
+    translation: SharedValue<number>,
     swipeable: SwipeableMethods
   ) => React.ReactNode;
 


### PR DESCRIPTION
## Description

Fixed the example provided with the `Reanimated Swipeable` docs, it looks like a fragment of it was missing.

Also, what's the verdict on [this issue](https://github.com/software-mansion/react-native-gesture-handler/pull/2962#discussion_r1666562893)?
Today I had to take a look at these docs again and it really occurred to me the way it's currently written can be really confusing.

Here's my proposition, it removes the `[0, +]` mapping in favour of a verbose explanation:

> ### `renderRightActions`
> 
> accepts a function.  
> The function receives the following arguments:
> 
> - `progress` value representing swiping progress relative to the width of the returned element.  
>   `progress` is `0` when `swipeable` is closed, `1` when `right` action is fully visible.
> 
> - `translation` horizontal translation of `swipeable` in pixels.
> - `swipeable` provides an object exposing the methods listed [here](#methods)
> 
> This function must return a `ReactNode`.

side-by-side comparison:
old|new
---|---
![image](https://github.com/user-attachments/assets/0ca633f3-05ce-4486-8310-d355183b7703)|![image](https://github.com/user-attachments/assets/07c9c647-0623-46d5-bce2-e48ee24cb70b)

Of course this change applies to both `renderLeftActions` and `renderRightActions` 