### PR TITLE
Fix broken links in the `quickstart` docs page

### DIFF
--- a/docs/docs/fundamentals/quickstart/index.md
+++ b/docs/docs/fundamentals/quickstart/index.md
@@ -53,4 +53,4 @@ To demonstrate how you would use the new API, let's make a simple app where you 
 
 Note the `start` shared value. We need it to store the position of the ball at the moment we grab it to be able to correctly position it later, because we only have access to translation relative to the starting point of the gesture.
 
-Now you can just add `Ball` component to some view in the app and see the results! (Or you can just check the code [here](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example/src/new_api/reanimated/index.tsx) and see it in action in the Example app.)
+Now you can just add `Ball` component to some view in the app and see the results! (Or you can just check the code [here](https://github.com/software-mansion/react-native-gesture-handler/blob/main/example/src/new_api/velocityTest/index.tsx) and see it in action in the Example app.)

--- a/docs/docs/fundamentals/quickstart/index.md
+++ b/docs/docs/fundamentals/quickstart/index.md
@@ -29,7 +29,7 @@ To demonstrate how you would use the new API, let's make a simple app where you 
 <Step title="Step 3">
   <div>
     We also need to define{' '}
-    <a href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/shared-values">
+    <a href="https://docs.swmansion.com/react-native-reanimated/docs/fundamentals/glossary#shared-value">
       shared values
     </a>{' '}
     to keep track of the ball position and create animated styles in order to be


### PR DESCRIPTION
## Description

Fix broken links in the `quickstart` docs page.

- replace the `SharedValue` description link
- replace the `ballTest` code link broken in #2919

## Test plan

- open the old links
- open the new links
- see how the old links are broken