### PR TITLE
[Android] Change `onTouchEvent` to `dispatchTouchEvent` in `NativeViewGestureHandler`

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -99,7 +99,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
       if (state == STATE_UNDETERMINED && !hook.canBegin(event)) {
         cancel()
       } else {
-        view.onTouchEvent(event)
+        view.dispatchTouchEvent(event)
         if ((state == STATE_UNDETERMINED || state == STATE_BEGAN) && view.isPressed) {
           activate()
         }
@@ -116,12 +116,12 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
       when {
         shouldActivateOnStart -> {
           tryIntercept(view, event)
-          view.onTouchEvent(event)
+          view.dispatchTouchEvent(event)
           activate()
         }
 
         tryIntercept(view, event) -> {
-          view.onTouchEvent(event)
+          view.dispatchTouchEvent(event)
           activate()
         }
 
@@ -136,7 +136,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
         }
       }
     } else if (state == STATE_ACTIVE) {
-      view.onTouchEvent(event)
+      view.dispatchTouchEvent(event)
     }
   }
 
@@ -145,7 +145,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     val event = MotionEvent.obtain(time, time, MotionEvent.ACTION_CANCEL, 0f, 0f, 0).apply {
       action = MotionEvent.ACTION_CANCEL
     }
-    view!!.onTouchEvent(event)
+    view!!.dispatchTouchEvent(event)
     event.recycle()
   }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -101,7 +101,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
       if (state == STATE_UNDETERMINED && !hook.canBegin(event)) {
         cancel()
       } else {
-        hook.triggerEvent(view, event)
+        hook.sendTouchEvent(view, event)
         if ((state == STATE_UNDETERMINED || state == STATE_BEGAN) && view.isPressed) {
           activate()
         }
@@ -118,12 +118,12 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
       when {
         shouldActivateOnStart -> {
           tryIntercept(view, event)
-          hook.triggerEvent(view, event)
+          hook.sendTouchEvent(view, event)
           activate()
         }
 
         tryIntercept(view, event) -> {
-          hook.triggerEvent(view, event)
+          hook.sendTouchEvent(view, event)
           activate()
         }
 
@@ -138,7 +138,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
         }
       }
     } else if (state == STATE_ACTIVE) {
-      hook.triggerEvent(view, event)
+      hook.sendTouchEvent(view, event)
     }
   }
 
@@ -147,7 +147,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     val event = MotionEvent.obtain(time, time, MotionEvent.ACTION_CANCEL, 0f, 0f, 0).apply {
       action = MotionEvent.ACTION_CANCEL
     }
-    hook.triggerEvent(view, event)
+    hook.sendTouchEvent(view, event)
     event.recycle()
   }
 
@@ -203,9 +203,9 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     fun shouldCancelRootViewGestureHandlerIfNecessary() = false
 
     /**
-     * Decides whether or not target view should pass event to children.
+     * Passes the event down to the underlying view using the correct method.
      */
-    fun triggerEvent(view: View?, event: MotionEvent) = view?.onTouchEvent(event)
+    fun sendTouchEvent(view: View?, event: MotionEvent) = view?.onTouchEvent(event)
   }
 
   private class EditTextHook(
@@ -293,6 +293,6 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     //
     // Calling onTouchEvent won't do anything on wrappers, therefore we use dispatchTouchEvent. This way
     // not only do we trigger onTouchEvent, but also pass event to children.
-    override fun triggerEvent(view: View?, event: MotionEvent) = view?.dispatchTouchEvent(event)
+    override fun sendTouchEvent(view: View?, event: MotionEvent) = view?.dispatchTouchEvent(event)
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -9,6 +9,7 @@ import android.widget.ScrollView
 import com.facebook.react.views.scroll.ReactScrollView
 import com.facebook.react.views.swiperefresh.ReactSwipeRefreshLayout
 import com.facebook.react.views.textinput.ReactEditText
+import com.facebook.react.views.view.ReactViewGroup
 import com.swmansion.gesturehandler.react.RNGestureHandlerButtonViewManager
 import com.swmansion.gesturehandler.react.isScreenReaderOn
 
@@ -82,6 +83,16 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     }
   }
 
