### PR TITLE
[Android] Include missing Gesture Handler in builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,8 @@
     "android/common/src/main/java/",
     "android/reanimated/src/main/java/",
     "android/noreanimated/src/main/java/",
+    "android/package77/",
+    "android/packageDeprecated/",
     "apple/",
     "Swipeable/",
     "ReanimatedSwipeable/",


### PR DESCRIPTION
## Description

#3278 introduced support for React Native 0.77. However, it didn't include newly added directories into package, which resulted in Gesture Handler not being built on Android.

## Test plan

Generate Gesture Handler package and add it to newly created app.
