### PR TITLE
feat: Add `simultaneousWithExternalGesture` to ReanimatedSwipable

### DIFF
--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -128,9 +128,9 @@ style object for the container (`Animated.View`), for example to override `overf
 
 style object for the children container (`Animated.View`), for example to apply `flex: 1`.
 
-### `simultaneousWithExternalGestures`
+### `simultaneousWithExternalGesture`
 
-An array of gesture configurations to be recognized simultaneously with the swipeable gesture. This is useful for allowing other gestures to work simultaneously with swipeable gesture handler.
+A gesture configuration to be recognized simultaneously with the swipeable gesture. This is useful for allowing other gestures to work simultaneously with swipeable gesture handler.
 
 For example, to enable a pan gesture alongside the swipeable gesture:
 
@@ -138,7 +138,7 @@ For example, to enable a pan gesture alongside the swipeable gesture:
 const panGesture = Gesture.Pan();
 
 <GestureDetector gesture={panGesture}>
-  <ReanimatedSwipeable simultaneousWithExternalGestures={[panGesture]} />
+  <ReanimatedSwipeable simultaneousWithExternalGesture={panGesture} />
 </GestureDetector>
 ```
 

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -128,9 +128,21 @@ style object for the container (`Animated.View`), for example to override `overf
 
 style object for the children container (`Animated.View`), for example to apply `flex: 1`.
 
-### `simultaneousGesture`
+### `simultaneousWithExternalGesture`
 
-An optional gesture configuration that allows another gesture to be recognized simultaneously with the swipeable gesture. This can be useful for implementing complex gesture interactions where multiple gestures need to be detected at the same time.
+An optional gesture configuration that enables another gesture to be recognized simultaneously with the swipeable gesture. This is useful for allowing swipeable gestures to work simultaneously with other gestures.
+
+For example, to enable a pan gesture alongside the swipeable gesture:
+
+```jsx
+const panGesture = Gesture.Pan();
+
+<GestureDetector gesture={panGesture}>
+  <ReanimatedSwipeable simultaneousWithExternalGesture={panGesture} />
+</GestureDetector>
+```
+
+More details can be found in the [gesture composition documentation](../fundamentals/gesture-composition.md#simultaneouswithexternalgesture).
 
 ### `enableTrackpadTwoFingerGesture` (iOS only)
 

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -128,9 +128,9 @@ style object for the container (`Animated.View`), for example to override `overf
 
 style object for the children container (`Animated.View`), for example to apply `flex: 1`.
 
-### `simultaneousWithExternalGesture`
+### `simultaneousWithExternalGestures`
 
-An optional gesture configuration that enables another gesture to be recognized simultaneously with the swipeable gesture. This is useful for allowing swipeable gestures to work simultaneously with other gestures.
+An optional gesture configuration that enable other gestures to be recognized simultaneously with the swipeable gesture. This is useful for allowing swipeable gestures to work simultaneously with other gestures.
 
 For example, to enable a pan gesture alongside the swipeable gesture:
 
@@ -138,7 +138,7 @@ For example, to enable a pan gesture alongside the swipeable gesture:
 const panGesture = Gesture.Pan();
 
 <GestureDetector gesture={panGesture}>
-  <ReanimatedSwipeable simultaneousWithExternalGesture={panGesture} />
+  <ReanimatedSwipeable simultaneousWithExternalGestures={[panGesture]} />
 </GestureDetector>
 ```
 

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -130,7 +130,7 @@ style object for the children container (`Animated.View`), for example to apply 
 
 ### `simultaneousWithExternalGestures`
 
-An optional gesture configuration that enable other gestures to be recognized simultaneously with the swipeable gesture. This is useful for allowing swipeable gestures to work simultaneously with other gestures.
+An array of gesture configurations to be recognized simultaneously with the swipeable gesture. This is useful for allowing other gestures to work simultaneously with swipeable gesture handler.
 
 For example, to enable a pan gesture alongside the swipeable gesture:
 

--- a/docs/docs/components/reanimated_swipeable.md
+++ b/docs/docs/components/reanimated_swipeable.md
@@ -128,6 +128,10 @@ style object for the container (`Animated.View`), for example to override `overf
 
 style object for the children container (`Animated.View`), for example to apply `flex: 1`.
 
+### `simultaneousGesture`
+
+An optional gesture configuration that allows another gesture to be recognized simultaneously with the swipeable gesture. This can be useful for implementing complex gesture interactions where multiple gestures need to be detected at the same time.
+
 ### `enableTrackpadTwoFingerGesture` (iOS only)
 
 Enables two-finger gestures on supported devices, for example iPads with trackpads.

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -5,6 +5,9 @@
     "baseUrl": ".",
     "paths": {
       "react-native-gesture-handler": ["../src/index.ts"],
+      "react-native-gesture-handler/ReanimatedSwipeable": [
+        "../src/components/ReanimatedSwipeable.tsx"
+      ],
       "react-native-gesture-handler/jest-utils": ["../src/jestUtils/index.ts"]
     }
   },

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -206,7 +206,7 @@ export interface SwipeableProps
 
   /**
    * A base gesture object containing the configuration and callbacks to be
-   * used simultaneously with `Swipeable`'s gesture object.
+   * used with the swipeable's gesture handler.
    */
   simultaneousGesture?: GestureType;
 }

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -205,7 +205,7 @@ export interface SwipeableProps
   childrenContainerStyle?: StyleProp<ViewStyle>;
 
   /**
-   * A gesture object containing the configuration and callbacks to be
+   * An array of gesture objects containing the configuration and callbacks to be
    * used with the swipeable's gesture handler.
    */
   simultaneousWithExternalGestures?: Exclude<GestureRef, number>[];

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -9,6 +9,7 @@ import React, {
   useImperativeHandle,
   useMemo,
 } from 'react';
