### PR TITLE
Check if handler was dropped before reattaching

### DIFF
--- a/apple/RNGestureHandlerManager.mm
+++ b/apple/RNGestureHandlerManager.mm
@@ -51,6 +51,7 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
   RNGestureHandlerRegistry *_registry;
   NSHashTable<RNRootViewGestureRecognizer *> *_rootViewGestureRecognizers;
   NSMutableDictionary<NSNumber *, NSNumber *> *_attachRetryCounter;
+  NSMutableSet *_droppedHandlers;
 #ifdef RCT_NEW_ARCH_ENABLED
   RCTModuleRegistry *_moduleRegistry;
   RCTViewRegistry *_viewRegistry;
@@ -90,6 +91,7 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
   _registry = [RNGestureHandlerRegistry new];
   _rootViewGestureRecognizers = [NSHashTable hashTableWithOptions:NSPointerFunctionsWeakMemory];
   _attachRetryCounter = [[NSMutableDictionary alloc] init];
+  _droppedHandlers = [NSMutableSet set];
 }
 
 - (void)createGestureHandler:(NSString *)handlerName tag:(NSNumber *)handlerTag config:(NSDictionary *)config
@@ -168,7 +170,9 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
       [_attachRetryCounter setObject:counter forKey:viewTag];
 
       dispatch_after(dispatch_time(DISPATCH_TIME_NOW, 0.1 * NSEC_PER_SEC), dispatch_get_main_queue(), ^{
-        [self attachGestureHandler:handlerTag toViewWithTag:viewTag withActionType:actionType];
+        if (![_droppedHandlers containsObject:handlerTag]) {
+          [self attachGestureHandler:handlerTag toViewWithTag:viewTag withActionType:actionType];
+        }
       });
     }
 
@@ -205,6 +209,7 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 - (void)dropGestureHandler:(NSNumber *)handlerTag
 {
   [_registry dropHandlerWithTag:handlerTag];
+  [_droppedHandlers addObject:handlerTag];
 }
 
 - (void)dropAllGestureHandlers


### PR DESCRIPTION
## Description

Currently Gesture Handler crashes apps that use `StrictMode`. 

### Problem description

`StrictMode` [calls effects twice](https://react.dev/reference/react/StrictMode#fixing-bugs-found-by-re-running-effects-in-development). That means that `attachGestureHandler` and `dropGestureHandler` will be called extra time. However, when `attachGestureHandler` is called for the first time, `view` is not yet initialized. It means that instead of attaching handler, we [schedule another attach later](https://github.com/software-mansion/react-native-gesture-handler/blob/fe66fe168ad102199f06d8365cbf5b20ad24e87e/apple/RNGestureHandlerManager.mm#L170). In the meantime, `dropGestureHandler` removes handler from registry. When we finally try to attach handler one more time, it no longer exists, therefore application crashes.

### Solution

While it is not the best solution, we decided to check which handlers were dropped. If we try to reattach already dropped handler, we simply don't do that. On the other hand, if we try to reattach handler that wasn't dropped, app will crash. In other words, we simply reattach handler iff handler has not been dropped before.

Fixes #3184 

## Test plan

<details>
<summary>Tested on the following reproduction:</summary>

```jsx
import { StrictMode } from 'react';
import { View } from 'react-native';
import {
  Gesture,
  GestureDetector,
  GestureHandlerRootView,
} from 'react-native-gesture-handler';

const Example = () => {
  const gesture = Gesture.Pan();

  return (
    <StrictMode>
      <GestureHandlerRootView>
        <GestureDetector gesture={gesture}>
          <View />
        </GestureDetector>
      </GestureHandlerRootView>
    </StrictMode>
  );
};
export default Example;
```

</details>