### PR TITLE
Prevent child gestures from activating when a parent gesture is already active

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -684,6 +684,22 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     }
   }
 
+  /*
+  * Returns true if the view this handler is attached to is a descendant of the view the other handler
+  * is attached to and false otherwise.
+  */
+  fun isDescendantOf(of: GestureHandler<*>): Boolean {
+    var view = this.view?.parent as? View
+    while (view != null) {
+      if (view == of.view) {
+        return true
+      }
+
+      view = view.parent as? View
+    }
+    return false
+  }
+
   // responsible for resetting the state of handler upon activation (may be called more than once
   // if the handler is waiting for failure of other one)
   open fun resetProgress() {}

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -85,11 +85,15 @@ class GestureHandlerOrchestrator(
   private fun hasOtherHandlerToWaitFor(handler: GestureHandler<*>) =
     gestureHandlers.any { !isFinished(it.state) && shouldHandlerWaitForOther(handler, it) }
 
-  private fun shouldBeCancelledByFinishedHandler(handler: GestureHandler<*>) = gestureHandlers.any { shouldHandlerWaitForOther(handler, it) && it.state == GestureHandler.STATE_END }
+  private fun shouldBeCancelledByFinishedHandler(handler: GestureHandler<*>) =
+    gestureHandlers.any { shouldHandlerWaitForOther(handler, it) && it.state == GestureHandler.STATE_END }
+
+  private fun shouldBeCancelledByActiveHandler(handler: GestureHandler<*>) =
+    gestureHandlers.any { handler.hasCommonPointers(it) && it.state == GestureHandler.STATE_ACTIVE && !canRunSimultaneously(handler, it) && handler.isDescendantOf(it) }
 
   private fun tryActivate(handler: GestureHandler<*>) {
     // If we are waiting for a gesture that has successfully finished, we should cancel handler
-    if (shouldBeCancelledByFinishedHandler(handler)) {
+    if (shouldBeCancelledByFinishedHandler(handler) || shouldBeCancelledByActiveHandler(handler)) {
       handler.cancel()
       return
     }


### PR DESCRIPTION
## Description

Restores https://github.com/software-mansion/react-native-gesture-handler/pull/3095 with a small change, I guess supersedes https://github.com/software-mansion/react-native-gesture-handler/pull/3264.

## Test plan

Same as in https://github.com/software-mansion/react-native-gesture-handler/pull/3095

See also https://github.com/software-mansion/react-native-gesture-handler/pull/3264#issuecomment-2541653797
