### PR TITLE
[MacOS] Fix `Pressable` being unresponsive

### DIFF
--- a/apple/RNGestureHandlerPointerTracker.m
+++ b/apple/RNGestureHandlerPointerTracker.m
@@ -72,7 +72,7 @@
 {
 #if TARGET_OS_OSX
   CGPoint absolutePos = [touch locationInWindow];
-  CGPoint relativePos = [touch.window.contentView convertPoint:absolutePos fromView:_gestureHandler.recognizer.view];
+  CGPoint relativePos = [_gestureHandler.recognizer.view convertPoint:absolutePos fromView:touch.window.contentView];
 #else
   CGPoint relativePos = [touch locationInView:_gestureHandler.recognizer.view];
   CGPoint absolutePos = [touch locationInView:_gestureHandler.recognizer.view.window];

--- a/apple/RNGestureHandlerPointerTracker.m
+++ b/apple/RNGestureHandlerPointerTracker.m
@@ -71,7 +71,7 @@
 - (NSDictionary *)extractPointerData:(int)index forTouch:(RNGHUITouch *)touch
 {
 #if TARGET_OS_OSX
-  CGFloat windowHeight = touch.window.frame.size.height;
+  CGFloat windowHeight = touch.window.contentView.frame.size.height;
   CGPoint yFlippedAbsolutePos = [touch locationInWindow];
   CGPoint absolutePos = CGPointMake(yFlippedAbsolutePos.x, windowHeight - yFlippedAbsolutePos.y);
   CGPoint relativePos = [_gestureHandler.recognizer.view convertPoint:absolutePos fromView:touch.window.contentView];

--- a/apple/RNGestureHandlerPointerTracker.m
+++ b/apple/RNGestureHandlerPointerTracker.m
@@ -71,7 +71,9 @@
 - (NSDictionary *)extractPointerData:(int)index forTouch:(RNGHUITouch *)touch
 {
 #if TARGET_OS_OSX
-  CGPoint absolutePos = [touch locationInWindow];
+  CGFloat windowHeight = touch.window.frame.size.height;
+  CGPoint yFlippedAbsolutePos = [touch locationInWindow];
+  CGPoint absolutePos = CGPointMake(yFlippedAbsolutePos.x, windowHeight - yFlippedAbsolutePos.y);
   CGPoint relativePos = [_gestureHandler.recognizer.view convertPoint:absolutePos fromView:touch.window.contentView];
 #else
   CGPoint relativePos = [touch locationInView:_gestureHandler.recognizer.view];

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -302,7 +302,7 @@ export default function Pressable(props: PressableProps) {
       Gesture.Native()
         .onBegin(() => {
           // Android sets BEGAN state on press down
-          if (Platform.OS === 'android') {
+          if (Platform.OS === 'android' || Platform.OS === 'macos') {
             isTouchPropagationAllowed.current = true;
           }
         })
@@ -358,10 +358,10 @@ export default function Pressable(props: PressableProps) {
     gesture.enabled(isPressableEnabled);
     gesture.runOnJS(true);
     gesture.hitSlop(appliedHitSlop);
-    gesture.shouldCancelWhenOutside(false);
+    gesture.shouldCancelWhenOutside(true);
 
-    if (Platform.OS !== 'web') {
-      gesture.shouldCancelWhenOutside(true);
+    if (Platform.OS === 'web') {
+      gesture.shouldCancelWhenOutside(false);
     }
   }
 

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -358,11 +358,7 @@ export default function Pressable(props: PressableProps) {
     gesture.enabled(isPressableEnabled);
     gesture.runOnJS(true);
     gesture.hitSlop(appliedHitSlop);
-    gesture.shouldCancelWhenOutside(true);
-
-    if (Platform.OS === 'web') {
-      gesture.shouldCancelWhenOutside(false);
-    }
+    gesture.shouldCancelWhenOutside(Platform.OS === 'web' ? false : true);
   }
 
   // Uses different hitSlop, to activate on hitSlop area instead of pressRetentionOffset area


### PR DESCRIPTION
## Description

This PR fixes incorrect `Pressable` behaviour on `MacOS`, which was caused by the following sub-issues:

- Pointer tracker on `MacOS` kept returning incorrect relative coordinates.
This was caused by converting the `absolute` coordinates from the `local` coordinate space to the `absolute` coordinate space instead of the other way around.

- There was no workflow set on the `Gesture.Native()` to allow for activation of `Pressable`

## Test plan

- Open any `Pressable` example on `MacOS`
- See how they all should work now.