### PR TITLE
Fixes Android event dispatcher for old arch

### DIFF
--- a/android/paper/src/main/java/com/swmansion/gesturehandler/ReactContextExtensions.kt
+++ b/android/paper/src/main/java/com/swmansion/gesturehandler/ReactContextExtensions.kt
@@ -6,7 +6,7 @@ import com.facebook.react.uimanager.events.Event
 
 fun ReactContext.dispatchEvent(event: Event<*>) {
   try {
-    this.getNativeModule(UIManagerModule::class.java)!!.getEventDispatcher().dispatchEvent(event)
+    this.getNativeModule(UIManagerModule::class.java)!!.eventDispatcher.dispatchEvent(event)
   } catch (e: NullPointerException) {
     throw Exception("Couldn't get an instance of UIManagerModule. Gesture Handler is unable to send an event.", e)
   }


### PR DESCRIPTION
## Description

This is similar to #3166, but for the old arch

## Test plan

Before this change, our app failed to build with RN 0.76.0-rc.6 without the new arch enabled. With this change, it builds and runs correctly.