### PR TITLE
Fix: debug build for tests 

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -153,6 +153,7 @@ android {
         exclude "**/libreact_render*.so"
         exclude "**/libreactnative.so"
         exclude "**/libjsi.so"
+        exclude "**/libc++_shared.so"
     }
 
     sourceSets.main {


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

Fixes #3232 

As stated in the [comment](https://github.com/software-mansion/react-native-gesture-handler/blob/main/android/build.gradle#L149-L152) gradle complains about duplicated versions of libraries. Excluding `libc++_shared.so` seems to solve the problem.

## Test plan

In android directory run:
`./gradlew assembleDebug assembleAndroidTest -DtestBuildType=debug`

Tested on new/old architecture with/without expo. 

<!--
Describe how did you test this change here.
-->
