### PR TITLE
Rewrite `bottomSheet` example as functional component

### DIFF
--- a/example/src/showcase/bottomSheet/index.tsx
+++ b/example/src/showcase/bottomSheet/index.tsx
@@ -1,9 +1,14 @@
-import React, { Component } from 'react';
+import React, {
+  Component,
+  ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import {
   Animated,
   StyleSheet,
   View,
-  Dimensions,
   NativeSyntheticEvent,
   NativeScrollEvent,
 } from 'react-native';
@@ -19,103 +24,92 @@ import {
 import { LoremIpsum } from '../../common';
 import { USE_NATIVE_DRIVER } from '../../config';
 
-type BottomSheetState = {
-  lastSnap: number;
-};
-
 const HEADER_HEIGHT = 50;
-const windowHeight = Dimensions.get('window').height;
-const SNAP_POINTS_FROM_TOP = [50, windowHeight * 0.4, windowHeight * 0.8];
 
-export class BottomSheet extends Component<
-  Record<string, unknown>,
-  BottomSheetState
-> {
-  private masterdrawer = React.createRef<TapGestureHandler>();
-  private drawer = React.createRef<PanGestureHandler>();
-  private drawerheader = React.createRef<PanGestureHandler>();
-  private scroll = React.createRef<NativeViewGestureHandler>();
-  private lastScrollYValue: number;
-  private lastScrollY: Animated.Value;
-  private onRegisterLastScroll: (
+export function BottomSheet() {
+  let lastScrollYValue: number;
+  let lastScrollY: Animated.Value;
+  let dragY: Animated.Value;
+  let reverseLastScrollY: Animated.AnimatedMultiplication<number>;
+  let translateYOffset: Animated.Value;
+  let translateY: Animated.AnimatedInterpolation<number>;
+
+  const [screenHeight, setScreenHeight] = useState(HEADER_HEIGHT + 1);
+
+  let onGestureEvent: (event: PanGestureHandlerGestureEvent) => void;
+  let onRegisterLastScroll: (
     event: NativeSyntheticEvent<NativeScrollEvent>
   ) => void;
-  private dragY: Animated.Value;
-  private onGestureEvent: (event: PanGestureHandlerGestureEvent) => void;
-  private reverseLastScrollY: Animated.AnimatedMultiplication<number>;
-  private translateYOffset: Animated.Value;
-  private translateY: Animated.AnimatedInterpolation<number>;
-  constructor(props: Record<string, unknown>) {
-    super(props);
-    const START = SNAP_POINTS_FROM_TOP[0];
-    const END = SNAP_POINTS_FROM_TOP[SNAP_POINTS_FROM_TOP.length - 1];
 
-    this.state = {
-      lastSnap: END,
-    };
+  const snapPoints = [HEADER_HEIGHT, screenHeight * 0.4, screenHeight * 0.8];
 
-    this.lastScrollYValue = 0;
-    this.lastScrollY = new Animated.Value(0);
-    this.onRegisterLastScroll = Animated.event(
-      [{ nativeEvent: { contentOffset: { y: this.lastScrollY } } }],
-      { useNativeDriver: USE_NATIVE_DRIVER }
-    );
-    this.lastScrollY.addListener(({ value }) => {
-      this.lastScrollYValue = value;
-    });
+  const masterdrawer = useRef<TapGestureHandler>(null);
+  const drawer = useRef<PanGestureHandler>(null);
+  const drawerheader = useRef<PanGestureHandler>(null);
+  const scroll = useRef<NativeViewGestureHandler>(null);
 
-    this.dragY = new Animated.Value(0);
-    this.onGestureEvent = Animated.event(
-      [{ nativeEvent: { translationY: this.dragY } }],
-      { useNativeDriver: USE_NATIVE_DRIVER }
-    );
+  const startSnapPoint = snapPoints[0];
+  const endSnapPoint = snapPoints[snapPoints.length - 1];
 
-    this.reverseLastScrollY = Animated.multiply(
-      new Animated.Value(-1),
-      this.lastScrollY
-    );
+  const [lastSnap, setLastSnap] = useState(endSnapPoint);
 
-    this.translateYOffset = new Animated.Value(END);
-    this.translateY = Animated.add(
-      this.translateYOffset,
-      Animated.add(this.dragY, this.reverseLastScrollY)
-    ).interpolate({
-      inputRange: [START, END],
-      outputRange: [START, END],
-      extrapolate: 'clamp',
-    });
-  }
-  private onHeaderHandlerStateChange = ({
+  lastScrollYValue = 0;
+  lastScrollY = new Animated.Value(0);
+  onRegisterLastScroll = Animated.event(
+    [{ nativeEvent: { contentOffset: { y: lastScrollY } } }],
+    { useNativeDriver: USE_NATIVE_DRIVER }
+  );
+  lastScrollY.addListener(({ value }) => {
+    lastScrollYValue = value;
+  });
+
+  dragY = new Animated.Value(0);
+  onGestureEvent = Animated.event([{ nativeEvent: { translationY: dragY } }], {
+    useNativeDriver: USE_NATIVE_DRIVER,
+  });
+
+  reverseLastScrollY = Animated.multiply(new Animated.Value(-1), lastScrollY);
+
+  translateYOffset = new Animated.Value(endSnapPoint);
+  translateY = Animated.add(
+    translateYOffset,
+    Animated.add(dragY, reverseLastScrollY)
+  ).interpolate({
+    inputRange: [startSnapPoint, endSnapPoint],
+    outputRange: [startSnapPoint, endSnapPoint],
+    extrapolate: 'clamp',
+  });
+
+  const onHeaderHandlerStateChange = ({
     nativeEvent,
   }: PanGestureHandlerStateChangeEvent) => {
     if (nativeEvent.oldState === State.BEGAN) {
-      this.lastScrollY.setValue(0);
+      lastScrollY.setValue(0);
     }
-    this.onHandlerStateChange({ nativeEvent });
+    onHandlerStateChange({ nativeEvent });
   };
-  private onHandlerStateChange = ({
+  const onHandlerStateChange = ({
     nativeEvent,
   }: PanGestureHandlerStateChangeEvent) => {
     if (nativeEvent.oldState === State.ACTIVE) {
       let { velocityY, translationY } = nativeEvent;
-      translationY -= this.lastScrollYValue;
+      translationY -= lastScrollYValue;
       const dragToss = 0.05;
-      const endOffsetY =
-        this.state.lastSnap + translationY + dragToss * velocityY;
+      const endOffsetY = lastSnap + translationY + dragToss * velocityY;
 
-      let destSnapPoint = SNAP_POINTS_FROM_TOP[0];
-      for (const snapPoint of SNAP_POINTS_FROM_TOP) {
+      let destSnapPoint = snapPoints[0];
+      for (const snapPoint of snapPoints) {
         const distFromSnap = Math.abs(snapPoint - endOffsetY);
         if (distFromSnap < Math.abs(destSnapPoint - endOffsetY)) {
           destSnapPoint = snapPoint;
         }
       }
-      this.setState({ lastSnap: destSnapPoint });
-      this.translateYOffset.extractOffset();
-      this.translateYOffset.setValue(translationY);
-      this.translateYOffset.flattenOffset();
-      this.dragY.setValue(0);
-      Animated.spring(this.translateYOffset, {
+      setLastSnap(destSnapPoint);
+      translateYOffset.extractOffset();
+      translateYOffset.setValue(translationY);
+      translateYOffset.flattenOffset();
+      dragY.setValue(0);
+      Animated.spring(translateYOffset, {
         velocity: velocityY,
         tension: 68,
         friction: 12,
@@ -124,68 +118,75 @@ export class BottomSheet extends Component<
       }).start();
     }
   };
-  render() {
-    return (
-      <TapGestureHandler
-        maxDurationMs={100000}
-        ref={this.masterdrawer}
-        maxDeltaY={this.state.lastSnap - SNAP_POINTS_FROM_TOP[0]}>
-        <View style={StyleSheet.absoluteFillObject} pointerEvents="box-none">
-          <Animated.View
-            style={[
-              StyleSheet.absoluteFillObject,
-              {
-                transform: [{ translateY: this.translateY }],
-              },
-            ]}>
-            <PanGestureHandler
-              ref={this.drawerheader}
-              simultaneousHandlers={[this.scroll, this.masterdrawer]}
-              shouldCancelWhenOutside={false}
-              enableTrackpadTwoFingerGesture
-              onGestureEvent={this.onGestureEvent}
-              onHandlerStateChange={this.onHeaderHandlerStateChange}>
-              <Animated.View style={styles.header} />
-            </PanGestureHandler>
-            <PanGestureHandler
-              ref={this.drawer}
-              simultaneousHandlers={[this.scroll, this.masterdrawer]}
-              shouldCancelWhenOutside={false}
-              onGestureEvent={this.onGestureEvent}
-              enableTrackpadTwoFingerGesture
-              onHandlerStateChange={this.onHandlerStateChange}>
-              <Animated.View style={styles.container}>
-                <NativeViewGestureHandler
-                  ref={this.scroll}
-                  waitFor={this.masterdrawer}
-                  simultaneousHandlers={this.drawer}>
-                  <Animated.ScrollView
-                    style={{ marginBottom: SNAP_POINTS_FROM_TOP[0] }}
-                    bounces={false}
-                    onScrollBeginDrag={this.onRegisterLastScroll}
-                    scrollEventThrottle={1}>
-                    <LoremIpsum />
-                    <LoremIpsum />
-                    <LoremIpsum />
-                  </Animated.ScrollView>
-                </NativeViewGestureHandler>
-              </Animated.View>
-            </PanGestureHandler>
-          </Animated.View>
-        </View>
-      </TapGestureHandler>
-    );
-  }
-}
 
-export default class Example extends Component {
-  render() {
-    return (
-      <View style={styles.container}>
-        <BottomSheet />
+  const mainViewRef = useRef<View>(null);
+
+  useEffect(() => {
+    mainViewRef.current?.measure((_x, _y, _w, height) => {
+      setScreenHeight(height - HEADER_HEIGHT);
+    });
+  }, []);
+
+  return (
+    <TapGestureHandler
+      maxDurationMs={100000}
+      ref={masterdrawer}
+      maxDeltaY={lastSnap - snapPoints[0]}>
+      <View
+        style={StyleSheet.absoluteFillObject}
+        pointerEvents="box-none"
+        ref={mainViewRef}>
+        <Animated.View
+          style={[
+            StyleSheet.absoluteFillObject,
+            {
+              transform: [{ translateY: translateY }],
+            },
+          ]}>
+          <PanGestureHandler
+            ref={drawerheader}
+            simultaneousHandlers={[scroll, masterdrawer]}
+            shouldCancelWhenOutside={false}
+            enableTrackpadTwoFingerGesture
+            onGestureEvent={onGestureEvent}
+            onHandlerStateChange={onHeaderHandlerStateChange}>
+            <Animated.View style={styles.header} />
+          </PanGestureHandler>
+          <PanGestureHandler
+            ref={drawer}
+            simultaneousHandlers={[scroll, masterdrawer]}
+            shouldCancelWhenOutside={false}
+            onGestureEvent={onGestureEvent}
+            enableTrackpadTwoFingerGesture
+            onHandlerStateChange={onHandlerStateChange}>
+            <Animated.View style={styles.container}>
+              <NativeViewGestureHandler
+                ref={scroll}
+                waitFor={masterdrawer}
+                simultaneousHandlers={drawer}>
+                <Animated.ScrollView
+                  style={{ marginBottom: snapPoints[0] }}
+                  bounces={false}
+                  onScrollBeginDrag={onRegisterLastScroll}
+                  scrollEventThrottle={1}>
+                  <LoremIpsum />
+                  <LoremIpsum />
+                  <LoremIpsum />
+                </Animated.ScrollView>
+              </NativeViewGestureHandler>
+            </Animated.View>
+          </PanGestureHandler>
+        </Animated.View>
       </View>
-    );
-  }
+    </TapGestureHandler>
+  );
+}
+export default function Example() {
+  return (
+    <View style={styles.container}>
+      <BottomSheet />
+    </View>
+  );
 }
 
 const styles = StyleSheet.create({

--- a/example/src/showcase/bottomSheet/index.tsx
+++ b/example/src/showcase/bottomSheet/index.tsx
@@ -19,6 +19,7 @@ import {
   TapGestureHandler,
   PanGestureHandlerStateChangeEvent,
   PanGestureHandlerGestureEvent,
+  Gesture,
 } from 'react-native-gesture-handler';
 
 import { LoremIpsum } from '../../common';
@@ -34,13 +35,14 @@ export function BottomSheet() {
   let translateYOffset: Animated.Value;
   let translateY: Animated.AnimatedInterpolation<number>;
 
-  const [screenHeight, setScreenHeight] = useState(HEADER_HEIGHT + 1);
+  const [screenHeight, setScreenHeight] = useState(HEADER_HEIGHT / 0.4 + 1);
 
   let onGestureEvent: (event: PanGestureHandlerGestureEvent) => void;
   let onRegisterLastScroll: (
     event: NativeSyntheticEvent<NativeScrollEvent>
   ) => void;
 
+  console.log('screenHeight:', screenHeight);
   const snapPoints = [HEADER_HEIGHT, screenHeight * 0.4, screenHeight * 0.8];
 
   const masterdrawer = useRef<TapGestureHandler>(null);
@@ -123,9 +125,12 @@ export function BottomSheet() {
 
   useEffect(() => {
     mainViewRef.current?.measure((_x, _y, _w, height) => {
-      setScreenHeight(height - HEADER_HEIGHT);
+      console.log('height:', height);
+      if (height) {
+        setScreenHeight(height - HEADER_HEIGHT);
+      }
     });
-  }, []);
+  }, [mainViewRef]);
 
   return (
     <TapGestureHandler


### PR DESCRIPTION
## Description

Rewrite `bottomSheet` example to be a function style component, to fix crashes on macOS and make working with this example easier.

## Test plan

- open the `showcase/bottomSheet` example in the example app.
- see how it works like it did previously