### PR TITLE
[macOS] Fix rotation

### DIFF
--- a/apple/Handlers/RNRotationHandler.m
+++ b/apple/Handlers/RNRotationHandler.m
@@ -149,7 +149,7 @@
 #if TARGET_OS_OSX
 - (RNGestureHandlerEventExtraData *)eventExtraData:(NSRotationGestureRecognizer *)recognizer
 {
-  return [RNGestureHandlerEventExtraData forRotation:recognizer.rotation
+  return [RNGestureHandlerEventExtraData forRotation:-recognizer.rotation
                                      withAnchorPoint:[recognizer locationInView:recognizer.view]
                                         withVelocity:((RNBetterRotationRecognizer *)recognizer).velocity
                                  withNumberOfTouches:2


### PR DESCRIPTION
## Description

Turns out that rotation on macOS works in opposite direction comparing to other platforms. This PR fixes that behavior.

## Test plan

<details>
<summary>Tested on the following code (check `rotation` value in event)</summary>

```tsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import { Gesture, GestureDetector } from 'react-native-gesture-handler';

export default function EmptyExample() {
  const g = Gesture.Rotation().onChange(console.log);
  return (
    <View style={styles.container}>
      <GestureDetector gesture={g}>
        <View style={{ width: 300, height: 300, backgroundColor: 'red' }} />
      </GestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
  },
});
```

</details>