### PR TITLE
Fix `onStart` callbacks of `ReanimatedSwipeable` being called every update

### DIFF
--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -577,7 +577,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             ? 'left'
             : 'right';
 
-        if (dragStarted.value === false) {
+        if (!dragStarted.value) {
           dragStarted.value = true;
           if (rowState.value === 0 && onSwipeableOpenStartDrag) {
             runOnJS(onSwipeableOpenStartDrag)(direction);
@@ -593,7 +593,9 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           handleRelease(event);
         }
       )
-      .onFinalize(() => (dragStarted.value = false));
+      .onFinalize(() => {
+        dragStarted.value = false;
+      });
 
     if (enableTrackpadTwoFingerGesture) {
       panGesture.enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture);

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -562,6 +562,8 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       }
     });
 
+    const dragStarted = useSharedValue<boolean>(false);
+
     const panGesture = Gesture.Pan()
       .onUpdate((event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
         userDrag.value = event.translationX;
@@ -575,18 +577,23 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             ? 'left'
             : 'right';
 
-        if (rowState.value === 0 && onSwipeableOpenStartDrag) {
-          runOnJS(onSwipeableOpenStartDrag)(direction);
-        } else if (rowState.value !== 0 && onSwipeableCloseStartDrag) {
-          runOnJS(onSwipeableCloseStartDrag)(direction);
+        if (dragStarted.value === false) {
+          dragStarted.value = true;
+          if (rowState.value === 0 && onSwipeableOpenStartDrag) {
+            runOnJS(onSwipeableOpenStartDrag)(direction);
+          } else if (rowState.value !== 0 && onSwipeableCloseStartDrag) {
+            runOnJS(onSwipeableCloseStartDrag)(direction);
+          }
         }
+
         updateAnimatedEvent();
       })
       .onEnd(
         (event: GestureStateChangeEvent<PanGestureHandlerEventPayload>) => {
           handleRelease(event);
         }
-      );
+      )
+      .onFinalize(() => (dragStarted.value = false));
 
     if (enableTrackpadTwoFingerGesture) {
       panGesture.enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture);


### PR DESCRIPTION
## Description

Fix `onStart` callbacks of `ReanimatedSwipeable` being called every update.

Moved from #3149

## Test plan

- open `Swipeable Reanimation` example
- replace the `ReanimatedSwipeable` component with the following code:
```js
<ReanimatedSwipeable
  containerStyle={styles.swipeable}
  onSwipeableOpenStartDrag={(direction) => console.log(direction)}
  onSwipeableCloseStartDrag={(direction) => console.log(direction)}>
  <Text>Swipeable!</Text>
</ReanimatedSwipeable>
```
- see how only one update is sent to the console, while before this PR new updates were constantly generated