### PR TITLE
Fix tvOS build

### DIFF
--- a/apple/Handlers/RNPanHandler.m
+++ b/apple/Handlers/RNPanHandler.m
@@ -464,9 +464,13 @@
               withVelocity:[recognizer velocityInView:recognizer.view.window]
        withNumberOfTouches:recognizer.numberOfTouches
            withPointerType:_pointerType
+#if !TARGET_OS_TV
             withStylusData:[panRecognizer.stylusData toDictionary]]; // In Objective-C calling method on nil returns
                                                                      // nil, therefore this line does not crash.
+#else
+            withStylusData:nil];
+#endif // TARGET_OS_TV
 }
-#endif
+#endif // TARGET_OS_OSX
 
 @end


### PR DESCRIPTION
## Description

After adding `stylusData` support, builds on `tvOS` fail. This PR fixes that

## Test plan

Add Gesture Handler to tvOS app (for example run `npx @react-native-community/cli@latest init TVTest --template @react-native-tvos/template-tv`) and check that it builds correctly.