### PR TITLE
[Web] Add `onPointerOutOfBounds` to `LongPress` gesture handler

### DIFF
--- a/src/web/handlers/LongPressGestureHandler.ts
+++ b/src/web/handlers/LongPressGestureHandler.ts
@@ -101,6 +101,12 @@ export default class LongPressGestureHandler extends GestureHandler {
     this.checkDistanceFail();
   }
 
+  protected onPointerOutOfBounds(event: AdaptedEvent): void {
+    super.onPointerOutOfBounds(event);
+    this.tracker.track(event);
+    this.checkDistanceFail();
+  }
+
   protected onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
     this.tracker.removeFromTracker(event.pointerId);


### PR DESCRIPTION
## Description

As pointed out in #3310, `LongPress` on web does not override `onPointerOutOfBounds` method, which leads to gesture not being cancelled even if `maxDistance` was exceeded.

Fixes #3310 

## Test plan

<details>
<summary>Tested on the following code:</summary>

```jsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import { Gesture, GestureDetector } from 'react-native-gesture-handler';

export default function EmptyExample() {
  const g = Gesture.LongPress()
    .onStart((e) => {
      console.log(e);
    })
    .onFinalize((e, s) => console.log(s))
    .shouldCancelWhenOutside(false);

  return (
    <View style={styles.container}>
      <GestureDetector gesture={g}>
        <View
          style={{
            width: 100,
            height: 100,
            backgroundColor: 'crimson',
          }}
        />
      </GestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```

</details>