### PR TITLE
[web] Add support for two finger pan

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -213,7 +213,7 @@ const EXAMPLES: ExamplesSection[] = [
       {
         name: 'Two finger Pan',
         component: TwoFingerPan,
-        unsupportedPlatforms: new Set(['android', 'macos', 'ios']),
+        unsupportedPlatforms: new Set(['android', 'macos']),
       },
     ],
   },

--- a/example/App.tsx
+++ b/example/App.tsx
@@ -39,6 +39,7 @@ import NestedButtons from './src/release_tests/nestedButtons';
 import PointerType from './src/release_tests/pointerType';
 import SwipeableReanimation from './src/release_tests/swipeableReanimation';
 import NestedGestureHandlerRootViewWithModal from './src/release_tests/nestedGHRootViewWithModal';
+import TwoFingerPan from 'src/release_tests/twoFingerPan';
 import { PinchableBox } from './src/recipes/scaleAndRotate';
 import PanAndScroll from './src/recipes/panAndScroll';
 import { BottomSheet } from './src/showcase/bottomSheet';
@@ -209,6 +210,11 @@ const EXAMPLES: ExamplesSection[] = [
         unsupportedPlatforms: new Set(['android', 'ios', 'macos']),
       },
       { name: 'Stylus data', component: StylusData },
+      {
+        name: 'Two finger Pan',
+        component: TwoFingerPan,
+        unsupportedPlatforms: new Set(['android', 'macos', 'ios']),
+      },
     ],
   },
   {

--- a/example/src/release_tests/twoFingerPan/index.tsx
+++ b/example/src/release_tests/twoFingerPan/index.tsx
@@ -1,0 +1,61 @@
+import { StyleSheet, View } from 'react-native';
+import Animated, {
+  SharedValue,
+  useAnimatedStyle,
+  useSharedValue,
+} from 'react-native-reanimated';
+
+import React from 'react';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+
+const BOX_SIZE = 270;
+
+export default function TwoFingerPan() {
+  const r = useSharedValue(128);
+  const b = useSharedValue(128);
+
+  const clampColor = (sv: SharedValue<number>) =>
+    sv.value < 0 ? 0 : sv.value > 255 ? 255 : sv.value;
+
+  const pan = Gesture.Pan()
+    .onChange((event) => {
+      r.value -= event.changeY;
+      b.value += event.changeX;
+
+      r.value = clampColor(r);
+      b.value = clampColor(b);
+
+      console.table({ red: r.value, blue: b.value });
+    })
+    .enableTrackpadTwoFingerGesture(true);
+
+  const animatedStyles = useAnimatedStyle(() => {
+    const backgroundColor = `rgb(${r.value}, 128, ${b.value})`;
+
+    return {
+      backgroundColor,
+    };
+  });
+
+  return (
+    <View style={styles.container} collapsable={false}>
+      <GestureDetector gesture={pan}>
+        <Animated.View style={[styles.box, animatedStyles]} />
+      </GestureDetector>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    height: '100%',
+  },
+  box: {
+    width: BOX_SIZE,
+    height: BOX_SIZE,
+    borderRadius: BOX_SIZE / 2,
+  },
+});

--- a/example/src/release_tests/twoFingerPan/index.tsx
+++ b/example/src/release_tests/twoFingerPan/index.tsx
@@ -10,20 +10,16 @@ import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
 const BOX_SIZE = 270;
 
