### PR TITLE
Infer accessibility label from children in RNGestureHandlerButton on iOS

### DIFF
--- a/apple/RNGestureHandlerButton.mm
+++ b/apple/RNGestureHandlerButton.mm
@@ -169,4 +169,32 @@
 }
 #endif
 
+- (NSString *)accessibilityLabel
+{
+  NSString *label = super.accessibilityLabel;
+  if (label) {
+    return label;
+  }
+  return RNGHRecursiveAccessibilityLabel(self);
+}
+
+// Vendored from RCTView.m to infer accessibility label from children
+static NSString *RNGHRecursiveAccessibilityLabel(UIView *view)
+{
+  NSMutableString *str = [NSMutableString stringWithString:@""];
+  for (UIView *subview in view.subviews) {
+    NSString *label = subview.accessibilityLabel;
+    if (!label) {
+      label = RNGHRecursiveAccessibilityLabel(subview);
+    }
+    if (label && label.length > 0) {
+      if (str.length > 0) {
+        [str appendString:@" "];
+      }
+      [str appendString:label];
+    }
+  }
+  return str.length == 0 ? nil : str;
+}
+
 @end

--- a/apple/RNGestureHandlerButton.mm
+++ b/apple/RNGestureHandlerButton.mm
@@ -112,6 +112,34 @@
   const CGFloat currentBorderRadius = radius * scaleFactor;
   layer.cornerRadius = currentBorderRadius;
 }
+
+- (NSString *)accessibilityLabel
+{
+  NSString *label = super.accessibilityLabel;
+  if (label) {
+    return label;
+  }
+  return RNGHRecursiveAccessibilityLabel(self);
+}
+
+// Vendored from RCTView.m to infer accessibility label from children
+static NSString *RNGHRecursiveAccessibilityLabel(UIView *view)
+{
+  NSMutableString *str = [NSMutableString stringWithString:@""];
+  for (UIView *subview in view.subviews) {
+    NSString *label = subview.accessibilityLabel;
+    if (!label) {
+      label = RNGHRecursiveAccessibilityLabel(subview);
+    }
+    if (label && label.length > 0) {
+      if (str.length > 0) {
+        [str appendString:@" "];
+      }
+      [str appendString:label];
+    }
+  }
+  return str.length == 0 ? nil : str;
+}
 #endif
 
 #if TARGET_OS_OSX && RCT_NEW_ARCH_ENABLED
@@ -168,33 +196,5 @@
   }
 }
 #endif
-
-- (NSString *)accessibilityLabel
-{
-  NSString *label = super.accessibilityLabel;
-  if (label) {
-    return label;
-  }
-  return RNGHRecursiveAccessibilityLabel(self);
-}
-
-// Vendored from RCTView.m to infer accessibility label from children
-static NSString *RNGHRecursiveAccessibilityLabel(RNGHUIView *view)
-{
-  NSMutableString *str = [NSMutableString stringWithString:@""];
-  for (RNGHUIView *subview in view.subviews) {
-    NSString *label = subview.accessibilityLabel;
-    if (!label) {
-      label = RNGHRecursiveAccessibilityLabel(subview);
-    }
-    if (label && label.length > 0) {
-      if (str.length > 0) {
-        [str appendString:@" "];
-      }
-      [str appendString:label];
-    }
-  }
-  return str.length == 0 ? nil : str;
-}
 
 @end

--- a/apple/RNGestureHandlerButton.mm
+++ b/apple/RNGestureHandlerButton.mm
@@ -179,10 +179,10 @@
 }
 
 // Vendored from RCTView.m to infer accessibility label from children
-static NSString *RNGHRecursiveAccessibilityLabel(UIView *view)
+static NSString *RNGHRecursiveAccessibilityLabel(RNGHUIView *view)
 {
   NSMutableString *str = [NSMutableString stringWithString:@""];
-  for (UIView *subview in view.subviews) {
+  for (RNGHUIView *subview in view.subviews) {
     NSString *label = subview.accessibilityLabel;
     if (!label) {
       label = RNGHRecursiveAccessibilityLabel(subview);

--- a/src/components/GestureButtonsProps.ts
+++ b/src/components/GestureButtonsProps.ts
@@ -1,8 +1,10 @@
 import * as React from 'react';
-import { StyleProp, ViewStyle } from 'react-native';
+import { AccessibilityProps, StyleProp, ViewStyle } from 'react-native';
 import type { NativeViewGestureHandlerProps } from '../handlers/NativeViewGestureHandler';
 
-export interface RawButtonProps extends NativeViewGestureHandlerProps {
+export interface RawButtonProps
+  extends NativeViewGestureHandlerProps,
+    AccessibilityProps {
   /**
    * Defines if more than one button could be pressed simultaneously. By default
    * set true.


### PR DESCRIPTION
## Description

When using RectButton and friends without an explicit `accessibilityLabel` prop set, the accessibility label is empty on iOS, whereas on Android it's correctly inferred from its children like other react-native components work. I tracked this down to this component not inheriting from `RCTView` where this algorithm is defined. So to fix this, I simply vendored that function with a new prefix. 

## Test plan

Validated via Maestro Studio.