### PR TITLE
Replace references with examples in docs

### DIFF
--- a/docs/docs/gestures/composed-gestures.md
+++ b/docs/docs/gestures/composed-gestures.md
@@ -5,7 +5,7 @@ sidebar_label: Composed gestures
 sidebar_position: 13
 ---
 
-Composed gestures (`Race`, `Simultaneous`, `Exclusive`) provide a simple way of building relations between gestures.
+Composed gestures (`Race`, `Simultaneous`, `Exclusive`) provide a simple way of building relations between gestures. See [Gesture Composition](/docs/fundamentals/gesture-composition) for more details.
 
 ## Reference
 

--- a/docs/docs/gestures/fling-gesture.md
+++ b/docs/docs/gestures/fling-gesture.md
@@ -42,21 +42,50 @@ The gesture will fail to recognize if the finger is lifted before being activate
 
 <samp id="FlingGestureBasicSrc">Fling Gesture</samp>
 
-## Reference
+## Example
 
 ```jsx
-import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import { StyleSheet } from 'react-native';
+import {
+  Gesture,
+  GestureDetector,
+  Directions,
+} from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+  withTiming,
+} from 'react-native-reanimated';
 
-function App() {
+export default function App() {
+  const position = useSharedValue(0);
   // highlight-next-line
-  const fling = Gesture.Fling();
+  const flingGesture = Gesture.Fling()
+    .direction(Directions.RIGHT)
+    .onStart((e) => {
+      position.value = withTiming(position.value + 10, { duration: 100 });
+    });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: position.value }],
+  }));
 
   return (
-    <GestureDetector gesture={fling}>
-      <Animated.View />
+    <GestureDetector gesture={flingGesture}>
+      <Animated.View style={[styles.box, animatedStyle]} />
     </GestureDetector>
   );
 }
+
+const styles = StyleSheet.create({
+  box: {
+    height: 120,
+    width: 120,
+    backgroundColor: '#b58df1',
+    borderRadius: 20,
+    marginBottom: 30,
+  },
+});
 ```
 
 ## Config
