### PR TITLE
Add error about functional components being used with old API

### DIFF
--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -234,6 +234,12 @@ export default function createHandler<
         )
       );
 
+      if (!this.viewNode) {
+        throw new Error(
+          `[Gesture Handler] Failed to obtain view for ${Handler.displayName}. Note that old API doesn't support functional components.`
+        );
+      }
+
       this.attachGestureHandler(findNodeHandle(this.viewNode) as number); // TODO(TS) - check if this can be null
     }
 


### PR DESCRIPTION
## Description

Old API does not support functional components as it requires assigning `ref` to handler's child. If someone tries to pass functional component into handler, behavior differs based on platform:

- Android - app will crash with the following error message:
<img width="341" alt="image" src="https://github.com/user-attachments/assets/a274b6e3-a36f-4f7d-8d23-c9606ae32974">

- Web - app will crash in `GestureHandlerDelegate`:
  - `Cannot read properties of undefined (reading 'isButtonInConfig')`

- iOS - app won't crash, but the handler doesn't work anyway


This PR adds `error` that will be thrown when handler cannot obtain target view. This will unify behavior across platforms, as well as provide explanation of what went wrong. 

## Test plan

<details>
<summary>Tested on the following code:</summary>

```jsx
import React from 'react';
import { View } from 'react-native';
import { TapGestureHandler } from 'react-native-gesture-handler';

const MyView = () => {
  return <View />;
};

export default function RectButtonBorders() {
  return (
    <TapGestureHandler onHandlerStateChange={() => console.log('click')}>
      <MyView />
    </TapGestureHandler>
  );
}
```

</details>
