### PR TITLE
Disable examples on unsupported platforms

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -86,7 +86,7 @@ import { Icon } from '@swmansion/icons';
 interface Example {
   name: string;
   component: React.ComponentType;
-  disabledOn?: Set<String>;
+  unsupportedPlatforms?: Set<String>;
 }
 interface ExamplesSection {
   sectionTitle: string;
@@ -135,12 +135,12 @@ const EXAMPLES: ExamplesSection[] = [
       {
         name: 'Pager & drawer',
         component: PagerAndDrawer,
-        disabledOn: new Set(['web', 'ios', 'macos']),
+        unsupportedPlatforms: new Set(['web', 'ios', 'macos']),
       },
       {
         name: 'Force touch',
         component: ForceTouch,
-        disabledOn: new Set(['web', 'android']),
+        unsupportedPlatforms: new Set(['web', 'android']),
       },
       { name: 'Fling', component: Fling },
     ],
@@ -182,7 +182,7 @@ const EXAMPLES: ExamplesSection[] = [
       {
         name: 'Nested buttons (sound & ripple)',
         component: NestedButtons,
-        disabledOn: new Set(['web', 'ios', 'macos']),
+        unsupportedPlatforms: new Set(['web', 'ios', 'macos']),
       },
       { name: 'Double pinch & rotate', component: DoublePinchRotate },
       { name: 'Double draggable', component: DoubleDraggable },
@@ -194,7 +194,7 @@ const EXAMPLES: ExamplesSection[] = [
       {
         name: 'ContextMenu',
         component: ContextMenu,
-        disabledOn: new Set(['android', 'ios', 'macos']),
+        unsupportedPlatforms: new Set(['android', 'ios', 'macos']),
       },
       { name: 'PointerType', component: PointerType },
       { name: 'Swipeable Reanimation', component: SwipeableReanimation },
@@ -203,7 +203,7 @@ const EXAMPLES: ExamplesSection[] = [
       {
         name: 'Web styles reset',
         component: WebStylesResetExample,
-        disabledOn: new Set(['android', 'ios', 'macos']),
+        unsupportedPlatforms: new Set(['android', 'ios', 'macos']),
       },
       { name: 'Stylus data', component: StylusData },
     ],
@@ -304,7 +304,7 @@ function MainScreen({ navigation }: StackScreenProps<ParamListBase>) {
           <MainScreenItem
             name={item.name}
             onPressItem={(name) => navigate(navigation, name)}
-            enabled={!item.disabledOn?.has(Platform.OS)}
+            enabled={!item.unsupportedPlatforms?.has(Platform.OS)}
           />
         )}
         renderSectionHeader={({ section: { sectionTitle } }) => (

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -361,10 +361,7 @@ function MainScreenItem({ name, onPressItem, enabled }: MainScreenItemProps) {
   return (
     <RectButton
       enabled={enabled}
-      style={[
-        styles.button,
-        !enabled && { backgroundColor: 'rgb(220, 220, 220)', opacity: 0.3 },
-      ]}
+      style={[styles.button, !enabled && styles.unavailableExample]}
       onPress={() => onPressItem(name)}>
       <Text style={styles.text}>{name}</Text>
       {Platform.OS !== 'macos' && enabled && (
@@ -432,5 +429,9 @@ const styles = StyleSheet.create({
           shadowRadius: 3.84,
         }
       : {}),
+  },
+  unavailableExample: {
+    backgroundColor: 'rgb(220, 220, 220)',
+    opacity: 0.3,
   },
 });

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -363,7 +363,7 @@ function MainScreenItem({ name, onPressItem, enabled }: MainScreenItemProps) {
       enabled={enabled}
       style={[
         styles.button,
-        !enabled && { backgroundColor: 'rgba(220, 220, 220, 0.8)' },
+        !enabled && { backgroundColor: 'rgb(220, 220, 220)', opacity: 0.3 },
       ]}
       onPress={() => onPressItem(name)}>
       <Text style={styles.text}>{name}</Text>

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -86,7 +86,7 @@ import { Icon } from '@swmansion/icons';
 interface Example {
   name: string;
   component: React.ComponentType;
-  unsupportedPlatforms?: Set<String>;
+  unsupportedPlatforms?: Set<typeof Platform.OS>;
 }
 interface ExamplesSection {
   sectionTitle: string;

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -140,7 +140,7 @@ const EXAMPLES: ExamplesSection[] = [
       {
         name: 'Force touch',
         component: ForceTouch,
-        unsupportedPlatforms: new Set(['web', 'android']),
+        unsupportedPlatforms: new Set(['web', 'android', 'macos']),
       },
       { name: 'Fling', component: Fling },
     ],

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -86,6 +86,7 @@ import { Icon } from '@swmansion/icons';
 interface Example {
   name: string;
   component: React.ComponentType;
+  disabledOn?: Set<String>;
 }
 interface ExamplesSection {
   sectionTitle: string;
@@ -131,8 +132,16 @@ const EXAMPLES: ExamplesSection[] = [
       { name: 'Bouncing box', component: BouncingBox },
       { name: 'Pan responder', component: PanResponder },
       { name: 'Horizontal drawer', component: HorizontalDrawer },
-      { name: 'Pager & drawer', component: PagerAndDrawer },
-      { name: 'Force touch', component: ForceTouch },
+      {
+        name: 'Pager & drawer',
+        component: PagerAndDrawer,
+        disabledOn: new Set(['web', 'ios', 'macos']),
+      },
+      {
+        name: 'Force touch',
+        component: ForceTouch,
+        disabledOn: new Set(['web', 'android']),
+      },
       { name: 'Fling', component: Fling },
     ],
   },
@@ -171,8 +180,9 @@ const EXAMPLES: ExamplesSection[] = [
         component: NestedPressables as React.ComponentType,
       },
       {
-        name: 'Nested buttons (sound & ripple on Android)',
+        name: 'Nested buttons (sound & ripple)',
         component: NestedButtons,
+        disabledOn: new Set(['web', 'ios', 'macos']),
       },
       { name: 'Double pinch & rotate', component: DoublePinchRotate },
       { name: 'Double draggable', component: DoubleDraggable },
@@ -181,12 +191,20 @@ const EXAMPLES: ExamplesSection[] = [
       { name: 'Combo', component: ComboWithGHScroll },
       { name: 'Touchables', component: TouchablesIndex as React.ComponentType },
       { name: 'MouseButtons', component: MouseButtons },
-      { name: 'ContextMenu (web only)', component: ContextMenu },
+      {
+        name: 'ContextMenu',
+        component: ContextMenu,
+        disabledOn: new Set(['android', 'ios', 'macos']),
+      },
       { name: 'PointerType', component: PointerType },
       { name: 'Swipeable Reanimation', component: SwipeableReanimation },
       { name: 'RectButton (borders)', component: RectButtonBorders },
       { name: 'Gesturized pressable', component: GesturizedPressable },
-      { name: 'Web styles reset', component: WebStylesResetExample },
+      {
+        name: 'Web styles reset',
+        component: WebStylesResetExample,
+        disabledOn: new Set(['android', 'ios', 'macos']),
+      },
       { name: 'Stylus data', component: StylusData },
     ],
   },
@@ -286,6 +304,7 @@ function MainScreen({ navigation }: StackScreenProps<ParamListBase>) {
           <MainScreenItem
             name={item.name}
             onPressItem={(name) => navigate(navigation, name)}
+            enabled={!item.disabledOn?.has(Platform.OS)}
           />
         )}
         renderSectionHeader={({ section: { sectionTitle } }) => (
@@ -335,13 +354,20 @@ function OpenLastExampleSetting() {
 interface MainScreenItemProps {
   name: string;
   onPressItem: (name: string) => void;
+  enabled: boolean;
 }
 
-function MainScreenItem({ name, onPressItem }: MainScreenItemProps) {
+function MainScreenItem({ name, onPressItem, enabled }: MainScreenItemProps) {
   return (
-    <RectButton style={[styles.button]} onPress={() => onPressItem(name)}>
+    <RectButton
+      enabled={enabled}
+      style={[
+        styles.button,
+        !enabled && { backgroundColor: 'rgba(220, 220, 220, 0.8)' },
+      ]}
+      onPress={() => onPressItem(name)}>
       <Text style={styles.text}>{name}</Text>
-      {Platform.OS !== 'macos' && (
+      {Platform.OS !== 'macos' && enabled && (
         <Icon name="chevron-small-right" size={24} color="#bbb" />
       )}
     </RectButton>


### PR DESCRIPTION
## Description

Some of our examples are platform-specific, which means that running them on other platforms doesn't make much sense. In this PR I've disabled navigation buttons so that opening such examples is not possible on unsupported platforms.

E.g.: _**Web styles reset**_ works only on `web`. After this PR you'll no longer be able to open it on other platforms, like `ios` or `android`.

<img width="329" alt="image" src="https://github.com/user-attachments/assets/847b25b0-d305-4787-ad24-aca399811a5a">

## Test plan

Go through example app