@@ -122,49 +151,3 @@ X coordinate of the current position of the pointer (finger or a leading pointer
 Y coordinate of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. The value is expressed in point units. It is recommended to use it instead of [`y`](#y) in cases when the original view can be transformed as an effect of the gesture.
 
 <BaseEventData />
-
-## Example
-
-```jsx
-import { StyleSheet } from 'react-native';
-import {
-  Gesture,
-  GestureDetector,
-  Directions,
-} from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-  withTiming,
-} from 'react-native-reanimated';
-
-export default function App() {
-  const position = useSharedValue(0);
-
-  const flingGesture = Gesture.Fling()
-    .direction(Directions.RIGHT)
-    .onStart((e) => {
-      position.value = withTiming(position.value + 10, { duration: 100 });
-    });
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: position.value }],
-  }));
-
-  return (
-    <GestureDetector gesture={flingGesture}>
-      <Animated.View style={[styles.box, animatedStyle]} />
-    </GestureDetector>
-  );
-}
-
-const styles = StyleSheet.create({
-  box: {
-    height: 120,
-    width: 120,
-    backgroundColor: '#b58df1',
-    borderRadius: 20,
-    marginBottom: 30,
-  },
-});
-```

--- a/docs/docs/gestures/hover-gesture.md
+++ b/docs/docs/gestures/hover-gesture.md
@@ -59,6 +59,11 @@ function App() {
 }
 ```
 
+
+## Remarks
+
+- Don't rely on `Hover` gesture to continue after the mouse button is clicked or the stylus touches the screen. If you want to handle both cases, [compose](/docs/fundamentals/gesture-composition) it with [`Pan` gesture](/docs/gestures/pan-gesture).
+
 ## Config
 
 ### Properties specific to `HoverGesture`:
@@ -115,7 +120,3 @@ Object that contains additional information about `stylus`. It consists of the f
 - [`pressure`](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pressure) - indicates the normalized pressure of the stylus.
 
 <BaseEventData />
-
-## Remarks
-
-- Don't rely on `Hover` gesture to continue after the mouse button is clicked or the stylus touches the screen. If you want to handle both cases, [compose](/docs/fundamentals/gesture-composition) it with [`Pan` gesture](/docs/gestures/pan-gesture).

--- a/docs/docs/gestures/long-press-gesture.md
+++ b/docs/docs/gestures/long-press-gesture.md
@@ -41,21 +41,36 @@ The gesture will fail to recognize a touch event if the finger is lifted before 
 
 <samp id="LongPressGestureBasic">Long Press Gesture</samp>
 
-## Reference
+## Example
 
 ```jsx
-import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import { View, StyleSheet } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
-function App() {
+export default function App() {
   // highlight-next-line
-  const longPress = Gesture.LongPress();
+  const longPressGesture = Gesture.LongPress().onEnd((e, success) => {
+    if (success) {
+      console.log(`Long pressed for ${e.duration} ms!`);
+    }
+  });
 
   return (
-    <GestureDetector gesture={longPress}>
-      <View />
+    <GestureDetector gesture={longPressGesture}>
+      <View style={styles.box} />
     </GestureDetector>
   );
 }
+
+const styles = StyleSheet.create({
+  box: {
+    height: 120,
+    width: 120,
+    backgroundColor: '#b58df1',
+    borderRadius: 20,
+    marginBottom: 30,
+  },
+});
 ```
 
 ## Config
@@ -114,34 +129,3 @@ Y coordinate, expressed in points, of the current position of the pointer (finge
 Duration of the long press (time since the start of the gesture), expressed in milliseconds.
 
 <BaseEventData />
-
-## Example
-
-```jsx
-import { View, StyleSheet } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-
-export default function App() {
-  const longPressGesture = Gesture.LongPress().onEnd((e, success) => {
-    if (success) {
-      console.log(`Long pressed for ${e.duration} ms!`);
-    }
-  });
-
-  return (
-    <GestureDetector gesture={longPressGesture}>
-      <View style={styles.box} />
-    </GestureDetector>
-  );
-}
-
-const styles = StyleSheet.create({
-  box: {
-    height: 120,
-    width: 120,
-    backgroundColor: '#b58df1',
-    borderRadius: 20,
-    marginBottom: 30,
-  },
-});
-```

--- a/docs/docs/gestures/pan-gesture.md
+++ b/docs/docs/gestures/pan-gesture.md
@@ -47,21 +47,63 @@ Gesture callback can be used for continuous tracking of the pan gesture. It prov
 
 <samp id="PanGestureBasicSrc">Pan Gesture</samp>
 
-## Reference
+## Example
 
 ```jsx
-import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import { StyleSheet } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  withTiming,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
 
-function App() {
+const END_POSITION = 200;
+
+export default function App() {
+  const onLeft = useSharedValue(true);
+  const position = useSharedValue(0);
+
   // highlight-next-line
-  const pan = Gesture.Pan();
+  const panGesture = Gesture.Pan()
+    .onUpdate((e) => {
+      if (onLeft.value) {
+        position.value = e.translationX;
+      } else {
+        position.value = END_POSITION + e.translationX;
+      }
+    })
+    .onEnd((e) => {
+      if (position.value > END_POSITION / 2) {
+        position.value = withTiming(END_POSITION, { duration: 100 });
+        onLeft.value = false;
+      } else {
+        position.value = withTiming(0, { duration: 100 });
+        onLeft.value = true;
+      }
+    });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ translateX: position.value }],
+  }));
 
   return (
-    <GestureDetector gesture={pan}>
-      <Animated.View />
+    // highlight-next-line
+    <GestureDetector gesture={panGesture}>
+      <Animated.View style={[styles.box, animatedStyle]} />
     </GestureDetector>
   );
 }
+
+const styles = StyleSheet.create({
+  box: {
+    height: 120,
+    width: 120,
+    backgroundColor: '#b58df1',
+    borderRadius: 20,
+    marginBottom: 30,
+  },
+});
 ```
 
 ## Multi touch pan handling
@@ -200,62 +242,3 @@ Object that contains additional information about `stylus`. It consists of the f
 - [`pressure`](https://developer.mozilla.org/en-US/docs/Web/API/PointerEvent/pressure) - indicates the normalized pressure of the stylus.
 
 <BaseEventData />
-
-## Example
-
-```jsx
-import { StyleSheet } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  withTiming,
-  useAnimatedStyle,
-} from 'react-native-reanimated';
-
-const END_POSITION = 200;
-
-export default function App() {
-  const onLeft = useSharedValue(true);
-  const position = useSharedValue(0);
-
-  // highlight-next-line
-  const panGesture = Gesture.Pan()
-    .onUpdate((e) => {
-      if (onLeft.value) {
-        position.value = e.translationX;
-      } else {
-        position.value = END_POSITION + e.translationX;
-      }
-    })
-    .onEnd((e) => {
-      if (position.value > END_POSITION / 2) {
-        position.value = withTiming(END_POSITION, { duration: 100 });
-        onLeft.value = false;
-      } else {
-        position.value = withTiming(0, { duration: 100 });
-        onLeft.value = true;
-      }
-    });
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ translateX: position.value }],
-  }));
-
-  return (
-    // highlight-next-line
-    <GestureDetector gesture={panGesture}>
-      <Animated.View style={[styles.box, animatedStyle]} />
-    </GestureDetector>
-  );
-}
-
-const styles = StyleSheet.create({
-  box: {
-    height: 120,
-    width: 120,
-    backgroundColor: '#b58df1',
-    borderRadius: 20,
-    marginBottom: 30,
-  },
-});
-```

--- a/docs/docs/gestures/pinch-gesture.md
+++ b/docs/docs/gestures/pinch-gesture.md
@@ -48,21 +48,49 @@ For example, map views use pinch gestures to change the zoom level of the map.
 
 <samp id="PinchGestureBasicSrc">Pinch Gesture</samp>
 
-## Reference
+## Example
 
 ```jsx
