### PR TITLE
Fix: onPressIn and onPressOut are triggered at the same time on Android

### DIFF
--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -352,7 +352,7 @@ export default function Pressable(props: PressableProps) {
 
   const isPressableEnabled = disabled !== true;
 
-  const gestures = [pressAndTouchGesture, hoverGesture, buttonGesture];
+  const gestures = [buttonGesture, pressAndTouchGesture, hoverGesture];
 
   for (const gesture of gestures) {
     gesture.enabled(isPressableEnabled);


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

The `pressInHandler` method [returns](https://github.com/software-mansion/react-native-gesture-handler/blob/main/src/components/Pressable/Pressable.tsx#L122-L124) early if the `isTouchPropagationAllowed` is `false`. On Android `pressInHandler` is called initially before the `isTouchPropagationAllowed` is set to `true` in [buttonGesture](https://github.com/software-mansion/react-native-gesture-handler/blob/main/src/components/Pressable/Pressable.tsx#L305-L307). Changing the order of gestures seems to fix it.

## Test plan

<!--
Describe how did you test this change here.
-->

<details>

<summary>Code</summary>

```ts
import * as React from 'react';
import {
  View,
  Text,
  Pressable as RNPressable,
  SafeAreaView,
  StyleSheet,
} from 'react-native';
import {
  GestureHandlerRootView,
  Pressable as RNGHPressable,
} from 'react-native-gesture-handler';

export default function HomeScreen() {
  return (
    <GestureHandlerRootView>
      <SafeAreaView style={{ flex: 1 }}>
        <View style={styles.container}>
          <RNGHPressable
            style={styles.pressableStyles}
            onPressIn={() => console.log(JSON.stringify('RNGH: onPressIn'))}
            onPressOut={() => console.log(JSON.stringify('RNGH: onPressOut'))}
            onPress={() => console.log(JSON.stringify('RNGH: onPress'))}>
            <Text style={styles.pressableText}>RNGH Pressable</Text>
          </RNGHPressable>
          <RNPressable
            style={styles.pressableStyles}
            onPressIn={() => console.log(JSON.stringify('RN: onPressIn'))}
            onPressOut={() => console.log(JSON.stringify('RN: onPressOut'))}
            onPress={() => console.log(JSON.stringify('RN: onPress'))}>
            <Text style={styles.pressableText}>RN Pressable</Text>
          </RNPressable>
        </View>
      </SafeAreaView>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    flexDirection: 'row',
    gap: 10,
    alignItems: 'center',
    justifyContent: 'center',
  },
  pressableStyles: {
    backgroundColor: '#3BE7BB',
    paddingVertical: 10,
    paddingHorizontal: 15,
    height: 50,
    alignItems: 'center',
    justifyContent: 'center',
  },
  pressableText: {
    color: '#000',
    fontSize: 16,
    fontWeight: 'bold',
  },
});

```

</details>
