### PR TITLE
Fix swipeable swiping to left when no `renderRightActions` is set

### DIFF
--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -230,7 +230,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const rowWidth = useSharedValue<number>(0);
     const leftWidth = useSharedValue<number>(0);
     const rightWidth = useSharedValue<number>(0);
-    const rightOffset = useSharedValue<number>(0);
+    const rightOffset = useSharedValue<number | null>(null);
 
     const leftActionTranslate = useSharedValue<number>(0);
     const rightActionTranslate = useSharedValue<number>(0);
@@ -266,19 +266,29 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const overshootLeftProp = overshootLeft;
     const overshootRightProp = overshootRight;
 
+    const updateRightElementWidth = () => {
+      'worklet';
+      if (rightOffset.value === null) {
+        rightOffset.value = rowWidth.value;
+      }
+      rightWidth.value = Math.max(0, rowWidth.value - rightOffset.value);
+    };
+
     const calculateCurrentOffset = useCallback(() => {
       'worklet';
+      updateRightElementWidth();
       if (rowState.value === 1) {
         return leftWidth.value;
       } else if (rowState.value === -1) {
-        return -rowWidth.value - rightOffset.value;
+        return -rowWidth.value - rightOffset.value!;
       }
       return 0;
     }, [leftWidth, rightOffset, rowState, rowWidth]);
 
     const updateAnimatedEvent = () => {
       'worklet';
-      rightWidth.value = Math.max(0, rowWidth.value - rightOffset.value);
+
+      updateRightElementWidth();
 
       const overshootLeft = overshootLeftProp ?? leftWidth.value > 0;
       const overshootRight = overshootRightProp ?? rightWidth.value > 0;
@@ -446,7 +456,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       },
       openRight() {
         'worklet';
-        rightWidth.value = rowWidth.value - rightOffset.value;
         animateRow(calculateCurrentOffset(), -rightWidth.value);
       },
       reset() {
@@ -520,7 +529,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       const { velocityX } = event;
       userDrag.value = event.translationX;
 
-      rightWidth.value = rowWidth.value - rightOffset.value;
+      updateRightElementWidth();
 
       const leftThreshold = leftThresholdProp ?? leftWidth.value / 2;
       const rightThreshold = rightThresholdProp ?? rightWidth.value / 2;

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -277,12 +277,11 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const calculateCurrentOffset = useCallback(() => {
       'worklet';
       updateRightElementWidth();
-      if (rowState.value === 1) {
-        return leftWidth.value;
-      } else if (rowState.value === -1) {
-        return -rowWidth.value - rightOffset.value!;
-      }
-      return 0;
+      return rowState.value === 1
+        ? leftWidth.value
+        : rowState.value === -1
+        ? -rowWidth.value - rightOffset.value!
+        : 0;
     }, [leftWidth, rightOffset, rowState, rowWidth]);
 
     const updateAnimatedEvent = () => {


### PR DESCRIPTION
## Description

Fixed `Swipeable` being able to be opened to the left when no right element is present.
This was caused by incorrectly set `rightOffset`, equal to `0` when no elements were present, even though it should've been set to `rowWidth`

## Test plan

- Open any swipeable example in the example app
- Remove the `renderRightActions` prop
- See how before this fix, `Swipeable` could've still been opened to the left, and now it can't be.