-import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import { StyleSheet } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
 
-function App() {
+export default function App() {
+  const scale = useSharedValue(1);
+  const savedScale = useSharedValue(1);
+
   // highlight-next-line
-  const pinch = Gesture.Pinch();
+  const pinchGesture = Gesture.Pinch()
+    .onUpdate((e) => {
+      scale.value = savedScale.value * e.scale;
+    })
+    .onEnd(() => {
+      savedScale.value = scale.value;
+    });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
 
   return (
-    <GestureDetector gesture={pinch}>
-      <Animated.View />
+    <GestureDetector gesture={pinchGesture}>
+      <Animated.View style={[styles.box, animatedStyle]} />
     </GestureDetector>
   );
 }
+
+const styles = StyleSheet.create({
+  box: {
+    height: 120,
+    width: 120,
+    backgroundColor: '#b58df1',
+    borderRadius: 20,
+    marginBottom: 30,
+  },
+});
 ```
 
 ## Config
@@ -96,47 +124,3 @@ Position expressed in points along X axis of center anchor point of gesture
 Position expressed in points along Y axis of center anchor point of gesture
 
 <BaseEventData />
-
-## Example
-
-```jsx
-import { StyleSheet } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-} from 'react-native-reanimated';
-
-export default function App() {
-  const scale = useSharedValue(1);
-  const savedScale = useSharedValue(1);
-
-  const pinchGesture = Gesture.Pinch()
-    .onUpdate((e) => {
-      scale.value = savedScale.value * e.scale;
-    })
-    .onEnd(() => {
-      savedScale.value = scale.value;
-    });
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ scale: scale.value }],
-  }));
-
-  return (
-    <GestureDetector gesture={pinchGesture}>
-      <Animated.View style={[styles.box, animatedStyle]} />
-    </GestureDetector>
-  );
-}
-
-const styles = StyleSheet.create({
-  box: {
-    height: 120,
-    width: 120,
-    backgroundColor: '#b58df1',
-    borderRadius: 20,
-    marginBottom: 30,
-  },
-});
-```

--- a/docs/docs/gestures/rotation-gesture.md
+++ b/docs/docs/gestures/rotation-gesture.md
@@ -45,21 +45,49 @@ Gesture callback can be used for continuous tracking of the rotation gesture. It
 
 <samp id="RotationGestureBasicSrc">Rotation Gesture</samp>
 
-## Reference
+## Example
 
 ```jsx
-import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import { StyleSheet } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
+import Animated, {
+  useSharedValue,
+  useAnimatedStyle,
+} from 'react-native-reanimated';
 
