### PR TITLE
Fix: cancelled events are not ended when manualActivation is used

### DIFF
--- a/apple/Handlers/RNFlingHandler.m
+++ b/apple/Handlers/RNFlingHandler.m
@@ -60,10 +60,6 @@
   _lastPoint = [[[touches allObjects] objectAtIndex:0] locationInView:_gestureHandler.recognizer.view];
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-
-  if (_gestureHandler.manualActivation) {
-    [self reset];
-  }
 }
 
 - (void)triggerAction

--- a/apple/Handlers/RNFlingHandler.m
+++ b/apple/Handlers/RNFlingHandler.m
@@ -60,7 +60,10 @@
   _lastPoint = [[[touches allObjects] objectAtIndex:0] locationInView:_gestureHandler.recognizer.view];
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-  [self reset];
+
+  if (_gestureHandler.manualActivation) {
+    [self reset];
+  }
 }
 
 - (void)triggerAction

--- a/apple/Handlers/RNForceTouchHandler.m
+++ b/apple/Handlers/RNForceTouchHandler.m
@@ -115,7 +115,10 @@ static const BOOL defaultFeedbackOnActivation = NO;
 {
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-  [self reset];
+
+  if (_gestureHandler.manualActivation) {
+    [self reset];
+  }
 }
 
 - (void)handleForceWithTouches:(NSSet<RNGHUITouch *> *)touches

--- a/apple/Handlers/RNForceTouchHandler.m
+++ b/apple/Handlers/RNForceTouchHandler.m
@@ -115,10 +115,6 @@ static const BOOL defaultFeedbackOnActivation = NO;
 {
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-
-  if (_gestureHandler.manualActivation) {
-    [self reset];
-  }
 }
 
 - (void)handleForceWithTouches:(NSSet<RNGHUITouch *> *)touches

--- a/apple/Handlers/RNLongPressHandler.m
+++ b/apple/Handlers/RNLongPressHandler.m
@@ -108,7 +108,10 @@
 {
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-  [self reset];
+
+  if (_gestureHandler.manualActivation) {
+    [self reset];
+  }
 }
 
 #else

--- a/apple/Handlers/RNLongPressHandler.m
+++ b/apple/Handlers/RNLongPressHandler.m
@@ -108,10 +108,6 @@
 {
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-
-  if (_gestureHandler.manualActivation) {
-    [self reset];
-  }
 }
 
 #else

--- a/apple/Handlers/RNManualHandler.m
+++ b/apple/Handlers/RNManualHandler.m
@@ -81,10 +81,6 @@
 {
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-
-  if (_gestureHandler.manualActivation) {
-    [self reset];
-  }
 }
 
 #else

--- a/apple/Handlers/RNManualHandler.m
+++ b/apple/Handlers/RNManualHandler.m
@@ -81,7 +81,10 @@
 {
   [super touchesCancelled:touches withEvent:event];
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-  [self reset];
+
+  if (_gestureHandler.manualActivation) {
+    [self reset];
+  }
 }
 
 #else

--- a/apple/Handlers/RNPanHandler.m
+++ b/apple/Handlers/RNPanHandler.m
@@ -196,12 +196,13 @@
 - (void)interactionsCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-
 #if !TARGET_OS_TV && !TARGET_OS_OSX
   [self tryUpdateStylusData:event];
 #endif
 
-  [self reset];
+  if (_gestureHandler.manualActivation) {
+    [self reset];
+  }
 }
 
 #if TARGET_OS_OSX

--- a/apple/Handlers/RNPanHandler.m
+++ b/apple/Handlers/RNPanHandler.m
@@ -199,10 +199,6 @@
 #if !TARGET_OS_TV && !TARGET_OS_OSX
   [self tryUpdateStylusData:event];
 #endif
-
-  if (_gestureHandler.manualActivation) {
-    [self reset];
-  }
 }
 
 #if TARGET_OS_OSX

--- a/apple/Handlers/RNPinchHandler.m
+++ b/apple/Handlers/RNPinchHandler.m
@@ -73,7 +73,10 @@
 - (void)interactionsCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-  [self reset];
+
+  if (_gestureHandler.manualActivation) {
+    [self reset];
+  }
 }
 
 #if TARGET_OS_OSX

--- a/apple/Handlers/RNPinchHandler.m
+++ b/apple/Handlers/RNPinchHandler.m
@@ -73,10 +73,6 @@
 - (void)interactionsCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-
-  if (_gestureHandler.manualActivation) {
-    [self reset];
-  }
 }
 
 #if TARGET_OS_OSX

--- a/apple/Handlers/RNRotationHandler.m
+++ b/apple/Handlers/RNRotationHandler.m
@@ -67,10 +67,6 @@
 - (void)interactionsCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-
-  if (_gestureHandler.manualActivation) {
-    [self reset];
-  }
 }
 
 #if TARGET_OS_OSX

--- a/apple/Handlers/RNRotationHandler.m
+++ b/apple/Handlers/RNRotationHandler.m
@@ -67,7 +67,10 @@
 - (void)interactionsCancelled:(NSSet *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-  [self reset];
+
+  if (_gestureHandler.manualActivation) {
+    [self reset];
+  }
 }
 
 #if TARGET_OS_OSX

--- a/apple/Handlers/RNTapHandler.m
+++ b/apple/Handlers/RNTapHandler.m
@@ -206,10 +206,6 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [super touchesCancelled:touches withEvent:event];
   [self interactionsCancelled:touches withEvent:event];
-
-  if (_gestureHandler.manualActivation) {
-    [self reset];
-  }
 }
 
 #endif

--- a/apple/Handlers/RNTapHandler.m
+++ b/apple/Handlers/RNTapHandler.m
@@ -206,7 +206,10 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [super touchesCancelled:touches withEvent:event];
   [self interactionsCancelled:touches withEvent:event];
-  [self reset];
+
+  if (_gestureHandler.manualActivation) {
+    [self reset];
+  }
 }
 
 #endif

--- a/apple/RNManualActivationRecognizer.m
+++ b/apple/RNManualActivationRecognizer.m
@@ -71,6 +71,7 @@
   [super touchesCancelled:touches withEvent:event];
 
   _activePointers = 0;
+  self.state = UIGestureRecognizerStateCancelled;
   [self reset];
 }
 


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

Fixes #3239

When the long press gesture is cancelled it is [forced](https://github.com/software-mansion/react-native-gesture-handler/blob/main/apple/Handlers/RNLongPressHandler.m#L111) to `reset`. However, base on [docs](https://developer.apple.com/documentation/uikit/uigesturerecognizer/reset()?changes=l_2&language=objc) `reset` is also called when the state changes to `failed`, `end` or `cancelled`, which means that it is called twice, leading to undefined order of state change events. 
~~Base on [this](https://github.com/software-mansion/react-native-gesture-handler/pull/3007) we can assume that~~  ~~it should only be forced to `reset` if `manualActivation` is enabled. The same applies to other gestures as well.~~

The issue here was the effect of not changing the state of `RNManualActivationRecognizer` [here](https://github.com/software-mansion/react-native-gesture-handler/blob/main/apple/RNManualActivationRecognizer.m#L69-L75) to `UIGestureRecognizerStateCancelled`.

## Test plan

<!--
Describe how did you test this change here.
-->

Tested on repro from the above-mentioned issue and on repro from this [PR](https://github.com/software-mansion/react-native-gesture-handler/pull/3007)
