### PR TITLE
Disable worklet warnings on web

### DIFF
--- a/src/handlers/gestures/GestureDetector/utils.ts
+++ b/src/handlers/gestures/GestureDetector/utils.ts
@@ -70,7 +70,7 @@ export function extractGestureRelations(gesture: GestureType) {
 }
 
 export function checkGestureCallbacksForWorklets(gesture: GestureType) {
-  if (!__DEV__) {
+  if (!__DEV__ || Platform.OS === 'web') {
     return;
   }
   // If a gesture is explicitly marked to run on the JS thread there is no need to check


### PR DESCRIPTION
## Description

This PR disables callback worklet warnings on web. These warnings are unnecessary since the web platform doesn't leverage worklets.