### PR TITLE
[Web] Remove `collapsable` property

### DIFF
--- a/src/handlers/gestures/GestureDetector/Wrap.web.tsx
+++ b/src/handlers/gestures/GestureDetector/Wrap.web.tsx
@@ -5,34 +5,28 @@ import { tagMessage } from '../../../utils';
 export const Wrap = forwardRef<HTMLDivElement, PropsWithChildren<{}>>(
   ({ children }, ref) => {
     try {
-      // I don't think that fighting with types over such a simple function is worth it
-      // The only thing it does is add 'collapsable: false' to the child component
-      // to make sure it is in the native view hierarchy so the detector can find
-      // correct viewTag to attach to.
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const child: any = React.Children.only(children);
 
       const isRNSVGNode =
         Object.getPrototypeOf(child?.type)?.name === 'WebShape';
 
-      const additionalProps = isRNSVGNode
-        ? { collapsable: false, ref }
-        : { collapsable: false };
+      if (isRNSVGNode) {
+        const clone = React.cloneElement(
+          child,
+          { ref },
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+          child.props.children
+        );
 
-      const clone = React.cloneElement(
-        child,
-        additionalProps,
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        child.props.children
-      );
+        return clone;
+      }
 
-      return isRNSVGNode ? (
-        clone
-      ) : (
+      return (
         <div
           ref={ref as LegacyRef<HTMLDivElement>}
           style={{ display: 'contents' }}>
-          {clone}
+          {child}
         </div>
       );
     } catch (e) {


### PR DESCRIPTION
## Description

Currently when we add component into `GestureDetector`, we add `collapsable={false}` to its props. However, it [does nothing on web](https://github.com/necolas/react-native-web/issues/1703), so we can safely remove it. This way we can get rid of the following error:

```
Warning: Received `false` for a non-boolean attribute `collapsable`.
```

Closes #3201 

## Test plan

<details>
<summary>Tested on the following code:</summary>

```jsx
import {
  GestureHandlerRootView,
  GestureDetector,
  Gesture,
} from 'react-native-gesture-handler';
import { View } from 'react-native';
import { Svg, Circle } from 'react-native-svg';
import { useState, useCallback } from 'react';

export default function App() {
  const [circleFill, setCircleFill] = useState('blue');
  const switchCircleColor = useCallback(
    () => setCircleFill((old) => (old === 'blue' ? 'brown' : 'blue')),
    [setCircleFill]
  );

  const tapGestureCircle = Gesture.Tap().runOnJS(true).onEnd(switchCircleColor);

  return (
    <GestureHandlerRootView style={{ flex: 1, paddingTop: 200 }}>
      <View style={{ padding: 10, borderWidth: 1, alignSelf: 'flex-start' }}>
        <Svg width={200} height={200}>
          <GestureDetector gesture={tapGestureCircle}>
            <Circle r={200} cx={210} cy={210} fill={circleFill} />
          </GestureDetector>
        </Svg>
      </View>
    </GestureHandlerRootView>
  );
}
```

</details>