-function App() {
+export default function App() {
+  const rotation = useSharedValue(1);
+  const savedRotation = useSharedValue(1);
+
   // highlight-next-line
-  const rotation = Gesture.Rotation();
+  const rotationGesture = Gesture.Rotation()
+    .onUpdate((e) => {
+      rotation.value = savedRotation.value + e.rotation;
+    })
+    .onEnd(() => {
+      savedRotation.value = rotation.value;
+    });
+
+  const animatedStyle = useAnimatedStyle(() => ({
+    transform: [{ rotateZ: `${(rotation.value / Math.PI) * 180}deg` }],
+  }));
 
   return (
-    <GestureDetector gesture={rotation}>
-      <Animated.View />
+    <GestureDetector gesture={rotationGesture}>
+      <Animated.View style={[styles.box, animatedStyle]} />
     </GestureDetector>
   );
 }
+
+const styles = StyleSheet.create({
+  box: {
+    height: 120,
+    width: 120,
+    backgroundColor: '#b58df1',
+    borderRadius: 20,
+    marginBottom: 30,
+  },
+});
 ```
 
 ## Config
@@ -93,47 +121,3 @@ X coordinate, expressed in points, of the gesture's central focal point (anchor)
 Y coordinate, expressed in points, of the gesture's central focal point (anchor).
 
 <BaseEventData />
-
-## Example
-
-```jsx
-import { StyleSheet } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-import Animated, {
-  useSharedValue,
-  useAnimatedStyle,
-} from 'react-native-reanimated';
-
-export default function App() {
-  const rotation = useSharedValue(1);
-  const savedRotation = useSharedValue(1);
-
-  const rotationGesture = Gesture.Rotation()
-    .onUpdate((e) => {
-      rotation.value = savedRotation.value + e.rotation;
-    })
-    .onEnd(() => {
-      savedRotation.value = rotation.value;
-    });
-
-  const animatedStyle = useAnimatedStyle(() => ({
-    transform: [{ rotateZ: `${(rotation.value / Math.PI) * 180}deg` }],
-  }));
-
-  return (
-    <GestureDetector gesture={rotationGesture}>
-      <Animated.View style={[styles.box, animatedStyle]} />
-    </GestureDetector>
-  );
-}
-
-const styles = StyleSheet.create({
-  box: {
-    height: 120,
-    width: 120,
-    backgroundColor: '#b58df1',
-    borderRadius: 20,
-    marginBottom: 30,
-  },
-});
-```

--- a/docs/docs/gestures/tap-gesture.md
+++ b/docs/docs/gestures/tap-gesture.md
@@ -46,21 +46,44 @@ In order for a gesture to [activate](/docs/fundamentals/states-events#active), s
 
 <samp id="TapGestureBasic">Tap Gesture</samp>
 
-## Reference
+## Example
 
 ```jsx
-import { GestureDetector, Gesture } from 'react-native-gesture-handler';
+import { View, StyleSheet } from 'react-native';
+import { Gesture, GestureDetector } from 'react-native-gesture-handler';
 
-function App() {
+export default function App() {
   // highlight-next-line
-  const tap = Gesture.Tap();
+  const singleTap = Gesture.Tap()
+    .maxDuration(250)
+    .onStart(() => {
+      console.log('Single tap!');
+    });
+
+  // highlight-next-line
+  const doubleTap = Gesture.Tap()
+    .maxDuration(250)
+    .numberOfTaps(2)
+    .onStart(() => {
+      console.log('Double tap!');
+    });
 
   return (
-    <GestureDetector gesture={tap}>
-      <View />
+    <GestureDetector gesture={Gesture.Exclusive(doubleTap, singleTap)}>
+      <View style={styles.box} />
     </GestureDetector>
   );
 }
+
+const styles = StyleSheet.create({
+  box: {
+    height: 120,
+    width: 120,
+    backgroundColor: '#b58df1',
+    borderRadius: 20,
+    marginBottom: 30,
+  },
+});
 ```
 
 ## Config
@@ -135,41 +158,3 @@ X coordinate, expressed in points, of the current position of the pointer (finge
 Y coordinate, expressed in points, of the current position of the pointer (finger or a leading pointer when there are multiple fingers placed) relative to the window. It is recommended to use `absoluteY` instead of [`y`](#y) in cases when the view attached to the [`GestureDetector`](/docs/gestures/gesture-detector) can be transformed as an effect of the gesture.
 
 <BaseEventData />
-
-## Example
-
-```jsx
-import { View, StyleSheet } from 'react-native';
-import { Gesture, GestureDetector } from 'react-native-gesture-handler';
-
-export default function App() {
-  const singleTap = Gesture.Tap()
-    .maxDuration(250)
-    .onStart(() => {
-      console.log('Single tap!');
-    });
-
-  const doubleTap = Gesture.Tap()
-    .maxDuration(250)
-    .numberOfTaps(2)
-    .onStart(() => {
-      console.log('Double tap!');
-    });
-
-  return (
-    <GestureDetector gesture={Gesture.Exclusive(doubleTap, singleTap)}>
-      <View style={styles.box} />
-    </GestureDetector>
-  );
-}
-
-const styles = StyleSheet.create({
-  box: {
-    height: 120,
-    width: 120,
-    backgroundColor: '#b58df1',
-    borderRadius: 20,
-    marginBottom: 30,
-  },
-});
-```


### PR DESCRIPTION
## Description

- Replaces references with examples (those were kinda useless tbh)
- Add link to composition from composed gesture
- Moves hover remarks higher so they aren't below a ton of common properties
