### PR TITLE
Bump `FabricExample` to 0.77.0-rc.6

### DIFF
--- a/FabricExample/ios/Podfile.lock
+++ b/FabricExample/ios/Podfile.lock
@@ -2,12 +2,12 @@ PODS:
   - boost (1.84.0)
   - DoubleConversion (1.1.6)
   - fast_float (6.1.4)
-  - FBLazyVector (0.77.0-rc.3)
+  - FBLazyVector (0.77.0-rc.6)
   - fmt (11.0.2)
   - glog (0.3.5)
-  - hermes-engine (0.77.0-rc.3):
-    - hermes-engine/Pre-built (= 0.77.0-rc.3)
-  - hermes-engine/Pre-built (0.77.0-rc.3)
+  - hermes-engine (0.77.0-rc.6):
+    - hermes-engine/Pre-built (= 0.77.0-rc.6)
+  - hermes-engine/Pre-built (0.77.0-rc.6)
   - RCT-Folly (2024.11.18.00):
     - boost
     - DoubleConversion
@@ -27,32 +27,32 @@ PODS:
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
-  - RCTDeprecation (0.77.0-rc.3)
-  - RCTRequired (0.77.0-rc.3)
-  - RCTTypeSafety (0.77.0-rc.3):
-    - FBLazyVector (= 0.77.0-rc.3)
-    - RCTRequired (= 0.77.0-rc.3)
-    - React-Core (= 0.77.0-rc.3)
-  - React (0.77.0-rc.3):
-    - React-Core (= 0.77.0-rc.3)
-    - React-Core/DevSupport (= 0.77.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.77.0-rc.3)
-    - React-RCTActionSheet (= 0.77.0-rc.3)
-    - React-RCTAnimation (= 0.77.0-rc.3)
-    - React-RCTBlob (= 0.77.0-rc.3)
-    - React-RCTImage (= 0.77.0-rc.3)
-    - React-RCTLinking (= 0.77.0-rc.3)
-    - React-RCTNetwork (= 0.77.0-rc.3)
-    - React-RCTSettings (= 0.77.0-rc.3)
-    - React-RCTText (= 0.77.0-rc.3)
-    - React-RCTVibration (= 0.77.0-rc.3)
-  - React-callinvoker (0.77.0-rc.3)
-  - React-Core (0.77.0-rc.3):
+  - RCTDeprecation (0.77.0-rc.6)
+  - RCTRequired (0.77.0-rc.6)
+  - RCTTypeSafety (0.77.0-rc.6):
+    - FBLazyVector (= 0.77.0-rc.6)
+    - RCTRequired (= 0.77.0-rc.6)
+    - React-Core (= 0.77.0-rc.6)
+  - React (0.77.0-rc.6):
+    - React-Core (= 0.77.0-rc.6)
+    - React-Core/DevSupport (= 0.77.0-rc.6)
+    - React-Core/RCTWebSocket (= 0.77.0-rc.6)
+    - React-RCTActionSheet (= 0.77.0-rc.6)
+    - React-RCTAnimation (= 0.77.0-rc.6)
+    - React-RCTBlob (= 0.77.0-rc.6)
+    - React-RCTImage (= 0.77.0-rc.6)
+    - React-RCTLinking (= 0.77.0-rc.6)
+    - React-RCTNetwork (= 0.77.0-rc.6)
+    - React-RCTSettings (= 0.77.0-rc.6)
+    - React-RCTText (= 0.77.0-rc.6)
+    - React-RCTVibration (= 0.77.0-rc.6)
+  - React-callinvoker (0.77.0-rc.6)
+  - React-Core (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.77.0-rc.3)
+    - React-Core/Default (= 0.77.0-rc.6)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -64,58 +64,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.77.0-rc.3):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/Default (0.77.0-rc.3):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/DevSupport (0.77.0-rc.3):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.11.18.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.77.0-rc.3)
-    - React-Core/RCTWebSocket (= 0.77.0-rc.3)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.1)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.77.0-rc.3):
+  - React-Core/CoreModulesHeaders (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -132,7 +81,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.77.0-rc.3):
+  - React-Core/Default (0.77.0-rc.6):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/DevSupport (0.77.0-rc.6):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.77.0-rc.6)
+    - React-Core/RCTWebSocket (= 0.77.0-rc.6)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -149,7 +132,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.77.0-rc.3):
+  - React-Core/RCTAnimationHeaders (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -166,7 +149,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTImageHeaders (0.77.0-rc.3):
+  - React-Core/RCTBlobHeaders (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -183,7 +166,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.77.0-rc.3):
+  - React-Core/RCTImageHeaders (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -200,7 +183,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.77.0-rc.3):
+  - React-Core/RCTLinkingHeaders (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -217,7 +200,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.77.0-rc.3):
+  - React-Core/RCTNetworkHeaders (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -234,7 +217,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTTextHeaders (0.77.0-rc.3):
+  - React-Core/RCTSettingsHeaders (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -251,7 +234,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTVibrationHeaders (0.77.0-rc.3):
+  - React-Core/RCTTextHeaders (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -268,12 +251,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-Core/RCTWebSocket (0.77.0-rc.3):
+  - React-Core/RCTVibrationHeaders (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.77.0-rc.3)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -285,22 +268,39 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.1)
     - Yoga
-  - React-CoreModules (0.77.0-rc.3):
+  - React-Core/RCTWebSocket (0.77.0-rc.6):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.11.18.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.77.0-rc.6)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.1)
+    - Yoga
+  - React-CoreModules (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
-    - RCTTypeSafety (= 0.77.0-rc.3)
-    - React-Core/CoreModulesHeaders (= 0.77.0-rc.3)
-    - React-jsi (= 0.77.0-rc.3)
+    - RCTTypeSafety (= 0.77.0-rc.6)
+    - React-Core/CoreModulesHeaders (= 0.77.0-rc.6)
+    - React-jsi (= 0.77.0-rc.6)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
     - React-RCTFBReactNativeSpec
-    - React-RCTImage (= 0.77.0-rc.3)
+    - React-RCTImage (= 0.77.0-rc.6)
     - ReactCommon
     - SocketRocket (= 0.7.1)
-  - React-cxxreact (0.77.0-rc.3):
+  - React-cxxreact (0.77.0-rc.6):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -308,16 +308,16 @@ PODS:
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.77.0-rc.3)
-    - React-debug (= 0.77.0-rc.3)
-    - React-jsi (= 0.77.0-rc.3)
+    - React-callinvoker (= 0.77.0-rc.6)
+    - React-debug (= 0.77.0-rc.6)
+    - React-jsi (= 0.77.0-rc.6)
     - React-jsinspector
-    - React-logger (= 0.77.0-rc.3)
-    - React-perflogger (= 0.77.0-rc.3)
-    - React-runtimeexecutor (= 0.77.0-rc.3)
-    - React-timing (= 0.77.0-rc.3)
-  - React-debug (0.77.0-rc.3)
-  - React-defaultsnativemodule (0.77.0-rc.3):
+    - React-logger (= 0.77.0-rc.6)
+    - React-perflogger (= 0.77.0-rc.6)
+    - React-runtimeexecutor (= 0.77.0-rc.6)
+    - React-timing (= 0.77.0-rc.6)
+  - React-debug (0.77.0-rc.6)
+  - React-defaultsnativemodule (0.77.0-rc.6):
     - hermes-engine
     - RCT-Folly
     - React-domnativemodule
@@ -327,7 +327,7 @@ PODS:
     - React-jsiexecutor
     - React-microtasksnativemodule
     - React-RCTFBReactNativeSpec
-  - React-domnativemodule (0.77.0-rc.3):
+  - React-domnativemodule (0.77.0-rc.6):
     - hermes-engine
     - RCT-Folly
     - React-Fabric
@@ -338,7 +338,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric (0.77.0-rc.3):
+  - React-Fabric (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -350,21 +350,21 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.77.0-rc.3)
-    - React-Fabric/attributedstring (= 0.77.0-rc.3)
-    - React-Fabric/componentregistry (= 0.77.0-rc.3)
-    - React-Fabric/componentregistrynative (= 0.77.0-rc.3)
-    - React-Fabric/components (= 0.77.0-rc.3)
-    - React-Fabric/core (= 0.77.0-rc.3)
-    - React-Fabric/dom (= 0.77.0-rc.3)
-    - React-Fabric/imagemanager (= 0.77.0-rc.3)
-    - React-Fabric/leakchecker (= 0.77.0-rc.3)
-    - React-Fabric/mounting (= 0.77.0-rc.3)
-    - React-Fabric/observers (= 0.77.0-rc.3)
-    - React-Fabric/scheduler (= 0.77.0-rc.3)
-    - React-Fabric/telemetry (= 0.77.0-rc.3)
-    - React-Fabric/templateprocessor (= 0.77.0-rc.3)
-    - React-Fabric/uimanager (= 0.77.0-rc.3)
+    - React-Fabric/animations (= 0.77.0-rc.6)
+    - React-Fabric/attributedstring (= 0.77.0-rc.6)
+    - React-Fabric/componentregistry (= 0.77.0-rc.6)
+    - React-Fabric/componentregistrynative (= 0.77.0-rc.6)
+    - React-Fabric/components (= 0.77.0-rc.6)
+    - React-Fabric/core (= 0.77.0-rc.6)
+    - React-Fabric/dom (= 0.77.0-rc.6)
+    - React-Fabric/imagemanager (= 0.77.0-rc.6)
+    - React-Fabric/leakchecker (= 0.77.0-rc.6)
+    - React-Fabric/mounting (= 0.77.0-rc.6)
+    - React-Fabric/observers (= 0.77.0-rc.6)
+    - React-Fabric/scheduler (= 0.77.0-rc.6)
+    - React-Fabric/telemetry (= 0.77.0-rc.6)
+    - React-Fabric/templateprocessor (= 0.77.0-rc.6)
+    - React-Fabric/uimanager (= 0.77.0-rc.6)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -374,28 +374,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.77.0-rc.3):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.77.0-rc.3):
+  - React-Fabric/animations (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -416,7 +395,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.77.0-rc.3):
+  - React-Fabric/attributedstring (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -437,7 +416,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.77.0-rc.3):
+  - React-Fabric/componentregistry (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -458,31 +437,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.77.0-rc.3):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.77.0-rc.3)
-    - React-Fabric/components/root (= 0.77.0-rc.3)
-    - React-Fabric/components/view (= 0.77.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.77.0-rc.3):
+  - React-Fabric/componentregistrynative (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -503,7 +458,31 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.77.0-rc.3):
+  - React-Fabric/components (0.77.0-rc.6):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.77.0-rc.6)
+    - React-Fabric/components/root (= 0.77.0-rc.6)
+    - React-Fabric/components/view (= 0.77.0-rc.6)
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/legacyviewmanagerinterop (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -524,7 +503,28 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.77.0-rc.3):
+  - React-Fabric/components/root (0.77.0-rc.6):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -546,7 +546,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.77.0-rc.3):
+  - React-Fabric/core (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -567,7 +567,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/dom (0.77.0-rc.3):
+  - React-Fabric/dom (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -588,7 +588,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.77.0-rc.3):
+  - React-Fabric/imagemanager (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -609,7 +609,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.77.0-rc.3):
+  - React-Fabric/leakchecker (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -630,7 +630,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.77.0-rc.3):
+  - React-Fabric/mounting (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -651,7 +651,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers (0.77.0-rc.3):
+  - React-Fabric/observers (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -663,7 +663,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/observers/events (= 0.77.0-rc.3)
+    - React-Fabric/observers/events (= 0.77.0-rc.6)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -673,7 +673,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/observers/events (0.77.0-rc.3):
+  - React-Fabric/observers/events (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -694,7 +694,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.77.0-rc.3):
+  - React-Fabric/scheduler (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -717,7 +717,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.77.0-rc.3):
+  - React-Fabric/telemetry (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -738,7 +738,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.77.0-rc.3):
+  - React-Fabric/templateprocessor (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -759,7 +759,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.77.0-rc.3):
+  - React-Fabric/uimanager (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -771,29 +771,7 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/uimanager/consistency (= 0.77.0-rc.3)
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererconsistency
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager/consistency (0.77.0-rc.3):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
+    - React-Fabric/uimanager/consistency (= 0.77.0-rc.6)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -804,7 +782,29 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricComponents (0.77.0-rc.3):
+  - React-Fabric/uimanager/consistency (0.77.0-rc.6):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererconsistency
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-FabricComponents (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -817,8 +817,8 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components (= 0.77.0-rc.3)
-    - React-FabricComponents/textlayoutmanager (= 0.77.0-rc.3)
+    - React-FabricComponents/components (= 0.77.0-rc.6)
+    - React-FabricComponents/textlayoutmanager (= 0.77.0-rc.6)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -829,7 +829,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components (0.77.0-rc.3):
+  - React-FabricComponents/components (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -842,15 +842,15 @@ PODS:
     - React-cxxreact
     - React-debug
     - React-Fabric
-    - React-FabricComponents/components/inputaccessory (= 0.77.0-rc.3)
-    - React-FabricComponents/components/iostextinput (= 0.77.0-rc.3)
-    - React-FabricComponents/components/modal (= 0.77.0-rc.3)
-    - React-FabricComponents/components/rncore (= 0.77.0-rc.3)
-    - React-FabricComponents/components/safeareaview (= 0.77.0-rc.3)
-    - React-FabricComponents/components/scrollview (= 0.77.0-rc.3)
-    - React-FabricComponents/components/text (= 0.77.0-rc.3)
-    - React-FabricComponents/components/textinput (= 0.77.0-rc.3)
-    - React-FabricComponents/components/unimplementedview (= 0.77.0-rc.3)
+    - React-FabricComponents/components/inputaccessory (= 0.77.0-rc.6)
+    - React-FabricComponents/components/iostextinput (= 0.77.0-rc.6)
+    - React-FabricComponents/components/modal (= 0.77.0-rc.6)
+    - React-FabricComponents/components/rncore (= 0.77.0-rc.6)
+    - React-FabricComponents/components/safeareaview (= 0.77.0-rc.6)
+    - React-FabricComponents/components/scrollview (= 0.77.0-rc.6)
+    - React-FabricComponents/components/text (= 0.77.0-rc.6)
+    - React-FabricComponents/components/textinput (= 0.77.0-rc.6)
+    - React-FabricComponents/components/unimplementedview (= 0.77.0-rc.6)
     - React-featureflags
     - React-graphics
     - React-jsi
@@ -861,53 +861,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/inputaccessory (0.77.0-rc.3):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/iostextinput (0.77.0-rc.3):
-    - DoubleConversion
-    - fast_float (= 6.1.4)
-    - fmt (= 11.0.2)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric
-    - React-featureflags
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-    - Yoga
-  - React-FabricComponents/components/modal (0.77.0-rc.3):
+  - React-FabricComponents/components/inputaccessory (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -930,7 +884,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/rncore (0.77.0-rc.3):
+  - React-FabricComponents/components/iostextinput (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -953,7 +907,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/safeareaview (0.77.0-rc.3):
+  - React-FabricComponents/components/modal (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -976,7 +930,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/scrollview (0.77.0-rc.3):
+  - React-FabricComponents/components/rncore (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -999,7 +953,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/text (0.77.0-rc.3):
+  - React-FabricComponents/components/safeareaview (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1022,7 +976,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/textinput (0.77.0-rc.3):
+  - React-FabricComponents/components/scrollview (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1045,7 +999,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/components/unimplementedview (0.77.0-rc.3):
+  - React-FabricComponents/components/text (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1068,7 +1022,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricComponents/textlayoutmanager (0.77.0-rc.3):
+  - React-FabricComponents/components/textinput (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1091,28 +1045,74 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-FabricImage (0.77.0-rc.3):
+  - React-FabricComponents/components/unimplementedview (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
-    - RCTRequired (= 0.77.0-rc.3)
-    - RCTTypeSafety (= 0.77.0-rc.3)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricComponents/textlayoutmanager (0.77.0-rc.6):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric
+    - React-featureflags
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+    - Yoga
+  - React-FabricImage (0.77.0-rc.6):
+    - DoubleConversion
+    - fast_float (= 6.1.4)
+    - fmt (= 11.0.2)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.11.18.00)
+    - RCTRequired (= 0.77.0-rc.6)
+    - RCTTypeSafety (= 0.77.0-rc.6)
     - React-Fabric
     - React-featureflags
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.77.0-rc.3)
+    - React-jsiexecutor (= 0.77.0-rc.6)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.77.0-rc.3)
-  - React-featureflagsnativemodule (0.77.0-rc.3):
+  - React-featureflags (0.77.0-rc.6)
+  - React-featureflagsnativemodule (0.77.0-rc.6):
     - hermes-engine
     - RCT-Folly
     - React-featureflags
@@ -1120,7 +1120,7 @@ PODS:
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - React-graphics (0.77.0-rc.3):
+  - React-graphics (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1129,20 +1129,20 @@ PODS:
     - React-jsi
     - React-jsiexecutor
     - React-utils
-  - React-hermes (0.77.0-rc.3):
+  - React-hermes (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.77.0-rc.3)
+    - React-cxxreact (= 0.77.0-rc.6)
     - React-jsi
-    - React-jsiexecutor (= 0.77.0-rc.3)
+    - React-jsiexecutor (= 0.77.0-rc.6)
     - React-jsinspector
-    - React-perflogger (= 0.77.0-rc.3)
+    - React-perflogger (= 0.77.0-rc.6)
     - React-runtimeexecutor
-  - React-idlecallbacksnativemodule (0.77.0-rc.3):
+  - React-idlecallbacksnativemodule (0.77.0-rc.6):
     - hermes-engine
     - RCT-Folly
     - React-jsi
@@ -1150,7 +1150,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-runtimescheduler
     - ReactCommon/turbomodule/core
-  - React-ImageManager (0.77.0-rc.3):
+  - React-ImageManager (0.77.0-rc.6):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -1159,7 +1159,7 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.77.0-rc.3):
+  - React-jserrorhandler (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1168,7 +1168,7 @@ PODS:
     - React-featureflags
     - React-jsi
     - ReactCommon/turbomodule/bridging
-  - React-jsi (0.77.0-rc.3):
+  - React-jsi (0.77.0-rc.6):
     - boost
     - DoubleConversion
     - fast_float (= 6.1.4)
@@ -1176,42 +1176,42 @@ PODS:
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-  - React-jsiexecutor (0.77.0-rc.3):
+  - React-jsiexecutor (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-cxxreact (= 0.77.0-rc.3)
-    - React-jsi (= 0.77.0-rc.3)
+    - React-cxxreact (= 0.77.0-rc.6)
+    - React-jsi (= 0.77.0-rc.6)
     - React-jsinspector
-    - React-perflogger (= 0.77.0-rc.3)
-  - React-jsinspector (0.77.0-rc.3):
+    - React-perflogger (= 0.77.0-rc.6)
+  - React-jsinspector (0.77.0-rc.6):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - React-featureflags
     - React-jsi
-    - React-perflogger (= 0.77.0-rc.3)
-    - React-runtimeexecutor (= 0.77.0-rc.3)
-  - React-jsitracing (0.77.0-rc.3):
+    - React-perflogger (= 0.77.0-rc.6)
+    - React-runtimeexecutor (= 0.77.0-rc.6)
+  - React-jsitracing (0.77.0-rc.6):
     - React-jsi
-  - React-logger (0.77.0-rc.3):
+  - React-logger (0.77.0-rc.6):
     - glog
-  - React-Mapbuffer (0.77.0-rc.3):
+  - React-Mapbuffer (0.77.0-rc.6):
     - glog
     - React-debug
-  - React-microtasksnativemodule (0.77.0-rc.3):
+  - React-microtasksnativemodule (0.77.0-rc.6):
     - hermes-engine
     - RCT-Folly
     - React-jsi
     - React-jsiexecutor
     - React-RCTFBReactNativeSpec
     - ReactCommon/turbomodule/core
-  - React-nativeconfig (0.77.0-rc.3)
-  - React-NativeModulesApple (0.77.0-rc.3):
+  - React-nativeconfig (0.77.0-rc.6)
+  - React-NativeModulesApple (0.77.0-rc.6):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -1222,17 +1222,17 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.77.0-rc.3):
+  - React-perflogger (0.77.0-rc.6):
     - DoubleConversion
     - RCT-Folly (= 2024.11.18.00)
-  - React-performancetimeline (0.77.0-rc.3):
+  - React-performancetimeline (0.77.0-rc.6):
     - RCT-Folly (= 2024.11.18.00)
     - React-cxxreact
     - React-featureflags
     - React-timing
-  - React-RCTActionSheet (0.77.0-rc.3):
-    - React-Core/RCTActionSheetHeaders (= 0.77.0-rc.3)
-  - React-RCTAnimation (0.77.0-rc.3):
+  - React-RCTActionSheet (0.77.0-rc.6):
+    - React-Core/RCTActionSheetHeaders (= 0.77.0-rc.6)
+  - React-RCTAnimation (0.77.0-rc.6):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTAnimationHeaders
@@ -1240,7 +1240,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTAppDelegate (0.77.0-rc.3):
+  - React-RCTAppDelegate (0.77.0-rc.6):
     - RCT-Folly (= 2024.11.18.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1265,7 +1265,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon
-  - React-RCTBlob (0.77.0-rc.3):
+  - React-RCTBlob (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
@@ -1279,7 +1279,7 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.77.0-rc.3):
+  - React-RCTFabric (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1302,7 +1302,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTFBReactNativeSpec (0.77.0-rc.3):
+  - React-RCTFBReactNativeSpec (0.77.0-rc.6):
     - hermes-engine
     - RCT-Folly
     - RCTRequired
@@ -1312,7 +1312,7 @@ PODS:
     - React-jsiexecutor
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTImage (0.77.0-rc.3):
+  - React-RCTImage (0.77.0-rc.6):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTImageHeaders
@@ -1321,14 +1321,14 @@ PODS:
     - React-RCTFBReactNativeSpec
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.77.0-rc.3):
-    - React-Core/RCTLinkingHeaders (= 0.77.0-rc.3)
-    - React-jsi (= 0.77.0-rc.3)
+  - React-RCTLinking (0.77.0-rc.6):
+    - React-Core/RCTLinkingHeaders (= 0.77.0-rc.6)
+    - React-jsi (= 0.77.0-rc.6)
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.77.0-rc.3)
-  - React-RCTNetwork (0.77.0-rc.3):
+    - ReactCommon/turbomodule/core (= 0.77.0-rc.6)
+  - React-RCTNetwork (0.77.0-rc.6):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTNetworkHeaders
@@ -1336,7 +1336,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTSettings (0.77.0-rc.3):
+  - React-RCTSettings (0.77.0-rc.6):
     - RCT-Folly (= 2024.11.18.00)
     - RCTTypeSafety
     - React-Core/RCTSettingsHeaders
@@ -1344,25 +1344,25 @@ PODS:
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-RCTText (0.77.0-rc.3):
-    - React-Core/RCTTextHeaders (= 0.77.0-rc.3)
+  - React-RCTText (0.77.0-rc.6):
+    - React-Core/RCTTextHeaders (= 0.77.0-rc.6)
     - Yoga
-  - React-RCTVibration (0.77.0-rc.3):
+  - React-RCTVibration (0.77.0-rc.6):
     - RCT-Folly (= 2024.11.18.00)
     - React-Core/RCTVibrationHeaders
     - React-jsi
     - React-NativeModulesApple
     - React-RCTFBReactNativeSpec
     - ReactCommon
-  - React-rendererconsistency (0.77.0-rc.3)
-  - React-rendererdebug (0.77.0-rc.3):
+  - React-rendererconsistency (0.77.0-rc.6)
+  - React-rendererdebug (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
-  - React-rncore (0.77.0-rc.3)
-  - React-RuntimeApple (0.77.0-rc.3):
+  - React-rncore (0.77.0-rc.6)
+  - React-RuntimeApple (0.77.0-rc.6):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-callinvoker
@@ -1383,7 +1383,7 @@ PODS:
     - React-RuntimeHermes
     - React-runtimescheduler
     - React-utils
-  - React-RuntimeCore (0.77.0-rc.3):
+  - React-RuntimeCore (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
@@ -1398,9 +1398,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.77.0-rc.3):
-    - React-jsi (= 0.77.0-rc.3)
-  - React-RuntimeHermes (0.77.0-rc.3):
+  - React-runtimeexecutor (0.77.0-rc.6):
+    - React-jsi (= 0.77.0-rc.6)
+  - React-RuntimeHermes (0.77.0-rc.6):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.11.18.00)
     - React-featureflags
@@ -1411,7 +1411,7 @@ PODS:
     - React-nativeconfig
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.77.0-rc.3):
+  - React-runtimescheduler (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
@@ -1426,16 +1426,16 @@ PODS:
     - React-runtimeexecutor
     - React-timing
     - React-utils
-  - React-timing (0.77.0-rc.3)
-  - React-utils (0.77.0-rc.3):
+  - React-timing (0.77.0-rc.6)
+  - React-utils (0.77.0-rc.6):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
     - React-debug
-    - React-jsi (= 0.77.0-rc.3)
-  - ReactAppDependencyProvider (0.77.0-rc.3):
+    - React-jsi (= 0.77.0-rc.6)
+  - ReactAppDependencyProvider (0.77.0-rc.6):
     - ReactCodegen
-  - ReactCodegen (0.77.0-rc.3):
+  - ReactCodegen (0.77.0-rc.6):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1456,49 +1456,49 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - ReactCommon (0.77.0-rc.3):
-    - ReactCommon/turbomodule (= 0.77.0-rc.3)
-  - ReactCommon/turbomodule (0.77.0-rc.3):
+  - ReactCommon (0.77.0-rc.6):
+    - ReactCommon/turbomodule (= 0.77.0-rc.6)
+  - ReactCommon/turbomodule (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.77.0-rc.3)
-    - React-cxxreact (= 0.77.0-rc.3)
-    - React-jsi (= 0.77.0-rc.3)
-    - React-logger (= 0.77.0-rc.3)
-    - React-perflogger (= 0.77.0-rc.3)
-    - ReactCommon/turbomodule/bridging (= 0.77.0-rc.3)
-    - ReactCommon/turbomodule/core (= 0.77.0-rc.3)
-  - ReactCommon/turbomodule/bridging (0.77.0-rc.3):
+    - React-callinvoker (= 0.77.0-rc.6)
+    - React-cxxreact (= 0.77.0-rc.6)
+    - React-jsi (= 0.77.0-rc.6)
+    - React-logger (= 0.77.0-rc.6)
+    - React-perflogger (= 0.77.0-rc.6)
+    - ReactCommon/turbomodule/bridging (= 0.77.0-rc.6)
+    - ReactCommon/turbomodule/core (= 0.77.0-rc.6)
+  - ReactCommon/turbomodule/bridging (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.77.0-rc.3)
-    - React-cxxreact (= 0.77.0-rc.3)
-    - React-jsi (= 0.77.0-rc.3)
-    - React-logger (= 0.77.0-rc.3)
-    - React-perflogger (= 0.77.0-rc.3)
-  - ReactCommon/turbomodule/core (0.77.0-rc.3):
+    - React-callinvoker (= 0.77.0-rc.6)
+    - React-cxxreact (= 0.77.0-rc.6)
+    - React-jsi (= 0.77.0-rc.6)
+    - React-logger (= 0.77.0-rc.6)
+    - React-perflogger (= 0.77.0-rc.6)
+  - ReactCommon/turbomodule/core (0.77.0-rc.6):
     - DoubleConversion
     - fast_float (= 6.1.4)
     - fmt (= 11.0.2)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.11.18.00)
-    - React-callinvoker (= 0.77.0-rc.3)
-    - React-cxxreact (= 0.77.0-rc.3)
-    - React-debug (= 0.77.0-rc.3)
-    - React-featureflags (= 0.77.0-rc.3)
-    - React-jsi (= 0.77.0-rc.3)
-    - React-logger (= 0.77.0-rc.3)
-    - React-perflogger (= 0.77.0-rc.3)
-    - React-utils (= 0.77.0-rc.3)
+    - React-callinvoker (= 0.77.0-rc.6)
+    - React-cxxreact (= 0.77.0-rc.6)
+    - React-debug (= 0.77.0-rc.6)
+    - React-featureflags (= 0.77.0-rc.6)
+    - React-jsi (= 0.77.0-rc.6)
+    - React-logger (= 0.77.0-rc.6)
+    - React-perflogger (= 0.77.0-rc.6)
+    - React-utils (= 0.77.0-rc.6)
   - RNGestureHandler (2.21.2):
     - DoubleConversion
     - glog
@@ -1739,71 +1739,71 @@ SPEC CHECKSUMS:
   boost: 7e761d76ca2ce687f7cc98e698152abd03a18f90
   DoubleConversion: cb417026b2400c8f53ae97020b2be961b59470cb
   fast_float: 06eeec4fe712a76acc9376682e4808b05ce978b6
-  FBLazyVector: e26777937ab3b311d2947c803f415f4dce6a2a83
+  FBLazyVector: dac4f80f363d25f0f06bbca8a982e583c71e18ae
   fmt: a40bb5bd0294ea969aaaba240a927bd33d878cdd
   glog: eb93e2f488219332457c3c4eafd2738ddc7e80b8
-  hermes-engine: 575828af78be1f25e248beda1f81c6923dd9bf67
+  hermes-engine: e929405329190e9df3ef45cea87293072747f2ef
   RCT-Folly: e78785aa9ba2ed998ea4151e314036f6c49e6d82
-  RCTDeprecation: 0aa4f2fa113b76d72f04464049d8ad89b10a3b9a
-  RCTRequired: 1a11d9a0ce65a2bed0ea43524e6e8fba6b22aaff
-  RCTTypeSafety: a8ec6cce58c61dea7ce45abda6d7dd9345cd6da3
-  React: 5460ad9a26bf08368831abd1eca5d454595bd808
-  React-callinvoker: 38e870e21bdcc465b782d7ed7e66d1f860de6e5a
-  React-Core: eecd285f9c52498fb37f93d2f5deaecd8814fa87
-  React-CoreModules: e0a4b7909fe2e66e0caa316e9660d8141977e026
-  React-cxxreact: 6df9d9d6e69f18ba700733ae03713a2204d19799
-  React-debug: cdd0a0fd96e2f733b1f3395caeccaadbfb01ace7
-  React-defaultsnativemodule: 416d949c57c6c11500d939359f691c3b8ee0921f
-  React-domnativemodule: 0f2a0bf2849fec0d27aabfedaa260b85dc60a33f
-  React-Fabric: ccabecea67eb87b4d9bc9cc6524063f00526eeb8
-  React-FabricComponents: cea154e1906c05b73be2e91a4233503c0476daaf
-  React-FabricImage: 4bdb8505438784caf272d4dc2573a0ab44036425
-  React-featureflags: 46cef6d5b7d8747f2e46e6ab057fc90598f3a50d
-  React-featureflagsnativemodule: c7ad38154a246c88394f4cfd4570f1f76adc84a7
-  React-graphics: f1c129b309247490264de4abffe7961461a0fea7
-  React-hermes: 56dfe845393fb93b65dd7ac29a7f61a2a4393cc7
-  React-idlecallbacksnativemodule: 667f2a35c53676f9db30210654a883ed6c72bc78
-  React-ImageManager: 0591af3cb455c96177fb359fd73cc716765acc89
-  React-jserrorhandler: 148d3db7415d910f6e6e2f22182541ad0c12bc3f
-  React-jsi: 46c6b06a1db0f132c64a79101ed8ef5fe244a606
-  React-jsiexecutor: 3b112281037f7600148c8423b0bd01ed15e4d779
-  React-jsinspector: bb2b295a311e7d1c0e029f039268fdf3afad9df6
-  React-jsitracing: b6bb8b8ea0fac83dce4b0e1f798fa693b399e098
-  React-logger: 9f78b1091eea83f8f893581667a08a318f89772c
-  React-Mapbuffer: 26b2594b80c9fcb43dc3860905792f8b81ca6fdc
-  React-microtasksnativemodule: a940ebba390f50e959af1bdb6a725e742e7bec9b
-  React-nativeconfig: b4cb3555f7941889ed7e03f2951dee7b0d0e4f32
-  React-NativeModulesApple: 0180d144c0790b70b36605ad88b2857c09f3dbe5
-  React-perflogger: 53113fae00a0ec7789201e0330c4abc7d820a02f
-  React-performancetimeline: 967e090dceb3a4ef6a2306c156b3794116dd907c
-  React-RCTActionSheet: 29a7b362b8572b341672df840076859ff375a5a7
-  React-RCTAnimation: 0abe7d9c2dee3f71ea20a111d2328c918a67e261
-  React-RCTAppDelegate: 2ba3ae94da8bdaee5839d8159506fdad5a2c6610
-  React-RCTBlob: 645ebd3686f414a817564448cc545cd94e5026cc
-  React-RCTFabric: a899cbea2cc00316524ae0fae7386dbc338bc778
-  React-RCTFBReactNativeSpec: 7150b9179ccf47910f9ad779462cf3942b4a9a8c
-  React-RCTImage: 070c07dadd86a44b39917aa1d3620972f57ae7d5
-  React-RCTLinking: 1b6c55d35183a5510a946f456598f70f4bb5dd6e
-  React-RCTNetwork: a3ad8edecd6295c95ad73f2f6afd6936b179d0a5
-  React-RCTSettings: f731df24eb99f20afa39c900cabe52f23ea3e38f
-  React-RCTText: 64e6f7367412972a38b60564822be9f3e503a317
-  React-RCTVibration: 8242f824653465c4bafee4c9bd046a0b6473564a
-  React-rendererconsistency: e2427f43934be7773f2140cd6110ed7dec813c95
-  React-rendererdebug: c5ff38fb6e536572671173b07f62d745fd1252fd
-  React-rncore: 36057ee3d327aec55239f051ecab89ea85de0af7
-  React-RuntimeApple: ccecabb34233013a8f6989cc09d5e95b16ff2e71
-  React-RuntimeCore: 3ce927031ed55e6d99c1ec22f081fd7e52299493
-  React-runtimeexecutor: d6e0f54f9ae4163a9969cee53c7647639dc2dd2e
-  React-RuntimeHermes: 2c9c22242e32d47c53b878ffb09617e14731fff2
-  React-runtimescheduler: 6d02d8627add151dcf6e92f6d700ae2cca62208f
-  React-timing: 777c58787a4b7936a683b1e7958e12551abcf76c
-  React-utils: 5258a9261253ca9c647e1cdc19533c4bf041dbef
-  ReactAppDependencyProvider: b779989664507490f90a3bf34576e493e46f00e4
-  ReactCodegen: cc251e1677641dac5f365d79f5325eb7913118bf
-  ReactCommon: 6b674ec949332e7e83a527bb6d84f13329e27e6c
+  RCTDeprecation: 897876d002199e7a9cbbb9aa77542dd2eb2452ef
+  RCTRequired: b7f9ef02940c891073f2b9b63165f524bd3d1847
+  RCTTypeSafety: c00136d479c43702c0a58b6667ad2d7b8389deba
+  React: 73c6c3d8d478df2505b82de03b3aa3085a12f099
+  React-callinvoker: 7bccda05aeced2bf72cd47144195738a9aea5af2
+  React-Core: b6ed4ebb79695502a25d0d79545459975fe77acc
+  React-CoreModules: a021240021d6c80cb025a62a3a771f2ce349c467
+  React-cxxreact: b668dce59958d9aea548ff49effd515b7c382f64
+  React-debug: 617cec1a9aae8f744115062c2e856fa9edf963f9
+  React-defaultsnativemodule: c5ea7aecfb100adc0cbc6e764b88a2e54f47a24f
+  React-domnativemodule: f1e3059260a54f3c574d71c67752c3e4ec97cc1c
+  React-Fabric: f518a5b815968db6f49218aae46ab19974c3b1b5
+  React-FabricComponents: b3919327a5e56f6b5d107f468ce5e4ef6ebad044
+  React-FabricImage: 8d2cae586b51552a0d6ec2ca4f2d2b2d4658d91b
+  React-featureflags: 0ae90e3e3bc0120468415e177811e6ecb5dd36c5
+  React-featureflagsnativemodule: 6ea071f8d2b0033c9cf7b75ff0625fae2b717ad5
+  React-graphics: ba09d3fecdd1f32c8b6ab2a19564d6d6d7db6b8d
+  React-hermes: 53741e3cee96092bfcfce466b798ef7fa7ab0ce9
+  React-idlecallbacksnativemodule: 1ddd412980d3b98b44d7a2e4fde03461f8e76f32
+  React-ImageManager: 358e62748a289e0efc9978a496777c8aed1128b3
+  React-jserrorhandler: 98db9aa8a7dbd762450c7f07c7e6ed8121ba1121
+  React-jsi: 9feee53db653f2e4a2ed22e2cc341b6860abee52
+  React-jsiexecutor: 506db18800f9e7a111bf20f5cfa00ebbb92d7f9f
+  React-jsinspector: 53e03bcb596e97080eba3c934b00917c770efba8
+  React-jsitracing: ba1da0ce04eb6ef8df7b2dc242480a9fcbf8e4b9
+  React-logger: 8c46a993ece3b82a72807f2ce28dff0a760f41b7
+  React-Mapbuffer: 832d9cebfe21f73b6ec0cca75bd5b4d4914ebecf
+  React-microtasksnativemodule: 2d62fe57c4e7c1d621d6bfe790b30086a47b2898
+  React-nativeconfig: b9c086f83aba945dad592d2556fe2b983f541032
+  React-NativeModulesApple: fc0216341125c18c358b91444b4dec19496444c6
+  React-perflogger: 58fc385b0781f4e6dd8e4ed89acbb82d9a0ecb55
+  React-performancetimeline: 8a19605e8432f08b293e64d0fb171d0f8e3f6ddf
+  React-RCTActionSheet: 88aa440fb2c9c723690047989f8fe3855e2b3024
+  React-RCTAnimation: 2da5527273366683eb95dd8b913e0d09c9eee913
+  React-RCTAppDelegate: 63b25ee0bd5c3d3e88b99bc537a1b593dfc95371
+  React-RCTBlob: 32fa3f1204455c8ec6183b932862b27946d01253
+  React-RCTFabric: 6424f85177676db35badce4682d523975ed7b52b
+  React-RCTFBReactNativeSpec: ff93000d84fd4e9ff1664b95bc3d55ce429de2db
+  React-RCTImage: 20662626d418c706e2e5eaa2e26b1f16c96554a9
+  React-RCTLinking: a6bbc71ffd7cd41f326a693f11adca40b22e6386
+  React-RCTNetwork: d792d57b8f79e3c7d27ff00fd383cd5f6bd69f75
+  React-RCTSettings: c6dba9792e89002c5f6eec6a9c2f3f58504433e2
+  React-RCTText: 7813f9b77ff23d7f99cba500ebe89f9321481fa0
+  React-RCTVibration: 8a2a0e2255c35a6de55551411ecd6d29c5e69099
+  React-rendererconsistency: f74a1be04eb6c092196d31f15eff014d2acfe0cc
+  React-rendererdebug: e3f4e632972009c14a8028283ca42dddf10a8dae
+  React-rncore: 523fc380d9c598cb4a531396878fdd3055c2b8af
+  React-RuntimeApple: 7dde21de50a331d13a91462d2ab5886c0823bc71
+  React-RuntimeCore: afe1b64dd4f4f369d225b17b48ffadf7e004dccb
+  React-runtimeexecutor: f3205d0a3840877ef42af3f2c783903dc1efd65b
+  React-RuntimeHermes: e6f049568f03d1b48f85eeae28355d98c04250f9
+  React-runtimescheduler: 9082769e5255974f8d1bfc423a3954662d2c3337
+  React-timing: e17ac82c31c73234701702d2b76fbd8695931d3b
+  React-utils: 6ecdab665e38582655a19c3532a5adfd6d1be572
+  ReactAppDependencyProvider: aa24ec89395a729888b289410623dbf3430f7cef
+  ReactCodegen: dac7cff2edc06de7b772ab59febc98a7b7bf4f78
+  ReactCommon: f4a0a4c9bd9e6b4706d9e77a13a5dc1c3d7aa2a4
   RNGestureHandler: 00efce651d14cb7ad42e5df042234dc7c3562312
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
-  Yoga: e30730c63678d5a706ed8760e3f76f4f410f7718
+  Yoga: 0c8754b0ea9edb13b6ce6b60f0f69eb5f164f16a
 
 PODFILE CHECKSUM: d42e92008e98fe107445c7108b66a452b97ce9ef
 

--- a/FabricExample/package.json
+++ b/FabricExample/package.json
@@ -16,7 +16,7 @@
     "patch-package": "^6.5.0",
     "postinstall-postinstall": "^2.1.0",
     "react": "18.3.1",
-    "react-native": "0.77.0-rc.3",
+    "react-native": "0.77.0-rc.6",
     "react-native-gesture-handler": "link:../"
   },
   "devDependencies": {
@@ -26,10 +26,10 @@
     "@react-native-community/cli": "15.0.1",
     "@react-native-community/cli-platform-android": "15.0.1",
     "@react-native-community/cli-platform-ios": "15.0.1",
-    "@react-native/babel-preset": "0.77.0-rc.3",
-    "@react-native/eslint-config": "0.77.0-rc.3",
-    "@react-native/metro-config": "0.77.0-rc.3",
-    "@react-native/typescript-config": "0.77.0-rc.3",
+    "@react-native/babel-preset": "0.77.0-rc.6",
+    "@react-native/eslint-config": "0.77.0-rc.6",
+    "@react-native/metro-config": "0.77.0-rc.6",
+    "@react-native/typescript-config": "0.77.0-rc.6",
     "@types/jest": "^29.5.13",
     "@types/react": "^18.2.6",
     "@types/react-test-renderer": "^18.0.0",

--- a/FabricExample/yarn.lock
+++ b/FabricExample/yarn.lock
@@ -1871,23 +1871,23 @@
     prompts "^2.4.2"
     semver "^7.5.2"
 
-"@react-native/assets-registry@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.77.0-rc.3.tgz#ba08ba067a1aa105bf4ed621bd57e303cf6044c3"
-  integrity sha512-k+5CfMGHGqz2oCjEix8OiExxLFzQVNwOF1ZInYi1o61XxgPT5lR0VhkkQW2v6vqj8MIxf259JXnOB6GRi6C85A==
+"@react-native/assets-registry@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/assets-registry/-/assets-registry-0.77.0-rc.6.tgz#82d9f3de10da60b29fce206cf80cfe0605b22bbf"
+  integrity sha512-7VAyf+oyyNzi7tYAxa1WvVxCQ9Sq+ZWU+njvIYWNdJy1kvq7BH5QqbauWPXQjnOPkXvw+5B1AcT+WC65/ilvqQ==
 
-"@react-native/babel-plugin-codegen@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.77.0-rc.3.tgz#c375feb1a0bddc814c888f01a9a81aa336a242e4"
-  integrity sha512-W5OOxsJdjQ+ff92o6v3tW5xw+yTgqQn1/St3sYNFATl4ppf1PBcfPUs+jYcrshPT+ArIU0fQ4++e3FZ7N103kg==
+"@react-native/babel-plugin-codegen@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-plugin-codegen/-/babel-plugin-codegen-0.77.0-rc.6.tgz#dad6b10c61e1e5c72918817b54e78e0a91f1f26b"
+  integrity sha512-gzZhyw3/erZx/IWWnckW9CJlo+Q4DmFm97m0BCmUicuEPNifKiQKea8CbFy1xwXb3PYPMcSPBslcyUjhsu+aTA==
   dependencies:
     "@babel/traverse" "^7.25.3"
-    "@react-native/codegen" "0.77.0-rc.3"
+    "@react-native/codegen" "0.77.0-rc.6"
 
-"@react-native/babel-preset@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.77.0-rc.3.tgz#8647c36610e44a0599090322dbc1e0aa53d8f4af"
-  integrity sha512-u/mosh9E73NCXbxL1Qqdp16IxjJ8AMjHTWZo39GSQqGW9//2MJbYHru1H1wt6jegHeNX1+IImJSCW9mGElXcVQ==
+"@react-native/babel-preset@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/babel-preset/-/babel-preset-0.77.0-rc.6.tgz#ab5ca858651ff28ba784b0019c8abe050c53a7ef"
+  integrity sha512-S+CJQTDaT98fZ0WarmaR3x4vomRr9fW5U9/cSZSmb8F0Pl+gdeOoJ0YRZUBm129/qlJnAvQhLVSXGyLg4+4YLQ==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/plugin-proposal-export-default-from" "^7.24.7"
@@ -1930,15 +1930,15 @@
     "@babel/plugin-transform-typescript" "^7.25.2"
     "@babel/plugin-transform-unicode-regex" "^7.24.7"
     "@babel/template" "^7.25.0"
-    "@react-native/babel-plugin-codegen" "0.77.0-rc.3"
+    "@react-native/babel-plugin-codegen" "0.77.0-rc.6"
     babel-plugin-syntax-hermes-parser "0.25.1"
     babel-plugin-transform-flow-enums "^0.0.2"
     react-refresh "^0.14.0"
 
-"@react-native/codegen@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.77.0-rc.3.tgz#163195b2b95a07958a83744dd8acdfaafb53e749"
-  integrity sha512-Va7mjv8mozt1XnvOvoBz8suFFSKeqzi/9dnlMxbgM/DW73Fml9vkB5HADFGvTUtIxmRpx6p6+jRc0E1/rgUzRw==
+"@react-native/codegen@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/codegen/-/codegen-0.77.0-rc.6.tgz#ae5294a5a87a77e096ac6844dca8f65a9db69185"
+  integrity sha512-2EymHGNDE/zknDfmAIpB8L1/b6OI4JrbmjXBXv2c4DOfRHE8F0BD4RwQOzXCji6SI30fgXN7pHfoF5gOarx+8g==
   dependencies:
     "@babel/parser" "^7.25.3"
     glob "^7.1.1"
@@ -1948,13 +1948,13 @@
     nullthrows "^1.1.1"
     yargs "^17.6.2"
 
-"@react-native/community-cli-plugin@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.77.0-rc.3.tgz#3dae1dec0956819ea312e4c4147463c82e7283ae"
-  integrity sha512-ZQEEU/FGa15PI/TK1VlP1+qR9cXpwTGtIaOKiZfoKmYg16ODan1bDmlXrzX819B1xkCz67JGkVfxKMP3vA/hYQ==
+"@react-native/community-cli-plugin@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/community-cli-plugin/-/community-cli-plugin-0.77.0-rc.6.tgz#0a4c09eccdcdee9ca601e73419ea6ce421765839"
+  integrity sha512-NF/9Tp0cy9I0+zR3XlmkbYheeIfdmMKBR8DTiGPsQVWcdYvQd1e1Y/6ZTQura08YlPpGjCeYXQcpo1ounrWc0A==
   dependencies:
-    "@react-native/dev-middleware" "0.77.0-rc.3"
-    "@react-native/metro-babel-transformer" "0.77.0-rc.3"
+    "@react-native/dev-middleware" "0.77.0-rc.6"
+    "@react-native/metro-babel-transformer" "0.77.0-rc.6"
     chalk "^4.0.0"
     debug "^2.2.0"
     invariant "^2.2.4"
@@ -1964,18 +1964,18 @@
     readline "^1.3.0"
     semver "^7.1.3"
 
-"@react-native/debugger-frontend@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.77.0-rc.3.tgz#9ddac49cd585993a6fc3d81d96a7d1ff0e35bf27"
-  integrity sha512-hHoBEVwIoaJHRCIdHbgcsikZhp0rvBTW0J9zXqusSqDeZDvk7HTEQENLcweds/dWYXYVhS70rIvgyBJl7IYR1w==
+"@react-native/debugger-frontend@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/debugger-frontend/-/debugger-frontend-0.77.0-rc.6.tgz#8ca6d60f451c24a239a652630a0d18b03be52ff5"
+  integrity sha512-qgiJ1/xLsE28I5bPh6hhTExhC9aaaGuyheIM0FK536PEeEEMJx6Myg/alTQL4h9pXSHZPtSgHKfjWIQ+9sjfSw==
 
-"@react-native/dev-middleware@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.77.0-rc.3.tgz#7ee8ba86148565d1e9ae55f2c376ba132b7ecbc8"
-  integrity sha512-5TvZrJDR/5VMfFohxWQcwO2QYf/CZzCIZYvi8TiAzxkpRb+QLBGjo8XVeY973xvwPyLJfhNNswZL/osomIlGTA==
+"@react-native/dev-middleware@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/dev-middleware/-/dev-middleware-0.77.0-rc.6.tgz#7bdeb731dafb88e9a872fe037673b1b4e63768a6"
+  integrity sha512-iq//tyd8quxdqJJ1ozFL1AZTksF/DoR0cuPx3Lds34PAMe4i1f93UmHOFSijJQ0iSOB0cp0aWUh8obOQMqUGkg==
   dependencies:
     "@isaacs/ttlcache" "^1.4.1"
-    "@react-native/debugger-frontend" "0.77.0-rc.3"
+    "@react-native/debugger-frontend" "0.77.0-rc.6"
     chrome-launcher "^0.15.2"
     chromium-edge-launcher "^0.2.0"
     connect "^3.6.5"
@@ -1986,14 +1986,14 @@
     serve-static "^1.16.2"
     ws "^6.2.3"
 
-"@react-native/eslint-config@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/eslint-config/-/eslint-config-0.77.0-rc.3.tgz#0e211e3f3deb2658cfbb59a184945652e2155144"
-  integrity sha512-xmaWwf1RYMuEPXvVmoTPoVR9Wm5jyAACPjDGNTOTcpszRK6ojpXfAGRHZDjA08SwaDhjFqx86Bh90VZI5DNUhw==
+"@react-native/eslint-config@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/eslint-config/-/eslint-config-0.77.0-rc.6.tgz#640256c7a1b5e5fbd82cb2a72256ec30867fe25c"
+  integrity sha512-pbQe6AuqeLJfIdCqnMtcQPWOi3BW795lrfaPxT0Hx+TH+3UKB1CanK/WWQQj0znAQSztdudwktBrjWZFh/E2YQ==
   dependencies:
     "@babel/core" "^7.25.2"
     "@babel/eslint-parser" "^7.25.1"
-    "@react-native/eslint-plugin" "0.77.0-rc.3"
+    "@react-native/eslint-plugin" "0.77.0-rc.6"
     "@typescript-eslint/eslint-plugin" "^7.1.1"
     "@typescript-eslint/parser" "^7.1.1"
     eslint-config-prettier "^8.5.0"
@@ -2004,55 +2004,55 @@
     eslint-plugin-react-hooks "^4.6.0"
     eslint-plugin-react-native "^4.0.0"
 
-"@react-native/eslint-plugin@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/eslint-plugin/-/eslint-plugin-0.77.0-rc.3.tgz#41ab18954adf44b087a743bea2d103f272834012"
-  integrity sha512-MG5g+IPzbr9iZ5dlse3URHLn4y3HRJdz24KNO6gko9iY1w2PhTPTIDusyAX+tsPoXNOGFZlihzN/rKijQRu3qw==
+"@react-native/eslint-plugin@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/eslint-plugin/-/eslint-plugin-0.77.0-rc.6.tgz#3dfd311dfccdcc25f8eaa1100ebb172e1e16914f"
+  integrity sha512-UKqIe43+zCg/G2/4Xupn8LTOdEfGZO3lfSbo6IOU9RS7RzKVake86joEDUo+BDVNhAhMXmY9LRcrVIFxvm3P0w==
 
-"@react-native/gradle-plugin@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.77.0-rc.3.tgz#a612506ce1461986359aeb818bc315fd12664125"
-  integrity sha512-uxsS/XRh95+EYJxUxdV9ExQU0DEJkUqW9BcPUyjJZev/ja0vk6nETzJHCoZRtaQ/0OFxEftfJqBIbSFut5sDsg==
+"@react-native/gradle-plugin@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/gradle-plugin/-/gradle-plugin-0.77.0-rc.6.tgz#52d283e0678bc8870b05ce1a9109e8414a16cc38"
+  integrity sha512-Cyjv/HRTlKmfj7+jarRytJLKJ5nAW+52b2VoHQAmPlZl71go1q0WJztKZ2/spDQy8eVA6jsR9uYGLnVfezyJCQ==
 
-"@react-native/js-polyfills@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.77.0-rc.3.tgz#6bd4fac9f42250389abbb484f99dc3f6d40fa31f"
-  integrity sha512-tSfgppTWY9IipBSvKnR5MfCp7c7k+1hiBNOzK9yVWdxytGWl+WBVQ1PVVS9902IxIpRPrBd5tTtF4GAiYvB+Uw==
+"@react-native/js-polyfills@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/js-polyfills/-/js-polyfills-0.77.0-rc.6.tgz#c9bd573302a971d2175ca9e791aea65ac37f2208"
+  integrity sha512-x9Z/KpXE6ZvfwZvimfjU69QvMgBsY6ap0I2REEnzTPnYuelZLQ2hDYjcKC4RBNxd3vEOODjPGdpXjkUUBDe2Eg==
 
-"@react-native/metro-babel-transformer@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.77.0-rc.3.tgz#c83f2f531717608d07c8af1e6bf7936528e72699"
-  integrity sha512-OQ8+o3IeVsQmwWVUKLPrPAei0iWwBuF1jiFSwOyYQEpwK+5nEKpIp8JONcASQTXpO0hKPsGdnqp6fp2uDRN6uA==
+"@react-native/metro-babel-transformer@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/metro-babel-transformer/-/metro-babel-transformer-0.77.0-rc.6.tgz#52b056e37709ea0401f50010746990b57a98a1a7"
+  integrity sha512-WcedK4YWUZoEmIFGj376a3LagH2O3lUPkrjvCWcAnl3UDjpFPNw5gHdzRDL3IlauhXQX+6626hTCSJ0FqAIstA==
   dependencies:
     "@babel/core" "^7.25.2"
-    "@react-native/babel-preset" "0.77.0-rc.3"
+    "@react-native/babel-preset" "0.77.0-rc.6"
     hermes-parser "0.25.1"
     nullthrows "^1.1.1"
 
-"@react-native/metro-config@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/metro-config/-/metro-config-0.77.0-rc.3.tgz#4ff66bb9adce7d36dd08eb14e3227af098fb5b33"
-  integrity sha512-K9kK7odOOyyKFe9BKyLaPV69+lyU3n/ywp5zNl0IbFH3hUTtfm+nv9YQ87+B0LRaEvBJOtXDCuXiMpcCdaS0Wg==
+"@react-native/metro-config@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/metro-config/-/metro-config-0.77.0-rc.6.tgz#cd0ad87ac71637a6d6e607f04a2585ac44b4b0ce"
+  integrity sha512-6anVEXdTwdJ1izIPBhFc/w38Sq4k+6UtI3i5T7t0qEcokkHjARCC1Uq84Oiheyr/9ObVVJ+ervnM8ZLcJTLaCg==
   dependencies:
-    "@react-native/js-polyfills" "0.77.0-rc.3"
-    "@react-native/metro-babel-transformer" "0.77.0-rc.3"
+    "@react-native/js-polyfills" "0.77.0-rc.6"
+    "@react-native/metro-babel-transformer" "0.77.0-rc.6"
     metro-config "^0.81.0"
     metro-runtime "^0.81.0"
 
-"@react-native/normalize-colors@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.77.0-rc.3.tgz#4c45e9b5ae55a8fbd6b21dbde0b05662dd256935"
-  integrity sha512-6/mGSoco1NU7vvNmKqtGYwzsIl4VP2bKp4t5HWMeu91vRPvxDHFEOESwXMeLslq1Evb/JNqsieFF+uZnU63DTg==
+"@react-native/normalize-colors@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/normalize-colors/-/normalize-colors-0.77.0-rc.6.tgz#d5375f5dd3c543304be85951d96c953f4945f425"
+  integrity sha512-lmc78245ModEG/qg0fiJU75t1nIjv95b8yiRgE0Xt/kbkfyZZbtKBCfvC2gc0J45iXRCUW6z6boxw1lEWnf8GQ==
 
-"@react-native/typescript-config@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/typescript-config/-/typescript-config-0.77.0-rc.3.tgz#cb9eaa397e504ecb8cf56ef7fe82d66b5d614519"
-  integrity sha512-hQQVN+1YOhEzomNBz/+r+d7E1pn+gPM23WtvENGHoojQkuSpb4zXIZoQuvbuXq6sPXoq4w7xA6ZxtQb1pwHCOA==
+"@react-native/typescript-config@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/typescript-config/-/typescript-config-0.77.0-rc.6.tgz#fe0a73f6f704885779c0b587571ac2b102067e5d"
+  integrity sha512-0+//wE3OLwgPByMENmKz10IekbMJmJPjJEP+ApeUIH/inwFEQ3UoVzW0e91yjgGHibkOIUKpC6Ga2CFKhJYasg==
 
-"@react-native/virtualized-lists@0.77.0-rc.3":
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.77.0-rc.3.tgz#b7552d4ab5ac41ee6e9bd50802a4247099f5affc"
-  integrity sha512-/CVHgAdVqRq+WmP6Ps4veUOLu+1AuQ2ALhG5udtN/UiFzAn2R5V7izXUPu/1oSAMYim0PSGMOPorAYokQ7OPhQ==
+"@react-native/virtualized-lists@0.77.0-rc.6":
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/@react-native/virtualized-lists/-/virtualized-lists-0.77.0-rc.6.tgz#fe3111296789740e3273f7a15601ac75a2e48615"
+  integrity sha512-4uDtx+NM6p4B2PLQNE/4lzZajB0eBK2TAXSjBRjLdcfqhh7hCn5i3z8ggatBAA3Jl52uQD82MaQaDNsU7SF0kA==
   dependencies:
     invariant "^2.2.4"
     nullthrows "^1.1.1"
@@ -5926,19 +5926,19 @@ react-is@^17.0.1:
   version "0.0.0"
   uid ""
 
-react-native@0.77.0-rc.3:
-  version "0.77.0-rc.3"
-  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.77.0-rc.3.tgz#a1e81f64115032257e4febc5d216215ee6f7e7b3"
-  integrity sha512-0olzBb7aiq0EUs+cl0ZmAw6RjzqQiqttjNmpe/gxtb0UE3hWJTS9zlL9vPQQPhsDK55x60hdxGl8cacoIIKW6Q==
+react-native@0.77.0-rc.6:
+  version "0.77.0-rc.6"
+  resolved "https://registry.yarnpkg.com/react-native/-/react-native-0.77.0-rc.6.tgz#6cc507d776fde11b7cecf7c3f57362001efcdf43"
+  integrity sha512-JT4vVcp6e21qugHixcp3KWSddqH7gOA7qrBq4gK0yKKGqeH0rwxQogpKXbaObJyUfb5u7dicDTcu94D4+O/stQ==
   dependencies:
     "@jest/create-cache-key-function" "^29.6.3"
-    "@react-native/assets-registry" "0.77.0-rc.3"
-    "@react-native/codegen" "0.77.0-rc.3"
-    "@react-native/community-cli-plugin" "0.77.0-rc.3"
-    "@react-native/gradle-plugin" "0.77.0-rc.3"
-    "@react-native/js-polyfills" "0.77.0-rc.3"
-    "@react-native/normalize-colors" "0.77.0-rc.3"
-    "@react-native/virtualized-lists" "0.77.0-rc.3"
+    "@react-native/assets-registry" "0.77.0-rc.6"
+    "@react-native/codegen" "0.77.0-rc.6"
+    "@react-native/community-cli-plugin" "0.77.0-rc.6"
+    "@react-native/gradle-plugin" "0.77.0-rc.6"
+    "@react-native/js-polyfills" "0.77.0-rc.6"
+    "@react-native/normalize-colors" "0.77.0-rc.6"
+    "@react-native/virtualized-lists" "0.77.0-rc.6"
     abort-controller "^3.0.0"
     anser "^1.4.9"
     ansi-regex "^5.0.0"


### PR DESCRIPTION
## Description

This PR bumps `FabricExample` app to React Native 0.77.0-rc.6

## Test plan

Build FabricExample on `iOS` and `Android`
