### PR TITLE
fix: Android event dispatcher change for 0.76.0-rc.6

### DIFF
--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -16,7 +16,7 @@
     "patch-package": "^6.5.0",
     "postinstall-postinstall": "^2.1.0",
     "react": "18.3.1",
-    "react-native": "0.76.0-rc.2",
+    "react-native": "0.76.0-rc.6",
     "react-native-gesture-handler": "link:../"
   },
   "devDependencies": {
@@ -26,10 +26,10 @@
     "@react-native-community/cli": "15.0.0-alpha.2",
     "@react-native-community/cli-platform-android": "15.0.0-alpha.2",
     "@react-native-community/cli-platform-ios": "15.0.0-alpha.2",
-    "@react-native/babel-preset": "0.76.0-rc.2",
-    "@react-native/eslint-config": "0.76.0-rc.2",
-    "@react-native/metro-config": "0.76.0-rc.2",
-    "@react-native/typescript-config": "0.76.0-rc.2",
+    "@react-native/babel-preset": "0.76.0-rc.6",
+    "@react-native/eslint-config": "0.76.0-rc.6",
+    "@react-native/metro-config": "0.76.0-rc.6",
+    "@react-native/typescript-config": "0.76.0-rc.6",
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",
     "babel-jest": "^29.6.3",

--- a/android/fabric/src/main/java/com/swmansion/gesturehandler/ReactContextExtensions.kt
+++ b/android/fabric/src/main/java/com/swmansion/gesturehandler/ReactContextExtensions.kt
@@ -8,5 +8,5 @@ import com.facebook.react.uimanager.events.Event
 
 fun ReactContext.dispatchEvent(event: Event<*>) {
   val fabricUIManager = UIManagerHelper.getUIManager(this, UIManagerType.FABRIC) as FabricUIManager
-  fabricUIManager.getEventDispatcher().dispatchEvent(event)
+  fabricUIManager.eventDispatcher.dispatchEvent(event)
 }

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.4.2-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
https://github.com/facebook/react-native/pull/47090/files

## Description
Fixes a build failure on RN 0.76.0-rc.6 as a result of a change in the way the event dispatcher is accessed.

See change here: https://github.com/facebook/react-native/pull/47090/files

Note: This change breaks RN 0.76.0-rc.5 and below

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan

<!--
Describe how did you test this change here.
-->
- Android build fails with RN 0.76.0-rc.6 before the change
- Successful build with RN 0.76.0-rc.6 after the change