### PR TITLE
fix: rippleColor shall be declared as integer

### DIFF
--- a/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerDelegate.java
+++ b/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerDelegate.java
@@ -35,7 +35,7 @@ public class RNGestureHandlerButtonManagerDelegate<T extends View, U extends Bas
         mViewManager.setEnabled(view, value == null ? true : (boolean) value);
         break;
       case "rippleColor":
-        mViewManager.setRippleColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        mViewManager.setRippleColor(view, value == null ? 0 : ((Double) value).intValue());
         break;
       case "rippleRadius":
         mViewManager.setRippleRadius(view, value == null ? 0 : ((Double) value).intValue());

--- a/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
+++ b/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
@@ -17,7 +17,7 @@ public interface RNGestureHandlerButtonManagerInterface<T extends View> {
   void setForeground(T view, boolean value);
   void setBorderless(T view, boolean value);
   void setEnabled(T view, boolean value);
-  void setRippleColor(T view, @Nullable Integer value);
+  void setRippleColor(T view, int value);
   void setRippleRadius(T view, int value);
   void setTouchSoundDisabled(T view, boolean value);
   void setBorderWidth(T view, float value);

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -104,7 +104,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
   }
 
   @ReactProp(name = "rippleColor")
-  override fun setRippleColor(view: ButtonViewGroup, rippleColor: Int?) {
+  override fun setRippleColor(view: ButtonViewGroup, rippleColor: Int) {
     view.rippleColor = rippleColor
   }
 

--- a/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -11,7 +11,7 @@ interface NativeProps extends ViewProps {
   foreground?: boolean;
   borderless?: boolean;
   enabled?: WithDefault<boolean, true>;
-  rippleColor?: ColorValue;
+  rippleColor?: Int32;
   rippleRadius?: Int32;
   touchSoundDisabled?: WithDefault<boolean, false>;
   borderWidth?: Float;


### PR DESCRIPTION
## Description

Fix rippleColor declaration on pressable
fix: https://github.com/software-mansion/react-native-gesture-handler/issues/3246
I think colorValue can be used without processColor but here an Int32 is needed

## Test plan

I tested with the sample included in the package.
I didn't retest with old architecture but no impact expected, And I already tested it sucessfully 