### PR TITLE
Fix `TwoFingerPan` import

### DIFF
--- a/example/App.tsx
+++ b/example/App.tsx
@@ -39,7 +39,7 @@ import NestedButtons from './src/release_tests/nestedButtons';
 import PointerType from './src/release_tests/pointerType';
 import SwipeableReanimation from './src/release_tests/swipeableReanimation';
 import NestedGestureHandlerRootViewWithModal from './src/release_tests/nestedGHRootViewWithModal';
-import TwoFingerPan from 'src/release_tests/twoFingerPan';
+import TwoFingerPan from './src/release_tests/twoFingerPan';
 import { PinchableBox } from './src/recipes/scaleAndRotate';
 import PanAndScroll from './src/recipes/panAndScroll';
 import { BottomSheet } from './src/showcase/bottomSheet';


### PR DESCRIPTION
## Description

Currently import for this example misses `./` at the beginning, which breaks MacOSExample.

## Test plan

Run examples (especially MacOSExample) 
