### PR TITLE
Fix : RN 0.76 attachHandlerWithTag Crash

### DIFF
--- a/apple/RNGestureHandlerRegistry.m
+++ b/apple/RNGestureHandlerRegistry.m
@@ -37,7 +37,10 @@
               withActionType:(RNGestureHandlerActionType)actionType
 {
   RNGestureHandler *handler = _handlers[handlerTag];
-  RCTAssert(handler != nil, @"Handler for tag %@ does not exists", handlerTag);
+  if (handler == nil) {
+    NSLog(@"Handler for tag %@ does not exist", handlerTag);
+    return;
+  }
   [handler unbindFromView];
   handler.actionType = actionType;
   [handler bindToView:view];


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

I don't know the exact reason for the absence of the handler, but it should work fine if you change it to that code.
I think it's probably a flow issue when using React Native 0.76 New Architecture with React Navigation v7.
Anyway, you can change the code to the following and it should work fine.
## Test plan

<!--
Describe how did you test this change here.
-->
