### PR TITLE
Fix `TouchableNativeFeedback` regression

### DIFF
--- a/example/src/release_tests/touchables/index.tsx
+++ b/example/src/release_tests/touchables/index.tsx
@@ -55,7 +55,7 @@ type Touchables = {
   color?: string;
   renderChild: (() => null) | ((color?: string) => React.ReactNode);
   text: string;
-  background?: (A: typeof TouchableNativeFeedback) => BackgroundPropType;
+  background?: (A: typeof RNTouchableNativeFeedback) => BackgroundPropType;
 };
 
 const TOUCHABLES: Touchables[] = [

--- a/example/src/release_tests/touchables/index.tsx
+++ b/example/src/release_tests/touchables/index.tsx
@@ -55,7 +55,7 @@ type Touchables = {
   color?: string;
   renderChild: (() => null) | ((color?: string) => React.ReactNode);
   text: string;
-  background?: (A: typeof RNTouchableNativeFeedback) => BackgroundPropType;
+  background?: (A: typeof TouchableNativeFeedback) => BackgroundPropType;
 };
 
 const TOUCHABLES: Touchables[] = [

--- a/src/components/touchables/TouchableNativeFeedback.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.tsx
@@ -1,22 +1,19 @@
-import React, { useEffect } from 'react';
 import { TouchableNativeFeedback as RNTouchableNativeFeedback } from 'react-native';
 import { tagMessage } from '../../utils';
 
 /**
  * @deprecated TouchableNativeFeedback will be removed in the future version of Gesture Handler.
  */
-const TouchableNativeFeedback: React.FC<
-  React.ComponentProps<typeof RNTouchableNativeFeedback>
-> = (props) => {
-  useEffect(() => {
+class TouchableNativeFeedback extends RNTouchableNativeFeedback {
+  componentDidMount() {
     console.warn(
       tagMessage(
-        'TouchableOpacity component will be removed in the future version of Gesture Handler.'
+        'TouchableNativeFeedback component will be removed in the future version of Gesture Handler.'
       )
     );
-  }, []);
 
-  return <RNTouchableNativeFeedback {...props} />;
-};
+    return super.componentDidMount?.();
+  }
+}
 
 export default TouchableNativeFeedback;

--- a/src/components/touchables/TouchableNativeFeedback.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.tsx
@@ -1,19 +1,6 @@
-import { TouchableNativeFeedback as RNTouchableNativeFeedback } from 'react-native';
-import { tagMessage } from '../../utils';
+import { TouchableNativeFeedback } from 'react-native';
 
 /**
  * @deprecated TouchableNativeFeedback will be removed in the future version of Gesture Handler.
  */
-class TouchableNativeFeedback extends RNTouchableNativeFeedback {
-  componentDidMount() {
-    console.warn(
-      tagMessage(
-        'TouchableNativeFeedback component will be removed in the future version of Gesture Handler.'
-      )
-    );
-
-    return super.componentDidMount?.();
-  }
-}
-
 export default TouchableNativeFeedback;

--- a/src/components/touchables/TouchableNativeFeedback.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.tsx
@@ -1,6 +1,8 @@
-import { TouchableNativeFeedback } from 'react-native';
+import { TouchableNativeFeedback as RNTouchableNativeFeedback } from 'react-native';
 
 /**
  * @deprecated TouchableNativeFeedback will be removed in the future version of Gesture Handler.
  */
+const TouchableNativeFeedback = RNTouchableNativeFeedback;
+
 export default TouchableNativeFeedback;


### PR DESCRIPTION
## Description

#3260 introduced a regression to the `Gesture Handlers`'s `TouchableNativeFeedback` component. 
The component used to be a direct reference to the `TouchableNativeFeedback`, which has a [couple of static methods](https://reactnative.dev/docs/touchablenativefeedback#methods).
When it was replaced with a function component, the static methods got removed, leaving only the render function of the `TouchableNativeFeedback`.

## Test plan

See how the type errors in the `example/src/release_tests/touchables/index.tsx` are resolved.