+  fun triggerEvent(event: MotionEvent) {
+    val view = view!!
+
+    if (view is ReactViewGroup) {
+      view.dispatchTouchEvent(event)
+    } else {
+      view.onTouchEvent(event)
+    }
+  }
+
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
     val view = view!!
 
@@ -99,7 +110,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
       if (state == STATE_UNDETERMINED && !hook.canBegin(event)) {
         cancel()
       } else {
-        view.dispatchTouchEvent(event)
+        triggerEvent(event)
         if ((state == STATE_UNDETERMINED || state == STATE_BEGAN) && view.isPressed) {
           activate()
         }
@@ -116,12 +127,12 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
       when {
         shouldActivateOnStart -> {
           tryIntercept(view, event)
-          view.dispatchTouchEvent(event)
+          triggerEvent(event)
           activate()
         }
 
         tryIntercept(view, event) -> {
-          view.dispatchTouchEvent(event)
+          triggerEvent(event)
           activate()
         }
 
@@ -136,7 +147,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
         }
       }
     } else if (state == STATE_ACTIVE) {
-      view.dispatchTouchEvent(event)
+      triggerEvent(event)
     }
   }
 
@@ -145,7 +156,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     val event = MotionEvent.obtain(time, time, MotionEvent.ACTION_CANCEL, 0f, 0f, 0).apply {
       action = MotionEvent.ACTION_CANCEL
     }
-    view!!.dispatchTouchEvent(event)
+    triggerEvent(event)
     event.recycle()
   }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -291,6 +291,6 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     // inside a `<View />` component in JS). In such cases, calling `onTouchEvent` wouldn't work as those are
     // ignored by the wrapper view. Instead `dispatchTouchEvent` can be used, which causes the view to dispatch
     // the event to its children.
-    override fun triggerEvent(view: View?, event: MotionEvent) = view?.dispatchTouchEvent(event)
+    override fun sendTouchEvent(view: View?, event: MotionEvent) = view?.dispatchTouchEvent(event)
   }
 }

--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -234,6 +234,12 @@ export default function createHandler<
         )
       );
 
+      if (!this.viewNode) {
+        throw new Error(
+          `[Gesture Handler] Failed to obtain view for ${Handler.displayName}. Note that old API doesn't support functional components.`
+        );
+      }
+
       this.attachGestureHandler(findNodeHandle(this.viewNode) as number); // TODO(TS) - check if this can be null
     }
 


### PR DESCRIPTION
## Description

Currently wrapping `WebView` into `NativeViewGestureHandler`  doesn't work as expected - events from `native` gesture do not reach `WebView`. This happens because inside `NativeViewGestureHandler` we call `onTouchEvent` method. In native hierarchy `WebView` is nested inside `ViewGroup`, which means that calling `onTouchEvent` instead of `dispatchTouchEvent` won't do anything to the `WebView`.

Should fix #2454 

Fixes #3196 

## Test plan

Tested on example app and the code below:

<details>
<summary>Test code</summary>

```jsx
import * as React from 'react';
import { View, StyleSheet } from 'react-native';
import { WebView } from 'react-native-webview';
import {
  Gesture,
  GestureDetector,
  GestureHandlerRootView,
} from 'react-native-gesture-handler';

function WebViewScreen() {
  const native = Gesture.Native()
    .shouldActivateOnStart(true)
    .disallowInterruption(true);
  const pan = Gesture.Pan().onChange(console.log);

  const g = Gesture.Simultaneous(native, pan);

  return (
    <View style={styles.webViewContainer}>
      <GestureDetector gesture={g}>
        <WebView
          source={{ uri: 'https://templates.tiptap.dev/nw6Cmz6HfD' }}
          style={styles.webView}
          javaScriptEnabled={true}
          domStorageEnabled={true}
          startInLoadingState={true}
          onError={(syntheticEvent) => {
            const { nativeEvent } = syntheticEvent;
            console.warn('WebView error: ', nativeEvent);
          }}
        />
      </GestureDetector>
    </View>
  );
}

export default function BuggyApp() {
  return (
    <GestureHandlerRootView>
      <WebViewScreen />
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  text: {
    fontSize: 18,
  },
  webView: {
    flex: 1,
  },
  webViewContainer: {
    flex: 1,
    width: '100%',
  },
});
```

</details>