### PR TITLE
Remove usage of class unavailable in RN 0.77

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/RNGestureHandlerPackage.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/RNGestureHandlerPackage.kt
@@ -1,6 +1,6 @@
 package com.swmansion.gesturehandler
 
-import com.facebook.react.TurboReactPackage
+import com.facebook.react.BaseReactPackage
 import com.facebook.react.ViewManagerOnDemandReactPackage
 import com.facebook.react.bridge.ModuleSpec
 import com.facebook.react.bridge.NativeModule
@@ -19,7 +19,7 @@ import com.swmansion.gesturehandler.react.RNGestureHandlerRootViewManager
     RNGestureHandlerModule::class
   ]
 )
-class RNGestureHandlerPackage : TurboReactPackage(), ViewManagerOnDemandReactPackage {
+class RNGestureHandlerPackage : BaseReactPackage(), ViewManagerOnDemandReactPackage {
   private val viewManagers: Map<String, ModuleSpec> by lazy {
     mapOf(
       RNGestureHandlerRootViewManager.REACT_CLASS to ModuleSpec.viewManagerSpec {


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

In `RN 0.77`, the `TurboReactPackage` class has been removed ([link](https://github.com/facebook/react-native/pull/47680))

This PR fixes this issue

Reported by @tomekzaw 

## Test plan

<!--
Describe how did you test this change here.
-->
