### PR TITLE
fix: missing ReanimatedDrawerLayout

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "ReanimatedSwipeable/",
     "jest-utils/",
     "DrawerLayout/",
+    "ReanimatedDrawerLayout/",
     "README.md",
     "jestSetup.js",
     "RNGestureHandler.podspec"


### PR DESCRIPTION
## Description

I'm getting error when importing `react-native-gesture-handler/ReanimatedDrawerLayout` because the folder is missing

## Test plan

Add the folder `ReanimatedDrawerLayout` on my local in `node_modules` and it works
