### PR TITLE
[Web] Fix `KeyboardEventManager` listeners unmount

### DIFF
--- a/src/web/tools/KeyboardEventManager.ts
+++ b/src/web/tools/KeyboardEventManager.ts
@@ -57,8 +57,8 @@ export default class KeyboardEventManager extends EventManager<HTMLElement> {
   }
 
   public unregisterListeners(): void {
-    this.view.addEventListener('keydown', this.keyDownCallback);
-    this.view.addEventListener('keyup', this.keyUpCallback);
+    this.view.removeEventListener('keydown', this.keyDownCallback);
+    this.view.removeEventListener('keyup', this.keyUpCallback);
   }
 
   protected mapEvent(


### PR DESCRIPTION
## Description

For some reason `KeyboardEventManager` uses `addEventListener` inside `unregisterListeners` method. This PR changes it to `removeEventListener`, so that listeners are correctly removed from elements.

## Test plan

I've tested that on my branch with removing `findNodeHandle`, so... you can trust me since `PointerEventManager` uses [the same logic](https://github.com/software-mansion/react-native-gesture-handler/blob/10f1e0c69cc945d1b529326eee27583c87ca66c0/src/web/tools/PointerEventManager.ts#L190) 😄 