### PR TITLE
fix: pressable style on android

### DIFF
--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -299,21 +299,15 @@ export default function Pressable(props: PressableProps) {
   // RNButton is placed inside ButtonGesture to enable Android's ripple and to capture non-propagating events
   const buttonGesture = useMemo(
     () =>
-      Gesture.Native()
-        .onBegin(() => {
-          // Android sets BEGAN state on press down
-          if (Platform.OS === 'android' || Platform.OS === 'macos') {
+      Gesture.Native().shouldActivateOnStart(true)
+        .onBegin(() => {          
+          if (Platform.OS === 'macos') {
             isTouchPropagationAllowed.current = true;
           }
         })
         .onStart(() => {
           if (Platform.OS === 'web') {
             isTouchPropagationAllowed.current = true;
-          }
-
-          // iOS sets ACTIVE state on press down
-          if (Platform.OS !== 'ios') {
-            return;
           }
 
           if (deferredEventPayload.current) {


### PR DESCRIPTION
## Description
The pressed style is not being applied on Android,
investigating the source code and docs, I managed to get it working by adding 
```
shouldActivateOnStart(value: boolean) (Android only)
```
https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/native-gesture#shouldactivateonstartvalue-boolean-android-only

and removing this early return that was causing `isTouchPropagationAllowed.current` to never be set on android
```
 if (Platform.OS !== 'ios') {
       return;
 }
```
<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

Reproduction of the issue (Pressed style not applied on Android)
https://snack.expo.dev/GGXCh7UBdjhl4KOuKCGXe
## Test plan

<!--
Describe how did you test this change here.
-->
Tested fix on iPhone 16, Pixel 9 pro and Moto G8