### PR TITLE
[`ReanimatedSwipeable`] Multiple bug fixes and improvements

### DIFF
--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -80,16 +80,6 @@ Receives swipe direction as an argument.
 a function that is called when `swipeable` starts animating on close.
 Receives swipe direction as an argument.
 
-### `onSwipeableOpenStartDrag`
-
-a function that is called when `swipeable` starts being dragged open.
-Receives swipe direction as an argument.
-
-### `onSwipeableCloseStartDrag`
-
-a function that is called when `swipeable` starts being dragged close.
-Receives swipe direction as an argument.
-
 ### `renderLeftActions`
 
 a function that returns a component which will be rendered under the swipeable after swiping it to the right.

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -80,6 +80,16 @@ Receives swipe direction as an argument.
 a function that is called when `swipeable` starts animating on close.
 Receives swipe direction as an argument.
 
+### `onSwipeableOpenStartDrag`
+
+a function that is called when `swipeable` starts being dragged open.
+Receives swipe direction as an argument.
+
+### `onSwipeableCloseStartDrag`
+
+a function that is called when `swipeable` starts being dragged close.
+Receives swipe direction as an argument.
+
 ### `renderLeftActions`
 
 a function that returns a component which will be rendered under the swipeable after swiping it to the right.

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -340,13 +340,13 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     const dispatchImmediateEvents = useCallback(
       (fromValue: number, toValue: number) => {
-        if (toValue > 0 && onSwipeableWillOpen) {
-          onSwipeableWillOpen('left');
-        } else if (toValue < 0 && onSwipeableWillOpen) {
-          onSwipeableWillOpen('right');
-        } else if (onSwipeableWillClose) {
-          const closingDirection = fromValue > 0 ? 'left' : 'right';
-          onSwipeableWillClose(closingDirection);
+        if (toValue > 0) {
+          onSwipeableWillOpen && onSwipeableWillOpen('left');
+        } else if (toValue < 0) {
+          onSwipeableWillOpen && onSwipeableWillOpen('right');
+        } else {
+          const closingDirection = fromValue > 0 ? 'left' : 'right'; // this is invalid too
+          onSwipeableWillClose && onSwipeableWillClose(closingDirection);
         }
       },
       [onSwipeableWillClose, onSwipeableWillOpen]
@@ -354,13 +354,14 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     const dispatchEndEvents = useCallback(
       (fromValue: number, toValue: number) => {
-        if (toValue > 0 && onSwipeableOpen) {
-          onSwipeableOpen('left', swipeableMethods.current);
-        } else if (toValue < 0 && onSwipeableOpen) {
-          onSwipeableOpen('right', swipeableMethods.current);
-        } else if (onSwipeableClose) {
-          const closingDirection = fromValue > 0 ? 'left' : 'right';
-          onSwipeableClose(closingDirection, swipeableMethods.current);
+        if (toValue > 0) {
+          onSwipeableOpen && onSwipeableOpen('left', swipeableMethods.current);
+        } else if (toValue < 0) {
+          onSwipeableOpen && onSwipeableOpen('right', swipeableMethods.current);
+        } else {
+          const closingDirection = fromValue > 0 ? 'left' : 'right'; // this is invalid too
+          onSwipeableClose &&
+            onSwipeableClose(closingDirection, swipeableMethods.current);
         }
       },
       [onSwipeableClose, onSwipeableOpen]

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -279,16 +279,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const overshootLeftProp = overshootLeft;
     const overshootRightProp = overshootRight;
 
-    const calculateCurrentOffset = useCallback(() => {
-      'worklet';
-      if (rowState.value === 1) {
-        return leftWidth.value;
-      } else if (rowState.value === -1) {
-        return -rowWidth.value - rightOffset.value;
-      }
-      return 0;
-    }, [leftWidth, rightOffset, rowState, rowWidth]);
-
     const updateAnimatedEvent = () => {
       'worklet';
       rightWidth.value = Math.max(0, rowWidth.value - rightOffset.value);
@@ -385,7 +375,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const animationOptionsProp = animationOptions;
 
     const animateRow = useCallback(
-      (_fromValue: number, toValue: number, velocityX?: number) => {
+      (toValue: number, velocityX?: number) => {
         'worklet';
 
         const translationSpringConfig = {
@@ -472,16 +462,16 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     swipeableMethods.current = {
       close() {
         'worklet';
-        animateRow(calculateCurrentOffset(), 0);
+        animateRow(0);
       },
       openLeft() {
         'worklet';
-        animateRow(calculateCurrentOffset(), leftWidth.value);
+        animateRow(leftWidth.value);
       },
       openRight() {
         'worklet';
         rightWidth.value = rowWidth.value - rightOffset.value;
-        animateRow(calculateCurrentOffset(), -rightWidth.value);
+        animateRow(-rightWidth.value);
       },
       reset() {
         'worklet';
@@ -559,7 +549,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       const leftThreshold = leftThresholdProp ?? leftWidth.value / 2;
       const rightThreshold = rightThresholdProp ?? rightWidth.value / 2;
 
-      const startOffsetX = calculateCurrentOffset() + userDrag.value / friction;
       const translationX = (userDrag.value + DRAG_TOSS * velocityX) / friction;
 
       let toValue = 0;
@@ -582,12 +571,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         }
       }
 
-      animateRow(startOffsetX, toValue, velocityX / friction);
+      animateRow(toValue, velocityX / friction);
     };
 
     const close = () => {
       'worklet';
-      animateRow(calculateCurrentOffset(), 0);
+      animateRow(0);
     };
 
     const tapGesture = Gesture.Tap().onStart(() => {

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -345,7 +345,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         } else if (toValue < 0) {
           onSwipeableWillOpen && onSwipeableWillOpen('right');
         } else {
-          const closingDirection = fromValue > 0 ? 'left' : 'right'; // this is invalid too
+          const closingDirection = fromValue > 0 ? 'left' : 'right';
           onSwipeableWillClose && onSwipeableWillClose(closingDirection);
         }
       },
@@ -359,7 +359,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         } else if (toValue < 0) {
           onSwipeableOpen && onSwipeableOpen('right', swipeableMethods.current);
         } else {
-          const closingDirection = fromValue > 0 ? 'left' : 'right'; // this is invalid too
+          const closingDirection = fromValue > 0 ? 'left' : 'right';
           onSwipeableClose &&
             onSwipeableClose(closingDirection, swipeableMethods.current);
         }
@@ -370,7 +370,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const animationOptionsProp = animationOptions;
 
     const animateRow = useCallback(
-      (fromValue: number, toValue: number, velocityX?: number) => {
+      (_fromValue: number, toValue: number, velocityX?: number) => {
         'worklet';
 
         const translationSpringConfig = {
@@ -402,12 +402,14 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             interpolate(velocityX, [-usedWidth, usedWidth], [-1, 1]),
         };
 
+        const frozenRowState = rowState.value;
+
         appliedTranslation.value = withSpring(
           toValue,
           translationSpringConfig,
           (isFinished) => {
             if (isFinished) {
-              runOnJS(dispatchEndEvents)(fromValue, toValue);
+              runOnJS(dispatchEndEvents)(frozenRowState, toValue);
             }
           }
         );
@@ -423,7 +425,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             ? withSpring(progressTarget, progressSpringConfig)
             : 0;
 
-        runOnJS(dispatchImmediateEvents)(fromValue, toValue);
+        runOnJS(dispatchImmediateEvents)(frozenRowState, toValue);
 
         rowState.value = Math.sign(toValue);
       },

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -585,8 +585,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       }
     });
 
-    const dragStarted = useSharedValue<boolean>(false);
-
     const panGesture = Gesture.Pan()
       .onUpdate((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
         userDrag.value = event.translationX;
@@ -600,23 +598,18 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             ? SwipeDirection.RIGHT
             : SwipeDirection.LEFT;
 
-        if (dragStarted.value === false) {
-          dragStarted.value = true;
-          if (rowState.value === 0 && onSwipeableOpenStartDrag) {
-            runOnJS(onSwipeableOpenStartDrag)(direction);
-          } else if (rowState.value !== 0 && onSwipeableCloseStartDrag) {
-            runOnJS(onSwipeableCloseStartDrag)(direction);
-          }
+        if (rowState.value === 0 && onSwipeableOpenStartDrag) {
+          runOnJS(onSwipeableOpenStartDrag)(direction);
+        } else if (rowState.value !== 0 && onSwipeableCloseStartDrag) {
+          runOnJS(onSwipeableCloseStartDrag)(direction);
         }
-
         updateAnimatedEvent();
       })
       .onEnd(
         (event: GestureStateChangeEvent<PanGestureHandlerEventPayload>) => {
           handleRelease(event);
         }
-      )
-      .onFinalize(() => (dragStarted.value = false));
+      );
 
     if (enableTrackpadTwoFingerGesture) {
       panGesture.enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture);

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -358,9 +358,9 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         } else if (toValue < 0) {
           onSwipeableWillOpen?.(SwipeDirection.LEFT);
         } else {
-          const closingDirection =
-            fromValue > 0 ? SwipeDirection.LEFT : SwipeDirection.RIGHT;
-          onSwipeableWillClose?.(closingDirection);
+          onSwipeableWillClose?.(
+            fromValue > 0 ? SwipeDirection.LEFT : SwipeDirection.RIGHT
+          );
         }
       },
       [onSwipeableWillClose, onSwipeableWillOpen]
@@ -373,9 +373,10 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         } else if (toValue < 0) {
           onSwipeableOpen?.(SwipeDirection.LEFT, swipeableMethods.current);
         } else {
-          const closingDirection =
-            fromValue > 0 ? SwipeDirection.LEFT : SwipeDirection.RIGHT;
-          onSwipeableClose?.(closingDirection, swipeableMethods.current);
+          onSwipeableClose?.(
+            fromValue > 0 ? SwipeDirection.LEFT : SwipeDirection.RIGHT,
+            swipeableMethods.current
+          );
         }
       },
       [onSwipeableClose, onSwipeableOpen]

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -341,12 +341,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const dispatchImmediateEvents = useCallback(
       (fromValue: number, toValue: number) => {
         if (toValue > 0) {
-          onSwipeableWillOpen && onSwipeableWillOpen('right');
+          onSwipeableWillOpen?.('right');
         } else if (toValue < 0) {
-          onSwipeableWillOpen && onSwipeableWillOpen('left');
+          onSwipeableWillOpen?.('left');
         } else {
           const closingDirection = fromValue > 0 ? 'left' : 'right';
-          onSwipeableWillClose && onSwipeableWillClose(closingDirection);
+          onSwipeableWillClose?.(closingDirection);
         }
       },
       [onSwipeableWillClose, onSwipeableWillOpen]
@@ -355,13 +355,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const dispatchEndEvents = useCallback(
       (fromValue: number, toValue: number) => {
         if (toValue > 0) {
-          onSwipeableOpen && onSwipeableOpen('right', swipeableMethods.current);
+          onSwipeableOpen?.('right', swipeableMethods.current);
         } else if (toValue < 0) {
-          onSwipeableOpen && onSwipeableOpen('left', swipeableMethods.current);
+          onSwipeableOpen?.('left', swipeableMethods.current);
         } else {
           const closingDirection = fromValue > 0 ? 'left' : 'right';
-          onSwipeableClose &&
-            onSwipeableClose(closingDirection, swipeableMethods.current);
+          onSwipeableClose?.(closingDirection, swipeableMethods.current);
         }
       },
       [onSwipeableClose, onSwipeableOpen]
@@ -596,7 +595,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             ? 'right'
             : 'left';
 
-        if (dragStarted.value == false) {
+        if (dragStarted.value === false) {
           dragStarted.value = true;
           if (rowState.value === 0 && onSwipeableOpenStartDrag) {
             runOnJS(onSwipeableOpenStartDrag)(direction);

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -591,8 +591,8 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             : rowState.value === 1
             ? 'left'
             : event.translationX > 0
-            ? 'left'
-            : 'right';
+            ? 'right'
+            : 'left';
 
         if (rowState.value === 0 && onSwipeableOpenStartDrag) {
           runOnJS(onSwipeableOpenStartDrag)(direction);

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -372,7 +372,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const animateRow = useCallback(
       (fromValue: number, toValue: number, velocityX?: number) => {
         'worklet';
-        rowState.value = Math.sign(toValue);
 
         const translationSpringConfig = {
           duration: 1000,
@@ -383,13 +382,24 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           ...animationOptionsProp,
         };
 
+        const isClosing = toValue === 0;
+        const moveToRight = isClosing ? rowState.value < 0 : toValue > 0;
+
+        const usedWidth = isClosing
+          ? moveToRight
+            ? rightWidth.value
+            : leftWidth.value
+          : moveToRight
+          ? leftWidth.value
+          : rightWidth.value;
+
         const progressSpringConfig = {
           ...translationSpringConfig,
           restDisplacementThreshold: 0.01,
           restSpeedThreshold: 0.01,
           velocity:
             velocityX &&
-            interpolate(velocityX, [-rowWidth.value, rowWidth.value], [-1, 1]),
+            interpolate(velocityX, [-usedWidth, usedWidth], [-1, 1]),
         };
 
         appliedTranslation.value = withSpring(
@@ -414,6 +424,8 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             : 0;
 
         runOnJS(dispatchImmediateEvents)(fromValue, toValue);
+
+        rowState.value = Math.sign(toValue);
       },
       [
         rowState,

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -111,7 +111,7 @@ export interface SwipeableProps
    * Called when action panel gets open (either right or left).
    */
   onSwipeableOpen?: (
-    direction: 'left' | 'right',
+    direction: SwipeDirection.LEFT | SwipeDirection.RIGHT,
     swipeable: SwipeableMethods
   ) => void;
 
@@ -119,29 +119,37 @@ export interface SwipeableProps
    * Called when action panel is closed.
    */
   onSwipeableClose?: (
-    direction: 'left' | 'right',
+    direction: SwipeDirection.LEFT | SwipeDirection.RIGHT,
     swipeable: SwipeableMethods
   ) => void;
 
   /**
    * Called when action panel starts animating on open (either right or left).
    */
-  onSwipeableWillOpen?: (direction: 'left' | 'right') => void;
+  onSwipeableWillOpen?: (
+    direction: SwipeDirection.LEFT | SwipeDirection.RIGHT
+  ) => void;
 
   /**
    * Called when action panel starts animating on close.
    */
-  onSwipeableWillClose?: (direction: 'left' | 'right') => void;
+  onSwipeableWillClose?: (
+    direction: SwipeDirection.LEFT | SwipeDirection.RIGHT
+  ) => void;
 
   /**
    * Called when action panel starts being shown on dragging to open.
    */
-  onSwipeableOpenStartDrag?: (direction: 'left' | 'right') => void;
+  onSwipeableOpenStartDrag?: (
+    direction: SwipeDirection.LEFT | SwipeDirection.RIGHT
+  ) => void;
 
   /**
    * Called when action panel starts being shown on dragging to close.
    */
-  onSwipeableCloseStartDrag?: (direction: 'left' | 'right') => void;
+  onSwipeableCloseStartDrag?: (
+    direction: SwipeDirection.LEFT | SwipeDirection.RIGHT
+  ) => void;
 
   /**
    * `progress`: Equals `0` when `swipeable` is closed, `1` when `swipeable` is opened.
@@ -195,6 +203,11 @@ export interface SwipeableMethods {
   openLeft: () => void;
   openRight: () => void;
   reset: () => void;
+}
+
+enum SwipeDirection {
+  LEFT = 'left',
+  RIGHT = 'right',
 }
 
 const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
@@ -341,11 +354,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const dispatchImmediateEvents = useCallback(
       (fromValue: number, toValue: number) => {
         if (toValue > 0) {
-          onSwipeableWillOpen?.('right');
+          onSwipeableWillOpen?.(SwipeDirection.RIGHT);
         } else if (toValue < 0) {
-          onSwipeableWillOpen?.('left');
+          onSwipeableWillOpen?.(SwipeDirection.LEFT);
         } else {
-          const closingDirection = fromValue > 0 ? 'left' : 'right';
+          const closingDirection =
+            fromValue > 0 ? SwipeDirection.LEFT : SwipeDirection.RIGHT;
           onSwipeableWillClose?.(closingDirection);
         }
       },
@@ -355,11 +369,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const dispatchEndEvents = useCallback(
       (fromValue: number, toValue: number) => {
         if (toValue > 0) {
-          onSwipeableOpen?.('right', swipeableMethods.current);
+          onSwipeableOpen?.(SwipeDirection.RIGHT, swipeableMethods.current);
         } else if (toValue < 0) {
-          onSwipeableOpen?.('left', swipeableMethods.current);
+          onSwipeableOpen?.(SwipeDirection.LEFT, swipeableMethods.current);
         } else {
-          const closingDirection = fromValue > 0 ? 'left' : 'right';
+          const closingDirection =
+            fromValue > 0 ? SwipeDirection.LEFT : SwipeDirection.RIGHT;
           onSwipeableClose?.(closingDirection, swipeableMethods.current);
         }
       },
@@ -588,12 +603,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
         const direction =
           rowState.value === -1
-            ? 'right'
+            ? SwipeDirection.RIGHT
             : rowState.value === 1
-            ? 'left'
+            ? SwipeDirection.LEFT
             : event.translationX > 0
-            ? 'right'
-            : 'left';
+            ? SwipeDirection.RIGHT
+            : SwipeDirection.LEFT;
 
         if (dragStarted.value === false) {
           dragStarted.value = true;

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -581,6 +581,8 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       }
     });
 
+    const dragStarted = useSharedValue<boolean>(false);
+
     const panGesture = Gesture.Pan()
       .onUpdate((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
         userDrag.value = event.translationX;
@@ -594,18 +596,23 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             ? 'right'
             : 'left';
 
-        if (rowState.value === 0 && onSwipeableOpenStartDrag) {
-          runOnJS(onSwipeableOpenStartDrag)(direction);
-        } else if (rowState.value !== 0 && onSwipeableCloseStartDrag) {
-          runOnJS(onSwipeableCloseStartDrag)(direction);
+        if (dragStarted.value == false) {
+          dragStarted.value = true;
+          if (rowState.value === 0 && onSwipeableOpenStartDrag) {
+            runOnJS(onSwipeableOpenStartDrag)(direction);
+          } else if (rowState.value !== 0 && onSwipeableCloseStartDrag) {
+            runOnJS(onSwipeableCloseStartDrag)(direction);
+          }
         }
+
         updateAnimatedEvent();
       })
       .onEnd(
         (event: GestureStateChangeEvent<PanGestureHandlerEventPayload>) => {
           handleRelease(event);
         }
-      );
+      )
+      .onFinalize(() => (dragStarted.value = false));
 
     if (enableTrackpadTwoFingerGesture) {
       panGesture.enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture);

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -341,9 +341,9 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const dispatchImmediateEvents = useCallback(
       (fromValue: number, toValue: number) => {
         if (toValue > 0) {
-          onSwipeableWillOpen && onSwipeableWillOpen('left');
-        } else if (toValue < 0) {
           onSwipeableWillOpen && onSwipeableWillOpen('right');
+        } else if (toValue < 0) {
+          onSwipeableWillOpen && onSwipeableWillOpen('left');
         } else {
           const closingDirection = fromValue > 0 ? 'left' : 'right';
           onSwipeableWillClose && onSwipeableWillClose(closingDirection);
@@ -355,9 +355,9 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const dispatchEndEvents = useCallback(
       (fromValue: number, toValue: number) => {
         if (toValue > 0) {
-          onSwipeableOpen && onSwipeableOpen('left', swipeableMethods.current);
-        } else if (toValue < 0) {
           onSwipeableOpen && onSwipeableOpen('right', swipeableMethods.current);
+        } else if (toValue < 0) {
+          onSwipeableOpen && onSwipeableOpen('left', swipeableMethods.current);
         } else {
           const closingDirection = fromValue > 0 ? 'left' : 'right';
           onSwipeableClose &&

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -42,6 +42,11 @@ type SwipeableExcludes = Exclude<
   'onGestureEvent' | 'onHandlerStateChange'
 >;
 
+enum SwipeDirection {
+  LEFT = 'left',
+  RIGHT = 'right',
+}
+
 export interface SwipeableProps
   extends Pick<PanGestureHandlerProps, SwipeableExcludes> {
   /**
@@ -203,11 +208,6 @@ export interface SwipeableMethods {
   openLeft: () => void;
   openRight: () => void;
   reset: () => void;
-}
-
-enum SwipeDirection {
-  LEFT = 'left',
-  RIGHT = 'right',
 }
 
 const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -340,13 +340,13 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     const dispatchImmediateEvents = useCallback(
       (fromValue: number, toValue: number) => {
-        if (toValue > 0 && onSwipeableWillOpen) {
-          onSwipeableWillOpen('left');
-        } else if (toValue < 0 && onSwipeableWillOpen) {
-          onSwipeableWillOpen('right');
-        } else if (onSwipeableWillClose) {
-          const closingDirection = fromValue > 0 ? 'left' : 'right';
-          onSwipeableWillClose(closingDirection);
+        if (toValue > 0) {
+          onSwipeableWillOpen && onSwipeableWillOpen('left');
+        } else if (toValue < 0) {
+          onSwipeableWillOpen && onSwipeableWillOpen('right');
+        } else {
+          const closingDirection = fromValue > 0 ? 'left' : 'right'; // this is invalid too
+          onSwipeableWillClose && onSwipeableWillClose(closingDirection);
         }
       },
       [onSwipeableWillClose, onSwipeableWillOpen]
@@ -354,13 +354,14 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     const dispatchEndEvents = useCallback(
       (fromValue: number, toValue: number) => {
-        if (toValue > 0 && onSwipeableOpen) {
-          onSwipeableOpen('left', swipeableMethods.current);
-        } else if (toValue < 0 && onSwipeableOpen) {
-          onSwipeableOpen('right', swipeableMethods.current);
-        } else if (onSwipeableClose) {
-          const closingDirection = fromValue > 0 ? 'left' : 'right';
-          onSwipeableClose(closingDirection, swipeableMethods.current);
+        if (toValue > 0) {
+          onSwipeableOpen && onSwipeableOpen('left', swipeableMethods.current);
+        } else if (toValue < 0) {
+          onSwipeableOpen && onSwipeableOpen('right', swipeableMethods.current);
+        } else {
+          const closingDirection = fromValue > 0 ? 'left' : 'right'; // this is invalid too
+          onSwipeableClose &&
+            onSwipeableClose(closingDirection, swipeableMethods.current);
         }
       },
       [onSwipeableClose, onSwipeableOpen]
@@ -371,7 +372,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const animateRow = useCallback(
       (fromValue: number, toValue: number, velocityX?: number) => {
         'worklet';
-        rowState.value = Math.sign(toValue);
 
         const translationSpringConfig = {
           duration: 1000,
@@ -382,14 +382,34 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           ...animationOptionsProp,
         };
 
+        const isClosing = toValue === 0;
+        const moveToRight = toValue > fromValue; // this can't be used
+
+        // fromValue = always current person value
+        // toValue = always 0 | leftWidth | rightWidth
+
+        const usedWidth = isClosing
+          ? moveToRight
+            ? rightWidth.value
+            : leftWidth.value
+          : moveToRight
+          ? leftWidth.value
+          : rightWidth.value;
+
+        console.log(
+          `(${fromValue}) -> (${toValue}) \n\tusedWidth(${usedWidth}), \n\tisClosing(${isClosing}), \n\tmoveToRight(${moveToRight}), \n\tlefterWidth(${leftWidth.value}), \n\trighterWidth(${rightWidth.value})`
+        );
+
         const progressSpringConfig = {
           ...translationSpringConfig,
           restDisplacementThreshold: 0.01,
           restSpeedThreshold: 0.01,
           velocity:
             velocityX &&
-            interpolate(velocityX, [-rowWidth.value, rowWidth.value], [-1, 1]),
+            interpolate(velocityX, [-usedWidth, usedWidth], [-1, 1]),
         };
+
+        rowState.value = Math.sign(toValue); // move accordingly
 
         appliedTranslation.value = withSpring(
           toValue,

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -384,7 +384,11 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
         const progressSpringConfig = {
           ...translationSpringConfig,
-          velocity: 0,
+          restDisplacementThreshold: 0.01,
+          restSpeedThreshold: 0.01,
+          velocity:
+            velocityX &&
+            interpolate(velocityX, [-rowWidth.value, rowWidth.value], [-1, 1]),
         };
 
         appliedTranslation.value = withSpring(


### PR DESCRIPTION
## Description

This PR applies multiple bug fixes and improvements to the `ReanimatedSwipeable`

### Changes:

- Fix reversed swipe direction being supplied to `open` and `willOpen` callbacks.
- Fix `startDrag` callbacks receiving invalid `direction` when opening swipeable.
- Fix unpredictable swipe direction being supplied to `close` and `willClose` callbacks.
- Fix `onSwipeableWillClose` and `onSwipeableClose` callbacks sometimes being called on open.
- Fix `progress` value skipping last `10%` of it's range and having a delay relative to the `translation`.  
  closes #3147

## Test plan

Will create an example showcasing outputs of all the affected callbacks, work in progress.
