### PR TITLE
Make `stylusData` property of the `GestureUpdateEvent` optional

### DIFF
--- a/src/handlers/GestureHandlerEventPayload.ts
+++ b/src/handlers/GestureHandlerEventPayload.ts
@@ -126,7 +126,7 @@ export type PanGestureHandlerEventPayload = {
   /**
    * Object containing additional stylus data.
    */
-  stylusData: StylusData | undefined;
+  stylusData?: StylusData | undefined;
 };
 
 export type PinchGestureHandlerEventPayload = {

--- a/src/handlers/GestureHandlerEventPayload.ts
+++ b/src/handlers/GestureHandlerEventPayload.ts
@@ -126,7 +126,7 @@ export type PanGestureHandlerEventPayload = {
   /**
    * Object containing additional stylus data.
    */
-  stylusData?: StylusData | undefined;
+  stylusData?: StylusData;
 };
 
 export type PinchGestureHandlerEventPayload = {
@@ -222,5 +222,5 @@ export type HoverGestureHandlerEventPayload = {
   /**
    * Object containing additional stylus data.
    */
-  stylusData: StylusData | undefined;
+  stylusData?: StylusData
 };

--- a/src/handlers/GestureHandlerEventPayload.ts
+++ b/src/handlers/GestureHandlerEventPayload.ts
@@ -222,5 +222,5 @@ export type HoverGestureHandlerEventPayload = {
   /**
    * Object containing additional stylus data.
    */
-  stylusData?: StylusData
+  stylusData?: StylusData;
 };


### PR DESCRIPTION
## Description

Idk what's your policy on types & whether the type `stylusData: StylusData | undefined` type is intended in this form or not, 
but currently when creating event of type `GestureUpdateEvent<PanGestureHandlerEventPayload>` user is forced to specify
`stylusData` even if there is none - in such case `stylusData: undefined` must be passed; the prop can not be just simply omitted.

![image](https://github.com/user-attachments/assets/a5d1a2ae-88d8-4191-bb33-6d45eeac428e)


I'm humbly suggesting that you consider relaxing these types a bit to `stylusData?: StylusData | undefined`, so that it 
does not have to be always specified. 

Context: this is just quality of life improvement IMO, not crucial. I've stubmled upon this when I've bumped version of `gesture-handler` in `react-native-screens` [(link)](https://github.com/software-mansion/react-native-screens/pull/2561)
 - current types forced me to add this field, and I've thought this is not pleasant.

## Test plan

N/A, every thing should work as before

