### PR TITLE
Make `blocksGesture` symmetric on native iOS

### DIFF
--- a/apple/RNGestureHandler.mm
+++ b/apple/RNGestureHandler.mm
@@ -461,8 +461,8 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer
     shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
+  RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
   if ([_handlersToWaitFor count]) {
-    RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
     if (handler != nil) {
       for (NSNumber *handlerTag in _handlersToWaitFor) {
         if ([handler.tag isEqual:handlerTag]) {
@@ -471,6 +471,15 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
       }
     }
   }
+
+  if (handler != nil) {
+    for (NSNumber *handlerTag in handler->_handlersThatShouldWait) {
+      if ([_tag isEqual:handlerTag]) {
+        return YES;
+      }
+    }
+  }
+
   return NO;
 }
 

--- a/apple/RNGestureHandler.mm
+++ b/apple/RNGestureHandler.mm
@@ -462,21 +462,19 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     shouldRequireFailureOfGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer
 {
   RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:otherGestureRecognizer];
-  if ([_handlersToWaitFor count]) {
-    if (handler != nil) {
-      for (NSNumber *handlerTag in _handlersToWaitFor) {
-        if ([handler.tag isEqual:handlerTag]) {
-          return YES;
-        }
-      }
+  if (handler == nil) {
+    return NO;
+  }
+
+  for (NSNumber *handlerTag in _handlersToWaitFor) {
+    if ([handler.tag isEqual:handlerTag]) {
+      return YES;
     }
   }
 
-  if (handler != nil) {
-    for (NSNumber *handlerTag in handler->_handlersThatShouldWait) {
-      if ([_tag isEqual:handlerTag]) {
-        return YES;
-      }
+  for (NSNumber *handlerTag in handler->_handlersThatShouldWait) {
+    if ([_tag isEqual:handlerTag]) {
+      return YES;
     }
   }
 


### PR DESCRIPTION
## Description

Should fix https://github.com/software-mansion/react-native-gesture-handler/issues/3321

This PR makes the native implementation of `blocksGesture` symmetric. Previously, the logic was implemented only in `shouldBeRequiredToFailByGestureRecognizer`, now, it's also in `shouldRequireFailureOfGestureRecognizer`.

## Test plan

Tested on the code from the issue
