### PR TITLE
[CI] Set Xcode version to 16.1

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Use latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: latest-stable
+          xcode-version: '16.1'
       - name: Use Node.js 18
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
## Description

For some reason some of our checks on CI are executed on Xcode 16.2 - those checks fail. Setting version to 16.1 resolves this problem (this is temporary solution).

## Test plan

Check that CI passes.