### PR TITLE
[Web] Simplify `PointerTracker` methods

### DIFF
--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -337,26 +337,13 @@ export default class GestureHandlerOrchestrator {
     const isPointerWithinBothBounds = (pointer: number) => {
       const point = handler.getTracker().getLastAbsoluteCoords(pointer);
 
-      // In some rare cases it may happen that this method will be called before handler
-      // has started tracking pointers. When it happens, `point` will be undefined, leading to
-      // silent fail
-      if (!point) {
-        return false;
-      }
-
       return (
         handler.getDelegate().isPointerInBounds(point) &&
         otherHandler.getDelegate().isPointerInBounds(point)
       );
     };
 
-    const handlerPointers: number[] = handler.getTrackedPointersID();
-    const otherPointers: number[] = otherHandler.getTrackedPointersID();
-
-    return (
-      handlerPointers.some(isPointerWithinBothBounds) ||
-      otherPointers.some(isPointerWithinBothBounds)
-    );
+    return handler.getTrackedPointersID().some(isPointerWithinBothBounds);
   }
 
   private isFinished(state: State): boolean {

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -337,6 +337,13 @@ export default class GestureHandlerOrchestrator {
     const isPointerWithinBothBounds = (pointer: number) => {
       const point = handler.getTracker().getLastAbsoluteCoords(pointer);
 
+      // In some rare cases it may happen that this method will be called before handler
+      // has started tracking pointers. When it happens, `point` will be undefined, leading to
+      // silent fail
+      if (!point) {
+        return false;
+      }
+
       return (
         handler.getDelegate().isPointerInBounds(point) &&
         otherHandler.getDelegate().isPointerInBounds(point)

--- a/src/web/tools/PointerTracker.ts
+++ b/src/web/tools/PointerTracker.ts
@@ -22,8 +22,8 @@ export default class PointerTracker {
 
   private lastMovedPointerId: number;
 
-  private cachedAbsoluteAverages: { x: number; y: number } = { x: 0, y: 0 };
-  private cachedRelativeAverages: { x: number; y: number } = { x: 0, y: 0 };
+  private cachedAbsoluteAverages: Point = { x: 0, y: 0 };
+  private cachedRelativeAverages: Point = { x: 0, y: 0 };
 
   public constructor() {
     this.lastMovedPointerId = NaN;

--- a/src/web/tools/PointerTracker.ts
+++ b/src/web/tools/PointerTracker.ts
@@ -121,35 +121,13 @@ export default class PointerTracker {
   }
 
   public getLastAbsoluteCoords(pointerId?: number) {
-    if (pointerId !== undefined) {
-      return {
-        x: this.trackedPointers.get(pointerId)?.abosoluteCoords.x as number,
-        y: this.trackedPointers.get(pointerId)?.abosoluteCoords.y as number,
-      };
-    } else {
-      return {
-        x: this.trackedPointers.get(this.lastMovedPointerId)?.abosoluteCoords
-          .x as number,
-        y: this.trackedPointers.get(this.lastMovedPointerId)?.abosoluteCoords
-          .y as number,
-      };
-    }
+    return this.trackedPointers.get(pointerId ?? this.lastMovedPointerId)
+      ?.abosoluteCoords as Point;
   }
 
   public getLastRelativeCoords(pointerId?: number) {
-    if (pointerId !== undefined) {
-      return {
-        x: this.trackedPointers.get(pointerId)?.relativeCoords.x as number,
-        y: this.trackedPointers.get(pointerId)?.relativeCoords.y as number,
-      };
-    } else {
-      return {
-        x: this.trackedPointers.get(this.lastMovedPointerId)?.relativeCoords
-          .x as number,
-        y: this.trackedPointers.get(this.lastMovedPointerId)?.relativeCoords
-          .y as number,
-      };
-    }
+    return this.trackedPointers.get(pointerId ?? this.lastMovedPointerId)
+      ?.relativeCoords as Point;
   }
 
   // Some handlers use these methods to send average values in native event.


### PR DESCRIPTION
## Description

This PR simplifies some methods found in `PointerTracker`. I've also found a little bug which was not caught because of how 
`tracker` worked before. 


## Test plan

Verified on example app (mostly `Draggable`/`Double Draggable` examples)
