### PR TITLE
Mark legacy web implementation as deprecated

### DIFF
--- a/src/EnableNewWebImplementation.ts
+++ b/src/EnableNewWebImplementation.ts
@@ -1,4 +1,5 @@
 import { Platform } from 'react-native';
+import { tagMessage } from './utils';
 
 let useNewWebImplementation = true;
 let getWasCalled = false;
@@ -11,7 +12,9 @@ export function enableExperimentalWebImplementation(
 ): void {
   // NO-OP since the new implementation is now the default
   console.warn(
-    'New web implementation is enabled by default. This function will be removed in Gesture Handler 3'
+    tagMessage(
+      'New web implementation is enabled by default. This function will be removed in Gesture Handler 3'
+    )
   );
 }
 
@@ -22,7 +25,9 @@ export function enableLegacyWebImplementation(
   shouldUseLegacyImplementation = true
 ): void {
   console.warn(
-    'Legacy web implementation is deprecated. This function will be removed in Gesture Handler 3'
+    tagMessage(
+      'Legacy web implementation is deprecated. This function will be removed in Gesture Handler 3.'
+    )
   );
 
   if (

--- a/src/EnableNewWebImplementation.ts
+++ b/src/EnableNewWebImplementation.ts
@@ -13,7 +13,7 @@ export function enableExperimentalWebImplementation(
   // NO-OP since the new implementation is now the default
   console.warn(
     tagMessage(
-      'New web implementation is enabled by default. This function will be removed in Gesture Handler 3'
+      'New web implementation is enabled by default. This function will be removed in Gesture Handler 3.'
     )
   );
 }

--- a/src/EnableNewWebImplementation.ts
+++ b/src/EnableNewWebImplementation.ts
@@ -42,9 +42,6 @@ export function enableLegacyWebImplementation(
   useNewWebImplementation = !shouldUseLegacyImplementation;
 }
 
-/**
- * @deprecated the legacy implementation is no longer supported. This function will be removed in Gesture Handler 3
- */
 export function isNewWebImplementationEnabled(): boolean {
   getWasCalled = true;
   return useNewWebImplementation;

--- a/src/EnableNewWebImplementation.ts
+++ b/src/EnableNewWebImplementation.ts
@@ -4,19 +4,19 @@ let useNewWebImplementation = true;
 let getWasCalled = false;
 
 /**
- * @deprecated the legacy implementation is no longer supported. This function will be removed in Gesture Handler 3
+ * @deprecated legacy implementation is no longer supported. This function will be removed in Gesture Handler 3
  */
 export function enableExperimentalWebImplementation(
   _shouldEnable = true
 ): void {
   // NO-OP since the new implementation is now the default
   console.warn(
-    'Legacy web implementation is deprecated and will be removed in Gesture Handler 3'
+    'Legacy web implementation is deprecated. This function will be removed in Gesture Handler 3'
   );
 }
 
 /**
- * @deprecated the legacy implementation is no longer supported. This function will be removed in Gesture Handler 3
+ * @deprecated legacy implementation is no longer supported. This function will be removed in Gesture Handler 3
  */
 export function enableLegacyWebImplementation(
   shouldUseLegacyImplementation = true

--- a/src/EnableNewWebImplementation.ts
+++ b/src/EnableNewWebImplementation.ts
@@ -7,11 +7,18 @@ export function enableExperimentalWebImplementation(
   _shouldEnable = true
 ): void {
   // NO-OP since the new implementation is now the default
+  console.warn(
+    'The legacy web implementation is deprecated in Gesture Handler 2 and will be removed in Gesture Handler 3'
+  );
 }
 
 export function enableLegacyWebImplementation(
   shouldUseLegacyImplementation = true
 ): void {
+  console.warn(
+    'The legacy web implementation is deprecated in Gesture Handler 2 and will be removed in Gesture Handler 3'
+  );
+
   if (
     Platform.OS !== 'web' ||
     useNewWebImplementation === !shouldUseLegacyImplementation

--- a/src/EnableNewWebImplementation.ts
+++ b/src/EnableNewWebImplementation.ts
@@ -22,7 +22,7 @@ export function enableLegacyWebImplementation(
   shouldUseLegacyImplementation = true
 ): void {
   console.warn(
-    'Legacy web implementation is deprecated and will be removed in Gesture Handler 3'
+    'Legacy web implementation is deprecated. This function will be removed in Gesture Handler 3'
   );
 
   if (

--- a/src/EnableNewWebImplementation.ts
+++ b/src/EnableNewWebImplementation.ts
@@ -3,20 +3,26 @@ import { Platform } from 'react-native';
 let useNewWebImplementation = true;
 let getWasCalled = false;
 
+/**
+ * @deprecated the legacy implementation is no longer supported. This function will be removed in Gesture Handler 3
+ */
 export function enableExperimentalWebImplementation(
   _shouldEnable = true
 ): void {
   // NO-OP since the new implementation is now the default
   console.warn(
-    'The legacy web implementation is deprecated in Gesture Handler 2 and will be removed in Gesture Handler 3'
+    'The legacy web implementation is deprecated and will be removed in Gesture Handler 3'
   );
 }
 
+/**
+ * @deprecated the legacy implementation is no longer supported. This function will be removed in Gesture Handler 3
+ */
 export function enableLegacyWebImplementation(
   shouldUseLegacyImplementation = true
 ): void {
   console.warn(
-    'The legacy web implementation is deprecated in Gesture Handler 2 and will be removed in Gesture Handler 3'
+    'The legacy web implementation is deprecated and will be removed in Gesture Handler 3'
   );
 
   if (
@@ -36,6 +42,9 @@ export function enableLegacyWebImplementation(
   useNewWebImplementation = !shouldUseLegacyImplementation;
 }
 
+/**
+ * @deprecated the legacy implementation is no longer supported. This function will be removed in Gesture Handler 3
+ */
 export function isNewWebImplementationEnabled(): boolean {
   getWasCalled = true;
   return useNewWebImplementation;

--- a/src/EnableNewWebImplementation.ts
+++ b/src/EnableNewWebImplementation.ts
@@ -4,14 +4,14 @@ let useNewWebImplementation = true;
 let getWasCalled = false;
 
 /**
- * @deprecated legacy implementation is no longer supported. This function will be removed in Gesture Handler 3
+ * @deprecated new web implementation is enabled by default. This function will be removed in Gesture Handler 3
  */
 export function enableExperimentalWebImplementation(
   _shouldEnable = true
 ): void {
   // NO-OP since the new implementation is now the default
   console.warn(
-    'Legacy web implementation is deprecated. This function will be removed in Gesture Handler 3'
+    'New web implementation is enabled by default. This function will be removed in Gesture Handler 3'
   );
 }
 

--- a/src/EnableNewWebImplementation.ts
+++ b/src/EnableNewWebImplementation.ts
@@ -11,7 +11,7 @@ export function enableExperimentalWebImplementation(
 ): void {
   // NO-OP since the new implementation is now the default
   console.warn(
-    'The legacy web implementation is deprecated and will be removed in Gesture Handler 3'
+    'Legacy web implementation is deprecated and will be removed in Gesture Handler 3'
   );
 }
 
@@ -22,7 +22,7 @@ export function enableLegacyWebImplementation(
   shouldUseLegacyImplementation = true
 ): void {
   console.warn(
-    'The legacy web implementation is deprecated and will be removed in Gesture Handler 3'
+    'Legacy web implementation is deprecated and will be removed in Gesture Handler 3'
   );
 
   if (


### PR DESCRIPTION
## Description

The legacy web implementation will be removed in Gesture Handler 3.
This PR explicitly marks it as deprecated before that removal occurs.
Suggested in [this](https://github.com/software-mansion/react-native-gesture-handler/pull/3229#discussion_r1861733787) github comment.

## Test plan

- see how trying to use `enableExperimentalWebImplementation` or `enableExperimentalWebImplementation` results in a warning.