+const clampColor = (v: number) => Math.min(255, Math.max(0, v));
+
 export default function TwoFingerPan() {
   const r = useSharedValue(128);
   const b = useSharedValue(128);
 
-  const clampColor = (sv: SharedValue<number>) =>
-    sv.value < 0 ? 0 : sv.value > 255 ? 255 : sv.value;
-
   const pan = Gesture.Pan()
     .onChange((event) => {
-      r.value -= event.changeY;
-      b.value += event.changeX;
-
-      r.value = clampColor(r);
-      b.value = clampColor(b);
+      r.value = clampColor(r.value - event.changeY);
+      b.value = clampColor(b.value + event.changeX);
 
       console.table({ red: r.value, blue: b.value });
     })

--- a/example/src/release_tests/twoFingerPan/index.tsx
+++ b/example/src/release_tests/twoFingerPan/index.tsx
@@ -19,9 +19,8 @@ export default function TwoFingerPan() {
     .onChange((event) => {
       r.value = clampColor(r.value - event.changeY);
       b.value = clampColor(b.value + event.changeX);
-
-      console.table({ red: r.value, blue: b.value });
     })
+    .runOnJS(true)
     .enableTrackpadTwoFingerGesture(true);
 
   const animatedStyles = useAnimatedStyle(() => {

--- a/example/src/release_tests/twoFingerPan/index.tsx
+++ b/example/src/release_tests/twoFingerPan/index.tsx
@@ -1,6 +1,5 @@
 import { StyleSheet, View } from 'react-native';
 import Animated, {
-  SharedValue,
   useAnimatedStyle,
   useSharedValue,
 } from 'react-native-reanimated';

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -74,6 +74,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     manager.setOnPointerOutOfBounds(this.onPointerOutOfBounds.bind(this));
     manager.setOnPointerMoveOver(this.onPointerMoveOver.bind(this));
     manager.setOnPointerMoveOut(this.onPointerMoveOut.bind(this));
+    manager.setOnWheel(this.onWheel.bind(this));
 
     manager.registerListeners();
   }
@@ -338,7 +339,10 @@ export default abstract class GestureHandler implements IGestureHandler {
   protected onPointerMoveOut(_event: AdaptedEvent): void {
     // Used only by hover gesture handler atm
   }
-  private tryToSendMoveEvent(out: boolean, event: AdaptedEvent): void {
+  protected onWheel(_event: AdaptedEvent): void {
+    // Used only by pan gesture handler
+  }
+  protected tryToSendMoveEvent(out: boolean, event: AdaptedEvent): void {
     if ((out && this.shouldCancelWhenOutside) || !this.enabled) {
       return;
     }

--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -57,6 +57,7 @@ export default class PanGestureHandler extends GestureHandler {
   private activateAfterLongPress = 0;
   private activationTimeout = 0;
 
+  private enableTrackpadTwoFingerGesture = false;
   private receivedWheelEvent = false;
   private endWheelTimeout = 0;
   private wheelDevice = WheelDevice.UNDETERMINED;
@@ -164,6 +165,11 @@ export default class PanGestureHandler extends GestureHandler {
       if (this.config.failOffsetYStart === undefined) {
         this.failOffsetYStart = Number.MIN_SAFE_INTEGER;
       }
+    }
+
+    if (this.config.enableTrackpadTwoFingerGesture !== undefined) {
+      this.enableTrackpadTwoFingerGesture =
+        this.config.enableTrackpadTwoFingerGesture;
     }
   }
 
@@ -372,7 +378,10 @@ export default class PanGestureHandler extends GestureHandler {
   }
 
   protected onWheel(event: AdaptedEvent): void {
-    if (this.wheelDevice === WheelDevice.MOUSE) {
+    if (
+      this.wheelDevice === WheelDevice.MOUSE ||
+      !this.enableTrackpadTwoFingerGesture
+    ) {
       return;
     }
 

--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -58,7 +58,6 @@ export default class PanGestureHandler extends GestureHandler {
   private activationTimeout = 0;
 
   private enableTrackpadTwoFingerGesture = false;
-  private receivedWheelEvent = false;
   private endWheelTimeout = 0;
   private wheelDevice = WheelDevice.UNDETERMINED;
 
@@ -362,19 +361,17 @@ export default class PanGestureHandler extends GestureHandler {
   }
 
   private scheduleWheelEnd(event: AdaptedEvent) {
-    this.endWheelTimeout = setTimeout(() => {
-      if (this.receivedWheelEvent) {
-        return;
-      }
+    clearTimeout(this.endWheelTimeout);
 
-      this.end();
-      this.tracker.removeFromTracker(event.pointerId);
-      this.currentState = State.UNDETERMINED;
+    this.endWheelTimeout = setTimeout(() => {
+      if (this.currentState === State.ACTIVE) {
+        this.end();
+        this.tracker.removeFromTracker(event.pointerId);
+        this.currentState = State.UNDETERMINED;
+      }
 
       this.wheelDevice = WheelDevice.UNDETERMINED;
     }, 30);
-
-    this.receivedWheelEvent = false;
   }
 
   protected onWheel(event: AdaptedEvent): void {
@@ -384,9 +381,6 @@ export default class PanGestureHandler extends GestureHandler {
     ) {
       return;
     }
-
-    this.receivedWheelEvent = true;
-    clearTimeout(this.endWheelTimeout);
 
     if (this.currentState === State.UNDETERMINED) {
       this.wheelDevice =

--- a/src/web/interfaces.ts
+++ b/src/web/interfaces.ts
@@ -78,6 +78,7 @@ export interface Config extends Record<string, ConfigArgs> {
   shouldActivateOnStart?: boolean;
   disallowInterruption?: boolean;
   direction?: Directions;
+  enableTrackpadTwoFingerGesture?: boolean;
 }
 
 type NativeEventArgs = number | State | boolean | undefined;

--- a/src/web/interfaces.ts
+++ b/src/web/interfaces.ts
@@ -151,6 +151,7 @@ export interface AdaptedEvent {
   time: number;
   button?: MouseButton;
   stylusData?: StylusData;
+  wheelDeltaY?: number;
 }
 
 export enum EventTypes {
@@ -170,4 +171,10 @@ export enum TouchEventType {
   MOVE,
   UP,
   CANCELLED,
+}
+
+export enum WheelDevice {
+  UNDETERMINED,
+  MOUSE,
+  TOUCHPAD,
 }

--- a/src/web/tools/EventManager.ts
+++ b/src/web/tools/EventManager.ts
@@ -37,6 +37,7 @@ export default abstract class EventManager<T> {
   protected onPointerOutOfBounds(_event: AdaptedEvent): void {}
   protected onPointerMoveOver(_event: AdaptedEvent): void {}
   protected onPointerMoveOut(_event: AdaptedEvent): void {}
+  protected onWheel(_event: AdaptedEvent): void {}
 
   public setOnPointerDown(callback: PointerEventCallback): void {
     this.onPointerDown = callback;
@@ -70,6 +71,9 @@ export default abstract class EventManager<T> {
   }
   public setOnPointerMoveOut(callback: PointerEventCallback): void {
     this.onPointerMoveOut = callback;
+  }
+  public setOnWheel(callback: PointerEventCallback): void {
+    this.onWheel = callback;
   }
 
   protected markAsInBounds(pointerId: number): void {

--- a/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/src/web/tools/GestureHandlerWebDelegate.ts
@@ -11,6 +11,7 @@ import EventManager from './EventManager';
 import { Config } from '../interfaces';
 import { MouseButton } from '../../handlers/gestureHandlerCommon';
 import KeyboardEventManager from './KeyboardEventManager';
+import WheelEventManager from './WheelEventManager';
 
 interface DefaultViewStyles {
   userSelect: string;
@@ -58,6 +59,7 @@ export class GestureHandlerWebDelegate
 
     this.eventManagers.push(new PointerEventManager(this.view));
     this.eventManagers.push(new KeyboardEventManager(this.view));
+    this.eventManagers.push(new WheelEventManager(this.view));
 
     this.eventManagers.forEach((manager) =>
       this.gestureHandler.attachEventManager(manager)

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -178,8 +178,6 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
   };
 
   private onWheelCallback = (event: WheelEvent) => {
-    event.preventDefault();
-
     this.wheelDelta.x += event.deltaX;
     this.wheelDelta.y += event.deltaY;
 

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -15,6 +15,10 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();
   private readonly mouseButtonsMapper = new Map<number, MouseButton>();
   private lastPosition: Point;
+  private wheelDelta = {
+    x: 0,
+    y: 0,
+  };
 
   constructor(view: HTMLElement) {
     super(view);
@@ -82,6 +86,10 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
   };
 
   private pointerMoveCallback = (event: PointerEvent) => {
+    this.wheelDelta = {
+      x: 0,
+      y: 0,
+    };
     const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.MOVE);
     const target = event.target as HTMLElement;
 
@@ -169,6 +177,16 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     }
   };
 
+  private onWheelCallback = (event: WheelEvent) => {
+    event.preventDefault();
+
+    this.wheelDelta.x += event.deltaX;
+    this.wheelDelta.y += event.deltaY;
+
+    const adaptedEvent = this.mapEvent(event, EventTypes.MOVE);
+    this.onWheel(adaptedEvent);
+  };
+
   public registerListeners(): void {
     this.view.addEventListener('pointerdown', this.pointerDownCallback);
     this.view.addEventListener('pointerup', this.pointerUpCallback);
@@ -185,6 +203,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       'lostpointercapture',
       this.lostPointerCaptureCallback
     );
+    this.view.addEventListener('wheel', this.onWheelCallback);
   }
 
   public unregisterListeners(): void {
@@ -200,7 +219,16 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     );
   }
 
-  protected mapEvent(event: PointerEvent, eventType: EventTypes): AdaptedEvent {
+  protected mapEvent(
+    event: PointerEvent | WheelEvent,
+    eventType: EventTypes
+  ): AdaptedEvent {
+    return event instanceof PointerEvent
+      ? this.mapPointerEvent(event, eventType)
+      : this.mapWheelEvent(event);
+  }
+
+  private mapPointerEvent(event: PointerEvent, eventType: EventTypes) {
     const rect = this.view.getBoundingClientRect();
     const { scaleX, scaleY } = calculateViewScale(this.view);
 
@@ -216,6 +244,21 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       button: this.mouseButtonsMapper.get(event.button),
       time: event.timeStamp,
       stylusData: tryExtractStylusData(event),
+    };
+  }
+
+  private mapWheelEvent(event: WheelEvent): AdaptedEvent {
+    return {
+      x: event.clientX + this.wheelDelta.x,
+      y: event.clientY + this.wheelDelta.y,
+      offsetX: event.offsetX - event.deltaX,
+      offsetY: event.offsetY - event.deltaY,
+      pointerId: -1,
+      eventType: EventTypes.MOVE,
+      pointerType: PointerType.OTHER,
+      time: event.timeStamp,
+      // @ts-ignore It does exist, but it's deprecated
+      wheelDeltaY: event.wheelDeltaY,
     };
   }
 

--- a/src/web/tools/PointerEventManager.ts
+++ b/src/web/tools/PointerEventManager.ts
@@ -15,10 +15,6 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();
   private readonly mouseButtonsMapper = new Map<number, MouseButton>();
   private lastPosition: Point;
-  private wheelDelta = {
-    x: 0,
-    y: 0,
-  };
 
   constructor(view: HTMLElement) {
     super(view);
@@ -86,10 +82,6 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
   };
 
   private pointerMoveCallback = (event: PointerEvent) => {
-    this.wheelDelta = {
-      x: 0,
-      y: 0,
-    };
     const adaptedEvent: AdaptedEvent = this.mapEvent(event, EventTypes.MOVE);
     const target = event.target as HTMLElement;
 
@@ -177,14 +169,6 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     }
   };
 
-  private onWheelCallback = (event: WheelEvent) => {
-    this.wheelDelta.x += event.deltaX;
-    this.wheelDelta.y += event.deltaY;
-
-    const adaptedEvent = this.mapEvent(event, EventTypes.MOVE);
-    this.onWheel(adaptedEvent);
-  };
-
   public registerListeners(): void {
     this.view.addEventListener('pointerdown', this.pointerDownCallback);
     this.view.addEventListener('pointerup', this.pointerUpCallback);
@@ -201,7 +185,6 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       'lostpointercapture',
       this.lostPointerCaptureCallback
     );
-    this.view.addEventListener('wheel', this.onWheelCallback);
   }
 
   public unregisterListeners(): void {
@@ -217,16 +200,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     );
   }
 
-  protected mapEvent(
-    event: PointerEvent | WheelEvent,
-    eventType: EventTypes
-  ): AdaptedEvent {
-    return event instanceof PointerEvent
-      ? this.mapPointerEvent(event, eventType)
-      : this.mapWheelEvent(event);
-  }
-
-  private mapPointerEvent(event: PointerEvent, eventType: EventTypes) {
+  protected mapEvent(event: PointerEvent, eventType: EventTypes): AdaptedEvent {
     const rect = this.view.getBoundingClientRect();
     const { scaleX, scaleY } = calculateViewScale(this.view);
 
@@ -242,21 +216,6 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       button: this.mouseButtonsMapper.get(event.button),
       time: event.timeStamp,
       stylusData: tryExtractStylusData(event),
-    };
-  }
-
-  private mapWheelEvent(event: WheelEvent): AdaptedEvent {
-    return {
-      x: event.clientX + this.wheelDelta.x,
-      y: event.clientY + this.wheelDelta.y,
-      offsetX: event.offsetX - event.deltaX,
-      offsetY: event.offsetY - event.deltaY,
-      pointerId: -1,
-      eventType: EventTypes.MOVE,
-      pointerType: PointerType.OTHER,
-      time: event.timeStamp,
-      // @ts-ignore It does exist, but it's deprecated
-      wheelDeltaY: event.wheelDeltaY,
     };
   }
 

--- a/src/web/tools/WheelEventManager.ts
+++ b/src/web/tools/WheelEventManager.ts
@@ -1,0 +1,48 @@
+import EventManager from './EventManager';
+import { AdaptedEvent, EventTypes } from '../interfaces';
+import { PointerType } from '../../PointerType';
+
+export default class WheelEventManager extends EventManager<HTMLElement> {
+  private wheelDelta = { x: 0, y: 0 };
+
+  private resetDelta = (_event: PointerEvent) => {
+    this.wheelDelta = { x: 0, y: 0 };
+  };
+
+  private wheelCallback = (event: WheelEvent) => {
+    this.wheelDelta.x += event.deltaX;
+    this.wheelDelta.y += event.deltaY;
+
+    const adaptedEvent = this.mapEvent(event);
+    this.onWheel(adaptedEvent);
+  };
+
+  public registerListeners(): void {
+    this.view.addEventListener('pointermove', this.resetDelta);
+    this.view.addEventListener('wheel', this.wheelCallback);
+  }
+
+  public unregisterListeners(): void {
+    this.view.removeEventListener('pointermove', this.resetDelta);
+    this.view.removeEventListener('wheel', this.wheelCallback);
+  }
+
+  protected mapEvent(event: WheelEvent): AdaptedEvent {
+    return {
+      x: event.clientX + this.wheelDelta.x,
+      y: event.clientY + this.wheelDelta.y,
+      offsetX: event.offsetX - event.deltaX,
+      offsetY: event.offsetY - event.deltaY,
+      pointerId: -1,
+      eventType: EventTypes.MOVE,
+      pointerType: PointerType.OTHER,
+      time: event.timeStamp,
+      // @ts-ignore It does exist, but it's deprecated
+      wheelDeltaY: event.wheelDeltaY,
+    };
+  }
+
+  public resetManager(): void {
+    super.resetManager();
+  }
+}


### PR DESCRIPTION
## Description

This PR adds support for two finger panning on touchpad on `web`.

>[!WARNING]
> Two finger gestures may be used as system/browser gestures (for example `swipe` to go back). This PR doesn't handle these cases.

## Implementation

Implementation is based on [WheelEvents](https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event). This leads to some limitations - whole state flow of `Pan` has to be managed inside one callback (`onWheel`).

### Ending gesture

Starting gesture is easy, in contrast to ending it. To finish gesture we use `timeout`  - if no `wheel event` was received since `setTimeout` was called, we can end gesture. 

### `Mouse` vs `Touchpad`

It is hard to determine whether `mouse` or `touchpad` was used to start the gesture. `WheelEvent` doesn't have any information about the device, therefore we have to use heuristics to check that. 

>[!NOTE]
> You cannot start gesture with mouse scroll.

To see if events were generated with mouse, we check whether `wheelDeltaY` property (which is now [deprecated](https://developer.mozilla.org/en-US/docs/Web/API/Element/wheel_event#event_properties)) of event is multiple of `120`. In short, this is standard `wheel delta` for mouse. Here you can find useful links that will tell more about why it works:

- https://stackoverflow.com/questions/10744645/detect-touchpad-vs-mouse-in-javascript
- https://devblogs.microsoft.com/oldnewthing/20130123-00/?p=5473  

>[!CAUTION]
> While this will work most of the times, it is possible that user will somehow generate this specific `wheel delta` with touchpad and gesture will not be recognized correctly.

Closes #800

## Test plan

Tested on new _**Two finger Pan**_ example
