### PR TITLE
Remove redundant example entry in `App.tsx`

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -109,7 +109,7 @@ const EXAMPLES: ExamplesSection[] = [
       { name: 'Chat Heads', component: ChatHeadsNewApi },
       { name: 'Drag and drop', component: DragNDrop },
       { name: 'New Swipeable', component: Swipeable },
-      { name: 'New Pressable', component: Pressable },
+      { name: 'Pressable', component: Pressable },
       { name: 'Hover', component: Hover },
       { name: 'Hoverable icons', component: HoverableIcons },
       {

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -120,7 +120,6 @@ const EXAMPLES: ExamplesSection[] = [
         name: 'Manual gestures',
         component: ManualGestures,
       },
-      { name: 'Pressable', component: Pressable },
     ],
   },
   {


### PR DESCRIPTION
## Description

There are 2 `Pressable` entries, likely as a result of merge conflicts which occurred between these two PRs:

[Update examples](https://github.com/software-mansion/react-native-gesture-handler/pull/2919/files) and [Make osx example utilise the common example app](https://github.com/software-mansion/react-native-gesture-handler/pull/3055)