### PR TITLE
Deprecate `Touchable` components 

### DIFF
--- a/src/components/touchables/GenericTouchable.tsx
+++ b/src/components/touchables/GenericTouchable.tsx
@@ -12,6 +12,7 @@ import {
 import type { NativeViewGestureHandlerPayload } from '../../handlers/GestureHandlerEventPayload';
 import type { TouchableNativeFeedbackExtraProps } from './TouchableNativeFeedbackProps';
 import type { GenericTouchableProps } from './GenericTouchableProps';
+import { tagMessage } from '../../utils';
 
 /**
  * Each touchable is a states' machine which preforms transitions.
@@ -65,6 +66,16 @@ export default class GenericTouchable extends Component<
 
   // State of touchable
   STATE: TouchableState = TOUCHABLE_STATE.UNDETERMINED;
+
+  constructor(props: GenericTouchableProps & InternalProps) {
+    super(props);
+
+    console.warn(
+      tagMessage(
+        'TouchableOpacity component will be removed in Gesture Handler 4'
+      )
+    );
+  }
 
   // handlePressIn in called on first touch on traveling inside component.
   // Handles state transition with delay.

--- a/src/components/touchables/TouchableHighlight.tsx
+++ b/src/components/touchables/TouchableHighlight.tsx
@@ -9,7 +9,6 @@ import {
   ColorValue,
   ViewProps,
 } from 'react-native';
-import { tagMessage } from '../../utils';
 
 interface State {
   extraChildStyle: null | {
@@ -48,12 +47,6 @@ export default class TouchableHighlight extends Component<
       extraChildStyle: null,
       extraUnderlayStyle: null,
     };
-
-    console.warn(
-      tagMessage(
-        'TouchableHighlight component will be removed in Gesture Handler 4'
-      )
-    );
   }
 
   // Copied from RN

--- a/src/components/touchables/TouchableHighlight.tsx
+++ b/src/components/touchables/TouchableHighlight.tsx
@@ -9,6 +9,7 @@ import {
   ColorValue,
   ViewProps,
 } from 'react-native';
+import { tagMessage } from '../../utils';
 
 interface State {
   extraChildStyle: null | {
@@ -19,10 +20,15 @@ interface State {
   };
 }
 
+/**
+ * @deprecated TouchableHighlight will be removed in Gesture Handler 4
+ */
 export type TouchableHighlightProps = RNTouchableHighlightProps &
   GenericTouchableProps;
 
 /**
+ * @deprecated TouchableHighlight will be removed in Gesture Handler 4
+ *
  * TouchableHighlight follows RN's implementation
  */
 export default class TouchableHighlight extends Component<
@@ -42,6 +48,12 @@ export default class TouchableHighlight extends Component<
       extraChildStyle: null,
       extraUnderlayStyle: null,
     };
+
+    console.warn(
+      tagMessage(
+        'TouchableHighlight component will be removed in Gesture Handler 4'
+      )
+    );
   }
 
   // Copied from RN

--- a/src/components/touchables/TouchableNativeFeedback.android.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.android.tsx
@@ -8,6 +8,8 @@ import {
 } from './TouchableNativeFeedbackProps';
 
 /**
+ * @deprecated TouchableNativeFeedback will be removed in Gesture Handler 4
+ *
  * TouchableNativeFeedback behaves slightly different than RN's TouchableNativeFeedback.
  * There's small difference with handling long press ripple since RN's implementation calls
  * ripple animation via bridge. This solution leaves all animations' handling for native components so

--- a/src/components/touchables/TouchableNativeFeedback.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.tsx
@@ -1,6 +1,12 @@
-import { TouchableNativeFeedback } from 'react-native';
+import { TouchableNativeFeedback as RNTouchableNativeFeedback } from 'react-native';
 
 /**
  * @deprecated TouchableNativeFeedback will be removed in Gesture Handler 4
  */
+const TouchableNativeFeedback: React.FC<
+  React.ComponentProps<typeof RNTouchableNativeFeedback>
+> = (props) => {
+  return <RNTouchableNativeFeedback {...props} />;
+};
+
 export default TouchableNativeFeedback;

--- a/src/components/touchables/TouchableNativeFeedback.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.tsx
@@ -1,3 +1,6 @@
 import { TouchableNativeFeedback } from 'react-native';
 
+/**
+ * @deprecated TouchableNativeFeedback will be removed in Gesture Handler 4
+ */
 export default TouchableNativeFeedback;

--- a/src/components/touchables/TouchableNativeFeedback.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.tsx
@@ -1,4 +1,6 @@
+import { useEffect } from 'react';
 import { TouchableNativeFeedback as RNTouchableNativeFeedback } from 'react-native';
+import { tagMessage } from '../../utils';
 
 /**
  * @deprecated TouchableNativeFeedback will be removed in Gesture Handler 4
@@ -6,6 +8,14 @@ import { TouchableNativeFeedback as RNTouchableNativeFeedback } from 'react-nati
 const TouchableNativeFeedback: React.FC<
   React.ComponentProps<typeof RNTouchableNativeFeedback>
 > = (props) => {
+  useEffect(() => {
+    console.warn(
+      tagMessage(
+        'TouchableOpacity component will be removed in Gesture Handler 4'
+      )
+    );
+  }, []);
+
   return <RNTouchableNativeFeedback {...props} />;
 };
 

--- a/src/components/touchables/TouchableNativeFeedbackProps.tsx
+++ b/src/components/touchables/TouchableNativeFeedbackProps.tsx
@@ -8,5 +8,8 @@ export type TouchableNativeFeedbackExtraProps = {
   foreground?: boolean;
 };
 
+/**
+ * @deprecated TouchableNativeFeedback will be removed in Gesture Handler 4
+ */
 export type TouchableNativeFeedbackProps = RNTouchableNativeFeedbackProps &
   GenericTouchableProps;

--- a/src/components/touchables/TouchableOpacity.tsx
+++ b/src/components/touchables/TouchableOpacity.tsx
@@ -10,12 +10,17 @@ import type { GenericTouchableProps } from './GenericTouchableProps';
 import * as React from 'react';
 import { Component } from 'react';
 
+/**
+ * @deprecated TouchableOpacity will be removed in Gesture Handler 4
+ */
 export type TouchableOpacityProps = RNTouchableOpacityProps &
   GenericTouchableProps & {
     useNativeAnimations?: boolean;
   };
 
 /**
+ * @deprecated TouchableOpacity will be removed in Gesture Handler 4
+ *
  * TouchableOpacity bases on timing animation which has been used in RN's core
  */
 export default class TouchableOpacity extends Component<TouchableOpacityProps> {

--- a/src/components/touchables/TouchableWithoutFeedback.tsx
+++ b/src/components/touchables/TouchableWithoutFeedback.tsx
@@ -3,8 +3,14 @@ import { PropsWithChildren } from 'react';
 import GenericTouchable from './GenericTouchable';
 import type { GenericTouchableProps } from './GenericTouchableProps';
 
+/**
+ * @deprecated TouchableWithoutFeedback will be removed in Gesture Handler 4
+ */
 export type TouchableWithoutFeedbackProps = GenericTouchableProps;
 
+/**
+ * @deprecated TouchableWithoutFeedback will be removed in Gesture Handler 4
+ */
 const TouchableWithoutFeedback = React.forwardRef<
   GenericTouchable,
   PropsWithChildren<TouchableWithoutFeedbackProps>


### PR DESCRIPTION
## Description

This PR deprecates `Touchable` components in our repo

## Test plan

Try importing any `Touchable` (or its `props`). After importing look at the console.
