### PR TITLE
Fix swipeable overlap bug

### DIFF
--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -536,6 +536,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       [
         appliedTranslation,
         renderRightActions,
+        rightActionAnimation,
         rightOffset,
         showRightProgress,
         swipeableMethods,
@@ -694,18 +695,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         </Animated.View>
       </GestureDetector>
     );
-
-    useAnimatedStyle(() => {
-      console.log('----------');
-      console.log('rowWidth', rowWidth.value);
-      console.log('leftWidth', leftWidth.value);
-      console.log('rightWidth', rightWidth.value);
-      console.log('rightOffset', rightOffset.value);
-      console.log('showLeftProgress', showLeftProgress.value);
-      console.log('showRightProgress', showRightProgress.value);
-      console.log('userDrag', userDrag.value);
-      return {};
-    });
 
     return testID ? (
       <View testID={testID}>{swipeableComponent}</View>

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -414,11 +414,11 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           const progressTarget = toValue === 0 ? 0 : 1;
 
           showLeftProgress.value =
-            leftWidth.value > 0
+            showLeftProgress.value > 0
               ? withSpring(progressTarget, progressSpringConfig)
               : 0;
           showRightProgress.value =
-            rightWidth.value > 0
+            showRightProgress.value > 0
               ? withSpring(progressTarget, progressSpringConfig)
               : 0;
 
@@ -481,9 +481,15 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       [rowWidth]
     );
 
+    const leftActionAnimation = useAnimatedStyle(() => {
+      return {
+        transform: [{ translateX: showLeftProgress.value === 0 ? -10000 : 0 }],
+      };
+    });
+
     const leftElement = useCallback(
       () => (
-        <Animated.View style={[styles.leftActions]}>
+        <Animated.View style={[styles.leftActions, leftActionAnimation]}>
           {renderLeftActions?.(
             showLeftProgress,
             appliedTranslation,
@@ -498,6 +504,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       ),
       [
         appliedTranslation,
+        leftActionAnimation,
         leftWidth,
         renderLeftActions,
         showLeftProgress,
@@ -505,9 +512,15 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       ]
     );
 
+    const rightActionAnimation = useAnimatedStyle(() => {
+      return {
+        transform: [{ translateX: showRightProgress.value === 0 ? 10000 : 0 }],
+      };
+    });
+
     const rightElement = useCallback(
       () => (
-        <Animated.View style={[styles.rightActions]}>
+        <Animated.View style={[styles.rightActions, rightActionAnimation]}>
           {renderRightActions?.(
             showRightProgress,
             appliedTranslation,
@@ -681,6 +694,18 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         </Animated.View>
       </GestureDetector>
     );
+
+    useAnimatedStyle(() => {
+      console.log('----------');
+      console.log('rowWidth', rowWidth.value);
+      console.log('leftWidth', leftWidth.value);
+      console.log('rightWidth', rightWidth.value);
+      console.log('rightOffset', rightOffset.value);
+      console.log('showLeftProgress', showLeftProgress.value);
+      console.log('showRightProgress', showRightProgress.value);
+      console.log('userDrag', userDrag.value);
+      return {};
+    });
 
     return testID ? (
       <View testID={testID}>{swipeableComponent}</View>

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -494,7 +494,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
               showLeftProgress.value === 0 ? -hiddenSwipeableOffset : 0,
           },
         ],
-        overflow: showLeftProgress.value === 0 ? 'hidden' : undefined,
       };
     });
 
@@ -531,7 +530,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
               showRightProgress.value === 0 ? hiddenSwipeableOffset : 0,
           },
         ],
-        overflow: showRightProgress.value === 0 ? 'hidden' : undefined,
       };
     });
 
@@ -731,9 +729,11 @@ const styles = StyleSheet.create({
   leftActions: {
     ...StyleSheet.absoluteFillObject,
     flexDirection: I18nManager.isRTL ? 'row-reverse' : 'row',
+    overflow: 'hidden',
   },
   rightActions: {
     ...StyleSheet.absoluteFillObject,
     flexDirection: I18nManager.isRTL ? 'row' : 'row-reverse',
+    overflow: 'hidden',
   },
 });

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -26,6 +26,7 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 import {
+  Dimensions,
   I18nManager,
   LayoutChangeEvent,
   StyleProp,
@@ -481,9 +482,18 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       [rowWidth]
     );
 
+    // React docs: "call this function on every render, rather than caching the value"
+    const hiddenSwipeableOffset = Dimensions.get('window').width + 1;
+
     const leftActionAnimation = useAnimatedStyle(() => {
       return {
-        transform: [{ translateX: showLeftProgress.value === 0 ? -10000 : 0 }],
+        transform: [
+          {
+            translateX:
+              showLeftProgress.value === 0 ? -hiddenSwipeableOffset : 0,
+          },
+        ],
+        overflow: showLeftProgress.value === 0 ? 'hidden' : undefined,
       };
     });
 
@@ -514,7 +524,13 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     const rightActionAnimation = useAnimatedStyle(() => {
       return {
-        transform: [{ translateX: showRightProgress.value === 0 ? 10000 : 0 }],
+        transform: [
+          {
+            translateX:
+              showRightProgress.value === 0 ? hiddenSwipeableOffset : 0,
+          },
+        ],
+        overflow: showRightProgress.value === 0 ? 'hidden' : undefined,
       };
     });
 

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -482,7 +482,8 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       [rowWidth]
     );
 
-    // React docs: "call this function on every render, rather than caching the value"
+    // As stated in `Dimensions.get` docstring, this function should be called on every render
+    // since dimensions may change (e.g. orientation change)
     const hiddenSwipeableOffset = Dimensions.get('window').width + 1;
 
     const leftActionAnimation = useAnimatedStyle(() => {


### PR DESCRIPTION
## Description

Reported by @blazejkustra 

Before this PR, the left action panel could've been partially or entirely covered the right action panel, when the left action panel was opened.

Similarily, the left action panel could've been seen below the right action panel, when the right action panel was opened.
 
## Test plan

- open `New swipeable` example in the `Gesture Handler Example App`
- swipe right on the `Gmail` swipeable
- see how it was `red` (right action) before this PR, and how it is `green` (left action) thanks to this PR
