### PR TITLE
[Web] Migrate to `get` and `set` API [1/2]

### DIFF
--- a/src/web/detectors/RotationGestureDetector.ts
+++ b/src/web/detectors/RotationGestureDetector.ts
@@ -10,27 +10,100 @@ export interface RotationGestureListener {
 export default class RotationGestureDetector
   implements RotationGestureListener
 {
-  onRotationBegin: (detector: RotationGestureDetector) => boolean;
-  onRotation: (detector: RotationGestureDetector) => boolean;
-  onRotationEnd: (detector: RotationGestureDetector) => void;
+  private _onRotationBegin: (detector: RotationGestureDetector) => boolean;
+  get onRotationBegin() {
+    return this._onRotationBegin;
+  }
+  set onRotationBegin(
+    callback: (detector: RotationGestureDetector) => boolean
+  ) {
+    this._onRotationBegin = callback;
+  }
 
-  private currentTime = 0;
-  private previousTime = 0;
+  private _onRotation: (detector: RotationGestureDetector) => boolean;
+  get onRotation() {
+    return this._onRotation;
+  }
+  set onRotation(callback: (detector: RotationGestureDetector) => boolean) {
+    this._onRotation = callback;
+  }
 
-  private previousAngle = 0;
-  private rotation = 0;
+  private _onRotationEnd: (detector: RotationGestureDetector) => void;
+  get onRotationEnd() {
+    return this._onRotationEnd;
+  }
+  set onRotationEnd(callback: (detector: RotationGestureDetector) => void) {
+    this._onRotationEnd = callback;
+  }
 
-  private anchorX = 0;
-  private anchorY = 0;
+  private _currentTime = 0;
+  get currentTime() {
+    return this._currentTime;
+  }
+  set currentTime(value: number) {
+    this._currentTime = value;
+  }
 
-  private isInProgress = false;
+  private _previousTime = 0;
+  get previousTime() {
+    return this._previousTime;
+  }
+  set previousTime(value: number) {
+    this._previousTime = value;
+  }
 
-  private keyPointers: number[] = [NaN, NaN];
+  private _previousAngle = 0;
+  get previousAngle() {
+    return this._previousAngle;
+  }
+  set previousAngle(value: number) {
+    this._previousAngle = value;
+  }
+
+  private _rotation = 0;
+  get rotation() {
+    return this._rotation;
+  }
+  set rotation(value: number) {
+    this._rotation = value;
+  }
+
+  private _anchorX = 0;
+  get anchorX() {
+    return this._anchorX;
+  }
+  set anchorX(value: number) {
+    this._anchorX = value;
+  }
+
+  private _anchorY = 0;
+  get anchorY() {
+    return this._anchorY;
+  }
+  set anchorY(value: number) {
+    this._anchorY = value;
+  }
+
+  private _isInProgress = false;
+  get isInProgress() {
+    return this._isInProgress;
+  }
+  set isInProgress(value: boolean) {
+    this._isInProgress = value;
+  }
+
+  private _keyPointers: number[] = [NaN, NaN];
+  get keyPointers() {
+    return this._keyPointers;
+  }
+  set keyPointers(values: number[]) {
+    this._keyPointers = values;
+  }
 
   constructor(callbacks: RotationGestureListener) {
-    this.onRotationBegin = callbacks.onRotationBegin;
-    this.onRotation = callbacks.onRotation;
-    this.onRotationEnd = callbacks.onRotationEnd;
+    this._onRotationBegin = callbacks.onRotationBegin;
+    this._onRotation = callbacks.onRotation;
+    this._onRotationEnd = callbacks.onRotationEnd;
   }
 
   private updateCurrent(event: AdaptedEvent, tracker: PointerTracker): void {

--- a/src/web/detectors/RotationGestureDetector.ts
+++ b/src/web/detectors/RotationGestureDetector.ts
@@ -159,82 +159,86 @@ export default class RotationGestureDetector
     this.isInProgress = false;
   }
 
-  get onRotationBegin() {
+  public get onRotationBegin() {
     return this._onRotationBegin;
   }
-  set onRotationBegin(
+  public set onRotationBegin(
     callback: (detector: RotationGestureDetector) => boolean
   ) {
     this._onRotationBegin = callback;
   }
 
-  get onRotation() {
+  public get onRotation() {
     return this._onRotation;
   }
-  set onRotation(callback: (detector: RotationGestureDetector) => boolean) {
+  public set onRotation(
+    callback: (detector: RotationGestureDetector) => boolean
+  ) {
     this._onRotation = callback;
   }
 
-  get onRotationEnd() {
+  public get onRotationEnd() {
     return this._onRotationEnd;
   }
-  set onRotationEnd(callback: (detector: RotationGestureDetector) => void) {
+  public set onRotationEnd(
+    callback: (detector: RotationGestureDetector) => void
+  ) {
     this._onRotationEnd = callback;
   }
 
-  get currentTime() {
+  public get currentTime() {
     return this._currentTime;
   }
-  set currentTime(value: number) {
+  public set currentTime(value: number) {
     this._currentTime = value;
   }
 
-  get previousTime() {
+  public get previousTime() {
     return this._previousTime;
   }
-  set previousTime(value: number) {
+  public set previousTime(value: number) {
     this._previousTime = value;
   }
 
-  get previousAngle() {
+  public get previousAngle() {
     return this._previousAngle;
   }
-  set previousAngle(value: number) {
+  public set previousAngle(value: number) {
     this._previousAngle = value;
   }
 
-  get rotation() {
+  public get rotation() {
     return this._rotation;
   }
-  set rotation(value: number) {
+  public set rotation(value: number) {
     this._rotation = value;
   }
 
-  get anchorX() {
+  public get anchorX() {
     return this._anchorX;
   }
-  set anchorX(value: number) {
+  public set anchorX(value: number) {
     this._anchorX = value;
   }
 
-  get anchorY() {
+  public get anchorY() {
     return this._anchorY;
   }
-  set anchorY(value: number) {
+  public set anchorY(value: number) {
     this._anchorY = value;
   }
 
-  get isInProgress() {
+  public get isInProgress() {
     return this._isInProgress;
   }
-  set isInProgress(value: boolean) {
+  public set isInProgress(value: boolean) {
     this._isInProgress = value;
   }
 
-  get keyPointers() {
+  public get keyPointers() {
     return this._keyPointers;
   }
-  set keyPointers(values: number[]) {
+  public set keyPointers(values: number[]) {
     this._keyPointers = values;
   }
 }

--- a/src/web/detectors/RotationGestureDetector.ts
+++ b/src/web/detectors/RotationGestureDetector.ts
@@ -10,9 +10,6 @@ export interface RotationGestureListener {
 export default class RotationGestureDetector
   implements RotationGestureListener
 {
-  private _onRotationBegin: (detector: RotationGestureDetector) => boolean;
-  private _onRotation: (detector: RotationGestureDetector) => boolean;
-  private _onRotationEnd: (detector: RotationGestureDetector) => void;
   private _currentTime = 0;
   private _previousTime = 0;
   private _previousAngle = 0;
@@ -22,10 +19,14 @@ export default class RotationGestureDetector
   private _isInProgress = false;
   private _keyPointers: number[] = [NaN, NaN];
 
+  onRotationBegin: (detector: RotationGestureDetector) => boolean;
+  onRotation: (detector: RotationGestureDetector) => boolean;
+  onRotationEnd: (detector: RotationGestureDetector) => void;
+
   constructor(callbacks: RotationGestureListener) {
-    this._onRotationBegin = callbacks.onRotationBegin;
-    this._onRotation = callbacks.onRotation;
-    this._onRotationEnd = callbacks.onRotationEnd;
+    this.onRotationBegin = callbacks.onRotationBegin;
+    this.onRotation = callbacks.onRotation;
+    this.onRotationEnd = callbacks.onRotationEnd;
   }
 
   private updateCurrent(event: AdaptedEvent, tracker: PointerTracker): void {
@@ -142,48 +143,9 @@ export default class RotationGestureDetector
     return this.currentTime + this.previousTime;
   }
 
-  public getAnchorX(): number {
-    return this.anchorX;
-  }
-
-  public getAnchorY(): number {
-    return this.anchorY;
-  }
-
-  public getRotation(): number {
-    return this.rotation;
-  }
-
   public reset(): void {
     this.keyPointers = [NaN, NaN];
     this.isInProgress = false;
-  }
-
-  public get onRotationBegin() {
-    return this._onRotationBegin;
-  }
-  public set onRotationBegin(
-    callback: (detector: RotationGestureDetector) => boolean
-  ) {
-    this._onRotationBegin = callback;
-  }
-
-  public get onRotation() {
-    return this._onRotation;
-  }
-  public set onRotation(
-    callback: (detector: RotationGestureDetector) => boolean
-  ) {
-    this._onRotation = callback;
-  }
-
-  public get onRotationEnd() {
-    return this._onRotationEnd;
-  }
-  public set onRotationEnd(
-    callback: (detector: RotationGestureDetector) => void
-  ) {
-    this._onRotationEnd = callback;
   }
 
   public get currentTime() {

--- a/src/web/detectors/RotationGestureDetector.ts
+++ b/src/web/detectors/RotationGestureDetector.ts
@@ -139,10 +139,6 @@ export default class RotationGestureDetector
     return true;
   }
 
-  public getTimeDelta(): number {
-    return this.currentTime + this.previousTime;
-  }
-
   public reset(): void {
     this.keyPointers = [NaN, NaN];
     this.isInProgress = false;
@@ -202,5 +198,9 @@ export default class RotationGestureDetector
   }
   public set keyPointers(values: number[]) {
     this._keyPointers = values;
+  }
+
+  public get timeDelta() {
+    return this.currentTime + this.previousTime;
   }
 }

--- a/src/web/detectors/RotationGestureDetector.ts
+++ b/src/web/detectors/RotationGestureDetector.ts
@@ -16,7 +16,7 @@ export default class RotationGestureDetector
   private _rotation = 0;
   private _anchorX = 0;
   private _anchorY = 0;
-  private _isInProgress = false;
+  private _inProgress = false;
   private _keyPointers: number[] = [NaN, NaN];
 
   onRotationBegin: (detector: RotationGestureDetector) => boolean;
@@ -67,11 +67,11 @@ export default class RotationGestureDetector
   }
 
   private finish(): void {
-    if (!this.isInProgress) {
+    if (!this.inProgress) {
       return;
     }
 
-    this.isInProgress = false;
+    this.inProgress = false;
     this.keyPointers = [NaN, NaN];
     this.onRotationEnd(this);
   }
@@ -90,14 +90,14 @@ export default class RotationGestureDetector
   public onTouchEvent(event: AdaptedEvent, tracker: PointerTracker): boolean {
     switch (event.eventType) {
       case EventTypes.DOWN:
-        this.isInProgress = false;
+        this.inProgress = false;
         break;
 
       case EventTypes.ADDITIONAL_POINTER_DOWN:
-        if (this.isInProgress) {
+        if (this.inProgress) {
           break;
         }
-        this.isInProgress = true;
+        this.inProgress = true;
 
         this.previousTime = event.time;
         this.previousAngle = NaN;
@@ -109,7 +109,7 @@ export default class RotationGestureDetector
         break;
 
       case EventTypes.MOVE:
-        if (!this.isInProgress) {
+        if (!this.inProgress) {
           break;
         }
 
@@ -119,7 +119,7 @@ export default class RotationGestureDetector
         break;
 
       case EventTypes.ADDITIONAL_POINTER_UP:
-        if (!this.isInProgress) {
+        if (!this.inProgress) {
           break;
         }
 
@@ -130,7 +130,7 @@ export default class RotationGestureDetector
         break;
 
       case EventTypes.UP:
-        if (this.isInProgress) {
+        if (this.inProgress) {
           this.finish();
         }
         break;
@@ -141,35 +141,35 @@ export default class RotationGestureDetector
 
   public reset(): void {
     this.keyPointers = [NaN, NaN];
-    this.isInProgress = false;
+    this.inProgress = false;
   }
 
   public get currentTime() {
     return this._currentTime;
   }
-  public set currentTime(value: number) {
-    this._currentTime = value;
+  public set currentTime(time: number) {
+    this._currentTime = time;
   }
 
   public get previousTime() {
     return this._previousTime;
   }
-  public set previousTime(value: number) {
-    this._previousTime = value;
+  public set previousTime(time: number) {
+    this._previousTime = time;
   }
 
   public get previousAngle() {
     return this._previousAngle;
   }
-  public set previousAngle(value: number) {
-    this._previousAngle = value;
+  public set previousAngle(angle: number) {
+    this._previousAngle = angle;
   }
 
   public get rotation() {
     return this._rotation;
   }
-  public set rotation(value: number) {
-    this._rotation = value;
+  public set rotation(angle: number) {
+    this._rotation = angle;
   }
 
   public get anchorX() {
@@ -186,18 +186,18 @@ export default class RotationGestureDetector
     this._anchorY = value;
   }
 
-  public get isInProgress() {
-    return this._isInProgress;
+  public get inProgress() {
+    return this._inProgress;
   }
-  public set isInProgress(value: boolean) {
-    this._isInProgress = value;
+  public set inProgress(inProgress: boolean) {
+    this._inProgress = inProgress;
   }
 
   public get keyPointers() {
     return this._keyPointers;
   }
-  public set keyPointers(values: number[]) {
-    this._keyPointers = values;
+  public set keyPointers(pointers: number[]) {
+    this._keyPointers = pointers;
   }
 
   public get timeDelta() {

--- a/src/web/detectors/RotationGestureDetector.ts
+++ b/src/web/detectors/RotationGestureDetector.ts
@@ -11,94 +11,16 @@ export default class RotationGestureDetector
   implements RotationGestureListener
 {
   private _onRotationBegin: (detector: RotationGestureDetector) => boolean;
-  get onRotationBegin() {
-    return this._onRotationBegin;
-  }
-  set onRotationBegin(
-    callback: (detector: RotationGestureDetector) => boolean
-  ) {
-    this._onRotationBegin = callback;
-  }
-
   private _onRotation: (detector: RotationGestureDetector) => boolean;
-  get onRotation() {
-    return this._onRotation;
-  }
-  set onRotation(callback: (detector: RotationGestureDetector) => boolean) {
-    this._onRotation = callback;
-  }
-
   private _onRotationEnd: (detector: RotationGestureDetector) => void;
-  get onRotationEnd() {
-    return this._onRotationEnd;
-  }
-  set onRotationEnd(callback: (detector: RotationGestureDetector) => void) {
-    this._onRotationEnd = callback;
-  }
-
   private _currentTime = 0;
-  get currentTime() {
-    return this._currentTime;
-  }
-  set currentTime(value: number) {
-    this._currentTime = value;
-  }
-
   private _previousTime = 0;
-  get previousTime() {
-    return this._previousTime;
-  }
-  set previousTime(value: number) {
-    this._previousTime = value;
-  }
-
   private _previousAngle = 0;
-  get previousAngle() {
-    return this._previousAngle;
-  }
-  set previousAngle(value: number) {
-    this._previousAngle = value;
-  }
-
   private _rotation = 0;
-  get rotation() {
-    return this._rotation;
-  }
-  set rotation(value: number) {
-    this._rotation = value;
-  }
-
   private _anchorX = 0;
-  get anchorX() {
-    return this._anchorX;
-  }
-  set anchorX(value: number) {
-    this._anchorX = value;
-  }
-
   private _anchorY = 0;
-  get anchorY() {
-    return this._anchorY;
-  }
-  set anchorY(value: number) {
-    this._anchorY = value;
-  }
-
   private _isInProgress = false;
-  get isInProgress() {
-    return this._isInProgress;
-  }
-  set isInProgress(value: boolean) {
-    this._isInProgress = value;
-  }
-
   private _keyPointers: number[] = [NaN, NaN];
-  get keyPointers() {
-    return this._keyPointers;
-  }
-  set keyPointers(values: number[]) {
-    this._keyPointers = values;
-  }
 
   constructor(callbacks: RotationGestureListener) {
     this._onRotationBegin = callbacks.onRotationBegin;
@@ -235,5 +157,84 @@ export default class RotationGestureDetector
   public reset(): void {
     this.keyPointers = [NaN, NaN];
     this.isInProgress = false;
+  }
+
+  get onRotationBegin() {
+    return this._onRotationBegin;
+  }
+  set onRotationBegin(
+    callback: (detector: RotationGestureDetector) => boolean
+  ) {
+    this._onRotationBegin = callback;
+  }
+
+  get onRotation() {
+    return this._onRotation;
+  }
+  set onRotation(callback: (detector: RotationGestureDetector) => boolean) {
+    this._onRotation = callback;
+  }
+
+  get onRotationEnd() {
+    return this._onRotationEnd;
+  }
+  set onRotationEnd(callback: (detector: RotationGestureDetector) => void) {
+    this._onRotationEnd = callback;
+  }
+
+  get currentTime() {
+    return this._currentTime;
+  }
+  set currentTime(value: number) {
+    this._currentTime = value;
+  }
+
+  get previousTime() {
+    return this._previousTime;
+  }
+  set previousTime(value: number) {
+    this._previousTime = value;
+  }
+
+  get previousAngle() {
+    return this._previousAngle;
+  }
+  set previousAngle(value: number) {
+    this._previousAngle = value;
+  }
+
+  get rotation() {
+    return this._rotation;
+  }
+  set rotation(value: number) {
+    this._rotation = value;
+  }
+
+  get anchorX() {
+    return this._anchorX;
+  }
+  set anchorX(value: number) {
+    this._anchorX = value;
+  }
+
+  get anchorY() {
+    return this._anchorY;
+  }
+  set anchorY(value: number) {
+    this._anchorY = value;
+  }
+
+  get isInProgress() {
+    return this._isInProgress;
+  }
+  set isInProgress(value: boolean) {
+    this._isInProgress = value;
+  }
+
+  get keyPointers() {
+    return this._keyPointers;
+  }
+  set keyPointers(values: number[]) {
+    this._keyPointers = values;
   }
 }

--- a/src/web/detectors/ScaleGestureDetector.ts
+++ b/src/web/detectors/ScaleGestureDetector.ts
@@ -10,32 +10,117 @@ export interface ScaleGestureListener {
 }
 
 export default class ScaleGestureDetector implements ScaleGestureListener {
-  public onScaleBegin: (detector: ScaleGestureDetector) => boolean;
-  public onScale: (detector: ScaleGestureDetector) => boolean;
-  public onScaleEnd: (detector: ScaleGestureDetector) => void;
+  private _onScaleBegin: (detector: ScaleGestureDetector) => boolean;
+  get onScaleBegin() {
+    return this._onScaleBegin;
+  }
+  set onScaleBegin(value: (detector: ScaleGestureDetector) => boolean) {
+    this._onScaleBegin = value;
+  }
 
-  private focusX!: number;
-  private focusY!: number;
+  private _onScale: (detector: ScaleGestureDetector) => boolean;
+  get onScale() {
+    return this._onScale;
+  }
+  set onScale(value: (detector: ScaleGestureDetector) => boolean) {
+    this._onScale = value;
+  }
 
-  private currentSpan!: number;
-  private prevSpan!: number;
-  private initialSpan!: number;
+  private _onScaleEnd: (detector: ScaleGestureDetector) => void;
+  get onScaleEnd() {
+    return this._onScaleEnd;
+  }
+  set onScaleEnd(value: (detector: ScaleGestureDetector) => void) {
+    this._onScaleEnd = value;
+  }
 
-  private currentTime!: number;
-  private prevTime!: number;
+  private _focusX!: number;
+  get focusX() {
+    return this._focusX;
+  }
+  set focusX(value: number) {
+    this._focusX = value;
+  }
 
-  private inProgress = false;
+  private _focusY!: number;
+  get focusY() {
+    return this._focusY;
+  }
+  set focusY(value: number) {
+    this._focusY = value;
+  }
 
-  private spanSlop: number;
-  private minSpan: number;
+  private _currentSpan!: number;
+  get currentSpan() {
+    return this._currentSpan;
+  }
+  set currentSpan(value: number) {
+    this._currentSpan = value;
+  }
+
+  private _prevSpan!: number;
+  get prevSpan() {
+    return this._prevSpan;
+  }
+  set prevSpan(value: number) {
+    this._prevSpan = value;
+  }
+
+  private _initialSpan!: number;
+  get initialSpan() {
+    return this._initialSpan;
+  }
+  set initialSpan(value: number) {
+    this._initialSpan = value;
+  }
+
+  private _currentTime!: number;
+  get currentTime() {
+    return this._currentTime;
+  }
+  set currentTime(value: number) {
+    this._currentTime = value;
+  }
+
+  private _prevTime!: number;
+  get prevTime() {
+    return this._prevTime;
+  }
+  set prevTime(value: number) {
+    this._prevTime = value;
+  }
+
+  private _inProgress = false;
+  get inProgress() {
+    return this._inProgress;
+  }
+  set inProgress(value: boolean) {
+    this._inProgress = value;
+  }
+
+  private _spanSlop: number;
+  get spanSlop() {
+    return this._spanSlop;
+  }
+  set spanSlop(value: number) {
+    this._spanSlop = value;
+  }
+
+  private _minSpan: number;
+  get minSpan() {
+    return this._minSpan;
+  }
+  set minSpan(value: number) {
+    this._minSpan = value;
+  }
 
   public constructor(callbacks: ScaleGestureListener) {
-    this.onScaleBegin = callbacks.onScaleBegin;
-    this.onScale = callbacks.onScale;
-    this.onScaleEnd = callbacks.onScaleEnd;
+    this._onScaleBegin = callbacks.onScaleBegin;
+    this._onScale = callbacks.onScale;
+    this._onScaleEnd = callbacks.onScaleEnd;
 
-    this.spanSlop = DEFAULT_TOUCH_SLOP * 2;
-    this.minSpan = 0;
+    this._spanSlop = DEFAULT_TOUCH_SLOP * 2;
+    this._minSpan = 0;
   }
 
   public onTouchEvent(event: AdaptedEvent, tracker: PointerTracker): boolean {

--- a/src/web/detectors/ScaleGestureDetector.ts
+++ b/src/web/detectors/ScaleGestureDetector.ts
@@ -10,9 +10,6 @@ export interface ScaleGestureListener {
 }
 
 export default class ScaleGestureDetector implements ScaleGestureListener {
-  private _onScaleBegin: (detector: ScaleGestureDetector) => boolean;
-  private _onScale: (detector: ScaleGestureDetector) => boolean;
-  private _onScaleEnd: (detector: ScaleGestureDetector) => void;
   private _focusX!: number;
   private _focusY!: number;
   private _currentSpan!: number;
@@ -24,10 +21,14 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
   private _spanSlop: number;
   private _minSpan: number;
 
+  onScaleBegin: (detector: ScaleGestureDetector) => boolean;
+  onScale: (detector: ScaleGestureDetector) => boolean;
+  onScaleEnd: (detector: ScaleGestureDetector) => void;
+
   public constructor(callbacks: ScaleGestureListener) {
-    this._onScaleBegin = callbacks.onScaleBegin;
-    this._onScale = callbacks.onScale;
-    this._onScaleEnd = callbacks.onScaleEnd;
+    this.onScaleBegin = callbacks.onScaleBegin;
+    this.onScale = callbacks.onScale;
+    this.onScaleEnd = callbacks.onScaleEnd;
 
     this._spanSlop = DEFAULT_TOUCH_SLOP * 2;
     this._minSpan = 0;
@@ -140,18 +141,6 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
     return true;
   }
 
-  public getCurrentSpan(): number {
-    return this.currentSpan;
-  }
-
-  public getFocusX(): number {
-    return this.focusX;
-  }
-
-  public getFocusY(): number {
-    return this.focusY;
-  }
-
   public getTimeDelta(): number {
     return this.currentTime - this.prevTime;
   }
@@ -162,27 +151,6 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
     }
 
     return this.prevSpan > 0 ? this.currentSpan / this.prevSpan : 1;
-  }
-
-  public get onScaleBegin() {
-    return this._onScaleBegin;
-  }
-  public set onScaleBegin(value: (detector: ScaleGestureDetector) => boolean) {
-    this._onScaleBegin = value;
-  }
-
-  public get onScale() {
-    return this._onScale;
-  }
-  public set onScale(value: (detector: ScaleGestureDetector) => boolean) {
-    this._onScale = value;
-  }
-
-  public get onScaleEnd() {
-    return this._onScaleEnd;
-  }
-  public set onScaleEnd(value: (detector: ScaleGestureDetector) => void) {
-    this._onScaleEnd = value;
   }
 
   public get focusX() {

--- a/src/web/detectors/ScaleGestureDetector.ts
+++ b/src/web/detectors/ScaleGestureDetector.ts
@@ -20,18 +20,23 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
   private _inProgress = false;
   private _spanSlop: number;
   private _minSpan: number;
+  private _pointerTracker: PointerTracker;
 
   onScaleBegin: (detector: ScaleGestureDetector) => boolean;
   onScale: (detector: ScaleGestureDetector) => boolean;
   onScaleEnd: (detector: ScaleGestureDetector) => void;
 
-  public constructor(callbacks: ScaleGestureListener) {
+  public constructor(
+    callbacks: ScaleGestureListener,
+    pointerTracker: PointerTracker
+  ) {
     this.onScaleBegin = callbacks.onScaleBegin;
     this.onScale = callbacks.onScale;
     this.onScaleEnd = callbacks.onScaleEnd;
 
     this._spanSlop = DEFAULT_TOUCH_SLOP * 2;
     this._minSpan = 0;
+    this._pointerTracker = pointerTracker;
   }
 
   public onTouchEvent(event: AdaptedEvent, tracker: PointerTracker): boolean {
@@ -141,18 +146,6 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
     return true;
   }
 
-  public getTimeDelta(): number {
-    return this.currentTime - this.prevTime;
-  }
-
-  public getScaleFactor(numOfPointers: number): number {
-    if (numOfPointers < 2) {
-      return 1;
-    }
-
-    return this.prevSpan > 0 ? this.currentSpan / this.prevSpan : 1;
-  }
-
   public get focusX() {
     return this._focusX;
   }
@@ -221,5 +214,24 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
   }
   public set minSpan(value: number) {
     this._minSpan = value;
+  }
+
+  public get pointerTracker() {
+    return this._pointerTracker;
+  }
+  public set pointerTracker(value: PointerTracker) {
+    this._pointerTracker = value;
+  }
+
+  public get timeDelta(): number {
+    return this.currentTime - this.prevTime;
+  }
+
+  public get scaleFactor() {
+    if (this.pointerTracker.getTrackedPointersCount() < 2) {
+      return 1;
+    }
+
+    return this.prevSpan > 0 ? this.currentSpan / this.prevSpan : 1;
   }
 }

--- a/src/web/detectors/ScaleGestureDetector.ts
+++ b/src/web/detectors/ScaleGestureDetector.ts
@@ -11,108 +11,18 @@ export interface ScaleGestureListener {
 
 export default class ScaleGestureDetector implements ScaleGestureListener {
   private _onScaleBegin: (detector: ScaleGestureDetector) => boolean;
-  get onScaleBegin() {
-    return this._onScaleBegin;
-  }
-  set onScaleBegin(value: (detector: ScaleGestureDetector) => boolean) {
-    this._onScaleBegin = value;
-  }
-
   private _onScale: (detector: ScaleGestureDetector) => boolean;
-  get onScale() {
-    return this._onScale;
-  }
-  set onScale(value: (detector: ScaleGestureDetector) => boolean) {
-    this._onScale = value;
-  }
-
   private _onScaleEnd: (detector: ScaleGestureDetector) => void;
-  get onScaleEnd() {
-    return this._onScaleEnd;
-  }
-  set onScaleEnd(value: (detector: ScaleGestureDetector) => void) {
-    this._onScaleEnd = value;
-  }
-
   private _focusX!: number;
-  get focusX() {
-    return this._focusX;
-  }
-  set focusX(value: number) {
-    this._focusX = value;
-  }
-
   private _focusY!: number;
-  get focusY() {
-    return this._focusY;
-  }
-  set focusY(value: number) {
-    this._focusY = value;
-  }
-
   private _currentSpan!: number;
-  get currentSpan() {
-    return this._currentSpan;
-  }
-  set currentSpan(value: number) {
-    this._currentSpan = value;
-  }
-
   private _prevSpan!: number;
-  get prevSpan() {
-    return this._prevSpan;
-  }
-  set prevSpan(value: number) {
-    this._prevSpan = value;
-  }
-
   private _initialSpan!: number;
-  get initialSpan() {
-    return this._initialSpan;
-  }
-  set initialSpan(value: number) {
-    this._initialSpan = value;
-  }
-
   private _currentTime!: number;
-  get currentTime() {
-    return this._currentTime;
-  }
-  set currentTime(value: number) {
-    this._currentTime = value;
-  }
-
   private _prevTime!: number;
-  get prevTime() {
-    return this._prevTime;
-  }
-  set prevTime(value: number) {
-    this._prevTime = value;
-  }
-
   private _inProgress = false;
-  get inProgress() {
-    return this._inProgress;
-  }
-  set inProgress(value: boolean) {
-    this._inProgress = value;
-  }
-
   private _spanSlop: number;
-  get spanSlop() {
-    return this._spanSlop;
-  }
-  set spanSlop(value: number) {
-    this._spanSlop = value;
-  }
-
   private _minSpan: number;
-  get minSpan() {
-    return this._minSpan;
-  }
-  set minSpan(value: number) {
-    this._minSpan = value;
-  }
 
   public constructor(callbacks: ScaleGestureListener) {
     this._onScaleBegin = callbacks.onScaleBegin;
@@ -252,5 +162,96 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
     }
 
     return this.prevSpan > 0 ? this.currentSpan / this.prevSpan : 1;
+  }
+
+  get onScaleBegin() {
+    return this._onScaleBegin;
+  }
+  set onScaleBegin(value: (detector: ScaleGestureDetector) => boolean) {
+    this._onScaleBegin = value;
+  }
+
+  get onScale() {
+    return this._onScale;
+  }
+  set onScale(value: (detector: ScaleGestureDetector) => boolean) {
+    this._onScale = value;
+  }
+
+  get onScaleEnd() {
+    return this._onScaleEnd;
+  }
+  set onScaleEnd(value: (detector: ScaleGestureDetector) => void) {
+    this._onScaleEnd = value;
+  }
+
+  get focusX() {
+    return this._focusX;
+  }
+  set focusX(value: number) {
+    this._focusX = value;
+  }
+
+  get focusY() {
+    return this._focusY;
+  }
+  set focusY(value: number) {
+    this._focusY = value;
+  }
+
+  get currentSpan() {
+    return this._currentSpan;
+  }
+  set currentSpan(value: number) {
+    this._currentSpan = value;
+  }
+
+  get prevSpan() {
+    return this._prevSpan;
+  }
+  set prevSpan(value: number) {
+    this._prevSpan = value;
+  }
+
+  get initialSpan() {
+    return this._initialSpan;
+  }
+  set initialSpan(value: number) {
+    this._initialSpan = value;
+  }
+
+  get currentTime() {
+    return this._currentTime;
+  }
+  set currentTime(value: number) {
+    this._currentTime = value;
+  }
+
+  get prevTime() {
+    return this._prevTime;
+  }
+  set prevTime(value: number) {
+    this._prevTime = value;
+  }
+
+  get inProgress() {
+    return this._inProgress;
+  }
+  set inProgress(value: boolean) {
+    this._inProgress = value;
+  }
+
+  get spanSlop() {
+    return this._spanSlop;
+  }
+  set spanSlop(value: number) {
+    this._spanSlop = value;
+  }
+
+  get minSpan() {
+    return this._minSpan;
+  }
+  set minSpan(value: number) {
+    this._minSpan = value;
   }
 }

--- a/src/web/detectors/ScaleGestureDetector.ts
+++ b/src/web/detectors/ScaleGestureDetector.ts
@@ -164,94 +164,94 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
     return this.prevSpan > 0 ? this.currentSpan / this.prevSpan : 1;
   }
 
-  get onScaleBegin() {
+  public get onScaleBegin() {
     return this._onScaleBegin;
   }
-  set onScaleBegin(value: (detector: ScaleGestureDetector) => boolean) {
+  public set onScaleBegin(value: (detector: ScaleGestureDetector) => boolean) {
     this._onScaleBegin = value;
   }
 
-  get onScale() {
+  public get onScale() {
     return this._onScale;
   }
-  set onScale(value: (detector: ScaleGestureDetector) => boolean) {
+  public set onScale(value: (detector: ScaleGestureDetector) => boolean) {
     this._onScale = value;
   }
 
-  get onScaleEnd() {
+  public get onScaleEnd() {
     return this._onScaleEnd;
   }
-  set onScaleEnd(value: (detector: ScaleGestureDetector) => void) {
+  public set onScaleEnd(value: (detector: ScaleGestureDetector) => void) {
     this._onScaleEnd = value;
   }
 
-  get focusX() {
+  public get focusX() {
     return this._focusX;
   }
-  set focusX(value: number) {
+  public set focusX(value: number) {
     this._focusX = value;
   }
 
-  get focusY() {
+  public get focusY() {
     return this._focusY;
   }
-  set focusY(value: number) {
+  public set focusY(value: number) {
     this._focusY = value;
   }
 
-  get currentSpan() {
+  public get currentSpan() {
     return this._currentSpan;
   }
-  set currentSpan(value: number) {
+  public set currentSpan(value: number) {
     this._currentSpan = value;
   }
 
-  get prevSpan() {
+  public get prevSpan() {
     return this._prevSpan;
   }
-  set prevSpan(value: number) {
+  public set prevSpan(value: number) {
     this._prevSpan = value;
   }
 
-  get initialSpan() {
+  public get initialSpan() {
     return this._initialSpan;
   }
-  set initialSpan(value: number) {
+  public set initialSpan(value: number) {
     this._initialSpan = value;
   }
 
-  get currentTime() {
+  public get currentTime() {
     return this._currentTime;
   }
-  set currentTime(value: number) {
+  public set currentTime(value: number) {
     this._currentTime = value;
   }
 
-  get prevTime() {
+  public get prevTime() {
     return this._prevTime;
   }
-  set prevTime(value: number) {
+  public set prevTime(value: number) {
     this._prevTime = value;
   }
 
-  get inProgress() {
+  public get inProgress() {
     return this._inProgress;
   }
-  set inProgress(value: boolean) {
+  public set inProgress(value: boolean) {
     this._inProgress = value;
   }
 
-  get spanSlop() {
+  public get spanSlop() {
     return this._spanSlop;
   }
-  set spanSlop(value: number) {
+  public set spanSlop(value: number) {
     this._spanSlop = value;
   }
 
-  get minSpan() {
+  public get minSpan() {
     return this._minSpan;
   }
-  set minSpan(value: number) {
+  public set minSpan(value: number) {
     this._minSpan = value;
   }
 }

--- a/src/web/detectors/ScaleGestureDetector.ts
+++ b/src/web/detectors/ScaleGestureDetector.ts
@@ -184,22 +184,22 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
   public get currentTime() {
     return this._currentTime;
   }
-  public set currentTime(value: number) {
-    this._currentTime = value;
+  public set currentTime(time: number) {
+    this._currentTime = time;
   }
 
   public get prevTime() {
     return this._prevTime;
   }
-  public set prevTime(value: number) {
-    this._prevTime = value;
+  public set prevTime(time: number) {
+    this._prevTime = time;
   }
 
   public get inProgress() {
     return this._inProgress;
   }
-  public set inProgress(value: boolean) {
-    this._inProgress = value;
+  public set inProgress(inProgress: boolean) {
+    this._inProgress = inProgress;
   }
 
   public get spanSlop() {
@@ -219,8 +219,8 @@ export default class ScaleGestureDetector implements ScaleGestureListener {
   public get pointerTracker() {
     return this._pointerTracker;
   }
-  public set pointerTracker(value: PointerTracker) {
-    this._pointerTracker = value;
+  public set pointerTracker(pointerTracker: PointerTracker) {
+    this._pointerTracker = pointerTracker;
   }
 
   public get timeDelta(): number {

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -1,7 +1,6 @@
 import { State } from '../../State';
 import { DiagonalDirections, Directions } from '../../Directions';
 import { AdaptedEvent, Config } from '../interfaces';
-
 import GestureHandler from './GestureHandler';
 import Vector from '../tools/Vector';
 import { coneToDeviation } from '../utils';
@@ -16,15 +15,61 @@ const AXIAL_DEVIATION_COSINE = coneToDeviation(DEFAULT_ALIGNMENT_CONE);
 const DIAGONAL_DEVIATION_COSINE = coneToDeviation(90 - DEFAULT_ALIGNMENT_CONE);
 
 export default class FlingGestureHandler extends GestureHandler {
-  private numberOfPointersRequired = DEFAULT_NUMBER_OF_TOUCHES_REQUIRED;
-  private direction: Directions = DEFAULT_DIRECTION;
+  private _numberOfPointersRequired = DEFAULT_NUMBER_OF_TOUCHES_REQUIRED;
+  get numberOfPointersRequired() {
+    return this._numberOfPointersRequired;
+  }
+  set numberOfPointersRequired(val: number) {
+    this._numberOfPointersRequired = val;
+  }
 
-  private maxDurationMs = DEFAULT_MAX_DURATION_MS;
-  private minVelocity = DEFAULT_MIN_VELOCITY;
-  private delayTimeout!: number;
+  private _direction: Directions = DEFAULT_DIRECTION;
+  get direction() {
+    return this._direction;
+  }
+  set direction(newDirection: Directions) {
+    this._direction = newDirection;
+  }
 
-  private maxNumberOfPointersSimultaneously = 0;
-  private keyPointer = NaN;
+  private _maxDurationMs = DEFAULT_MAX_DURATION_MS;
+  get maxDurationMs() {
+    return this._maxDurationMs;
+  }
+  set maxDurationMs(value: number) {
+    this._maxDurationMs = value;
+  }
+
+  private _minVelocity = DEFAULT_MIN_VELOCITY;
+  get minVelocity() {
+    return this._minVelocity;
+  }
+  set minVelocity(value: number) {
+    this._minVelocity = value;
+  }
+
+  private _delayTimeout!: number;
+  get delayTimeout() {
+    return this._delayTimeout;
+  }
+  set delayTimeout(value: number) {
+    this._delayTimeout = value;
+  }
+
+  private _maxNumberOfPointersSimultaneously = 0;
+  get maxNumberOfPointersSimultaneously() {
+    return this._maxNumberOfPointersSimultaneously;
+  }
+  set maxNumberOfPointersSimultaneously(value: number) {
+    this._maxNumberOfPointersSimultaneously = value;
+  }
+
+  private _keyPointer = NaN;
+  get keyPointer() {
+    return this._keyPointer;
+  }
+  set keyPointer(value: number) {
+    this._keyPointer = value;
+  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -195,52 +195,52 @@ export default class FlingGestureHandler extends GestureHandler {
     this.direction = DEFAULT_DIRECTION;
   }
 
-  get numberOfPointersRequired() {
+  public get numberOfPointersRequired() {
     return this._numberOfPointersRequired;
   }
-  set numberOfPointersRequired(val: number) {
+  public set numberOfPointersRequired(val: number) {
     this._numberOfPointersRequired = val;
   }
 
-  get direction() {
+  public get direction() {
     return this._direction;
   }
-  set direction(newDirection: Directions) {
+  public set direction(newDirection: Directions) {
     this._direction = newDirection;
   }
 
-  get maxDurationMs() {
+  public get maxDurationMs() {
     return this._maxDurationMs;
   }
-  set maxDurationMs(value: number) {
+  public set maxDurationMs(value: number) {
     this._maxDurationMs = value;
   }
 
-  get minVelocity() {
+  public get minVelocity() {
     return this._minVelocity;
   }
-  set minVelocity(value: number) {
+  public set minVelocity(value: number) {
     this._minVelocity = value;
   }
 
-  get delayTimeout() {
+  public get delayTimeout() {
     return this._delayTimeout;
   }
-  set delayTimeout(value: number) {
+  public set delayTimeout(value: number) {
     this._delayTimeout = value;
   }
 
-  get maxNumberOfPointersSimultaneously() {
+  public get maxNumberOfPointersSimultaneously() {
     return this._maxNumberOfPointersSimultaneously;
   }
-  set maxNumberOfPointersSimultaneously(value: number) {
+  public set maxNumberOfPointersSimultaneously(value: number) {
     this._maxNumberOfPointersSimultaneously = value;
   }
 
-  get keyPointer() {
+  public get keyPointer() {
     return this._keyPointer;
   }
-  set keyPointer(value: number) {
+  public set keyPointer(value: number) {
     this._keyPointer = value;
   }
 }

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -198,15 +198,15 @@ export default class FlingGestureHandler extends GestureHandler {
   public get numberOfPointersRequired() {
     return this._numberOfPointersRequired;
   }
-  public set numberOfPointersRequired(val: number) {
-    this._numberOfPointersRequired = val;
+  public set numberOfPointersRequired(value: number) {
+    this._numberOfPointersRequired = value;
   }
 
   public get direction() {
     return this._direction;
   }
-  public set direction(newDirection: Directions) {
-    this._direction = newDirection;
+  public set direction(direction: Directions) {
+    this._direction = direction;
   }
 
   public get maxDurationMs() {

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -51,7 +51,10 @@ export default class FlingGestureHandler extends GestureHandler {
   }
 
   private tryEndFling(): boolean {
-    const velocityVector = Vector.fromVelocity(this.tracker, this.keyPointer);
+    const velocityVector = Vector.fromVelocity(
+      this.pointerTracker,
+      this.keyPointer
+    );
 
     const getAlignment = (
       direction: Directions | DiagonalDirections,
@@ -109,7 +112,7 @@ export default class FlingGestureHandler extends GestureHandler {
       return;
     }
 
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
     this.keyPointer = event.pointerId;
 
     super.onPointerDown(event);
@@ -119,35 +122,35 @@ export default class FlingGestureHandler extends GestureHandler {
   }
 
   protected onPointerAdd(event: AdaptedEvent): void {
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
     super.onPointerAdd(event);
     this.newPointerAction();
   }
 
   private newPointerAction(): void {
-    if (this.currentState === State.UNDETERMINED) {
+    if (this.state === State.UNDETERMINED) {
       this.startFling();
     }
 
-    if (this.currentState !== State.BEGAN) {
+    if (this.state !== State.BEGAN) {
       return;
     }
 
     this.tryEndFling();
 
     if (
-      this.tracker.getTrackedPointersCount() >
+      this.pointerTracker.getTrackedPointersCount() >
       this.maxNumberOfPointersSimultaneously
     ) {
       this.maxNumberOfPointersSimultaneously =
-        this.tracker.getTrackedPointersCount();
+        this.pointerTracker.getTrackedPointersCount();
     }
   }
 
   private pointerMoveAction(event: AdaptedEvent): void {
-    this.tracker.track(event);
+    this.pointerTracker.track(event);
 
-    if (this.currentState !== State.BEGAN) {
+    if (this.state !== State.BEGAN) {
       return;
     }
 
@@ -177,11 +180,11 @@ export default class FlingGestureHandler extends GestureHandler {
   }
 
   private onUp(event: AdaptedEvent): void {
-    if (this.currentState === State.BEGAN) {
+    if (this.state === State.BEGAN) {
       this.endFling();
     }
 
-    this.tracker.removeFromTracker(event.pointerId);
+    this.pointerTracker.removeFromTracker(event.pointerId);
   }
 
   public activate(force?: boolean): void {

--- a/src/web/handlers/FlingGestureHandler.ts
+++ b/src/web/handlers/FlingGestureHandler.ts
@@ -16,60 +16,12 @@ const DIAGONAL_DEVIATION_COSINE = coneToDeviation(90 - DEFAULT_ALIGNMENT_CONE);
 
 export default class FlingGestureHandler extends GestureHandler {
   private _numberOfPointersRequired = DEFAULT_NUMBER_OF_TOUCHES_REQUIRED;
-  get numberOfPointersRequired() {
-    return this._numberOfPointersRequired;
-  }
-  set numberOfPointersRequired(val: number) {
-    this._numberOfPointersRequired = val;
-  }
-
   private _direction: Directions = DEFAULT_DIRECTION;
-  get direction() {
-    return this._direction;
-  }
-  set direction(newDirection: Directions) {
-    this._direction = newDirection;
-  }
-
   private _maxDurationMs = DEFAULT_MAX_DURATION_MS;
-  get maxDurationMs() {
-    return this._maxDurationMs;
-  }
-  set maxDurationMs(value: number) {
-    this._maxDurationMs = value;
-  }
-
   private _minVelocity = DEFAULT_MIN_VELOCITY;
-  get minVelocity() {
-    return this._minVelocity;
-  }
-  set minVelocity(value: number) {
-    this._minVelocity = value;
-  }
-
   private _delayTimeout!: number;
-  get delayTimeout() {
-    return this._delayTimeout;
-  }
-  set delayTimeout(value: number) {
-    this._delayTimeout = value;
-  }
-
   private _maxNumberOfPointersSimultaneously = 0;
-  get maxNumberOfPointersSimultaneously() {
-    return this._maxNumberOfPointersSimultaneously;
-  }
-  set maxNumberOfPointersSimultaneously(value: number) {
-    this._maxNumberOfPointersSimultaneously = value;
-  }
-
   private _keyPointer = NaN;
-  get keyPointer() {
-    return this._keyPointer;
-  }
-  set keyPointer(value: number) {
-    this._keyPointer = value;
-  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
@@ -241,5 +193,54 @@ export default class FlingGestureHandler extends GestureHandler {
     super.resetConfig();
     this.numberOfPointersRequired = DEFAULT_NUMBER_OF_TOUCHES_REQUIRED;
     this.direction = DEFAULT_DIRECTION;
+  }
+
+  get numberOfPointersRequired() {
+    return this._numberOfPointersRequired;
+  }
+  set numberOfPointersRequired(val: number) {
+    this._numberOfPointersRequired = val;
+  }
+
+  get direction() {
+    return this._direction;
+  }
+  set direction(newDirection: Directions) {
+    this._direction = newDirection;
+  }
+
+  get maxDurationMs() {
+    return this._maxDurationMs;
+  }
+  set maxDurationMs(value: number) {
+    this._maxDurationMs = value;
+  }
+
+  get minVelocity() {
+    return this._minVelocity;
+  }
+  set minVelocity(value: number) {
+    this._minVelocity = value;
+  }
+
+  get delayTimeout() {
+    return this._delayTimeout;
+  }
+  set delayTimeout(value: number) {
+    this._delayTimeout = value;
+  }
+
+  get maxNumberOfPointersSimultaneously() {
+    return this._maxNumberOfPointersSimultaneously;
+  }
+  set maxNumberOfPointersSimultaneously(value: number) {
+    this._maxNumberOfPointersSimultaneously = value;
+  }
+
+  get keyPointer() {
+    return this._keyPointer;
+  }
+  set keyPointer(value: number) {
+    this._keyPointer = value;
   }
 }

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -288,13 +288,6 @@ export default abstract class GestureHandler implements IGestureHandler {
     this.resetProgress();
   }
 
-  public getShouldResetProgress(): boolean {
-    return this.shouldResetProgress;
-  }
-  public setShouldResetProgress(value: boolean): void {
-    this.shouldResetProgress = value;
-  }
-
   public shouldWaitForHandlerFailure(handler: IGestureHandler): boolean {
     if (handler === this) {
       return false;

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -698,115 +698,117 @@ export default abstract class GestureHandler implements IGestureHandler {
     );
   }
 
-  get lastSentState() {
+  public get lastSentState() {
     return this._lastSentState;
   }
-  set lastSentState(val: State | null) {
+  public set lastSentState(val: State | null) {
     this._lastSentState = val;
   }
 
-  get state() {
+  public get state() {
     return this._state;
   }
-  set state(newState: State) {
+  public set state(newState: State) {
     this._state = newState;
   }
 
-  get shouldCancelWhenOutside() {
+  public get shouldCancelWhenOutside() {
     return this._shouldCancelWhenOutside;
   }
-  set shouldCancelWhenOutside(val: boolean) {
+  public set shouldCancelWhenOutside(val: boolean) {
     this._shouldCancelWhenOutside = val;
   }
 
-  get hasCustomActivationCriteria() {
+  public get hasCustomActivationCriteria() {
     return this._hasCustomActivationCriteria;
   }
-  set hasCustomActivationCriteria(val: boolean) {
+  public set hasCustomActivationCriteria(val: boolean) {
     this._hasCustomActivationCriteria = val;
   }
 
-  get enabled() {
+  public get enabled() {
     return this._enabled;
   }
-  set enabled(val: boolean) {
+  public set enabled(val: boolean) {
     this._enabled = val;
   }
 
-  get viewRef() {
+  public get viewRef() {
     return this._viewRef;
   }
-  set viewRef(val: number) {
+  public set viewRef(val: number) {
     this._viewRef = val;
   }
 
-  get propsRef() {
+  public get propsRef() {
     return this._propsRef;
   }
-  set propsRef(val: React.RefObject<unknown>) {
+  public set propsRef(val: React.RefObject<unknown>) {
     this._propsRef = val;
   }
 
-  get handlerTag() {
+  public get handlerTag() {
     return this._handlerTag;
   }
-  set handlerTag(tag: number) {
+  public set handlerTag(tag: number) {
     this._handlerTag = tag;
   }
 
-  get config() {
+  public get config() {
     return this._config;
   }
-  set config(newConfig: Config) {
+  public set config(newConfig: Config) {
     this._config = newConfig;
   }
 
-  get pointerTracker() {
+  public get pointerTracker() {
     return this._pointerTracker;
   }
-  set pointerTracker(tracker: PointerTracker) {
+  public set pointerTracker(tracker: PointerTracker) {
     this._pointerTracker = tracker;
   }
 
-  get activationIndex() {
+  public get activationIndex() {
     return this._activationIndex;
   }
-  set activationIndex(val: number) {
+  public set activationIndex(val: number) {
     this._activationIndex = val;
   }
 
-  get awaiting() {
+  public get awaiting() {
     return this._awaiting;
   }
-  set awaiting(val: boolean) {
+  public set awaiting(val: boolean) {
     this._awaiting = val;
   }
 
-  get active() {
+  public get active() {
     return this._active;
   }
-  set active(val: boolean) {
+  public set active(val: boolean) {
     this._active = val;
   }
 
-  get shouldResetProgress() {
+  public get shouldResetProgress() {
     return this._shouldResetProgress;
   }
-  set shouldResetProgress(val: boolean) {
+  public set shouldResetProgress(val: boolean) {
     this._shouldResetProgress = val;
   }
 
-  get pointerType() {
+  public get pointerType() {
     return this._pointerType;
   }
-  set pointerType(newPointerType: PointerType) {
+  public set pointerType(newPointerType: PointerType) {
     this._pointerType = newPointerType;
   }
 
-  get delegate() {
+  public get delegate() {
     return this._delegate;
   }
-  set delegate(newDelegate: GestureHandlerDelegate<unknown, IGestureHandler>) {
+  public set delegate(
+    newDelegate: GestureHandlerDelegate<unknown, IGestureHandler>
+  ) {
     this._delegate = newDelegate;
   }
 }

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -21,43 +21,138 @@ import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 
 export default abstract class GestureHandler implements IGestureHandler {
   private lastSentState: State | null = null;
-  protected currentState: State = State.UNDETERMINED;
 
-  protected shouldCancelWhenOutside = false;
-  protected hasCustomActivationCriteria = false;
-  protected enabled = false;
+  private _state: State = State.UNDETERMINED;
+  get state() {
+    return this._state;
+  }
+  set state(newState: State) {
+    this._state = newState;
+  }
 
-  private viewRef!: number;
-  private propsRef!: React.RefObject<unknown>;
-  private handlerTag!: number;
-  protected config: Config = { enabled: false };
+  private _shouldCancelWhenOutside = false;
+  get shouldCancelWhenOutside() {
+    return this._shouldCancelWhenOutside;
+  }
+  set shouldCancelWhenOutside(val: boolean) {
+    this._shouldCancelWhenOutside = val;
+  }
 
-  protected tracker: PointerTracker = new PointerTracker();
+  private _hasCustomActivationCriteria = false;
+  get hasCustomActivationCriteria() {
+    return this._hasCustomActivationCriteria;
+  }
+  set hasCustomActivationCriteria(val: boolean) {
+    this._hasCustomActivationCriteria = val;
+  }
 
-  // Orchestrator properties
-  protected activationIndex = 0;
-  protected awaiting = false;
-  protected active = false;
-  protected shouldResetProgress = false;
-  protected pointerType: PointerType = PointerType.MOUSE;
+  private _enabled = false;
+  get enabled() {
+    return this._enabled;
+  }
+  set enabled(val: boolean) {
+    this._enabled = val;
+  }
 
-  protected delegate: GestureHandlerDelegate<unknown, IGestureHandler>;
+  private _viewRef!: number;
+  get viewRef() {
+    return this._viewRef;
+  }
+  set viewRef(val: number) {
+    this._viewRef = val;
+  }
+
+  private _propsRef!: React.RefObject<unknown>;
+  get propsRef() {
+    return this._propsRef;
+  }
+  set propsRef(val: React.RefObject<unknown>) {
+    this._propsRef = val;
+  }
+
+  private _handlerTag!: number;
+  get handlerTag() {
+    return this._handlerTag;
+  }
+  set handlerTag(tag: number) {
+    this._handlerTag = tag;
+  }
+
+  private _config: Config = { enabled: false };
+  get config() {
+    return this._config;
+  }
+  set config(newConfig: Config) {
+    this._config = newConfig;
+  }
+
+  private _pointerTracker: PointerTracker = new PointerTracker();
+  get pointerTracker() {
+    return this._pointerTracker;
+  }
+  set pointerTracker(tracker: PointerTracker) {
+    this._pointerTracker = tracker;
+  }
+
+  private _activationIndex = 0;
+  get activationIndex() {
+    return this._activationIndex;
+  }
+  set activationIndex(val: number) {
+    this._activationIndex = val;
+  }
+
+  private _awaiting = false;
+  get awaiting() {
+    return this._awaiting;
+  }
+  set awaiting(val: boolean) {
+    this._awaiting = val;
+  }
+
+  private _active = false;
+  get active() {
+    return this._active;
+  }
+  set active(val: boolean) {
+    this._active = val;
+  }
+
+  private _shouldResetProgress = false;
+  get shouldResetProgress() {
+    return this._shouldResetProgress;
+  }
+  set shouldResetProgress(val: boolean) {
+    this._shouldResetProgress = val;
+  }
+
+  private _pointerType: PointerType = PointerType.MOUSE;
+  get pointerType() {
+    return this._pointerType;
+  }
+  set pointerType(newPointerType: PointerType) {
+    this._pointerType = newPointerType;
+  }
+
+  private _delegate: GestureHandlerDelegate<unknown, IGestureHandler>;
+  get delegate() {
+    return this._delegate;
+  }
+  set delegate(newDelegate: GestureHandlerDelegate<unknown, IGestureHandler>) {
+    this._delegate = newDelegate;
+  }
 
   public constructor(
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
   ) {
-    this.delegate = delegate;
+    this._delegate = delegate;
   }
-
-  //
-  // Initializing handler
-  //
 
   protected init(viewRef: number, propsRef: React.RefObject<unknown>) {
     this.propsRef = propsRef;
     this.viewRef = viewRef;
 
-    this.currentState = State.UNDETERMINED;
+    this.state = State.UNDETERMINED;
 
     this.delegate.init(viewRef, this);
   }
@@ -79,36 +174,28 @@ export default abstract class GestureHandler implements IGestureHandler {
     manager.registerListeners();
   }
 
-  //
-  // Resetting handler
-  //
-
   protected onCancel(): void {}
   protected onReset(): void {}
   protected resetProgress(): void {}
 
   public reset(): void {
-    this.tracker.resetTracker();
+    this.pointerTracker.resetTracker();
     this.onReset();
     this.resetProgress();
     this.delegate.reset();
-    this.currentState = State.UNDETERMINED;
+    this.state = State.UNDETERMINED;
   }
 
-  //
-  // State logic
-  //
-
   public moveToState(newState: State, sendIfDisabled?: boolean) {
-    if (this.currentState === newState) {
+    if (this.state === newState) {
       return;
     }
 
-    const oldState = this.currentState;
-    this.currentState = newState;
+    const oldState = this.state;
+    this.state = newState;
 
     if (
-      this.tracker.getTrackedPointersCount() > 0 &&
+      this.pointerTracker.getTrackedPointersCount() > 0 &&
       this.config.needsPointerData &&
       this.isFinished()
     ) {
@@ -125,7 +212,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     this.onStateChange(newState, oldState);
 
     if (!this.enabled && this.isFinished()) {
-      this.currentState = State.UNDETERMINED;
+      this.state = State.UNDETERMINED;
     }
   }
 
@@ -136,7 +223,7 @@ export default abstract class GestureHandler implements IGestureHandler {
       return;
     }
 
-    if (this.currentState === State.UNDETERMINED) {
+    if (this.state === State.UNDETERMINED) {
       this.moveToState(State.BEGAN);
     }
   }
@@ -145,12 +232,9 @@ export default abstract class GestureHandler implements IGestureHandler {
    * @param {boolean} sendIfDisabled - Used when handler becomes disabled. With this flag orchestrator will be forced to send fail event
    */
   public fail(sendIfDisabled?: boolean): void {
-    if (
-      this.currentState === State.ACTIVE ||
-      this.currentState === State.BEGAN
-    ) {
+    if (this.state === State.ACTIVE || this.state === State.BEGAN) {
       // Here the order of calling the delegate and moveToState is important.
-      // At this point we can use currentState as previuos state, because immediately after changing cursor we call moveToState method.
+      // At this point we can use state as previuos state, because immediately after changing cursor we call moveToState method.
       this.delegate.onFail();
 
       this.moveToState(State.FAILED, sendIfDisabled);
@@ -164,9 +248,9 @@ export default abstract class GestureHandler implements IGestureHandler {
    */
   public cancel(sendIfDisabled?: boolean): void {
     if (
-      this.currentState === State.ACTIVE ||
-      this.currentState === State.UNDETERMINED ||
-      this.currentState === State.BEGAN
+      this.state === State.ACTIVE ||
+      this.state === State.UNDETERMINED ||
+      this.state === State.BEGAN
     ) {
       this.onCancel();
 
@@ -180,8 +264,7 @@ export default abstract class GestureHandler implements IGestureHandler {
   public activate(force = false) {
     if (
       (this.config.manualActivation !== true || force) &&
-      (this.currentState === State.UNDETERMINED ||
-        this.currentState === State.BEGAN)
+      (this.state === State.UNDETERMINED || this.state === State.BEGAN)
     ) {
       this.delegate.onActivate();
       this.moveToState(State.ACTIVE);
@@ -189,10 +272,7 @@ export default abstract class GestureHandler implements IGestureHandler {
   }
 
   public end() {
-    if (
-      this.currentState === State.BEGAN ||
-      this.currentState === State.ACTIVE
-    ) {
+    if (this.state === State.BEGAN || this.state === State.ACTIVE) {
       // Same as above - order matters
       this.delegate.onEnd();
 
@@ -202,36 +282,11 @@ export default abstract class GestureHandler implements IGestureHandler {
     this.resetProgress();
   }
 
-  //
-  // Methods for orchestrator
-  //
-
-  public isAwaiting(): boolean {
-    return this.awaiting;
-  }
-  public setAwaiting(value: boolean): void {
-    this.awaiting = value;
-  }
-
-  public isActive(): boolean {
-    return this.active;
-  }
-  public setActive(value: boolean): void {
-    this.active = value;
-  }
-
   public getShouldResetProgress(): boolean {
     return this.shouldResetProgress;
   }
   public setShouldResetProgress(value: boolean): void {
     this.shouldResetProgress = value;
-  }
-
-  public getActivationIndex(): number {
-    return this.activationIndex;
-  }
-  public setActivationIndex(value: number): void {
-    this.activationIndex = value;
   }
 
   public shouldWaitForHandlerFailure(handler: IGestureHandler): boolean {
@@ -278,10 +333,6 @@ export default abstract class GestureHandler implements IGestureHandler {
     );
   }
 
-  //
-  // Event actions
-  //
-
   protected onPointerDown(event: AdaptedEvent): void {
     GestureHandlerOrchestrator.getInstance().recordHandlerIfNotPresent(this);
     this.pointerType = event.pointerType;
@@ -308,7 +359,7 @@ export default abstract class GestureHandler implements IGestureHandler {
   }
   protected onPointerLeave(event: AdaptedEvent): void {
     if (this.shouldCancelWhenOutside) {
-      switch (this.currentState) {
+      switch (this.state) {
         case State.ACTIVE:
           this.cancel();
           break;
@@ -348,7 +399,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     }
 
     if (this.active) {
-      this.sendEvent(this.currentState, this.currentState);
+      this.sendEvent(this.state, this.state);
     }
 
     this.tryToSendTouchEvent(event);
@@ -398,7 +449,7 @@ export default abstract class GestureHandler implements IGestureHandler {
       this.lastSentState = newState;
       invokeNullableMethod(onGestureHandlerStateChange, resultEvent);
     }
-    if (this.currentState === State.ACTIVE) {
+    if (this.state === State.ACTIVE) {
       resultEvent.nativeEvent.oldState = undefined;
       invokeNullableMethod(onGestureHandlerEvent, resultEvent);
     }
@@ -407,10 +458,10 @@ export default abstract class GestureHandler implements IGestureHandler {
   private transformEventData(newState: State, oldState: State): ResultEvent {
     return {
       nativeEvent: {
-        numberOfPointers: this.tracker.getTrackedPointersCount(),
+        numberOfPointers: this.pointerTracker.getTrackedPointersCount(),
         state: newState,
         pointerInside: this.delegate.isPointerInBounds(
-          this.tracker.getAbsoluteCoordsAverage()
+          this.pointerTracker.getAbsoluteCoordsAverage()
         ),
         ...this.transformNativeEvent(),
         handlerTag: this.handlerTag,
@@ -430,7 +481,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     const all: PointerData[] = [];
     const changed: PointerData[] = [];
 
-    const trackerData = this.tracker.getData();
+    const trackerData = this.pointerTracker.getData();
 
     // This if handles edge case where all pointers have been cancelled
     // When pointercancel is triggered, reset method is called. This means that tracker will be reset after first pointer being cancelled
@@ -441,7 +492,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     }
 
     trackerData.forEach((element: TrackerElement, key: number): void => {
-      const id: number = this.tracker.getMappedTouchEventId(key);
+      const id: number = this.pointerTracker.getMappedTouchEventId(key);
 
       all.push({
         id: id,
@@ -456,7 +507,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     // However, if the event is cancel, we want to cancel all pointers to avoid crashes
     if (event.eventType !== EventTypes.CANCEL) {
       changed.push({
-        id: this.tracker.getMappedTouchEventId(event.pointerId),
+        id: this.pointerTracker.getMappedTouchEventId(event.pointerId),
         x: event.x - rect.pageX,
         y: event.y - rect.pageY,
         absoluteX: event.x,
@@ -464,7 +515,7 @@ export default abstract class GestureHandler implements IGestureHandler {
       });
     } else {
       trackerData.forEach((element: TrackerElement, key: number): void => {
-        const id: number = this.tracker.getMappedTouchEventId(key);
+        const id: number = this.pointerTracker.getMappedTouchEventId(key);
 
         changed.push({
           id: id,
@@ -510,7 +561,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     return {
       nativeEvent: {
         handlerTag: this.handlerTag,
-        state: this.currentState,
+        state: this.state,
         eventType: eventType,
         changedTouches: changed,
         allTouches: all,
@@ -527,14 +578,14 @@ export default abstract class GestureHandler implements IGestureHandler {
     const all: PointerData[] = [];
     const changed: PointerData[] = [];
 
-    const trackerData = this.tracker.getData();
+    const trackerData = this.pointerTracker.getData();
 
     if (trackerData.size === 0) {
       return;
     }
 
     trackerData.forEach((element: TrackerElement, key: number): void => {
-      const id: number = this.tracker.getMappedTouchEventId(key);
+      const id: number = this.pointerTracker.getMappedTouchEventId(key);
 
       all.push({
         id: id,
@@ -556,7 +607,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     const cancelEvent: ResultTouchEvent = {
       nativeEvent: {
         handlerTag: this.handlerTag,
-        state: this.currentState,
+        state: this.state,
         eventType: TouchEventType.CANCELLED,
         changedTouches: changed,
         allTouches: all,
@@ -574,8 +625,8 @@ export default abstract class GestureHandler implements IGestureHandler {
 
   protected transformNativeEvent(): Record<string, unknown> {
     // Those properties are shared by most handlers and if not this method will be overriden
-    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
-    const lastRelativeCoords = this.tracker.getRelativeCoordsAverage();
+    const lastCoords = this.pointerTracker.getAbsoluteCoordsAverage();
+    const lastRelativeCoords = this.pointerTracker.getRelativeCoordsAverage();
 
     return {
       x: lastRelativeCoords.x,
@@ -585,10 +636,6 @@ export default abstract class GestureHandler implements IGestureHandler {
     };
   }
 
-  //
-  // Handling config
-  //
-
   public updateGestureConfig({ enabled = true, ...props }: Config): void {
     this.config = { enabled: enabled, ...props };
     this.enabled = enabled;
@@ -596,7 +643,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     this.delegate.onEnabledChange(enabled);
 
     if (this.config.shouldCancelWhenOutside !== undefined) {
-      this.setShouldCancelWhenOutside(this.config.shouldCancelWhenOutside);
+      this.shouldCancelWhenOutside = this.config.shouldCancelWhenOutside;
     }
 
     this.validateHitSlops();
@@ -605,7 +652,7 @@ export default abstract class GestureHandler implements IGestureHandler {
       return;
     }
 
-    switch (this.currentState) {
+    switch (this.state) {
       case State.ACTIVE:
         this.fail(true);
         break;
@@ -728,7 +775,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     }
 
     const rect = this.delegate.measureView();
-    const { x, y } = this.tracker.getLastAbsoluteCoords();
+    const { x, y } = this.pointerTracker.getLastAbsoluteCoords();
     const offsetX: number = x - rect.pageX;
     const offsetY: number = y - rect.pageY;
 
@@ -751,60 +798,16 @@ export default abstract class GestureHandler implements IGestureHandler {
     this.delegate.destroy(this.config);
   }
 
-  //
-  // Getters and setters
-  //
-
-  public getTag(): number {
-    return this.handlerTag;
-  }
-
-  public setTag(tag: number): void {
-    this.handlerTag = tag;
-  }
-
-  public getConfig() {
-    return this.config;
-  }
-
-  public getDelegate(): GestureHandlerDelegate<unknown, IGestureHandler> {
-    return this.delegate;
-  }
-
-  public getTracker(): PointerTracker {
-    return this.tracker;
-  }
-
   public getTrackedPointersID(): number[] {
-    return this.tracker.getTrackedPointersID();
-  }
-
-  public getState(): State {
-    return this.currentState;
-  }
-
-  public isEnabled(): boolean {
-    return this.enabled;
+    return this.pointerTracker.getTrackedPointersID();
   }
 
   private isFinished(): boolean {
     return (
-      this.currentState === State.END ||
-      this.currentState === State.FAILED ||
-      this.currentState === State.CANCELLED
+      this.state === State.END ||
+      this.state === State.FAILED ||
+      this.state === State.CANCELLED
     );
-  }
-
-  protected setShouldCancelWhenOutside(shouldCancel: boolean) {
-    this.shouldCancelWhenOutside = shouldCancel;
-  }
-
-  protected getShouldCancelWhenOutside(): boolean {
-    return this.shouldCancelWhenOutside;
-  }
-
-  public getPointerType(): PointerType {
-    return this.pointerType;
   }
 }
 

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -21,132 +21,21 @@ import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 
 export default abstract class GestureHandler implements IGestureHandler {
   private _lastSentState: State | null = null;
-  get lastSentState() {
-    return this._lastSentState;
-  }
-  set lastSentState(val: State | null) {
-    this._lastSentState = val;
-  }
-
   private _state: State = State.UNDETERMINED;
-  get state() {
-    return this._state;
-  }
-  set state(newState: State) {
-    this._state = newState;
-  }
-
   private _shouldCancelWhenOutside = false;
-  get shouldCancelWhenOutside() {
-    return this._shouldCancelWhenOutside;
-  }
-  set shouldCancelWhenOutside(val: boolean) {
-    this._shouldCancelWhenOutside = val;
-  }
-
   private _hasCustomActivationCriteria = false;
-  get hasCustomActivationCriteria() {
-    return this._hasCustomActivationCriteria;
-  }
-  set hasCustomActivationCriteria(val: boolean) {
-    this._hasCustomActivationCriteria = val;
-  }
-
   private _enabled = false;
-  get enabled() {
-    return this._enabled;
-  }
-  set enabled(val: boolean) {
-    this._enabled = val;
-  }
-
   private _viewRef!: number;
-  get viewRef() {
-    return this._viewRef;
-  }
-  set viewRef(val: number) {
-    this._viewRef = val;
-  }
-
   private _propsRef!: React.RefObject<unknown>;
-  get propsRef() {
-    return this._propsRef;
-  }
-  set propsRef(val: React.RefObject<unknown>) {
-    this._propsRef = val;
-  }
-
-  private _handlerTag!: number;
-  get handlerTag() {
-    return this._handlerTag;
-  }
-  set handlerTag(tag: number) {
-    this._handlerTag = tag;
-  }
-
   private _config: Config = { enabled: false };
-  get config() {
-    return this._config;
-  }
-  set config(newConfig: Config) {
-    this._config = newConfig;
-  }
-
+  private _handlerTag!: number;
   private _pointerTracker: PointerTracker = new PointerTracker();
-  get pointerTracker() {
-    return this._pointerTracker;
-  }
-  set pointerTracker(tracker: PointerTracker) {
-    this._pointerTracker = tracker;
-  }
-
   private _activationIndex = 0;
-  get activationIndex() {
-    return this._activationIndex;
-  }
-  set activationIndex(val: number) {
-    this._activationIndex = val;
-  }
-
   private _awaiting = false;
-  get awaiting() {
-    return this._awaiting;
-  }
-  set awaiting(val: boolean) {
-    this._awaiting = val;
-  }
-
   private _active = false;
-  get active() {
-    return this._active;
-  }
-  set active(val: boolean) {
-    this._active = val;
-  }
-
   private _shouldResetProgress = false;
-  get shouldResetProgress() {
-    return this._shouldResetProgress;
-  }
-  set shouldResetProgress(val: boolean) {
-    this._shouldResetProgress = val;
-  }
-
   private _pointerType: PointerType = PointerType.MOUSE;
-  get pointerType() {
-    return this._pointerType;
-  }
-  set pointerType(newPointerType: PointerType) {
-    this._pointerType = newPointerType;
-  }
-
   private _delegate: GestureHandlerDelegate<unknown, IGestureHandler>;
-  get delegate() {
-    return this._delegate;
-  }
-  set delegate(newDelegate: GestureHandlerDelegate<unknown, IGestureHandler>) {
-    this._delegate = newDelegate;
-  }
 
   public constructor(
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
@@ -807,6 +696,118 @@ export default abstract class GestureHandler implements IGestureHandler {
       this.state === State.FAILED ||
       this.state === State.CANCELLED
     );
+  }
+
+  get lastSentState() {
+    return this._lastSentState;
+  }
+  set lastSentState(val: State | null) {
+    this._lastSentState = val;
+  }
+
+  get state() {
+    return this._state;
+  }
+  set state(newState: State) {
+    this._state = newState;
+  }
+
+  get shouldCancelWhenOutside() {
+    return this._shouldCancelWhenOutside;
+  }
+  set shouldCancelWhenOutside(val: boolean) {
+    this._shouldCancelWhenOutside = val;
+  }
+
+  get hasCustomActivationCriteria() {
+    return this._hasCustomActivationCriteria;
+  }
+  set hasCustomActivationCriteria(val: boolean) {
+    this._hasCustomActivationCriteria = val;
+  }
+
+  get enabled() {
+    return this._enabled;
+  }
+  set enabled(val: boolean) {
+    this._enabled = val;
+  }
+
+  get viewRef() {
+    return this._viewRef;
+  }
+  set viewRef(val: number) {
+    this._viewRef = val;
+  }
+
+  get propsRef() {
+    return this._propsRef;
+  }
+  set propsRef(val: React.RefObject<unknown>) {
+    this._propsRef = val;
+  }
+
+  get handlerTag() {
+    return this._handlerTag;
+  }
+  set handlerTag(tag: number) {
+    this._handlerTag = tag;
+  }
+
+  get config() {
+    return this._config;
+  }
+  set config(newConfig: Config) {
+    this._config = newConfig;
+  }
+
+  get pointerTracker() {
+    return this._pointerTracker;
+  }
+  set pointerTracker(tracker: PointerTracker) {
+    this._pointerTracker = tracker;
+  }
+
+  get activationIndex() {
+    return this._activationIndex;
+  }
+  set activationIndex(val: number) {
+    this._activationIndex = val;
+  }
+
+  get awaiting() {
+    return this._awaiting;
+  }
+  set awaiting(val: boolean) {
+    this._awaiting = val;
+  }
+
+  get active() {
+    return this._active;
+  }
+  set active(val: boolean) {
+    this._active = val;
+  }
+
+  get shouldResetProgress() {
+    return this._shouldResetProgress;
+  }
+  set shouldResetProgress(val: boolean) {
+    this._shouldResetProgress = val;
+  }
+
+  get pointerType() {
+    return this._pointerType;
+  }
+  set pointerType(newPointerType: PointerType) {
+    this._pointerType = newPointerType;
+  }
+
+  get delegate() {
+    return this._delegate;
+  }
+  set delegate(newDelegate: GestureHandlerDelegate<unknown, IGestureHandler>) {
+    this._delegate = newDelegate;
   }
 }
 

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -701,50 +701,50 @@ export default abstract class GestureHandler implements IGestureHandler {
   public get lastSentState() {
     return this._lastSentState;
   }
-  public set lastSentState(val: State | null) {
-    this._lastSentState = val;
+  public set lastSentState(state: State | null) {
+    this._lastSentState = state;
   }
 
   public get state() {
     return this._state;
   }
-  public set state(newState: State) {
-    this._state = newState;
+  public set state(state: State) {
+    this._state = state;
   }
 
   public get shouldCancelWhenOutside() {
     return this._shouldCancelWhenOutside;
   }
-  public set shouldCancelWhenOutside(val: boolean) {
-    this._shouldCancelWhenOutside = val;
+  public set shouldCancelWhenOutside(value: boolean) {
+    this._shouldCancelWhenOutside = value;
   }
 
   public get hasCustomActivationCriteria() {
     return this._hasCustomActivationCriteria;
   }
-  public set hasCustomActivationCriteria(val: boolean) {
-    this._hasCustomActivationCriteria = val;
+  public set hasCustomActivationCriteria(value: boolean) {
+    this._hasCustomActivationCriteria = value;
   }
 
   public get enabled() {
     return this._enabled;
   }
-  public set enabled(val: boolean) {
-    this._enabled = val;
+  public set enabled(value: boolean) {
+    this._enabled = value;
   }
 
   public get viewRef() {
     return this._viewRef;
   }
-  public set viewRef(val: number) {
-    this._viewRef = val;
+  public set viewRef(value: number) {
+    this._viewRef = value;
   }
 
   public get propsRef() {
     return this._propsRef;
   }
-  public set propsRef(val: React.RefObject<unknown>) {
-    this._propsRef = val;
+  public set propsRef(propsRef: React.RefObject<unknown>) {
+    this._propsRef = propsRef;
   }
 
   public get handlerTag() {
@@ -757,59 +757,59 @@ export default abstract class GestureHandler implements IGestureHandler {
   public get config() {
     return this._config;
   }
-  public set config(newConfig: Config) {
-    this._config = newConfig;
+  public set config(config: Config) {
+    this._config = config;
   }
 
   public get pointerTracker() {
     return this._pointerTracker;
   }
-  public set pointerTracker(tracker: PointerTracker) {
-    this._pointerTracker = tracker;
+  public set pointerTracker(pointerTracker: PointerTracker) {
+    this._pointerTracker = pointerTracker;
   }
 
   public get activationIndex() {
     return this._activationIndex;
   }
-  public set activationIndex(val: number) {
-    this._activationIndex = val;
+  public set activationIndex(value: number) {
+    this._activationIndex = value;
   }
 
   public get awaiting() {
     return this._awaiting;
   }
-  public set awaiting(val: boolean) {
-    this._awaiting = val;
+  public set awaiting(value: boolean) {
+    this._awaiting = value;
   }
 
   public get active() {
     return this._active;
   }
-  public set active(val: boolean) {
-    this._active = val;
+  public set active(value: boolean) {
+    this._active = value;
   }
 
   public get shouldResetProgress() {
     return this._shouldResetProgress;
   }
-  public set shouldResetProgress(val: boolean) {
-    this._shouldResetProgress = val;
+  public set shouldResetProgress(value: boolean) {
+    this._shouldResetProgress = value;
   }
 
   public get pointerType() {
     return this._pointerType;
   }
-  public set pointerType(newPointerType: PointerType) {
-    this._pointerType = newPointerType;
+  public set pointerType(pointerType: PointerType) {
+    this._pointerType = pointerType;
   }
 
   public get delegate() {
     return this._delegate;
   }
   public set delegate(
-    newDelegate: GestureHandlerDelegate<unknown, IGestureHandler>
+    delegate: GestureHandlerDelegate<unknown, IGestureHandler>
   ) {
-    this._delegate = newDelegate;
+    this._delegate = delegate;
   }
 }
 

--- a/src/web/handlers/GestureHandler.ts
+++ b/src/web/handlers/GestureHandler.ts
@@ -20,7 +20,13 @@ import { PointerType } from '../../PointerType';
 import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 
 export default abstract class GestureHandler implements IGestureHandler {
-  private lastSentState: State | null = null;
+  private _lastSentState: State | null = null;
+  get lastSentState() {
+    return this._lastSentState;
+  }
+  set lastSentState(val: State | null) {
+    this._lastSentState = val;
+  }
 
   private _state: State = State.UNDETERMINED;
   get state() {

--- a/src/web/handlers/HoverGestureHandler.ts
+++ b/src/web/handlers/HoverGestureHandler.ts
@@ -24,18 +24,18 @@ export default class HoverGestureHandler extends GestureHandler {
   protected onPointerMoveOver(event: AdaptedEvent): void {
     GestureHandlerOrchestrator.getInstance().recordHandlerIfNotPresent(this);
 
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
     this.stylusData = event.stylusData;
     super.onPointerMoveOver(event);
 
-    if (this.getState() === State.UNDETERMINED) {
+    if (this.state === State.UNDETERMINED) {
       this.begin();
       this.activate();
     }
   }
 
   protected onPointerMoveOut(event: AdaptedEvent): void {
-    this.tracker.removeFromTracker(event.pointerId);
+    this.pointerTracker.removeFromTracker(event.pointerId);
     this.stylusData = event.stylusData;
 
     super.onPointerMoveOut(event);
@@ -44,7 +44,7 @@ export default class HoverGestureHandler extends GestureHandler {
   }
 
   protected onPointerMove(event: AdaptedEvent): void {
-    this.tracker.track(event);
+    this.pointerTracker.track(event);
     this.stylusData = event.stylusData;
 
     super.onPointerMove(event);

--- a/src/web/handlers/HoverGestureHandler.ts
+++ b/src/web/handlers/HoverGestureHandler.ts
@@ -58,7 +58,7 @@ export default class HoverGestureHandler extends GestureHandler {
   public get stylusData() {
     return this._stylusData;
   }
-  public set stylusData(value: StylusData | undefined) {
-    this._stylusData = value;
+  public set stylusData(stylusData: StylusData | undefined) {
+    this._stylusData = stylusData;
   }
 }

--- a/src/web/handlers/HoverGestureHandler.ts
+++ b/src/web/handlers/HoverGestureHandler.ts
@@ -55,10 +55,10 @@ export default class HoverGestureHandler extends GestureHandler {
     this.reset();
   }
 
-  get stylusData() {
+  public get stylusData() {
     return this._stylusData;
   }
-  set stylusData(value: StylusData | undefined) {
+  public set stylusData(value: StylusData | undefined) {
     this._stylusData = value;
   }
 }

--- a/src/web/handlers/HoverGestureHandler.ts
+++ b/src/web/handlers/HoverGestureHandler.ts
@@ -4,7 +4,13 @@ import GestureHandlerOrchestrator from '../tools/GestureHandlerOrchestrator';
 import GestureHandler from './GestureHandler';
 
 export default class HoverGestureHandler extends GestureHandler {
-  private stylusData: StylusData | undefined;
+  private _stylusData: StylusData | undefined;
+  get stylusData() {
+    return this._stylusData;
+  }
+  set stylusData(value: StylusData | undefined) {
+    this._stylusData = value;
+  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>) {
     super.init(ref, propsRef);

--- a/src/web/handlers/HoverGestureHandler.ts
+++ b/src/web/handlers/HoverGestureHandler.ts
@@ -5,12 +5,6 @@ import GestureHandler from './GestureHandler';
 
 export default class HoverGestureHandler extends GestureHandler {
   private _stylusData: StylusData | undefined;
-  get stylusData() {
-    return this._stylusData;
-  }
-  set stylusData(value: StylusData | undefined) {
-    this._stylusData = value;
-  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>) {
     super.init(ref, propsRef);
@@ -59,5 +53,12 @@ export default class HoverGestureHandler extends GestureHandler {
   protected onPointerCancel(event: AdaptedEvent): void {
     super.onPointerCancel(event);
     this.reset();
+  }
+
+  get stylusData() {
+    return this._stylusData;
+  }
+  set stylusData(value: StylusData | undefined) {
+    this._stylusData = value;
   }
 }

--- a/src/web/handlers/IGestureHandler.ts
+++ b/src/web/handlers/IGestureHandler.ts
@@ -10,16 +10,12 @@ export default interface IGestureHandler {
   active: boolean;
   awaiting: boolean;
   activationIndex: number;
-
   config: Config;
-
   delegate: GestureHandlerDelegate<unknown, unknown>;
-
   enabled: boolean;
-
   pointerTracker: PointerTracker;
   pointerType: PointerType;
-
+  shouldResetProgress: boolean;
   state: State;
   handlerTag: number;
 
@@ -38,8 +34,6 @@ export default interface IGestureHandler {
   cancel: () => void;
 
   reset: () => void;
-
-  setShouldResetProgress: (value: boolean) => void;
 
   shouldWaitForHandlerFailure: (handler: IGestureHandler) => boolean;
   shouldRequireToWaitForFailure: (handler: IGestureHandler) => boolean;

--- a/src/web/handlers/IGestureHandler.ts
+++ b/src/web/handlers/IGestureHandler.ts
@@ -1,25 +1,34 @@
-import type { PointerType } from '../../PointerType';
+import { PointerType } from '../../PointerType';
 import type { MouseButton } from '../../handlers/gestureHandlerCommon';
 import type { State } from '../../State';
 import type { Config } from '../interfaces';
 import type EventManager from '../tools/EventManager';
-import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
-import type PointerTracker from '../tools/PointerTracker';
+import { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import PointerTracker from '../tools/PointerTracker';
 
 export default interface IGestureHandler {
-  getTag: () => number;
-  getState: () => State;
-  getConfig: () => Config;
-  getDelegate: () => GestureHandlerDelegate<unknown, this>;
+  active: boolean;
+  awaiting: boolean;
+  activationIndex: number;
+
+  config: Config;
+
+  delegate: GestureHandlerDelegate<unknown, unknown>;
+
+  enabled: boolean;
+
+  pointerTracker: PointerTracker;
+  pointerType: PointerType;
+
+  state: State;
+  handlerTag: number;
 
   attachEventManager: (manager: EventManager<unknown>) => void;
 
   isButtonInConfig: (
     mouseButton: MouseButton | undefined
   ) => boolean | number | undefined;
-  getPointerType: () => PointerType;
 
-  getTracker: () => PointerTracker;
   getTrackedPointersID: () => number[];
 
   begin: () => void;
@@ -29,12 +38,7 @@ export default interface IGestureHandler {
   cancel: () => void;
 
   reset: () => void;
-  isEnabled: () => boolean;
-  isActive: () => boolean;
-  setActive: (value: boolean) => void;
-  isAwaiting: () => boolean;
-  setAwaiting: (value: boolean) => void;
-  setActivationIndex: (value: number) => void;
+
   setShouldResetProgress: (value: boolean) => void;
 
   shouldWaitForHandlerFailure: (handler: IGestureHandler) => boolean;

--- a/src/web/handlers/LongPressGestureHandler.ts
+++ b/src/web/handlers/LongPressGestureHandler.ts
@@ -9,76 +9,14 @@ const SCALING_FACTOR = 10;
 
 export default class LongPressGestureHandler extends GestureHandler {
   private _minDurationMs = DEFAULT_MIN_DURATION_MS;
-  get minDurationMs() {
-    return this._minDurationMs;
-  }
-  set minDurationMs(value: number) {
-    this._minDurationMs = value;
-  }
-
   private _defaultMaxDistSq = DEFAULT_MAX_DIST_DP * SCALING_FACTOR;
-  get defaultMaxDistSq() {
-    return this._defaultMaxDistSq;
-  }
-  set defaultMaxDistSq(value: number) {
-    this._defaultMaxDistSq = value;
-  }
-
   private _maxDistSq = this.defaultMaxDistSq;
-  get maxDistSq() {
-    return this._maxDistSq;
-  }
-  set maxDistSq(value: number) {
-    this._maxDistSq = value;
-  }
-
   private _numberOfPointers = 1;
-  get numberOfPointers() {
-    return this._numberOfPointers;
-  }
-  set numberOfPointers(value: number) {
-    this._numberOfPointers = value;
-  }
-
   private _startX = 0;
-  get startX() {
-    return this._startX;
-  }
-  set startX(value: number) {
-    this._startX = value;
-  }
-
   private _startY = 0;
-  get startY() {
-    return this._startY;
-  }
-  set startY(value: number) {
-    this._startY = value;
-  }
-
   private _startTime = 0;
-  get startTime() {
-    return this._startTime;
-  }
-  set startTime(value: number) {
-    this._startTime = value;
-  }
-
   private _previousTime = 0;
-  get previousTime() {
-    return this._previousTime;
-  }
-  set previousTime(value: number) {
-    this._previousTime = value;
-  }
-
   private _activationTimeout: number | undefined;
-  get activationTimeout() {
-    return this._activationTimeout;
-  }
-  set activationTimeout(value: number | undefined) {
-    this._activationTimeout = value;
-  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>) {
     if (this.config.enableContextMenu === undefined) {
@@ -228,5 +166,68 @@ export default class LongPressGestureHandler extends GestureHandler {
     } else {
       this.fail();
     }
+  }
+
+  get minDurationMs() {
+    return this._minDurationMs;
+  }
+  set minDurationMs(value: number) {
+    this._minDurationMs = value;
+  }
+
+  get defaultMaxDistSq() {
+    return this._defaultMaxDistSq;
+  }
+  set defaultMaxDistSq(value: number) {
+    this._defaultMaxDistSq = value;
+  }
+
+  get maxDistSq() {
+    return this._maxDistSq;
+  }
+  set maxDistSq(value: number) {
+    this._maxDistSq = value;
+  }
+
+  get numberOfPointers() {
+    return this._numberOfPointers;
+  }
+  set numberOfPointers(value: number) {
+    this._numberOfPointers = value;
+  }
+
+  get startX() {
+    return this._startX;
+  }
+  set startX(value: number) {
+    this._startX = value;
+  }
+
+  get startY() {
+    return this._startY;
+  }
+  set startY(value: number) {
+    this._startY = value;
+  }
+
+  get startTime() {
+    return this._startTime;
+  }
+  set startTime(value: number) {
+    this._startTime = value;
+  }
+
+  get previousTime() {
+    return this._previousTime;
+  }
+  set previousTime(value: number) {
+    this._previousTime = value;
+  }
+
+  get activationTimeout() {
+    return this._activationTimeout;
+  }
+  set activationTimeout(value: number | undefined) {
+    this._activationTimeout = value;
   }
 }

--- a/src/web/handlers/LongPressGestureHandler.ts
+++ b/src/web/handlers/LongPressGestureHandler.ts
@@ -213,15 +213,15 @@ export default class LongPressGestureHandler extends GestureHandler {
   public get startTime() {
     return this._startTime;
   }
-  public set startTime(value: number) {
-    this._startTime = value;
+  public set startTime(time: number) {
+    this._startTime = time;
   }
 
   public get previousTime() {
     return this._previousTime;
   }
-  public set previousTime(value: number) {
-    this._previousTime = value;
+  public set previousTime(time: number) {
+    this._previousTime = time;
   }
 
   public get activationTimeout() {

--- a/src/web/handlers/LongPressGestureHandler.ts
+++ b/src/web/handlers/LongPressGestureHandler.ts
@@ -168,66 +168,66 @@ export default class LongPressGestureHandler extends GestureHandler {
     }
   }
 
-  get minDurationMs() {
+  public get minDurationMs() {
     return this._minDurationMs;
   }
-  set minDurationMs(value: number) {
+  public set minDurationMs(value: number) {
     this._minDurationMs = value;
   }
 
-  get defaultMaxDistSq() {
+  public get defaultMaxDistSq() {
     return this._defaultMaxDistSq;
   }
-  set defaultMaxDistSq(value: number) {
+  public set defaultMaxDistSq(value: number) {
     this._defaultMaxDistSq = value;
   }
 
-  get maxDistSq() {
+  public get maxDistSq() {
     return this._maxDistSq;
   }
-  set maxDistSq(value: number) {
+  public set maxDistSq(value: number) {
     this._maxDistSq = value;
   }
 
-  get numberOfPointers() {
+  public get numberOfPointers() {
     return this._numberOfPointers;
   }
-  set numberOfPointers(value: number) {
+  public set numberOfPointers(value: number) {
     this._numberOfPointers = value;
   }
 
-  get startX() {
+  public get startX() {
     return this._startX;
   }
-  set startX(value: number) {
+  public set startX(value: number) {
     this._startX = value;
   }
 
-  get startY() {
+  public get startY() {
     return this._startY;
   }
-  set startY(value: number) {
+  public set startY(value: number) {
     this._startY = value;
   }
 
-  get startTime() {
+  public get startTime() {
     return this._startTime;
   }
-  set startTime(value: number) {
+  public set startTime(value: number) {
     this._startTime = value;
   }
 
-  get previousTime() {
+  public get previousTime() {
     return this._previousTime;
   }
-  set previousTime(value: number) {
+  public set previousTime(value: number) {
     this._previousTime = value;
   }
 
-  get activationTimeout() {
+  public get activationTimeout() {
     return this._activationTimeout;
   }
-  set activationTimeout(value: number | undefined) {
+  public set activationTimeout(value: number | undefined) {
     this._activationTimeout = value;
   }
 }

--- a/src/web/handlers/LongPressGestureHandler.ts
+++ b/src/web/handlers/LongPressGestureHandler.ts
@@ -8,18 +8,77 @@ const DEFAULT_MAX_DIST_DP = 10;
 const SCALING_FACTOR = 10;
 
 export default class LongPressGestureHandler extends GestureHandler {
-  private minDurationMs = DEFAULT_MIN_DURATION_MS;
-  private defaultMaxDistSq = DEFAULT_MAX_DIST_DP * SCALING_FACTOR;
+  private _minDurationMs = DEFAULT_MIN_DURATION_MS;
+  get minDurationMs() {
+    return this._minDurationMs;
+  }
+  set minDurationMs(value: number) {
+    this._minDurationMs = value;
+  }
 
-  private maxDistSq = this.defaultMaxDistSq;
-  private numberOfPointers = 1;
-  private startX = 0;
-  private startY = 0;
+  private _defaultMaxDistSq = DEFAULT_MAX_DIST_DP * SCALING_FACTOR;
+  get defaultMaxDistSq() {
+    return this._defaultMaxDistSq;
+  }
+  set defaultMaxDistSq(value: number) {
+    this._defaultMaxDistSq = value;
+  }
 
-  private startTime = 0;
-  private previousTime = 0;
+  private _maxDistSq = this.defaultMaxDistSq;
+  get maxDistSq() {
+    return this._maxDistSq;
+  }
+  set maxDistSq(value: number) {
+    this._maxDistSq = value;
+  }
 
-  private activationTimeout: number | undefined;
+  private _numberOfPointers = 1;
+  get numberOfPointers() {
+    return this._numberOfPointers;
+  }
+  set numberOfPointers(value: number) {
+    this._numberOfPointers = value;
+  }
+
+  private _startX = 0;
+  get startX() {
+    return this._startX;
+  }
+  set startX(value: number) {
+    this._startX = value;
+  }
+
+  private _startY = 0;
+  get startY() {
+    return this._startY;
+  }
+  set startY(value: number) {
+    this._startY = value;
+  }
+
+  private _startTime = 0;
+  get startTime() {
+    return this._startTime;
+  }
+  set startTime(value: number) {
+    this._startTime = value;
+  }
+
+  private _previousTime = 0;
+  get previousTime() {
+    return this._previousTime;
+  }
+  set previousTime(value: number) {
+    this._previousTime = value;
+  }
+
+  private _activationTimeout: number | undefined;
+  get activationTimeout() {
+    return this._activationTimeout;
+  }
+  set activationTimeout(value: number | undefined) {
+    this._activationTimeout = value;
+  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>) {
     if (this.config.enableContextMenu === undefined) {

--- a/src/web/handlers/LongPressGestureHandler.ts
+++ b/src/web/handlers/LongPressGestureHandler.ts
@@ -67,7 +67,7 @@ export default class LongPressGestureHandler extends GestureHandler {
       return;
     }
 
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
     super.onPointerDown(event);
 
     this.startX = event.x;
@@ -80,14 +80,15 @@ export default class LongPressGestureHandler extends GestureHandler {
   }
   protected onPointerAdd(event: AdaptedEvent): void {
     super.onPointerAdd(event);
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
 
-    if (this.tracker.getTrackedPointersCount() > this.numberOfPointers) {
+    if (this.pointerTracker.getTrackedPointersCount() > this.numberOfPointers) {
       this.fail();
       return;
     }
 
-    const absoluteCoordsAverage = this.tracker.getAbsoluteCoordsAverage();
+    const absoluteCoordsAverage =
+      this.pointerTracker.getAbsoluteCoordsAverage();
 
     this.startX = absoluteCoordsAverage.x;
     this.startY = absoluteCoordsAverage.y;
@@ -97,15 +98,15 @@ export default class LongPressGestureHandler extends GestureHandler {
 
   protected onPointerMove(event: AdaptedEvent): void {
     super.onPointerMove(event);
-    this.tracker.track(event);
+    this.pointerTracker.track(event);
     this.checkDistanceFail();
   }
 
   protected onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
-    this.tracker.removeFromTracker(event.pointerId);
+    this.pointerTracker.removeFromTracker(event.pointerId);
 
-    if (this.currentState === State.ACTIVE) {
+    if (this.state === State.ACTIVE) {
       this.end();
     } else {
       this.fail();
@@ -114,18 +115,18 @@ export default class LongPressGestureHandler extends GestureHandler {
 
   protected onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
-    this.tracker.removeFromTracker(event.pointerId);
+    this.pointerTracker.removeFromTracker(event.pointerId);
 
     if (
-      this.tracker.getTrackedPointersCount() < this.numberOfPointers &&
-      this.getState() !== State.ACTIVE
+      this.pointerTracker.getTrackedPointersCount() < this.numberOfPointers &&
+      this.state !== State.ACTIVE
     ) {
       this.fail();
     }
   }
 
   private tryBegin(): void {
-    if (this.currentState !== State.UNDETERMINED) {
+    if (this.state !== State.UNDETERMINED) {
       return;
     }
 
@@ -136,7 +137,9 @@ export default class LongPressGestureHandler extends GestureHandler {
   }
 
   private tryActivate(): void {
-    if (this.tracker.getTrackedPointersCount() !== this.numberOfPointers) {
+    if (
+      this.pointerTracker.getTrackedPointersCount() !== this.numberOfPointers
+    ) {
       return;
     }
 
@@ -150,7 +153,8 @@ export default class LongPressGestureHandler extends GestureHandler {
   }
 
   private checkDistanceFail(): void {
-    const absoluteCoordsAverage = this.tracker.getAbsoluteCoordsAverage();
+    const absoluteCoordsAverage =
+      this.pointerTracker.getAbsoluteCoordsAverage();
 
     const dx = absoluteCoordsAverage.x - this.startX;
     const dy = absoluteCoordsAverage.y - this.startY;
@@ -160,7 +164,7 @@ export default class LongPressGestureHandler extends GestureHandler {
       return;
     }
 
-    if (this.currentState === State.ACTIVE) {
+    if (this.state === State.ACTIVE) {
       this.cancel();
     } else {
       this.fail();

--- a/src/web/handlers/ManualGestureHandler.ts
+++ b/src/web/handlers/ManualGestureHandler.ts
@@ -11,7 +11,7 @@ export default class ManualGestureHandler extends GestureHandler {
   }
 
   protected onPointerDown(event: AdaptedEvent): void {
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
     super.onPointerDown(event);
     this.begin();
 
@@ -19,27 +19,27 @@ export default class ManualGestureHandler extends GestureHandler {
   }
 
   protected onPointerAdd(event: AdaptedEvent): void {
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
     super.onPointerAdd(event);
   }
 
   protected onPointerMove(event: AdaptedEvent): void {
-    this.tracker.track(event);
+    this.pointerTracker.track(event);
     super.onPointerMove(event);
   }
 
   protected onPointerOutOfBounds(event: AdaptedEvent): void {
-    this.tracker.track(event);
+    this.pointerTracker.track(event);
     super.onPointerOutOfBounds(event);
   }
 
   protected onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
-    this.tracker.removeFromTracker(event.pointerId);
+    this.pointerTracker.removeFromTracker(event.pointerId);
   }
 
   protected onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
-    this.tracker.removeFromTracker(event.pointerId);
+    this.pointerTracker.removeFromTracker(event.pointerId);
   }
 }

--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -173,8 +173,8 @@ export default class NativeViewGestureHandler extends GestureHandler {
   public get buttonRole() {
     return this._buttonRole;
   }
-  public set buttonRole(value: boolean) {
-    this._buttonRole = value;
+  public set buttonRole(isButton: boolean) {
+    this._buttonRole = isButton;
   }
 
   public get shouldActivateOnStart() {

--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -6,53 +6,12 @@ import { AdaptedEvent, Config } from '../interfaces';
 import GestureHandler from './GestureHandler';
 export default class NativeViewGestureHandler extends GestureHandler {
   private _buttonRole!: boolean;
-  get buttonRole() {
-    return this._buttonRole;
-  }
-  set buttonRole(value: boolean) {
-    this._buttonRole = value;
-  }
-
   // TODO: Implement logic for activation on start
   private _shouldActivateOnStart = false;
-  get shouldActivateOnStart() {
-    return this._shouldActivateOnStart;
-  }
-  set shouldActivateOnStart(value: boolean) {
-    this._shouldActivateOnStart = value;
-  }
-
   private _disallowInterruption = false;
-  get disallowInterruption() {
-    return this._disallowInterruption;
-  }
-  set disallowInterruption(value: boolean) {
-    this._disallowInterruption = value;
-  }
-
   private _startX = 0;
-  get startX() {
-    return this._startX;
-  }
-  set startX(value: number) {
-    this._startX = value;
-  }
-
   private _startY = 0;
-  get startY() {
-    return this._startY;
-  }
-  set startY(value: number) {
-    this._startY = value;
-  }
-
   private _minDistSq = DEFAULT_TOUCH_SLOP * DEFAULT_TOUCH_SLOP;
-  get minDistSq() {
-    return this._minDistSq;
-  }
-  set minDistSq(value: number) {
-    this._minDistSq = value;
-  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
@@ -209,5 +168,47 @@ export default class NativeViewGestureHandler extends GestureHandler {
 
   public isButton(): boolean {
     return this.buttonRole;
+  }
+
+  get buttonRole() {
+    return this._buttonRole;
+  }
+  set buttonRole(value: boolean) {
+    this._buttonRole = value;
+  }
+
+  get shouldActivateOnStart() {
+    return this._shouldActivateOnStart;
+  }
+  set shouldActivateOnStart(value: boolean) {
+    this._shouldActivateOnStart = value;
+  }
+
+  get disallowInterruption() {
+    return this._disallowInterruption;
+  }
+  set disallowInterruption(value: boolean) {
+    this._disallowInterruption = value;
+  }
+
+  get startX() {
+    return this._startX;
+  }
+  set startX(value: number) {
+    this._startX = value;
+  }
+
+  get startY() {
+    return this._startY;
+  }
+  set startY(value: number) {
+    this._startY = value;
+  }
+
+  get minDistSq() {
+    return this._minDistSq;
+  }
+  set minDistSq(value: number) {
+    this._minDistSq = value;
   }
 }

--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -170,45 +170,45 @@ export default class NativeViewGestureHandler extends GestureHandler {
     return this.buttonRole;
   }
 
-  get buttonRole() {
+  public get buttonRole() {
     return this._buttonRole;
   }
-  set buttonRole(value: boolean) {
+  public set buttonRole(value: boolean) {
     this._buttonRole = value;
   }
 
-  get shouldActivateOnStart() {
+  public get shouldActivateOnStart() {
     return this._shouldActivateOnStart;
   }
-  set shouldActivateOnStart(value: boolean) {
+  public set shouldActivateOnStart(value: boolean) {
     this._shouldActivateOnStart = value;
   }
 
-  get disallowInterruption() {
+  public get disallowInterruption() {
     return this._disallowInterruption;
   }
-  set disallowInterruption(value: boolean) {
+  public set disallowInterruption(value: boolean) {
     this._disallowInterruption = value;
   }
 
-  get startX() {
+  public get startX() {
     return this._startX;
   }
-  set startX(value: number) {
+  public set startX(value: number) {
     this._startX = value;
   }
 
-  get startY() {
+  public get startY() {
     return this._startY;
   }
-  set startY(value: number) {
+  public set startY(value: number) {
     this._startY = value;
   }
 
-  get minDistSq() {
+  public get minDistSq() {
     return this._minDistSq;
   }
-  set minDistSq(value: number) {
+  public set minDistSq(value: number) {
     this._minDistSq = value;
   }
 }

--- a/src/web/handlers/NativeViewGestureHandler.ts
+++ b/src/web/handlers/NativeViewGestureHandler.ts
@@ -5,16 +5,54 @@ import { AdaptedEvent, Config } from '../interfaces';
 
 import GestureHandler from './GestureHandler';
 export default class NativeViewGestureHandler extends GestureHandler {
-  private buttonRole!: boolean;
+  private _buttonRole!: boolean;
+  get buttonRole() {
+    return this._buttonRole;
+  }
+  set buttonRole(value: boolean) {
+    this._buttonRole = value;
+  }
 
   // TODO: Implement logic for activation on start
-  // @ts-ignore Logic yet to be implemented
-  private shouldActivateOnStart = false;
-  private disallowInterruption = false;
+  private _shouldActivateOnStart = false;
+  get shouldActivateOnStart() {
+    return this._shouldActivateOnStart;
+  }
+  set shouldActivateOnStart(value: boolean) {
+    this._shouldActivateOnStart = value;
+  }
 
-  private startX = 0;
-  private startY = 0;
-  private minDistSq = DEFAULT_TOUCH_SLOP * DEFAULT_TOUCH_SLOP;
+  private _disallowInterruption = false;
+  get disallowInterruption() {
+    return this._disallowInterruption;
+  }
+  set disallowInterruption(value: boolean) {
+    this._disallowInterruption = value;
+  }
+
+  private _startX = 0;
+  get startX() {
+    return this._startX;
+  }
+  set startX(value: number) {
+    this._startX = value;
+  }
+
+  private _startY = 0;
+  get startY() {
+    return this._startY;
+  }
+  set startY(value: number) {
+    this._startY = value;
+  }
+
+  private _minDistSq = DEFAULT_TOUCH_SLOP * DEFAULT_TOUCH_SLOP;
+  get minDistSq() {
+    return this._minDistSq;
+  }
+  set minDistSq(value: number) {
+    this._minDistSq = value;
+  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);

--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -8,58 +8,244 @@ const DEFAULT_MIN_POINTERS = 1;
 const DEFAULT_MAX_POINTERS = 10;
 const DEFAULT_MIN_DIST_SQ = DEFAULT_TOUCH_SLOP * DEFAULT_TOUCH_SLOP;
 
+const PAN_CUSTOM_ACTIVATION_PROPERTIES = [
+  'activeOffsetXStart',
+  'activeOffsetXEnd',
+  'failOffsetXStart',
+  'failOffsetXEnd',
+  'activeOffsetYStart',
+  'activeOffsetYEnd',
+  'failOffsetYStart',
+  'failOffsetYEnd',
+  'minVelocityX',
+  'minVelocityY',
+  'minVelocity',
+];
+
 export default class PanGestureHandler extends GestureHandler {
-  private readonly customActivationProperties: string[] = [
-    'activeOffsetXStart',
-    'activeOffsetXEnd',
-    'failOffsetXStart',
-    'failOffsetXEnd',
-    'activeOffsetYStart',
-    'activeOffsetYEnd',
-    'failOffsetYStart',
-    'failOffsetYEnd',
-    'minVelocityX',
-    'minVelocityY',
-    'minVelocity',
-  ];
+  private _velocityX = 0;
+  get velocityX() {
+    return this._velocityX;
+  }
+  set velocityX(value: number) {
+    this._velocityX = value;
+  }
 
-  public velocityX = 0;
-  public velocityY = 0;
+  private _velocityY = 0;
+  get velocityY() {
+    return this._velocityY;
+  }
+  set velocityY(value: number) {
+    this._velocityY = value;
+  }
 
-  private minDistSq = DEFAULT_MIN_DIST_SQ;
+  private _minDistSq = DEFAULT_MIN_DIST_SQ;
+  get minDistSq() {
+    return this._minDistSq;
+  }
+  set minDistSq(value: number) {
+    this._minDistSq = value;
+  }
 
-  private activeOffsetXStart = -Number.MAX_SAFE_INTEGER;
-  private activeOffsetXEnd = Number.MIN_SAFE_INTEGER;
-  private failOffsetXStart = Number.MIN_SAFE_INTEGER;
-  private failOffsetXEnd = Number.MAX_SAFE_INTEGER;
+  private _activeOffsetXStart = -Number.MAX_SAFE_INTEGER;
+  get activeOffsetXStart() {
+    return this._activeOffsetXStart;
+  }
+  set activeOffsetXStart(value: number) {
+    this._activeOffsetXStart = value;
+  }
 
-  private activeOffsetYStart = Number.MAX_SAFE_INTEGER;
-  private activeOffsetYEnd = Number.MIN_SAFE_INTEGER;
-  private failOffsetYStart = Number.MIN_SAFE_INTEGER;
-  private failOffsetYEnd = Number.MAX_SAFE_INTEGER;
+  private _activeOffsetXEnd = Number.MIN_SAFE_INTEGER;
+  get activeOffsetXEnd() {
+    return this._activeOffsetXEnd;
+  }
+  set activeOffsetXEnd(value: number) {
+    this._activeOffsetXEnd = value;
+  }
 
-  private minVelocityX = Number.MAX_SAFE_INTEGER;
-  private minVelocityY = Number.MAX_SAFE_INTEGER;
-  private minVelocitySq = Number.MAX_SAFE_INTEGER;
+  private _failOffsetXStart = Number.MIN_SAFE_INTEGER;
+  get failOffsetXStart() {
+    return this._failOffsetXStart;
+  }
+  set failOffsetXStart(value: number) {
+    this._failOffsetXStart = value;
+  }
 
-  private minPointers = DEFAULT_MIN_POINTERS;
-  private maxPointers = DEFAULT_MAX_POINTERS;
+  private _failOffsetXEnd = Number.MAX_SAFE_INTEGER;
+  get failOffsetXEnd() {
+    return this._failOffsetXEnd;
+  }
+  set failOffsetXEnd(value: number) {
+    this._failOffsetXEnd = value;
+  }
 
-  private startX = 0;
-  private startY = 0;
-  private offsetX = 0;
-  private offsetY = 0;
-  private lastX = 0;
-  private lastY = 0;
+  private _activeOffsetYStart = Number.MAX_SAFE_INTEGER;
+  get activeOffsetYStart() {
+    return this._activeOffsetYStart;
+  }
+  set activeOffsetYStart(value: number) {
+    this._activeOffsetYStart = value;
+  }
 
-  private stylusData: StylusData | undefined;
+  private _activeOffsetYEnd = Number.MIN_SAFE_INTEGER;
+  get activeOffsetYEnd() {
+    return this._activeOffsetYEnd;
+  }
+  set activeOffsetYEnd(value: number) {
+    this._activeOffsetYEnd = value;
+  }
 
-  private activateAfterLongPress = 0;
-  private activationTimeout = 0;
+  private _failOffsetYStart = Number.MIN_SAFE_INTEGER;
+  get failOffsetYStart() {
+    return this._failOffsetYStart;
+  }
+  set failOffsetYStart(value: number) {
+    this._failOffsetYStart = value;
+  }
 
-  private enableTrackpadTwoFingerGesture = false;
-  private endWheelTimeout = 0;
-  private wheelDevice = WheelDevice.UNDETERMINED;
+  private _failOffsetYEnd = Number.MAX_SAFE_INTEGER;
+  get failOffsetYEnd() {
+    return this._failOffsetYEnd;
+  }
+  set failOffsetYEnd(value: number) {
+    this._failOffsetYEnd = value;
+  }
+
+  private _minVelocityX = Number.MAX_SAFE_INTEGER;
+  get minVelocityX() {
+    return this._minVelocityX;
+  }
+  set minVelocityX(value: number) {
+    this._minVelocityX = value;
+  }
+
+  private _minVelocityY = Number.MAX_SAFE_INTEGER;
+  get minVelocityY() {
+    return this._minVelocityY;
+  }
+  set minVelocityY(value: number) {
+    this._minVelocityY = value;
+  }
+
+  private _minVelocitySq = Number.MAX_SAFE_INTEGER;
+  get minVelocitySq() {
+    return this._minVelocitySq;
+  }
+  set minVelocitySq(value: number) {
+    this._minVelocitySq = value;
+  }
+
+  private _minPointers = DEFAULT_MIN_POINTERS;
+  get minPointers() {
+    return this._minPointers;
+  }
+  set minPointers(value: number) {
+    this._minPointers = value;
+  }
+
+  private _maxPointers = DEFAULT_MAX_POINTERS;
+  get maxPointers() {
+    return this._maxPointers;
+  }
+  set maxPointers(value: number) {
+    this._maxPointers = value;
+  }
+
+  private _startX = 0;
+  get startX() {
+    return this._startX;
+  }
+  set startX(value: number) {
+    this._startX = value;
+  }
+
+  private _startY = 0;
+  get startY() {
+    return this._startY;
+  }
+  set startY(value: number) {
+    this._startY = value;
+  }
+
+  private _offsetX = 0;
+  get offsetX() {
+    return this._offsetX;
+  }
+  set offsetX(value: number) {
+    this._offsetX = value;
+  }
+
+  private _offsetY = 0;
+  get offsetY() {
+    return this._offsetY;
+  }
+  set offsetY(value: number) {
+    this._offsetY = value;
+  }
+
+  private _lastX = 0;
+  get lastX() {
+    return this._lastX;
+  }
+  set lastX(value: number) {
+    this._lastX = value;
+  }
+
+  private _lastY = 0;
+  get lastY() {
+    return this._lastY;
+  }
+  set lastY(value: number) {
+    this._lastY = value;
+  }
+
+  private _stylusData: StylusData | undefined;
+  get stylusData() {
+    return this._stylusData;
+  }
+  set stylusData(value: StylusData | undefined) {
+    this._stylusData = value;
+  }
+
+  private _activateAfterLongPress = 0;
+  get activateAfterLongPress() {
+    return this._activateAfterLongPress;
+  }
+  set activateAfterLongPress(value: number) {
+    this._activateAfterLongPress = value;
+  }
+
+  private _activationTimeout = 0;
+  get activationTimeout() {
+    return this._activationTimeout;
+  }
+  set activationTimeout(value: number) {
+    this._activationTimeout = value;
+  }
+
+  private _enableTrackpadTwoFingerGesture = false;
+  get enableTrackpadTwoFingerGesture() {
+    return this._enableTrackpadTwoFingerGesture;
+  }
+  set enableTrackpadTwoFingerGesture(value: boolean) {
+    this._enableTrackpadTwoFingerGesture = value;
+  }
+
+  private _endWheelTimeout = 0;
+  get endWheelTimeout() {
+    return this._endWheelTimeout;
+  }
+  set endWheelTimeout(value: number) {
+    this._endWheelTimeout = value;
+  }
+
+  private _wheelDevice = WheelDevice.UNDETERMINED;
+  get wheelDevice() {
+    return this._wheelDevice;
+  }
+  set wheelDevice(value: WheelDevice) {
+    this._wheelDevice = value;
+  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
@@ -69,7 +255,7 @@ export default class PanGestureHandler extends GestureHandler {
     this.resetConfig();
 
     super.updateGestureConfig({ enabled: enabled, ...props });
-    this.checkCustomActivationCriteria(this.customActivationProperties);
+    this.checkCustomActivationCriteria(PAN_CUSTOM_ACTIVATION_PROPERTIES);
 
     if (this.config.minDist !== undefined) {
       this.minDistSq = this.config.minDist * this.config.minDist;

--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -576,199 +576,199 @@ export default class PanGestureHandler extends GestureHandler {
     this.startY = this.lastY;
   }
 
-  get velocityX() {
+  public get velocityX() {
     return this._velocityX;
   }
-  set velocityX(value: number) {
+  public set velocityX(value: number) {
     this._velocityX = value;
   }
 
-  get velocityY() {
+  public get velocityY() {
     return this._velocityY;
   }
-  set velocityY(value: number) {
+  public set velocityY(value: number) {
     this._velocityY = value;
   }
 
-  get minDistSq() {
+  public get minDistSq() {
     return this._minDistSq;
   }
-  set minDistSq(value: number) {
+  public set minDistSq(value: number) {
     this._minDistSq = value;
   }
 
-  get activeOffsetXStart() {
+  public get activeOffsetXStart() {
     return this._activeOffsetXStart;
   }
-  set activeOffsetXStart(value: number) {
+  public set activeOffsetXStart(value: number) {
     this._activeOffsetXStart = value;
   }
 
-  get activeOffsetXEnd() {
+  public get activeOffsetXEnd() {
     return this._activeOffsetXEnd;
   }
-  set activeOffsetXEnd(value: number) {
+  public set activeOffsetXEnd(value: number) {
     this._activeOffsetXEnd = value;
   }
 
-  get failOffsetXStart() {
+  public get failOffsetXStart() {
     return this._failOffsetXStart;
   }
-  set failOffsetXStart(value: number) {
+  public set failOffsetXStart(value: number) {
     this._failOffsetXStart = value;
   }
 
-  get failOffsetXEnd() {
+  public get failOffsetXEnd() {
     return this._failOffsetXEnd;
   }
-  set failOffsetXEnd(value: number) {
+  public set failOffsetXEnd(value: number) {
     this._failOffsetXEnd = value;
   }
 
-  get activeOffsetYStart() {
+  public get activeOffsetYStart() {
     return this._activeOffsetYStart;
   }
-  set activeOffsetYStart(value: number) {
+  public set activeOffsetYStart(value: number) {
     this._activeOffsetYStart = value;
   }
 
-  get activeOffsetYEnd() {
+  public get activeOffsetYEnd() {
     return this._activeOffsetYEnd;
   }
-  set activeOffsetYEnd(value: number) {
+  public set activeOffsetYEnd(value: number) {
     this._activeOffsetYEnd = value;
   }
 
-  get failOffsetYStart() {
+  public get failOffsetYStart() {
     return this._failOffsetYStart;
   }
-  set failOffsetYStart(value: number) {
+  public set failOffsetYStart(value: number) {
     this._failOffsetYStart = value;
   }
 
-  get failOffsetYEnd() {
+  public get failOffsetYEnd() {
     return this._failOffsetYEnd;
   }
-  set failOffsetYEnd(value: number) {
+  public set failOffsetYEnd(value: number) {
     this._failOffsetYEnd = value;
   }
 
-  get minVelocityX() {
+  public get minVelocityX() {
     return this._minVelocityX;
   }
-  set minVelocityX(value: number) {
+  public set minVelocityX(value: number) {
     this._minVelocityX = value;
   }
 
-  get minVelocityY() {
+  public get minVelocityY() {
     return this._minVelocityY;
   }
-  set minVelocityY(value: number) {
+  public set minVelocityY(value: number) {
     this._minVelocityY = value;
   }
 
-  get minVelocitySq() {
+  public get minVelocitySq() {
     return this._minVelocitySq;
   }
-  set minVelocitySq(value: number) {
+  public set minVelocitySq(value: number) {
     this._minVelocitySq = value;
   }
 
-  get minPointers() {
+  public get minPointers() {
     return this._minPointers;
   }
-  set minPointers(value: number) {
+  public set minPointers(value: number) {
     this._minPointers = value;
   }
 
-  get maxPointers() {
+  public get maxPointers() {
     return this._maxPointers;
   }
-  set maxPointers(value: number) {
+  public set maxPointers(value: number) {
     this._maxPointers = value;
   }
 
-  get startX() {
+  public get startX() {
     return this._startX;
   }
-  set startX(value: number) {
+  public set startX(value: number) {
     this._startX = value;
   }
 
-  get startY() {
+  public get startY() {
     return this._startY;
   }
-  set startY(value: number) {
+  public set startY(value: number) {
     this._startY = value;
   }
 
-  get offsetX() {
+  public get offsetX() {
     return this._offsetX;
   }
-  set offsetX(value: number) {
+  public set offsetX(value: number) {
     this._offsetX = value;
   }
 
-  get offsetY() {
+  public get offsetY() {
     return this._offsetY;
   }
-  set offsetY(value: number) {
+  public set offsetY(value: number) {
     this._offsetY = value;
   }
 
-  get lastX() {
+  public get lastX() {
     return this._lastX;
   }
-  set lastX(value: number) {
+  public set lastX(value: number) {
     this._lastX = value;
   }
 
-  get lastY() {
+  public get lastY() {
     return this._lastY;
   }
-  set lastY(value: number) {
+  public set lastY(value: number) {
     this._lastY = value;
   }
 
-  get stylusData() {
+  public get stylusData() {
     return this._stylusData;
   }
-  set stylusData(value: StylusData | undefined) {
+  public set stylusData(value: StylusData | undefined) {
     this._stylusData = value;
   }
 
-  get activateAfterLongPress() {
+  public get activateAfterLongPress() {
     return this._activateAfterLongPress;
   }
-  set activateAfterLongPress(value: number) {
+  public set activateAfterLongPress(value: number) {
     this._activateAfterLongPress = value;
   }
 
-  get activationTimeout() {
+  public get activationTimeout() {
     return this._activationTimeout;
   }
-  set activationTimeout(value: number) {
+  public set activationTimeout(value: number) {
     this._activationTimeout = value;
   }
 
-  get enableTrackpadTwoFingerGesture() {
+  public get enableTrackpadTwoFingerGesture() {
     return this._enableTrackpadTwoFingerGesture;
   }
-  set enableTrackpadTwoFingerGesture(value: boolean) {
+  public set enableTrackpadTwoFingerGesture(value: boolean) {
     this._enableTrackpadTwoFingerGesture = value;
   }
 
-  get endWheelTimeout() {
+  public get endWheelTimeout() {
     return this._endWheelTimeout;
   }
-  set endWheelTimeout(value: number) {
+  public set endWheelTimeout(value: number) {
     this._endWheelTimeout = value;
   }
 
-  get wheelDevice() {
+  public get wheelDevice() {
     return this._wheelDevice;
   }
-  set wheelDevice(value: WheelDevice) {
+  public set wheelDevice(value: WheelDevice) {
     this._wheelDevice = value;
   }
 }

--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -733,8 +733,8 @@ export default class PanGestureHandler extends GestureHandler {
   public get stylusData() {
     return this._stylusData;
   }
-  public set stylusData(value: StylusData | undefined) {
-    this._stylusData = value;
+  public set stylusData(stylusData: StylusData | undefined) {
+    this._stylusData = stylusData;
   }
 
   public get activateAfterLongPress() {

--- a/src/web/handlers/PanGestureHandler.ts
+++ b/src/web/handlers/PanGestureHandler.ts
@@ -24,228 +24,33 @@ const PAN_CUSTOM_ACTIVATION_PROPERTIES = [
 
 export default class PanGestureHandler extends GestureHandler {
   private _velocityX = 0;
-  get velocityX() {
-    return this._velocityX;
-  }
-  set velocityX(value: number) {
-    this._velocityX = value;
-  }
-
   private _velocityY = 0;
-  get velocityY() {
-    return this._velocityY;
-  }
-  set velocityY(value: number) {
-    this._velocityY = value;
-  }
-
   private _minDistSq = DEFAULT_MIN_DIST_SQ;
-  get minDistSq() {
-    return this._minDistSq;
-  }
-  set minDistSq(value: number) {
-    this._minDistSq = value;
-  }
-
   private _activeOffsetXStart = -Number.MAX_SAFE_INTEGER;
-  get activeOffsetXStart() {
-    return this._activeOffsetXStart;
-  }
-  set activeOffsetXStart(value: number) {
-    this._activeOffsetXStart = value;
-  }
-
   private _activeOffsetXEnd = Number.MIN_SAFE_INTEGER;
-  get activeOffsetXEnd() {
-    return this._activeOffsetXEnd;
-  }
-  set activeOffsetXEnd(value: number) {
-    this._activeOffsetXEnd = value;
-  }
-
   private _failOffsetXStart = Number.MIN_SAFE_INTEGER;
-  get failOffsetXStart() {
-    return this._failOffsetXStart;
-  }
-  set failOffsetXStart(value: number) {
-    this._failOffsetXStart = value;
-  }
-
   private _failOffsetXEnd = Number.MAX_SAFE_INTEGER;
-  get failOffsetXEnd() {
-    return this._failOffsetXEnd;
-  }
-  set failOffsetXEnd(value: number) {
-    this._failOffsetXEnd = value;
-  }
-
   private _activeOffsetYStart = Number.MAX_SAFE_INTEGER;
-  get activeOffsetYStart() {
-    return this._activeOffsetYStart;
-  }
-  set activeOffsetYStart(value: number) {
-    this._activeOffsetYStart = value;
-  }
-
   private _activeOffsetYEnd = Number.MIN_SAFE_INTEGER;
-  get activeOffsetYEnd() {
-    return this._activeOffsetYEnd;
-  }
-  set activeOffsetYEnd(value: number) {
-    this._activeOffsetYEnd = value;
-  }
-
   private _failOffsetYStart = Number.MIN_SAFE_INTEGER;
-  get failOffsetYStart() {
-    return this._failOffsetYStart;
-  }
-  set failOffsetYStart(value: number) {
-    this._failOffsetYStart = value;
-  }
-
   private _failOffsetYEnd = Number.MAX_SAFE_INTEGER;
-  get failOffsetYEnd() {
-    return this._failOffsetYEnd;
-  }
-  set failOffsetYEnd(value: number) {
-    this._failOffsetYEnd = value;
-  }
-
   private _minVelocityX = Number.MAX_SAFE_INTEGER;
-  get minVelocityX() {
-    return this._minVelocityX;
-  }
-  set minVelocityX(value: number) {
-    this._minVelocityX = value;
-  }
-
   private _minVelocityY = Number.MAX_SAFE_INTEGER;
-  get minVelocityY() {
-    return this._minVelocityY;
-  }
-  set minVelocityY(value: number) {
-    this._minVelocityY = value;
-  }
-
   private _minVelocitySq = Number.MAX_SAFE_INTEGER;
-  get minVelocitySq() {
-    return this._minVelocitySq;
-  }
-  set minVelocitySq(value: number) {
-    this._minVelocitySq = value;
-  }
-
   private _minPointers = DEFAULT_MIN_POINTERS;
-  get minPointers() {
-    return this._minPointers;
-  }
-  set minPointers(value: number) {
-    this._minPointers = value;
-  }
-
   private _maxPointers = DEFAULT_MAX_POINTERS;
-  get maxPointers() {
-    return this._maxPointers;
-  }
-  set maxPointers(value: number) {
-    this._maxPointers = value;
-  }
-
   private _startX = 0;
-  get startX() {
-    return this._startX;
-  }
-  set startX(value: number) {
-    this._startX = value;
-  }
-
   private _startY = 0;
-  get startY() {
-    return this._startY;
-  }
-  set startY(value: number) {
-    this._startY = value;
-  }
-
   private _offsetX = 0;
-  get offsetX() {
-    return this._offsetX;
-  }
-  set offsetX(value: number) {
-    this._offsetX = value;
-  }
-
   private _offsetY = 0;
-  get offsetY() {
-    return this._offsetY;
-  }
-  set offsetY(value: number) {
-    this._offsetY = value;
-  }
-
   private _lastX = 0;
-  get lastX() {
-    return this._lastX;
-  }
-  set lastX(value: number) {
-    this._lastX = value;
-  }
-
   private _lastY = 0;
-  get lastY() {
-    return this._lastY;
-  }
-  set lastY(value: number) {
-    this._lastY = value;
-  }
-
   private _stylusData: StylusData | undefined;
-  get stylusData() {
-    return this._stylusData;
-  }
-  set stylusData(value: StylusData | undefined) {
-    this._stylusData = value;
-  }
-
   private _activateAfterLongPress = 0;
-  get activateAfterLongPress() {
-    return this._activateAfterLongPress;
-  }
-  set activateAfterLongPress(value: number) {
-    this._activateAfterLongPress = value;
-  }
-
   private _activationTimeout = 0;
-  get activationTimeout() {
-    return this._activationTimeout;
-  }
-  set activationTimeout(value: number) {
-    this._activationTimeout = value;
-  }
-
   private _enableTrackpadTwoFingerGesture = false;
-  get enableTrackpadTwoFingerGesture() {
-    return this._enableTrackpadTwoFingerGesture;
-  }
-  set enableTrackpadTwoFingerGesture(value: boolean) {
-    this._enableTrackpadTwoFingerGesture = value;
-  }
-
   private _endWheelTimeout = 0;
-  get endWheelTimeout() {
-    return this._endWheelTimeout;
-  }
-  set endWheelTimeout(value: number) {
-    this._endWheelTimeout = value;
-  }
-
   private _wheelDevice = WheelDevice.UNDETERMINED;
-  get wheelDevice() {
-    return this._wheelDevice;
-  }
-  set wheelDevice(value: WheelDevice) {
-    this._wheelDevice = value;
-  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
@@ -769,5 +574,201 @@ export default class PanGestureHandler extends GestureHandler {
 
     this.startX = this.lastX;
     this.startY = this.lastY;
+  }
+
+  get velocityX() {
+    return this._velocityX;
+  }
+  set velocityX(value: number) {
+    this._velocityX = value;
+  }
+
+  get velocityY() {
+    return this._velocityY;
+  }
+  set velocityY(value: number) {
+    this._velocityY = value;
+  }
+
+  get minDistSq() {
+    return this._minDistSq;
+  }
+  set minDistSq(value: number) {
+    this._minDistSq = value;
+  }
+
+  get activeOffsetXStart() {
+    return this._activeOffsetXStart;
+  }
+  set activeOffsetXStart(value: number) {
+    this._activeOffsetXStart = value;
+  }
+
+  get activeOffsetXEnd() {
+    return this._activeOffsetXEnd;
+  }
+  set activeOffsetXEnd(value: number) {
+    this._activeOffsetXEnd = value;
+  }
+
+  get failOffsetXStart() {
+    return this._failOffsetXStart;
+  }
+  set failOffsetXStart(value: number) {
+    this._failOffsetXStart = value;
+  }
+
+  get failOffsetXEnd() {
+    return this._failOffsetXEnd;
+  }
+  set failOffsetXEnd(value: number) {
+    this._failOffsetXEnd = value;
+  }
+
+  get activeOffsetYStart() {
+    return this._activeOffsetYStart;
+  }
+  set activeOffsetYStart(value: number) {
+    this._activeOffsetYStart = value;
+  }
+
+  get activeOffsetYEnd() {
+    return this._activeOffsetYEnd;
+  }
+  set activeOffsetYEnd(value: number) {
+    this._activeOffsetYEnd = value;
+  }
+
+  get failOffsetYStart() {
+    return this._failOffsetYStart;
+  }
+  set failOffsetYStart(value: number) {
+    this._failOffsetYStart = value;
+  }
+
+  get failOffsetYEnd() {
+    return this._failOffsetYEnd;
+  }
+  set failOffsetYEnd(value: number) {
+    this._failOffsetYEnd = value;
+  }
+
+  get minVelocityX() {
+    return this._minVelocityX;
+  }
+  set minVelocityX(value: number) {
+    this._minVelocityX = value;
+  }
+
+  get minVelocityY() {
+    return this._minVelocityY;
+  }
+  set minVelocityY(value: number) {
+    this._minVelocityY = value;
+  }
+
+  get minVelocitySq() {
+    return this._minVelocitySq;
+  }
+  set minVelocitySq(value: number) {
+    this._minVelocitySq = value;
+  }
+
+  get minPointers() {
+    return this._minPointers;
+  }
+  set minPointers(value: number) {
+    this._minPointers = value;
+  }
+
+  get maxPointers() {
+    return this._maxPointers;
+  }
+  set maxPointers(value: number) {
+    this._maxPointers = value;
+  }
+
+  get startX() {
+    return this._startX;
+  }
+  set startX(value: number) {
+    this._startX = value;
+  }
+
+  get startY() {
+    return this._startY;
+  }
+  set startY(value: number) {
+    this._startY = value;
+  }
+
+  get offsetX() {
+    return this._offsetX;
+  }
+  set offsetX(value: number) {
+    this._offsetX = value;
+  }
+
+  get offsetY() {
+    return this._offsetY;
+  }
+  set offsetY(value: number) {
+    this._offsetY = value;
+  }
+
+  get lastX() {
+    return this._lastX;
+  }
+  set lastX(value: number) {
+    this._lastX = value;
+  }
+
+  get lastY() {
+    return this._lastY;
+  }
+  set lastY(value: number) {
+    this._lastY = value;
+  }
+
+  get stylusData() {
+    return this._stylusData;
+  }
+  set stylusData(value: StylusData | undefined) {
+    this._stylusData = value;
+  }
+
+  get activateAfterLongPress() {
+    return this._activateAfterLongPress;
+  }
+  set activateAfterLongPress(value: number) {
+    this._activateAfterLongPress = value;
+  }
+
+  get activationTimeout() {
+    return this._activationTimeout;
+  }
+  set activationTimeout(value: number) {
+    this._activationTimeout = value;
+  }
+
+  get enableTrackpadTwoFingerGesture() {
+    return this._enableTrackpadTwoFingerGesture;
+  }
+  set enableTrackpadTwoFingerGesture(value: boolean) {
+    this._enableTrackpadTwoFingerGesture = value;
+  }
+
+  get endWheelTimeout() {
+    return this._endWheelTimeout;
+  }
+  set endWheelTimeout(value: number) {
+    this._endWheelTimeout = value;
+  }
+
+  get wheelDevice() {
+    return this._wheelDevice;
+  }
+  set wheelDevice(value: WheelDevice) {
+    this._wheelDevice = value;
   }
 }

--- a/src/web/handlers/PinchGestureHandler.ts
+++ b/src/web/handlers/PinchGestureHandler.ts
@@ -9,37 +9,9 @@ import ScaleGestureDetector, {
 
 export default class PinchGestureHandler extends GestureHandler {
   private _scale = 1;
-  get scale() {
-    return this._scale;
-  }
-  set scale(value: number) {
-    this._scale = value;
-  }
-
   private _velocity = 0;
-  get velocity() {
-    return this._velocity;
-  }
-  set velocity(value: number) {
-    this._velocity = value;
-  }
-
   private _startingSpan = 0;
-  get startingSpan() {
-    return this._startingSpan;
-  }
-  set startingSpan(value: number) {
-    this._startingSpan = value;
-  }
-
   private _spanSlop = DEFAULT_TOUCH_SLOP;
-  get spanSlop() {
-    return this._spanSlop;
-  }
-  set spanSlop(value: number) {
-    this._spanSlop = value;
-  }
-
   private _scaleDetectorListener: ScaleGestureListener = {
     onScaleBegin: (detector: ScaleGestureDetector): boolean => {
       this.startingSpan = detector.getCurrentSpan();
@@ -70,22 +42,8 @@ export default class PinchGestureHandler extends GestureHandler {
       // eslint-disable-next-line @typescript-eslint/no-empty-function
     ): void => {},
   };
-
-  get scaleDetectorListener() {
-    return this._scaleDetectorListener;
-  }
-  set scaleDetectorListener(listener: ScaleGestureListener) {
-    this._scaleDetectorListener = listener;
-  }
-
   private _scaleGestureDetector: ScaleGestureDetector =
     new ScaleGestureDetector(this.scaleDetectorListener);
-  get scaleGestureDetector() {
-    return this._scaleGestureDetector;
-  }
-  set scaleGestureDetector(detector: ScaleGestureDetector) {
-    this._scaleGestureDetector = detector;
-  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>) {
     super.init(ref, propsRef);
@@ -194,5 +152,47 @@ export default class PinchGestureHandler extends GestureHandler {
     }
     this.velocity = 0;
     this.scale = 1;
+  }
+
+  get scale() {
+    return this._scale;
+  }
+  set scale(value: number) {
+    this._scale = value;
+  }
+
+  get velocity() {
+    return this._velocity;
+  }
+  set velocity(value: number) {
+    this._velocity = value;
+  }
+
+  get startingSpan() {
+    return this._startingSpan;
+  }
+  set startingSpan(value: number) {
+    this._startingSpan = value;
+  }
+
+  get spanSlop() {
+    return this._spanSlop;
+  }
+  set spanSlop(value: number) {
+    this._spanSlop = value;
+  }
+
+  get scaleDetectorListener() {
+    return this._scaleDetectorListener;
+  }
+  set scaleDetectorListener(listener: ScaleGestureListener) {
+    this._scaleDetectorListener = listener;
+  }
+
+  get scaleGestureDetector() {
+    return this._scaleGestureDetector;
+  }
+  set scaleGestureDetector(detector: ScaleGestureDetector) {
+    this._scaleGestureDetector = detector;
   }
 }

--- a/src/web/handlers/PinchGestureHandler.ts
+++ b/src/web/handlers/PinchGestureHandler.ts
@@ -19,11 +19,9 @@ export default class PinchGestureHandler extends GestureHandler {
     },
     onScale: (detector: ScaleGestureDetector): boolean => {
       const prevScaleFactor: number = this.scale;
-      this.scale *= detector.getScaleFactor(
-        this.pointerTracker.getTrackedPointersCount()
-      );
+      this.scale *= detector.scaleFactor;
 
-      const delta = detector.getTimeDelta();
+      const delta = detector.timeDelta;
       if (delta > 0) {
         this.velocity = (this.scale - prevScaleFactor) / delta;
       }
@@ -42,7 +40,7 @@ export default class PinchGestureHandler extends GestureHandler {
     ): void => {},
   };
   private _scaleGestureDetector: ScaleGestureDetector =
-    new ScaleGestureDetector(this.scaleDetectorListener);
+    new ScaleGestureDetector(this.scaleDetectorListener, this.pointerTracker);
 
   public init(ref: number, propsRef: React.RefObject<unknown>) {
     super.init(ref, propsRef);

--- a/src/web/handlers/PinchGestureHandler.ts
+++ b/src/web/handlers/PinchGestureHandler.ts
@@ -14,7 +14,7 @@ export default class PinchGestureHandler extends GestureHandler {
   private _spanSlop = DEFAULT_TOUCH_SLOP;
   private _scaleDetectorListener: ScaleGestureListener = {
     onScaleBegin: (detector: ScaleGestureDetector): boolean => {
-      this.startingSpan = detector.getCurrentSpan();
+      this.startingSpan = detector.currentSpan;
       return true;
     },
     onScale: (detector: ScaleGestureDetector): boolean => {
@@ -29,8 +29,7 @@ export default class PinchGestureHandler extends GestureHandler {
       }
 
       if (
-        Math.abs(this.startingSpan - detector.getCurrentSpan()) >=
-          this.spanSlop &&
+        Math.abs(this.startingSpan - detector.currentSpan) >= this.spanSlop &&
         this.state === State.BEGAN
       ) {
         this.activate();
@@ -57,8 +56,8 @@ export default class PinchGestureHandler extends GestureHandler {
 
   protected transformNativeEvent() {
     return {
-      focalX: this.scaleGestureDetector.getFocusX(),
-      focalY: this.scaleGestureDetector.getFocusY(),
+      focalX: this.scaleGestureDetector.focusX,
+      focalY: this.scaleGestureDetector.focusY,
       velocity: this.velocity,
       scale: this.scale,
     };

--- a/src/web/handlers/PinchGestureHandler.ts
+++ b/src/web/handlers/PinchGestureHandler.ts
@@ -8,13 +8,39 @@ import ScaleGestureDetector, {
 } from '../detectors/ScaleGestureDetector';
 
 export default class PinchGestureHandler extends GestureHandler {
-  private scale = 1;
-  private velocity = 0;
+  private _scale = 1;
+  get scale() {
+    return this._scale;
+  }
+  set scale(value: number) {
+    this._scale = value;
+  }
 
-  private startingSpan = 0;
-  private spanSlop = DEFAULT_TOUCH_SLOP;
+  private _velocity = 0;
+  get velocity() {
+    return this._velocity;
+  }
+  set velocity(value: number) {
+    this._velocity = value;
+  }
 
-  private scaleDetectorListener: ScaleGestureListener = {
+  private _startingSpan = 0;
+  get startingSpan() {
+    return this._startingSpan;
+  }
+  set startingSpan(value: number) {
+    this._startingSpan = value;
+  }
+
+  private _spanSlop = DEFAULT_TOUCH_SLOP;
+  get spanSlop() {
+    return this._spanSlop;
+  }
+  set spanSlop(value: number) {
+    this._spanSlop = value;
+  }
+
+  private _scaleDetectorListener: ScaleGestureListener = {
     onScaleBegin: (detector: ScaleGestureDetector): boolean => {
       this.startingSpan = detector.getCurrentSpan();
       return true;
@@ -45,9 +71,21 @@ export default class PinchGestureHandler extends GestureHandler {
     ): void => {},
   };
 
-  private scaleGestureDetector: ScaleGestureDetector = new ScaleGestureDetector(
-    this.scaleDetectorListener
-  );
+  get scaleDetectorListener() {
+    return this._scaleDetectorListener;
+  }
+  set scaleDetectorListener(listener: ScaleGestureListener) {
+    this._scaleDetectorListener = listener;
+  }
+
+  private _scaleGestureDetector: ScaleGestureDetector =
+    new ScaleGestureDetector(this.scaleDetectorListener);
+  get scaleGestureDetector() {
+    return this._scaleGestureDetector;
+  }
+  set scaleGestureDetector(detector: ScaleGestureDetector) {
+    this._scaleGestureDetector = detector;
+  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>) {
     super.init(ref, propsRef);

--- a/src/web/handlers/PinchGestureHandler.ts
+++ b/src/web/handlers/PinchGestureHandler.ts
@@ -154,45 +154,45 @@ export default class PinchGestureHandler extends GestureHandler {
     this.scale = 1;
   }
 
-  get scale() {
+  public get scale() {
     return this._scale;
   }
-  set scale(value: number) {
+  public set scale(value: number) {
     this._scale = value;
   }
 
-  get velocity() {
+  public get velocity() {
     return this._velocity;
   }
-  set velocity(value: number) {
+  public set velocity(value: number) {
     this._velocity = value;
   }
 
-  get startingSpan() {
+  public get startingSpan() {
     return this._startingSpan;
   }
-  set startingSpan(value: number) {
+  public set startingSpan(value: number) {
     this._startingSpan = value;
   }
 
-  get spanSlop() {
+  public get spanSlop() {
     return this._spanSlop;
   }
-  set spanSlop(value: number) {
+  public set spanSlop(value: number) {
     this._spanSlop = value;
   }
 
-  get scaleDetectorListener() {
+  public get scaleDetectorListener() {
     return this._scaleDetectorListener;
   }
-  set scaleDetectorListener(listener: ScaleGestureListener) {
+  public set scaleDetectorListener(listener: ScaleGestureListener) {
     this._scaleDetectorListener = listener;
   }
 
-  get scaleGestureDetector() {
+  public get scaleGestureDetector() {
     return this._scaleGestureDetector;
   }
-  set scaleGestureDetector(detector: ScaleGestureDetector) {
+  public set scaleGestureDetector(detector: ScaleGestureDetector) {
     this._scaleGestureDetector = detector;
   }
 }

--- a/src/web/handlers/RotationGestureHandler.ts
+++ b/src/web/handlers/RotationGestureHandler.ts
@@ -169,45 +169,45 @@ export default class RotationGestureHandler extends GestureHandler {
     this.rotationGestureDetector.reset();
   }
 
-  get rotation() {
+  public get rotation() {
     return this._rotation;
   }
-  set rotation(value: number) {
+  public set rotation(value: number) {
     this._rotation = value;
   }
 
-  get velocity() {
+  public get velocity() {
     return this._velocity;
   }
-  set velocity(value: number) {
+  public set velocity(value: number) {
     this._velocity = value;
   }
 
-  get cachedAnchorX() {
+  public get cachedAnchorX() {
     return this._cachedAnchorX;
   }
-  set cachedAnchorX(value: number) {
+  public set cachedAnchorX(value: number) {
     this._cachedAnchorX = value;
   }
 
-  get cachedAnchorY() {
+  public get cachedAnchorY() {
     return this._cachedAnchorY;
   }
-  set cachedAnchorY(value: number) {
+  public set cachedAnchorY(value: number) {
     this._cachedAnchorY = value;
   }
 
-  get rotationGestureListener(): RotationGestureListener {
+  public get rotationGestureListener(): RotationGestureListener {
     return this._rotationGestureListener;
   }
-  set rotationGestureListener(listener: RotationGestureListener) {
+  public set rotationGestureListener(listener: RotationGestureListener) {
     this._rotationGestureListener = listener;
   }
 
-  get rotationGestureDetector(): RotationGestureDetector {
+  public get rotationGestureDetector(): RotationGestureDetector {
     return this._rotationGestureDetector;
   }
-  set rotationGestureDetector(detector: RotationGestureDetector) {
+  public set rotationGestureDetector(detector: RotationGestureDetector) {
     this._rotationGestureDetector = detector;
   }
 }

--- a/src/web/handlers/RotationGestureHandler.ts
+++ b/src/web/handlers/RotationGestureHandler.ts
@@ -19,7 +19,7 @@ export default class RotationGestureHandler extends GestureHandler {
       const previousRotation: number = this.rotation;
       this.rotation += detector.rotation;
 
-      const delta = detector.getTimeDelta();
+      const delta = detector.timeDelta;
 
       if (delta > 0) {
         this.velocity = (this.rotation - previousRotation) / delta;

--- a/src/web/handlers/RotationGestureHandler.ts
+++ b/src/web/handlers/RotationGestureHandler.ts
@@ -29,7 +29,7 @@ export default class RotationGestureHandler extends GestureHandler {
 
       if (
         Math.abs(this.rotation) >= ROTATION_RECOGNITION_THRESHOLD &&
-        this.currentState === State.BEGAN
+        this.state === State.BEGAN
       ) {
         this.activate();
       }
@@ -47,7 +47,7 @@ export default class RotationGestureHandler extends GestureHandler {
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
 
-    this.setShouldCancelWhenOutside(false);
+    this.shouldCancelWhenOutside = false;
   }
 
   public updateGestureConfig({ enabled = true, ...props }: Config): void {
@@ -76,22 +76,22 @@ export default class RotationGestureHandler extends GestureHandler {
   }
 
   protected onPointerDown(event: AdaptedEvent): void {
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
     super.onPointerDown(event);
 
     this.tryToSendTouchEvent(event);
   }
 
   protected onPointerAdd(event: AdaptedEvent): void {
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
     super.onPointerAdd(event);
 
     this.tryBegin();
-    this.rotationGestureDetector.onTouchEvent(event, this.tracker);
+    this.rotationGestureDetector.onTouchEvent(event, this.pointerTracker);
   }
 
   protected onPointerMove(event: AdaptedEvent): void {
-    if (this.tracker.getTrackedPointersCount() < 2) {
+    if (this.pointerTracker.getTrackedPointersCount() < 2) {
       return;
     }
 
@@ -102,15 +102,15 @@ export default class RotationGestureHandler extends GestureHandler {
       this.cachedAnchorY = this.getAnchorY();
     }
 
-    this.tracker.track(event);
+    this.pointerTracker.track(event);
 
-    this.rotationGestureDetector.onTouchEvent(event, this.tracker);
+    this.rotationGestureDetector.onTouchEvent(event, this.pointerTracker);
 
     super.onPointerMove(event);
   }
 
   protected onPointerOutOfBounds(event: AdaptedEvent): void {
-    if (this.tracker.getTrackedPointersCount() < 2) {
+    if (this.pointerTracker.getTrackedPointersCount() < 2) {
       return;
     }
 
@@ -121,23 +121,23 @@ export default class RotationGestureHandler extends GestureHandler {
       this.cachedAnchorY = this.getAnchorY();
     }
 
-    this.tracker.track(event);
+    this.pointerTracker.track(event);
 
-    this.rotationGestureDetector.onTouchEvent(event, this.tracker);
+    this.rotationGestureDetector.onTouchEvent(event, this.pointerTracker);
 
     super.onPointerOutOfBounds(event);
   }
 
   protected onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
-    this.tracker.removeFromTracker(event.pointerId);
-    this.rotationGestureDetector.onTouchEvent(event, this.tracker);
+    this.pointerTracker.removeFromTracker(event.pointerId);
+    this.rotationGestureDetector.onTouchEvent(event, this.pointerTracker);
 
-    if (this.currentState !== State.ACTIVE) {
+    if (this.state !== State.ACTIVE) {
       return;
     }
 
-    if (this.currentState === State.ACTIVE) {
+    if (this.state === State.ACTIVE) {
       this.end();
     } else {
       this.fail();
@@ -146,12 +146,12 @@ export default class RotationGestureHandler extends GestureHandler {
 
   protected onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
-    this.rotationGestureDetector.onTouchEvent(event, this.tracker);
-    this.tracker.removeFromTracker(event.pointerId);
+    this.rotationGestureDetector.onTouchEvent(event, this.pointerTracker);
+    this.pointerTracker.removeFromTracker(event.pointerId);
   }
 
   protected tryBegin(): void {
-    if (this.currentState !== State.UNDETERMINED) {
+    if (this.state !== State.UNDETERMINED) {
       return;
     }
 
@@ -163,7 +163,7 @@ export default class RotationGestureHandler extends GestureHandler {
   }
 
   protected onReset(): void {
-    if (this.currentState === State.ACTIVE) {
+    if (this.state === State.ACTIVE) {
       return;
     }
 

--- a/src/web/handlers/RotationGestureHandler.ts
+++ b/src/web/handlers/RotationGestureHandler.ts
@@ -9,13 +9,39 @@ import RotationGestureDetector, {
 const ROTATION_RECOGNITION_THRESHOLD = Math.PI / 36;
 
 export default class RotationGestureHandler extends GestureHandler {
-  private rotation = 0;
-  private velocity = 0;
+  private _rotation = 0;
+  get rotation() {
+    return this._rotation;
+  }
+  set rotation(value: number) {
+    this._rotation = value;
+  }
 
-  private cachedAnchorX = 0;
-  private cachedAnchorY = 0;
+  private _velocity = 0;
+  get velocity() {
+    return this._velocity;
+  }
+  set velocity(value: number) {
+    this._velocity = value;
+  }
 
-  private rotationGestureListener: RotationGestureListener = {
+  private _cachedAnchorX = 0;
+  get cachedAnchorX() {
+    return this._cachedAnchorX;
+  }
+  set cachedAnchorX(value: number) {
+    this._cachedAnchorX = value;
+  }
+
+  private _cachedAnchorY = 0;
+  get cachedAnchorY() {
+    return this._cachedAnchorY;
+  }
+  set cachedAnchorY(value: number) {
+    this._cachedAnchorY = value;
+  }
+
+  private _rotationGestureListener: RotationGestureListener = {
     onRotationBegin: (_detector: RotationGestureDetector): boolean => true,
     onRotation: (detector: RotationGestureDetector): boolean => {
       const previousRotation: number = this.rotation;
@@ -41,8 +67,21 @@ export default class RotationGestureHandler extends GestureHandler {
     },
   };
 
-  private rotationGestureDetector: RotationGestureDetector =
+  get rotationGestureListener(): RotationGestureListener {
+    return this._rotationGestureListener;
+  }
+  set rotationGestureListener(listener: RotationGestureListener) {
+    this._rotationGestureListener = listener;
+  }
+
+  private _rotationGestureDetector: RotationGestureDetector =
     new RotationGestureDetector(this.rotationGestureListener);
+  get rotationGestureDetector(): RotationGestureDetector {
+    return this._rotationGestureDetector;
+  }
+  set rotationGestureDetector(detector: RotationGestureDetector) {
+    this._rotationGestureDetector = detector;
+  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);

--- a/src/web/handlers/RotationGestureHandler.ts
+++ b/src/web/handlers/RotationGestureHandler.ts
@@ -10,37 +10,9 @@ const ROTATION_RECOGNITION_THRESHOLD = Math.PI / 36;
 
 export default class RotationGestureHandler extends GestureHandler {
   private _rotation = 0;
-  get rotation() {
-    return this._rotation;
-  }
-  set rotation(value: number) {
-    this._rotation = value;
-  }
-
   private _velocity = 0;
-  get velocity() {
-    return this._velocity;
-  }
-  set velocity(value: number) {
-    this._velocity = value;
-  }
-
   private _cachedAnchorX = 0;
-  get cachedAnchorX() {
-    return this._cachedAnchorX;
-  }
-  set cachedAnchorX(value: number) {
-    this._cachedAnchorX = value;
-  }
-
   private _cachedAnchorY = 0;
-  get cachedAnchorY() {
-    return this._cachedAnchorY;
-  }
-  set cachedAnchorY(value: number) {
-    this._cachedAnchorY = value;
-  }
-
   private _rotationGestureListener: RotationGestureListener = {
     onRotationBegin: (_detector: RotationGestureDetector): boolean => true,
     onRotation: (detector: RotationGestureDetector): boolean => {
@@ -66,22 +38,8 @@ export default class RotationGestureHandler extends GestureHandler {
       this.end();
     },
   };
-
-  get rotationGestureListener(): RotationGestureListener {
-    return this._rotationGestureListener;
-  }
-  set rotationGestureListener(listener: RotationGestureListener) {
-    this._rotationGestureListener = listener;
-  }
-
   private _rotationGestureDetector: RotationGestureDetector =
     new RotationGestureDetector(this.rotationGestureListener);
-  get rotationGestureDetector(): RotationGestureDetector {
-    return this._rotationGestureDetector;
-  }
-  set rotationGestureDetector(detector: RotationGestureDetector) {
-    this._rotationGestureDetector = detector;
-  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
@@ -209,5 +167,47 @@ export default class RotationGestureHandler extends GestureHandler {
     this.rotation = 0;
     this.velocity = 0;
     this.rotationGestureDetector.reset();
+  }
+
+  get rotation() {
+    return this._rotation;
+  }
+  set rotation(value: number) {
+    this._rotation = value;
+  }
+
+  get velocity() {
+    return this._velocity;
+  }
+  set velocity(value: number) {
+    this._velocity = value;
+  }
+
+  get cachedAnchorX() {
+    return this._cachedAnchorX;
+  }
+  set cachedAnchorX(value: number) {
+    this._cachedAnchorX = value;
+  }
+
+  get cachedAnchorY() {
+    return this._cachedAnchorY;
+  }
+  set cachedAnchorY(value: number) {
+    this._cachedAnchorY = value;
+  }
+
+  get rotationGestureListener(): RotationGestureListener {
+    return this._rotationGestureListener;
+  }
+  set rotationGestureListener(listener: RotationGestureListener) {
+    this._rotationGestureListener = listener;
+  }
+
+  get rotationGestureDetector(): RotationGestureDetector {
+    return this._rotationGestureDetector;
+  }
+  set rotationGestureDetector(detector: RotationGestureDetector) {
+    this._rotationGestureDetector = detector;
   }
 }

--- a/src/web/handlers/RotationGestureHandler.ts
+++ b/src/web/handlers/RotationGestureHandler.ts
@@ -17,7 +17,7 @@ export default class RotationGestureHandler extends GestureHandler {
     onRotationBegin: (_detector: RotationGestureDetector): boolean => true,
     onRotation: (detector: RotationGestureDetector): boolean => {
       const previousRotation: number = this.rotation;
-      this.rotation += detector.getRotation();
+      this.rotation += detector.rotation;
 
       const delta = detector.getTimeDelta();
 
@@ -61,13 +61,13 @@ export default class RotationGestureHandler extends GestureHandler {
   }
 
   public getAnchorX(): number {
-    const anchorX = this.rotationGestureDetector.getAnchorX();
+    const anchorX = this.rotationGestureDetector.anchorX;
 
     return anchorX ? anchorX : this.cachedAnchorX;
   }
 
   public getAnchorY(): number {
-    const anchorY = this.rotationGestureDetector.getAnchorY();
+    const anchorY = this.rotationGestureDetector.anchorY;
 
     return anchorY ? anchorY : this.cachedAnchorY;
   }

--- a/src/web/handlers/RotationGestureHandler.ts
+++ b/src/web/handlers/RotationGestureHandler.ts
@@ -172,8 +172,8 @@ export default class RotationGestureHandler extends GestureHandler {
   public get rotation() {
     return this._rotation;
   }
-  public set rotation(value: number) {
-    this._rotation = value;
+  public set rotation(angle: number) {
+    this._rotation = angle;
   }
 
   public get velocity() {

--- a/src/web/handlers/TapGestureHandler.ts
+++ b/src/web/handlers/TapGestureHandler.ts
@@ -9,27 +9,141 @@ const DEFAULT_NUMBER_OF_TAPS = 1;
 const DEFAULT_MIN_NUMBER_OF_POINTERS = 1;
 
 export default class TapGestureHandler extends GestureHandler {
-  private maxDeltaX = Number.MIN_SAFE_INTEGER;
-  private maxDeltaY = Number.MIN_SAFE_INTEGER;
-  private maxDistSq = Number.MIN_SAFE_INTEGER;
-  private maxDurationMs = DEFAULT_MAX_DURATION_MS;
-  private maxDelayMs = DEFAULT_MAX_DELAY_MS;
+  private _maxDeltaX = Number.MIN_SAFE_INTEGER;
+  get maxDeltaX() {
+    return this._maxDeltaX;
+  }
+  set maxDeltaX(value: number) {
+    this._maxDeltaX = value;
+  }
 
-  private numberOfTaps = DEFAULT_NUMBER_OF_TAPS;
-  private minNumberOfPointers = DEFAULT_MIN_NUMBER_OF_POINTERS;
-  private currentMaxNumberOfPointers = 1;
+  private _maxDeltaY = Number.MIN_SAFE_INTEGER;
+  get maxDeltaY() {
+    return this._maxDeltaY;
+  }
+  set maxDeltaY(value: number) {
+    this._maxDeltaY = value;
+  }
 
-  private startX = 0;
-  private startY = 0;
-  private offsetX = 0;
-  private offsetY = 0;
-  private lastX = 0;
-  private lastY = 0;
+  private _maxDistSq = Number.MIN_SAFE_INTEGER;
+  get maxDistSq() {
+    return this._maxDistSq;
+  }
+  set maxDistSq(value: number) {
+    this._maxDistSq = value;
+  }
 
-  private waitTimeout: number | undefined;
-  private delayTimeout: number | undefined;
+  private _maxDurationMs = DEFAULT_MAX_DURATION_MS;
+  get maxDurationMs() {
+    return this._maxDurationMs;
+  }
+  set maxDurationMs(value: number) {
+    this._maxDurationMs = value;
+  }
 
-  private tapsSoFar = 0;
+  private _maxDelayMs = DEFAULT_MAX_DELAY_MS;
+  get maxDelayMs() {
+    return this._maxDelayMs;
+  }
+  set maxDelayMs(value: number) {
+    this._maxDelayMs = value;
+  }
+
+  private _numberOfTaps = DEFAULT_NUMBER_OF_TAPS;
+  get numberOfTaps() {
+    return this._numberOfTaps;
+  }
+  set numberOfTaps(value: number) {
+    this._numberOfTaps = value;
+  }
+
+  private _minNumberOfPointers = DEFAULT_MIN_NUMBER_OF_POINTERS;
+  get minNumberOfPointers() {
+    return this._minNumberOfPointers;
+  }
+  set minNumberOfPointers(value: number) {
+    this._minNumberOfPointers = value;
+  }
+
+  private _currentMaxNumberOfPointers = 1;
+  get currentMaxNumberOfPointers() {
+    return this._currentMaxNumberOfPointers;
+  }
+  set currentMaxNumberOfPointers(value: number) {
+    this._currentMaxNumberOfPointers = value;
+  }
+
+  private _startX = 0;
+  get startX() {
+    return this._startX;
+  }
+  set startX(value: number) {
+    this._startX = value;
+  }
+
+  private _startY = 0;
+  get startY() {
+    return this._startY;
+  }
+  set startY(value: number) {
+    this._startY = value;
+  }
+
+  private _offsetX = 0;
+  get offsetX() {
+    return this._offsetX;
+  }
+  set offsetX(value: number) {
+    this._offsetX = value;
+  }
+
+  private _offsetY = 0;
+  get offsetY() {
+    return this._offsetY;
+  }
+  set offsetY(value: number) {
+    this._offsetY = value;
+  }
+
+  private _lastX = 0;
+  get lastX() {
+    return this._lastX;
+  }
+  set lastX(value: number) {
+    this._lastX = value;
+  }
+
+  private _lastY = 0;
+  get lastY() {
+    return this._lastY;
+  }
+  set lastY(value: number) {
+    this._lastY = value;
+  }
+
+  private _waitTimeout: number | undefined;
+  get waitTimeout() {
+    return this._waitTimeout;
+  }
+  set waitTimeout(value: number | undefined) {
+    this._waitTimeout = value;
+  }
+
+  private _delayTimeout: number | undefined;
+  get delayTimeout() {
+    return this._delayTimeout;
+  }
+  set delayTimeout(value: number | undefined) {
+    this._delayTimeout = value;
+  }
+
+  private _tapsSoFar = 0;
+  get tapsSoFar() {
+    return this._tapsSoFar;
+  }
+  set tapsSoFar(value: number) {
+    this._tapsSoFar = value;
+  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);

--- a/src/web/handlers/TapGestureHandler.ts
+++ b/src/web/handlers/TapGestureHandler.ts
@@ -10,140 +10,22 @@ const DEFAULT_MIN_NUMBER_OF_POINTERS = 1;
 
 export default class TapGestureHandler extends GestureHandler {
   private _maxDeltaX = Number.MIN_SAFE_INTEGER;
-  get maxDeltaX() {
-    return this._maxDeltaX;
-  }
-  set maxDeltaX(value: number) {
-    this._maxDeltaX = value;
-  }
-
   private _maxDeltaY = Number.MIN_SAFE_INTEGER;
-  get maxDeltaY() {
-    return this._maxDeltaY;
-  }
-  set maxDeltaY(value: number) {
-    this._maxDeltaY = value;
-  }
-
   private _maxDistSq = Number.MIN_SAFE_INTEGER;
-  get maxDistSq() {
-    return this._maxDistSq;
-  }
-  set maxDistSq(value: number) {
-    this._maxDistSq = value;
-  }
-
   private _maxDurationMs = DEFAULT_MAX_DURATION_MS;
-  get maxDurationMs() {
-    return this._maxDurationMs;
-  }
-  set maxDurationMs(value: number) {
-    this._maxDurationMs = value;
-  }
-
   private _maxDelayMs = DEFAULT_MAX_DELAY_MS;
-  get maxDelayMs() {
-    return this._maxDelayMs;
-  }
-  set maxDelayMs(value: number) {
-    this._maxDelayMs = value;
-  }
-
   private _numberOfTaps = DEFAULT_NUMBER_OF_TAPS;
-  get numberOfTaps() {
-    return this._numberOfTaps;
-  }
-  set numberOfTaps(value: number) {
-    this._numberOfTaps = value;
-  }
-
   private _minNumberOfPointers = DEFAULT_MIN_NUMBER_OF_POINTERS;
-  get minNumberOfPointers() {
-    return this._minNumberOfPointers;
-  }
-  set minNumberOfPointers(value: number) {
-    this._minNumberOfPointers = value;
-  }
-
   private _currentMaxNumberOfPointers = 1;
-  get currentMaxNumberOfPointers() {
-    return this._currentMaxNumberOfPointers;
-  }
-  set currentMaxNumberOfPointers(value: number) {
-    this._currentMaxNumberOfPointers = value;
-  }
-
   private _startX = 0;
-  get startX() {
-    return this._startX;
-  }
-  set startX(value: number) {
-    this._startX = value;
-  }
-
   private _startY = 0;
-  get startY() {
-    return this._startY;
-  }
-  set startY(value: number) {
-    this._startY = value;
-  }
-
   private _offsetX = 0;
-  get offsetX() {
-    return this._offsetX;
-  }
-  set offsetX(value: number) {
-    this._offsetX = value;
-  }
-
   private _offsetY = 0;
-  get offsetY() {
-    return this._offsetY;
-  }
-  set offsetY(value: number) {
-    this._offsetY = value;
-  }
-
   private _lastX = 0;
-  get lastX() {
-    return this._lastX;
-  }
-  set lastX(value: number) {
-    this._lastX = value;
-  }
-
   private _lastY = 0;
-  get lastY() {
-    return this._lastY;
-  }
-  set lastY(value: number) {
-    this._lastY = value;
-  }
-
   private _waitTimeout: number | undefined;
-  get waitTimeout() {
-    return this._waitTimeout;
-  }
-  set waitTimeout(value: number | undefined) {
-    this._waitTimeout = value;
-  }
-
   private _delayTimeout: number | undefined;
-  get delayTimeout() {
-    return this._delayTimeout;
-  }
-  set delayTimeout(value: number | undefined) {
-    this._delayTimeout = value;
-  }
-
   private _tapsSoFar = 0;
-  get tapsSoFar() {
-    return this._tapsSoFar;
-  }
-  set tapsSoFar(value: number) {
-    this._tapsSoFar = value;
-  }
 
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
@@ -397,5 +279,124 @@ export default class TapGestureHandler extends GestureHandler {
     this.clearTimeouts();
     this.tapsSoFar = 0;
     this.currentMaxNumberOfPointers = 0;
+  }
+
+  get maxDeltaX() {
+    return this._maxDeltaX;
+  }
+  set maxDeltaX(value: number) {
+    this._maxDeltaX = value;
+  }
+
+  get maxDeltaY() {
+    return this._maxDeltaY;
+  }
+  set maxDeltaY(value: number) {
+    this._maxDeltaY = value;
+  }
+
+  get maxDistSq() {
+    return this._maxDistSq;
+  }
+  set maxDistSq(value: number) {
+    this._maxDistSq = value;
+  }
+
+  get maxDurationMs() {
+    return this._maxDurationMs;
+  }
+  set maxDurationMs(value: number) {
+    this._maxDurationMs = value;
+  }
+
+  get maxDelayMs() {
+    return this._maxDelayMs;
+  }
+  set maxDelayMs(value: number) {
+    this._maxDelayMs = value;
+  }
+
+  get numberOfTaps() {
+    return this._numberOfTaps;
+  }
+  set numberOfTaps(value: number) {
+    this._numberOfTaps = value;
+  }
+
+  get minNumberOfPointers() {
+    return this._minNumberOfPointers;
+  }
+  set minNumberOfPointers(value: number) {
+    this._minNumberOfPointers = value;
+  }
+
+  get currentMaxNumberOfPointers() {
+    return this._currentMaxNumberOfPointers;
+  }
+  set currentMaxNumberOfPointers(value: number) {
+    this._currentMaxNumberOfPointers = value;
+  }
+
+  get startX() {
+    return this._startX;
+  }
+  set startX(value: number) {
+    this._startX = value;
+  }
+
+  get startY() {
+    return this._startY;
+  }
+  set startY(value: number) {
+    this._startY = value;
+  }
+
+  get offsetX() {
+    return this._offsetX;
+  }
+  set offsetX(value: number) {
+    this._offsetX = value;
+  }
+
+  get offsetY() {
+    return this._offsetY;
+  }
+  set offsetY(value: number) {
+    this._offsetY = value;
+  }
+
+  get lastX() {
+    return this._lastX;
+  }
+  set lastX(value: number) {
+    this._lastX = value;
+  }
+
+  get lastY() {
+    return this._lastY;
+  }
+  set lastY(value: number) {
+    this._lastY = value;
+  }
+
+  get waitTimeout() {
+    return this._waitTimeout;
+  }
+  set waitTimeout(value: number | undefined) {
+    this._waitTimeout = value;
+  }
+
+  get delayTimeout() {
+    return this._delayTimeout;
+  }
+  set delayTimeout(value: number | undefined) {
+    this._delayTimeout = value;
+  }
+
+  get tapsSoFar() {
+    return this._tapsSoFar;
+  }
+  set tapsSoFar(value: number) {
+    this._tapsSoFar = value;
   }
 }

--- a/src/web/handlers/TapGestureHandler.ts
+++ b/src/web/handlers/TapGestureHandler.ts
@@ -281,122 +281,122 @@ export default class TapGestureHandler extends GestureHandler {
     this.currentMaxNumberOfPointers = 0;
   }
 
-  get maxDeltaX() {
+  public get maxDeltaX() {
     return this._maxDeltaX;
   }
-  set maxDeltaX(value: number) {
+  public set maxDeltaX(value: number) {
     this._maxDeltaX = value;
   }
 
-  get maxDeltaY() {
+  public get maxDeltaY() {
     return this._maxDeltaY;
   }
-  set maxDeltaY(value: number) {
+  public set maxDeltaY(value: number) {
     this._maxDeltaY = value;
   }
 
-  get maxDistSq() {
+  public get maxDistSq() {
     return this._maxDistSq;
   }
-  set maxDistSq(value: number) {
+  public set maxDistSq(value: number) {
     this._maxDistSq = value;
   }
 
-  get maxDurationMs() {
+  public get maxDurationMs() {
     return this._maxDurationMs;
   }
-  set maxDurationMs(value: number) {
+  public set maxDurationMs(value: number) {
     this._maxDurationMs = value;
   }
 
-  get maxDelayMs() {
+  public get maxDelayMs() {
     return this._maxDelayMs;
   }
-  set maxDelayMs(value: number) {
+  public set maxDelayMs(value: number) {
     this._maxDelayMs = value;
   }
 
-  get numberOfTaps() {
+  public get numberOfTaps() {
     return this._numberOfTaps;
   }
-  set numberOfTaps(value: number) {
+  public set numberOfTaps(value: number) {
     this._numberOfTaps = value;
   }
 
-  get minNumberOfPointers() {
+  public get minNumberOfPointers() {
     return this._minNumberOfPointers;
   }
-  set minNumberOfPointers(value: number) {
+  public set minNumberOfPointers(value: number) {
     this._minNumberOfPointers = value;
   }
 
-  get currentMaxNumberOfPointers() {
+  public get currentMaxNumberOfPointers() {
     return this._currentMaxNumberOfPointers;
   }
-  set currentMaxNumberOfPointers(value: number) {
+  public set currentMaxNumberOfPointers(value: number) {
     this._currentMaxNumberOfPointers = value;
   }
 
-  get startX() {
+  public get startX() {
     return this._startX;
   }
-  set startX(value: number) {
+  public set startX(value: number) {
     this._startX = value;
   }
 
-  get startY() {
+  public get startY() {
     return this._startY;
   }
-  set startY(value: number) {
+  public set startY(value: number) {
     this._startY = value;
   }
 
-  get offsetX() {
+  public get offsetX() {
     return this._offsetX;
   }
-  set offsetX(value: number) {
+  public set offsetX(value: number) {
     this._offsetX = value;
   }
 
-  get offsetY() {
+  public get offsetY() {
     return this._offsetY;
   }
-  set offsetY(value: number) {
+  public set offsetY(value: number) {
     this._offsetY = value;
   }
 
-  get lastX() {
+  public get lastX() {
     return this._lastX;
   }
-  set lastX(value: number) {
+  public set lastX(value: number) {
     this._lastX = value;
   }
 
-  get lastY() {
+  public get lastY() {
     return this._lastY;
   }
-  set lastY(value: number) {
+  public set lastY(value: number) {
     this._lastY = value;
   }
 
-  get waitTimeout() {
+  public get waitTimeout() {
     return this._waitTimeout;
   }
-  set waitTimeout(value: number | undefined) {
+  public set waitTimeout(value: number | undefined) {
     this._waitTimeout = value;
   }
 
-  get delayTimeout() {
+  public get delayTimeout() {
     return this._delayTimeout;
   }
-  set delayTimeout(value: number | undefined) {
+  public set delayTimeout(value: number | undefined) {
     this._delayTimeout = value;
   }
 
-  get tapsSoFar() {
+  public get tapsSoFar() {
     return this._tapsSoFar;
   }
-  set tapsSoFar(value: number) {
+  public set tapsSoFar(value: number) {
     this._tapsSoFar = value;
   }
 }

--- a/src/web/handlers/TapGestureHandler.ts
+++ b/src/web/handlers/TapGestureHandler.ts
@@ -109,7 +109,7 @@ export default class TapGestureHandler extends GestureHandler {
       return;
     }
 
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
     super.onPointerDown(event);
 
     this.trySettingPosition(event);
@@ -127,13 +127,13 @@ export default class TapGestureHandler extends GestureHandler {
 
   protected onPointerAdd(event: AdaptedEvent): void {
     super.onPointerAdd(event);
-    this.tracker.addToTracker(event);
+    this.pointerTracker.addToTracker(event);
     this.trySettingPosition(event);
 
     this.offsetX += this.lastX - this.startX;
     this.offsetY += this.lastY - this.startY;
 
-    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    const lastCoords = this.pointerTracker.getAbsoluteCoordsAverage();
     this.lastX = lastCoords.x;
     this.lastY = lastCoords.y;
 
@@ -146,23 +146,23 @@ export default class TapGestureHandler extends GestureHandler {
   protected onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
 
-    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    const lastCoords = this.pointerTracker.getAbsoluteCoordsAverage();
     this.lastX = lastCoords.x;
     this.lastY = lastCoords.y;
 
-    this.tracker.removeFromTracker(event.pointerId);
+    this.pointerTracker.removeFromTracker(event.pointerId);
 
     this.updateState(event);
   }
 
   protected onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
-    this.tracker.removeFromTracker(event.pointerId);
+    this.pointerTracker.removeFromTracker(event.pointerId);
 
     this.offsetX += this.lastX - this.startX;
     this.offsetY += this.lastY = this.startY;
 
-    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    const lastCoords = this.pointerTracker.getAbsoluteCoordsAverage();
     this.lastX = lastCoords.x;
     this.lastY = lastCoords.y;
 
@@ -174,9 +174,9 @@ export default class TapGestureHandler extends GestureHandler {
 
   protected onPointerMove(event: AdaptedEvent): void {
     this.trySettingPosition(event);
-    this.tracker.track(event);
+    this.pointerTracker.track(event);
 
-    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    const lastCoords = this.pointerTracker.getAbsoluteCoordsAverage();
     this.lastX = lastCoords.x;
     this.lastY = lastCoords.y;
 
@@ -187,9 +187,9 @@ export default class TapGestureHandler extends GestureHandler {
 
   protected onPointerOutOfBounds(event: AdaptedEvent): void {
     this.trySettingPosition(event);
-    this.tracker.track(event);
+    this.pointerTracker.track(event);
 
-    const lastCoords = this.tracker.getAbsoluteCoordsAverage();
+    const lastCoords = this.pointerTracker.getAbsoluteCoordsAverage();
     this.lastX = lastCoords.x;
     this.lastY = lastCoords.y;
 
@@ -200,9 +200,11 @@ export default class TapGestureHandler extends GestureHandler {
 
   private updateState(event: AdaptedEvent): void {
     if (
-      this.currentMaxNumberOfPointers < this.tracker.getTrackedPointersCount()
+      this.currentMaxNumberOfPointers <
+      this.pointerTracker.getTrackedPointersCount()
     ) {
-      this.currentMaxNumberOfPointers = this.tracker.getTrackedPointersCount();
+      this.currentMaxNumberOfPointers =
+        this.pointerTracker.getTrackedPointersCount();
     }
 
     if (this.shouldFail()) {
@@ -210,7 +212,7 @@ export default class TapGestureHandler extends GestureHandler {
       return;
     }
 
-    switch (this.currentState) {
+    switch (this.state) {
       case State.UNDETERMINED:
         if (event.eventType === EventTypes.DOWN) {
           this.begin();
@@ -231,7 +233,7 @@ export default class TapGestureHandler extends GestureHandler {
   }
 
   private trySettingPosition(event: AdaptedEvent): void {
-    if (this.currentState !== State.UNDETERMINED) {
+    if (this.state !== State.UNDETERMINED) {
       return;
     }
 

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -26,9 +26,9 @@ export default class GestureHandlerOrchestrator {
 
   private cleanHandler(handler: IGestureHandler): void {
     handler.reset();
-    handler.setActive(false);
-    handler.setAwaiting(false);
-    handler.setActivationIndex(Number.MAX_VALUE);
+    handler.active = false;
+    handler.awaiting = false;
+    handler.activationIndex = Number.MAX_VALUE;
   }
 
   public removeHandlerFromOrchestrator(handler: IGestureHandler): void {
@@ -41,7 +41,7 @@ export default class GestureHandlerOrchestrator {
 
     if (indexInAwaitingHandlers >= 0) {
       this.awaitingHandlers.splice(indexInAwaitingHandlers, 1);
-      this.awaitingHandlersTags.delete(handler.getTag());
+      this.awaitingHandlersTags.delete(handler.handlerTag);
     }
   }
 
@@ -51,7 +51,7 @@ export default class GestureHandlerOrchestrator {
     for (let i = this.gestureHandlers.length - 1; i >= 0; --i) {
       const handler = this.gestureHandlers[i];
 
-      if (this.isFinished(handler.getState()) && !handler.isAwaiting()) {
+      if (this.isFinished(handler.state) && !handler.awaiting) {
         this.cleanHandler(handler);
         handlersToRemove.add(handler);
       }
@@ -65,7 +65,7 @@ export default class GestureHandlerOrchestrator {
   private hasOtherHandlerToWaitFor(handler: IGestureHandler): boolean {
     const hasToWaitFor = (otherHandler: IGestureHandler) => {
       return (
-        !this.isFinished(otherHandler.getState()) &&
+        !this.isFinished(otherHandler.state) &&
         this.shouldHandlerWaitForOther(handler, otherHandler)
       );
     };
@@ -79,7 +79,7 @@ export default class GestureHandlerOrchestrator {
     const shouldBeCancelled = (otherHandler: IGestureHandler) => {
       return (
         this.shouldHandlerWaitForOther(handler, otherHandler) &&
-        otherHandler.getState() === State.END
+        otherHandler.state === State.END
       );
     };
 
@@ -97,7 +97,7 @@ export default class GestureHandlerOrchestrator {
       return;
     }
 
-    const handlerState = handler.getState();
+    const handlerState = handler.state;
 
     if (handlerState === State.CANCELLED || handlerState === State.FAILED) {
       return;
@@ -129,7 +129,7 @@ export default class GestureHandlerOrchestrator {
   private cleanupAwaitingHandlers(handler: IGestureHandler): void {
     const shouldWait = (otherHandler: IGestureHandler) => {
       return (
-        !otherHandler.isAwaiting() &&
+        !otherHandler.awaiting &&
         this.shouldHandlerWaitForOther(otherHandler, handler)
       );
     };
@@ -137,12 +137,12 @@ export default class GestureHandlerOrchestrator {
     for (const otherHandler of this.awaitingHandlers) {
       if (shouldWait(otherHandler)) {
         this.cleanHandler(otherHandler);
-        this.awaitingHandlersTags.delete(otherHandler.getTag());
+        this.awaitingHandlersTags.delete(otherHandler.handlerTag);
       }
     }
 
     this.awaitingHandlers = this.awaitingHandlers.filter((otherHandler) =>
-      this.awaitingHandlersTags.has(otherHandler.getTag())
+      this.awaitingHandlersTags.has(otherHandler.handlerTag)
     );
   }
 
@@ -152,7 +152,7 @@ export default class GestureHandlerOrchestrator {
     oldState: State,
     sendIfDisabled?: boolean
   ): void {
-    if (!handler.isEnabled() && !sendIfDisabled) {
+    if (!handler.enabled && !sendIfDisabled) {
       return;
     }
 
@@ -162,7 +162,7 @@ export default class GestureHandlerOrchestrator {
       for (const otherHandler of this.awaitingHandlers) {
         if (
           !this.shouldHandlerWaitForOther(otherHandler, handler) ||
-          !this.awaitingHandlersTags.has(otherHandler.getTag())
+          !this.awaitingHandlersTags.has(otherHandler.handlerTag)
         ) {
           continue;
         }
@@ -174,7 +174,7 @@ export default class GestureHandlerOrchestrator {
 
         otherHandler.cancel();
 
-        if (otherHandler.getState() === State.END) {
+        if (otherHandler.state === State.END) {
           // Handle edge case, where discrete gestures end immediately after activation thus
           // their state is set to END and when the gesture they are waiting for activates they
           // should be cancelled, however `cancel` was never sent as gestures were already in the END state.
@@ -182,14 +182,14 @@ export default class GestureHandlerOrchestrator {
           otherHandler.sendEvent(State.CANCELLED, State.BEGAN);
         }
 
-        otherHandler.setAwaiting(false);
+        otherHandler.awaiting = false;
       }
     }
 
     if (newState === State.ACTIVE) {
       this.tryActivate(handler);
     } else if (oldState === State.ACTIVE || oldState === State.END) {
-      if (handler.isActive()) {
+      if (handler.active) {
         handler.sendEvent(newState, oldState);
       } else if (
         oldState === State.ACTIVE &&
@@ -214,11 +214,11 @@ export default class GestureHandlerOrchestrator {
   }
 
   private makeActive(handler: IGestureHandler): void {
-    const currentState = handler.getState();
+    const currentState = handler.state;
 
-    handler.setActive(true);
+    handler.active = true;
     handler.setShouldResetProgress(true);
-    handler.setActivationIndex(this.activationIndex++);
+    handler.activationIndex = this.activationIndex++;
 
     for (let i = this.gestureHandlers.length - 1; i >= 0; --i) {
       if (this.shouldHandlerBeCancelledBy(this.gestureHandlers[i], handler)) {
@@ -228,7 +228,7 @@ export default class GestureHandlerOrchestrator {
 
     for (const otherHandler of this.awaitingHandlers) {
       if (this.shouldHandlerBeCancelledBy(otherHandler, handler)) {
-        otherHandler.setAwaiting(false);
+        otherHandler.awaiting = false;
       }
     }
 
@@ -241,11 +241,11 @@ export default class GestureHandlerOrchestrator {
       }
     }
 
-    if (!handler.isAwaiting()) {
+    if (!handler.awaiting) {
       return;
     }
 
-    handler.setAwaiting(false);
+    handler.awaiting = false;
 
     this.awaitingHandlers = this.awaitingHandlers.filter(
       (otherHandler) => otherHandler !== handler
@@ -258,10 +258,10 @@ export default class GestureHandlerOrchestrator {
     }
 
     this.awaitingHandlers.push(handler);
-    this.awaitingHandlersTags.add(handler.getTag());
+    this.awaitingHandlersTags.add(handler.handlerTag);
 
-    handler.setAwaiting(true);
-    handler.setActivationIndex(this.activationIndex++);
+    handler.awaiting = true;
+    handler.activationIndex = this.activationIndex++;
   }
 
   public recordHandlerIfNotPresent(handler: IGestureHandler): void {
@@ -271,9 +271,9 @@ export default class GestureHandlerOrchestrator {
 
     this.gestureHandlers.push(handler);
 
-    handler.setActive(false);
-    handler.setAwaiting(false);
-    handler.setActivationIndex(Number.MAX_SAFE_INTEGER);
+    handler.active = false;
+    handler.awaiting = false;
+    handler.activationIndex = Number.MAX_SAFE_INTEGER;
   }
 
   private shouldHandlerWaitForOther(
@@ -306,7 +306,7 @@ export default class GestureHandlerOrchestrator {
       return false;
     }
 
-    if (handler.isAwaiting() || handler.getState() === State.ACTIVE) {
+    if (handler.awaiting || handler.state === State.ACTIVE) {
       // For now it always returns false
       return handler.shouldBeCancelledByOther(otherHandler);
     }
@@ -316,7 +316,7 @@ export default class GestureHandlerOrchestrator {
 
     if (
       !PointerTracker.shareCommonPointers(handlerPointers, otherPointers) &&
-      handler.getDelegate().getView() !== otherHandler.getDelegate().getView()
+      handler.delegate.getView() !== otherHandler.delegate.getView()
     ) {
       return this.checkOverlap(handler, otherHandler);
     }
@@ -335,11 +335,11 @@ export default class GestureHandlerOrchestrator {
     // TODO: Find better way to handle that issue, for example by activation order and handler cancelling
 
     const isPointerWithinBothBounds = (pointer: number) => {
-      const point = handler.getTracker().getLastAbsoluteCoords(pointer);
+      const point = handler.pointerTracker.getLastAbsoluteCoords(pointer);
 
       return (
-        handler.getDelegate().isPointerInBounds(point) &&
-        otherHandler.getDelegate().isPointerInBounds(point)
+        handler.delegate.isPointerInBounds(point) &&
+        otherHandler.delegate.isPointerInBounds(point)
       );
     };
 
@@ -361,8 +361,8 @@ export default class GestureHandlerOrchestrator {
   public cancelMouseAndPenGestures(currentHandler: IGestureHandler): void {
     this.gestureHandlers.forEach((handler: IGestureHandler) => {
       if (
-        handler.getPointerType() !== PointerType.MOUSE &&
-        handler.getPointerType() !== PointerType.STYLUS
+        handler.pointerType !== PointerType.MOUSE &&
+        handler.pointerType !== PointerType.STYLUS
       ) {
         return;
       }
@@ -377,7 +377,7 @@ export default class GestureHandlerOrchestrator {
         //
         // However, handler will receive manually created onPointerEnter that is triggered in EventManager in onPointerMove method.
         // There may be possibility to use that fact to make handler respond properly to first mouse click
-        handler.getTracker().resetTracker();
+        handler.pointerTracker.resetTracker();
       }
     });
   }

--- a/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/src/web/tools/GestureHandlerOrchestrator.ts
@@ -217,7 +217,7 @@ export default class GestureHandlerOrchestrator {
     const currentState = handler.state;
 
     handler.active = true;
-    handler.setShouldResetProgress(true);
+    handler.shouldResetProgress = true;
     handler.activationIndex = this.activationIndex++;
 
     for (let i = this.gestureHandlers.length - 1; i >= 0; --i) {

--- a/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/src/web/tools/GestureHandlerWebDelegate.ts
@@ -37,7 +37,7 @@ export class GestureHandlerWebDelegate
   init(viewRef: number, handler: IGestureHandler): void {
     if (!viewRef) {
       throw new Error(
-        `Cannot find HTML Element for handler ${handler.getTag()}`
+        `Cannot find HTML Element for handler ${handler.handlerTag}`
       );
     }
 
@@ -51,7 +51,7 @@ export class GestureHandlerWebDelegate
       touchAction: this.view.style.touchAction,
     };
 
-    const config = handler.getConfig();
+    const config = handler.config;
 
     this.setUserSelect(config.enabled);
     this.setTouchAction(config.enabled);
@@ -88,12 +88,12 @@ export class GestureHandlerWebDelegate
   }
 
   tryResetCursor() {
-    const config = this.gestureHandler.getConfig();
+    const config = this.gestureHandler.config;
 
     if (
       config.activeCursor &&
       config.activeCursor !== 'auto' &&
-      this.gestureHandler.getState() === State.ACTIVE
+      this.gestureHandler.state === State.ACTIVE
     ) {
       this.view.style.cursor = 'auto';
     }
@@ -132,7 +132,7 @@ export class GestureHandlerWebDelegate
   }
 
   private setUserSelect(isHandlerEnabled: boolean) {
-    const { userSelect } = this.gestureHandler.getConfig();
+    const { userSelect } = this.gestureHandler.config;
 
     this.view.style['userSelect'] = isHandlerEnabled
       ? userSelect ?? 'none'
@@ -144,7 +144,7 @@ export class GestureHandlerWebDelegate
   }
 
   private setTouchAction(isHandlerEnabled: boolean) {
-    const { touchAction } = this.gestureHandler.getConfig();
+    const { touchAction } = this.gestureHandler.config;
 
     this.view.style['touchAction'] = isHandlerEnabled
       ? touchAction ?? 'none'
@@ -157,7 +157,7 @@ export class GestureHandlerWebDelegate
   }
 
   private setContextMenu(isHandlerEnabled: boolean) {
-    const config = this.gestureHandler.getConfig();
+    const config = this.gestureHandler.config;
 
     if (isHandlerEnabled) {
       this.addContextMenuListeners(config);
@@ -181,7 +181,7 @@ export class GestureHandlerWebDelegate
   }
 
   onActivate(): void {
-    const config = this.gestureHandler.getConfig();
+    const config = this.gestureHandler.config;
 
     if (
       (!this.view.style.cursor || this.view.style.cursor === 'auto') &&

--- a/src/web/tools/InteractionManager.ts
+++ b/src/web/tools/InteractionManager.ts
@@ -13,7 +13,7 @@ export default class InteractionManager {
   private constructor() {}
 
   public configureInteractions(handler: IGestureHandler, config: Config) {
-    this.dropRelationsForHandlerWithTag(handler.getTag());
+    this.dropRelationsForHandlerWithTag(handler.handlerTag);
 
     if (config.waitFor) {
       const waitFor: number[] = [];
@@ -27,7 +27,7 @@ export default class InteractionManager {
         }
       });
 
-      this.waitForRelations.set(handler.getTag(), waitFor);
+      this.waitForRelations.set(handler.handlerTag, waitFor);
     }
 
     if (config.simultaneousHandlers) {
@@ -40,7 +40,7 @@ export default class InteractionManager {
         }
       });
 
-      this.simultaneousRelations.set(handler.getTag(), simultaneousHandlers);
+      this.simultaneousRelations.set(handler.handlerTag, simultaneousHandlers);
     }
 
     if (config.blocksHandlers) {
@@ -53,7 +53,7 @@ export default class InteractionManager {
         }
       });
 
-      this.blocksHandlersRelations.set(handler.getTag(), blocksHandlers);
+      this.blocksHandlersRelations.set(handler.handlerTag, blocksHandlers);
     }
   }
 
@@ -62,12 +62,12 @@ export default class InteractionManager {
     otherHandler: IGestureHandler
   ): boolean {
     const waitFor: number[] | undefined = this.waitForRelations.get(
-      handler.getTag()
+      handler.handlerTag
     );
 
     return (
-      waitFor?.find((tag: number) => {
-        return tag === otherHandler.getTag();
+      waitFor?.find((handlerTag: number) => {
+        return handlerTag === otherHandler.handlerTag;
       }) !== undefined
     );
   }
@@ -77,11 +77,11 @@ export default class InteractionManager {
     otherHandler: IGestureHandler
   ): boolean {
     const simultaneousHandlers: number[] | undefined =
-      this.simultaneousRelations.get(handler.getTag());
+      this.simultaneousRelations.get(handler.handlerTag);
 
     return (
-      simultaneousHandlers?.find((tag: number) => {
-        return tag === otherHandler.getTag();
+      simultaneousHandlers?.find((handlerTag: number) => {
+        return handlerTag === otherHandler.handlerTag;
       }) !== undefined
     );
   }
@@ -91,12 +91,12 @@ export default class InteractionManager {
     otherHandler: IGestureHandler
   ): boolean {
     const waitFor: number[] | undefined = this.blocksHandlersRelations.get(
-      handler.getTag()
+      handler.handlerTag
     );
 
     return (
-      waitFor?.find((tag: number) => {
-        return tag === otherHandler.getTag();
+      waitFor?.find((handlerTag: number) => {
+        return handlerTag === otherHandler.handlerTag;
       }) !== undefined
     );
   }
@@ -108,7 +108,7 @@ export default class InteractionManager {
     // We check constructor name instead of using `instanceof` in order do avoid circular dependencies
     const isNativeHandler =
       otherHandler.constructor.name === 'NativeViewGestureHandler';
-    const isActive = otherHandler.getState() === State.ACTIVE;
+    const isActive = otherHandler.state === State.ACTIVE;
     const isButton = otherHandler.isButton?.() === true;
 
     return isNativeHandler && isActive && !isButton;

--- a/src/web/tools/NodeManager.ts
+++ b/src/web/tools/NodeManager.ts
@@ -28,7 +28,7 @@ export default abstract class NodeManager {
     }
 
     this.gestures[handlerTag] = handler;
-    this.gestures[handlerTag].setTag(handlerTag);
+    this.gestures[handlerTag].handlerTag = handlerTag;
   }
 
   public static dropGestureHandler(handlerTag: number): void {


### PR DESCRIPTION
## Description

In this PR I've migrated our handlers into `get`/`set` functions instead of traditional getters and setters convention (like in `Java`). 

>[!NOTE]
> This PR changes only handlers and detectors, `tools` directory is not a part of this PR as it would get too big.

## Test plan

Run web example