### PR TITLE
[docs] Add `Swipe & Scroll` guide

### DIFF
--- a/docs/docs/guides/swipe-and-scroll.md
+++ b/docs/docs/guides/swipe-and-scroll.md
@@ -1,9 +1,7 @@
 ---
 id: swipe-and-scroll
-title: Swipeable components inside ScrollView (web)
+title: Custom swipeable components inside ScrollView (web)
 ---
-
-## Adding custom swipeable components into `ScrollView`
 
 While we recommend using our own [`ReanimatedSwipeable`](../components/reanimated_swipeable.md) component, creating your own version of swipeable gives you more control over its behavior. Common issue here is that after creating your own swipeable component, scroll does not work. In that case, try adding [`touchAction`](../gestures/gesture-detector.md#touchaction-web-only) set to `"pan-y"`, like this:
 

--- a/docs/docs/guides/swipe-and-scroll.md
+++ b/docs/docs/guides/swipe-and-scroll.md
@@ -1,0 +1,14 @@
+---
+id: swipe-and-scroll
+title: Swipeable components inside ScrollView (web)
+---
+
+## Adding custom swipeable components into `ScrollView`
+
+While we recommend using our own [`ReanimatedSwipeable`](../components/reanimated_swipeable.md) component, creating your own version of swipeable gives you more control over its behavior. Common issue here is that after creating your own swipeable component, scroll does not work. In that case, try adding [`touchAction`](../gestures/gesture-detector.md#touchaction-web-only) set to `"pan-y"`, like this:
+
+```jsx
+<GestureDetector gesture={...} ... touchAction="pan-y">
+  ...
+</GestureDetector>
+```

--- a/docs/src/css/typography.css
+++ b/docs/src/css/typography.css
@@ -183,6 +183,11 @@ code {
   border-bottom: 1px solid var(--ifm-font-color-base);
 }
 
+.markdown h2 code {
+  font-size: 22px;
+  font-weight: 600;
+}
+
 /* Sidebar */
 [class*='menu__list-item-collapsible'] a {
   font-family: var(--swm-title-font);


### PR DESCRIPTION
## Description

At the beginning of new web implementation `Swipeable` component was blocking `scroll` on `web`. We did fix it by adding `touch-action: pan-y;` as a property to our handlers, and making it default in `Pan` used  under the hood of `Swipeable`.

However, some of our users prefer to create their own versions of `Swipeable` - that's where they encounter this issue.

This PR adds guide section about fixing this problem.

It also changes font size of `code` inside headers such that it is no longer ridiculously small.
## Test plan

Run docs