### PR TITLE
Add missing `ReanimatedSwipeable` documentation

### DIFF
--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -82,12 +82,12 @@ Receives swipe direction as an argument.
 
 ### `onSwipeableOpenStartDrag`
 
-a function that is called when `swipeable` starts being dragged open.
+a function that is called when a user starts to drag the `swipable` to open.
 Receives swipe direction as an argument.
 
 ### `onSwipeableCloseStartDrag`
 
-a function that is called when `swipeable` starts being dragged close.
+a function that is called when a user starts to drag the `swipable` to close.
 Receives swipe direction as an argument.
 
 ### `renderLeftActions`

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -80,6 +80,16 @@ Receives swipe direction as an argument.
 a function that is called when `swipeable` starts animating on close.
 Receives swipe direction as an argument.
 
+### `onSwipeableOpenStartDrag`
+
+a function that is called when `swipeable` starts being dragged open.
+Receives swipe direction as an argument.
+
+### `onSwipeableCloseStartDrag`
+
+a function that is called when `swipeable` starts being dragged close.
+Receives swipe direction as an argument.
+
 ### `renderLeftActions`
 
 a function that returns a component which will be rendered under the swipeable after swiping it to the right.


### PR DESCRIPTION
## Description

Add missing documentation for `onSwipeableOpenStartDrag` and `onSwipeableOpenStartDrag` callbacks of `ReanimatedSwipeable`

Moved from #3149