+import { GestureType } from '../handlers/gestures/gesture';
 import { GestureObjects as Gesture } from '../handlers/gestures/gestureObjects';
 import { GestureDetector } from '../handlers/gestures/GestureDetector';
 import {
@@ -202,6 +203,12 @@ export interface SwipeableProps
    * apply `flex: 1`
    */
   childrenContainerStyle?: StyleProp<ViewStyle>;
+
+  /**
+   * A base gesture object containing the configuration and callbacks to be
+   * used simultaneously with `Swipeable`'s gesture object.
+   */
+  simultaneousGesture?: GestureType;
 }
 
 export interface SwipeableMethods {
@@ -247,6 +254,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       onSwipeableClose,
       renderLeftActions,
       renderRightActions,
+      simultaneousGesture,
       ...remainingProps
     } = props;
 
@@ -713,8 +721,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       [appliedTranslation, rowState]
     );
 
+    const swipeableGesture = simultaneousGesture
+      ? Gesture.Simultaneous(panGesture, simultaneousGesture)
+      : panGesture;
+
     const swipeableComponent = (
-      <GestureDetector gesture={panGesture} touchAction="pan-y">
+      <GestureDetector gesture={swipeableGesture} touchAction="pan-y">
         <Animated.View
           {...remainingProps}
           onLayout={onRowLayout}

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -661,9 +661,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           .enabled(enabled !== false)
           .enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture)
           .activeOffsetX([-dragOffsetFromRightEdge, dragOffsetFromLeftEdge])
-          .simultaneousWithExternalGesture(
-            ...(simultaneousWithExternalGestures ?? [])
-          )
           .onStart(updateElementWidths)
           .onUpdate(
             (event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
@@ -697,7 +694,10 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           )
           .onFinalize(() => {
             dragStarted.value = false;
-          }),
+          })
+          .simultaneousWithExternalGesture(
+            ...(simultaneousWithExternalGestures ?? [])
+          ),
       [
         dragOffsetFromLeftEdge,
         dragOffsetFromRightEdge,

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -645,18 +645,27 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     const dragStarted = useSharedValue<boolean>(false);
 
-    const tapGesture = useMemo(
-      () =>
-        Gesture.Tap()
-          .shouldCancelWhenOutside(true)
-          .onStart(() => {
-            if (rowState.value !== 0) {
-              close();
-            }
-          }),
-      [close, rowState]
-    );
+    const tapGesture = useMemo(() => {
+      const tap = Gesture.Tap()
+        .shouldCancelWhenOutside(true)
+        .onStart(() => {
+          if (rowState.value !== 0) {
+            close();
+          }
+        });
 
+      if (!simultaneousWithExternalGesture) {
+        return tap;
+      }
+
+      if (Array.isArray(simultaneousWithExternalGesture)) {
+        tap.simultaneousWithExternalGesture(...simultaneousWithExternalGesture);
+      } else {
+        tap.simultaneousWithExternalGesture(simultaneousWithExternalGesture);
+      }
+
+      return tap;
+    }, [close, rowState, simultaneousWithExternalGesture]);
     const panGesture = useMemo(() => {
       const pan = Gesture.Pan()
         .enabled(enabled !== false)

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -666,6 +666,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
       return tap;
     }, [close, rowState, simultaneousWithExternalGesture]);
+
     const panGesture = useMemo(() => {
       const pan = Gesture.Pan()
         .enabled(enabled !== false)


### PR DESCRIPTION
## Description
This PR adds a new prop to `RenimatedSwipable` that allows adding a gesture config that can be used simultaneously with `ReanimatedSwipeable`'s gesture config.

The new prop is called `simultaneousWithExternalGesture`, it uses the the cross-component interaction methodology that's mentioned in the [documentation here](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition/#simultaneouswithexternalgesture).

I also update the docs for it

### Motivation
I've been recently using ReanimatedSwipeable component, and I tried to add an additional gesture config to enable haptic feedback and "release to run function" kind of interaction

After looking through the issues in the repo, I found this issue #2862, I tried to apply it, but it turned out that it was only applicable to the Swipable component

I tried to find a way to add a gesture config that would work simultaneously with the swipeable one but I couldn't find a way to add it. So I looked through the documentation of RNGH for simultaneous gesture handlers and came up with this solution

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

## Test plan
I already tested it locally on both iOS and Android, and the callbacks work as expected

Not sure if there's something else to do here since this is my first contribution

<!--
Describe how did you test this change here.
-->
