### PR TITLE
Fix `Swipeable` misalignment after resizing on web

### DIFF
--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -530,7 +530,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         appliedTranslation,
         renderRightActions,
         rightWidth,
-        rowWidth.value,
+        rowWidth,
         showRightProgress,
         swipeableMethods,
       ]

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -432,16 +432,27 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       );
 
     const leftLayoutRef = useAnimatedRef();
+    const leftWrapperLayoutRef = useAnimatedRef();
     const rightLayoutRef = useAnimatedRef();
 
     const updateElementWidths = useCallback(() => {
       'worklet';
       const leftLayout = measure(leftLayoutRef);
+      const leftWrapperLayout = measure(leftWrapperLayoutRef);
       const rightLayout = measure(rightLayoutRef);
       leftWidth.value = leftLayout?.pageX ?? 0;
       rightWidth.value =
-        rowWidth.value - (rightLayout?.pageX ?? rowWidth.value);
-    }, [leftLayoutRef, rightLayoutRef, leftWidth, rightWidth, rowWidth]);
+        rowWidth.value -
+        (rightLayout?.pageX ?? rowWidth.value) +
+        (leftWrapperLayout?.pageX ?? 0);
+    }, [
+      leftLayoutRef,
+      leftWrapperLayoutRef,
+      rightLayoutRef,
+      leftWidth,
+      rightWidth,
+      rowWidth.value,
+    ]);
 
     const swipeableMethods = useMemo<SwipeableMethods>(
       () => ({
@@ -517,7 +528,9 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     const leftElement = useCallback(
       () => (
-        <Animated.View style={[styles.leftActions, leftActionAnimation]}>
+        <Animated.View
+          ref={leftWrapperLayoutRef}
+          style={[styles.leftActions, leftActionAnimation]}>
           {renderLeftActions?.(
             showLeftProgress,
             appliedTranslation,
@@ -530,6 +543,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         appliedTranslation,
         leftActionAnimation,
         leftLayoutRef,
+        leftWrapperLayoutRef,
         renderLeftActions,
         showLeftProgress,
         swipeableMethods,

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -22,6 +22,7 @@ import Animated, {
   interpolate,
   measure,
   runOnJS,
+  runOnUI,
   useAnimatedRef,
   useAnimatedStyle,
   useSharedValue,
@@ -446,17 +447,37 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       () => ({
         close() {
           'worklet';
-          animateRow(0);
+          if (_WORKLET) {
+            animateRow(0);
+            return;
+          }
+          runOnUI(() => {
+            animateRow(0);
+          });
         },
         openLeft() {
           'worklet';
-          updateElementWidths();
-          animateRow(leftWidth.value);
+          if (_WORKLET) {
+            updateElementWidths();
+            animateRow(leftWidth.value);
+            return;
+          }
+          runOnUI(() => {
+            updateElementWidths();
+            animateRow(leftWidth.value);
+          });
         },
         openRight() {
           'worklet';
-          updateElementWidths();
-          animateRow(-rightWidth.value);
+          if (_WORKLET) {
+            updateElementWidths();
+            animateRow(-rightWidth.value);
+            return;
+          }
+          runOnUI(() => {
+            updateElementWidths();
+            animateRow(-rightWidth.value);
+          });
         },
         reset() {
           'worklet';

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -468,12 +468,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     const onRowLayout = useCallback(
       ({ nativeEvent }: LayoutChangeEvent) => {
-        rowWidth.value = nativeEvent.layout.width;
-        leftLayoutRef.current?.measure((x) =>
-          runOnUI(() => (leftWidth.value = x))()
+        runOnUI(() => (rowWidth.value = nativeEvent.layout.width))();
+        leftLayoutRef.current?.measure((_x, _y, _w, _h, pX) =>
+          runOnUI(() => (leftWidth.value = pX))()
         );
-        rightLayoutRef.current?.measure((x) =>
-          runOnUI(() => (rightWidth.value = Math.max(rowWidth.value - x, 0)))()
+        rightLayoutRef.current?.measure((_x, _y, _w, _h, pX) =>
+          runOnUI(() => (rightWidth.value = rowWidth.value - pX))()
         );
       },
       [leftWidth, rightWidth, rowWidth]

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -430,6 +430,17 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         ]
       );
 
+    const leftLayoutRef = useAnimatedRef();
+    const rightLayoutRef = useAnimatedRef();
+
+    const updateElementWidths = useCallback(() => {
+      'worklet';
+      const leftLayout = measure(leftLayoutRef);
+      const rightLayout = measure(rightLayoutRef);
+      leftWidth.value = leftLayout?.pageX ?? 0;
+      rightWidth.value = rowWidth.value - (rightLayout?.pageX ?? 0);
+    }, [leftLayoutRef, rightLayoutRef, leftWidth, rightWidth, rowWidth]);
+
     const swipeableMethods = useMemo<SwipeableMethods>(
       () => ({
         close() {
@@ -438,10 +449,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         },
         openLeft() {
           'worklet';
+          updateElementWidths();
           animateRow(leftWidth.value);
         },
         openRight() {
           'worklet';
+          updateElementWidths();
           animateRow(-rightWidth.value);
         },
         reset() {
@@ -453,13 +466,14 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         },
       }),
       [
+        animateRow,
+        updateElementWidths,
         leftWidth,
         rightWidth,
         userDrag,
         showLeftProgress,
         appliedTranslation,
         rowState,
-        animateRow,
       ]
     );
 
@@ -469,9 +483,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       },
       [rowWidth]
     );
-
-    const leftLayoutRef = useAnimatedRef();
-    const rightLayoutRef = useAnimatedRef();
 
     const leftElement = useCallback(
       () => (
@@ -584,12 +595,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           .enabled(enabled !== false)
           .enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture)
           .activeOffsetX([-dragOffsetFromRightEdge, dragOffsetFromLeftEdge])
-          .onStart(() => {
-            const leftLayout = measure(leftLayoutRef);
-            const rightLayout = measure(rightLayoutRef);
-            leftWidth.value = leftLayout?.pageX ?? 0;
-            rightWidth.value = rowWidth.value - (rightLayout?.pageX ?? 0);
-          })
+          .onStart(updateElementWidths)
           .onUpdate(
             (event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
               userDrag.value = event.translationX;
@@ -630,15 +636,11 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         enableTrackpadTwoFingerGesture,
         enabled,
         handleRelease,
-        leftLayoutRef,
-        leftWidth,
         onSwipeableCloseStartDrag,
         onSwipeableOpenStartDrag,
-        rightLayoutRef,
-        rightWidth,
         rowState,
-        rowWidth,
         updateAnimatedEvent,
+        updateElementWidths,
         userDrag,
       ]
     );

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -471,9 +471,10 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       ({ nativeEvent }: LayoutChangeEvent) => {
         rowWidth.value = nativeEvent.layout.width;
         runOnUI(() => {
+          'worklet';
           const leftLayout = measure(leftLayoutRef);
-          leftWidth.value = leftLayout?.pageX ?? 0;
           const rightLayout = measure(rightLayoutRef);
+          leftWidth.value = leftLayout?.pageX ?? 0;
           rightWidth.value = rowWidth.value - (rightLayout?.pageX ?? 0);
         });
       },

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -29,7 +29,6 @@ import Animated, {
   withSpring,
 } from 'react-native-reanimated';
 import {
-  Dimensions,
   I18nManager,
   LayoutChangeEvent,
   StyleProp,
@@ -509,16 +508,10 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     // As stated in `Dimensions.get` docstring, this function should be called on every render
     // since dimensions may change (e.g. orientation change)
-    const hiddenSwipeableOffset = Dimensions.get('window').width + 1;
 
     const leftActionAnimation = useAnimatedStyle(() => {
       return {
-        transform: [
-          {
-            translateX:
-              showLeftProgress.value === 0 ? -hiddenSwipeableOffset : 0,
-          },
-        ],
+        opacity: showLeftProgress.value === 0 ? 0 : 1,
       };
     });
 
@@ -545,12 +538,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     const rightActionAnimation = useAnimatedStyle(() => {
       return {
-        transform: [
-          {
-            translateX:
-              showRightProgress.value === 0 ? hiddenSwipeableOffset : 0,
-          },
-        ],
+        opacity: showRightProgress.value === 0 ? 0 : 1,
       };
     });
 

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -403,16 +403,17 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             }
           );
 
-          const progressTarget = toValue === 0 ? 0 : 1;
+          const progressTarget = toValue === 0 ? 0 : 1 * Math.sign(toValue);
 
-          showLeftProgress.value =
-            showLeftProgress.value > 0
-              ? withSpring(progressTarget, progressSpringConfig)
-              : 0;
-          showRightProgress.value =
-            showRightProgress.value > 0
-              ? withSpring(progressTarget, progressSpringConfig)
-              : 0;
+          showLeftProgress.value = withSpring(
+            Math.max(progressTarget, 0),
+            progressSpringConfig
+          );
+
+          showRightProgress.value = withSpring(
+            Math.max(-progressTarget, 0),
+            progressSpringConfig
+          );
 
           dispatchImmediateEvents(frozenRowState, toValue);
 

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -22,7 +22,6 @@ import Animated, {
   SharedValue,
   interpolate,
   runOnJS,
-  runOnUI,
   useAnimatedStyle,
   useSharedValue,
   withSpring,
@@ -468,12 +467,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
 
     const onRowLayout = useCallback(
       ({ nativeEvent }: LayoutChangeEvent) => {
-        runOnUI(() => (rowWidth.value = nativeEvent.layout.width))();
-        leftLayoutRef.current?.measure((_x, _y, _w, _h, pX) =>
-          runOnUI(() => (leftWidth.value = pX))()
+        rowWidth.value = nativeEvent.layout.width;
+        leftLayoutRef.current?.measure(
+          (_x, _y, _w, _h, pX) => (leftWidth.value = pX)
         );
-        rightLayoutRef.current?.measure((_x, _y, _w, _h, pX) =>
-          runOnUI(() => (rightWidth.value = rowWidth.value - pX))()
+        rightLayoutRef.current?.measure(
+          (_x, _y, _w, _h, pX) => (rightWidth.value = rowWidth.value - pX)
         );
       },
       [leftWidth, rightWidth, rowWidth]
@@ -490,7 +489,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           <View
             ref={leftLayoutRef}
             onLayout={({ nativeEvent }) =>
-              runOnUI(() => (leftWidth.value = nativeEvent.layout.x))()
+              (leftWidth.value = nativeEvent.layout.x)
             }
           />
         </Animated.View>
@@ -515,13 +514,10 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           <View
             ref={rightLayoutRef}
             onLayout={({ nativeEvent }) => {
-              runOnUI(
-                () =>
-                  (rightWidth.value = Math.max(
-                    rowWidth.value - nativeEvent.layout.x,
-                    0
-                  ))
-              )();
+              rightWidth.value = Math.max(
+                rowWidth.value - nativeEvent.layout.x,
+                0
+              );
             }}
           />
         </Animated.View>

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -453,7 +453,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           }
           runOnUI(() => {
             animateRow(0);
-          });
+          })();
         },
         openLeft() {
           'worklet';
@@ -465,7 +465,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           runOnUI(() => {
             updateElementWidths();
             animateRow(leftWidth.value);
-          });
+          })();
         },
         openRight() {
           'worklet';
@@ -477,7 +477,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           runOnUI(() => {
             updateElementWidths();
             animateRow(-rightWidth.value);
-          });
+          })();
         },
         reset() {
           'worklet';

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -438,7 +438,8 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       const leftLayout = measure(leftLayoutRef);
       const rightLayout = measure(rightLayoutRef);
       leftWidth.value = leftLayout?.pageX ?? 0;
-      rightWidth.value = rowWidth.value - (rightLayout?.pageX ?? 0);
+      rightWidth.value =
+        rowWidth.value - (rightLayout?.pageX ?? rowWidth.value);
     }, [leftLayoutRef, rightLayoutRef, leftWidth, rightWidth, rowWidth]);
 
     const swipeableMethods = useMemo<SwipeableMethods>(

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -440,7 +440,9 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       const leftLayout = measure(leftLayoutRef);
       const leftWrapperLayout = measure(leftWrapperLayoutRef);
       const rightLayout = measure(rightLayoutRef);
-      leftWidth.value = leftLayout?.pageX ?? 0;
+      leftWidth.value =
+        (leftLayout?.pageX ?? 0) - (leftWrapperLayout?.pageX ?? 0);
+
       rightWidth.value =
         rowWidth.value -
         (rightLayout?.pageX ?? rowWidth.value) +

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -697,6 +697,7 @@ export type SwipeableRef = ForwardedRef<SwipeableMethods>;
 const styles = StyleSheet.create({
   container: {
     overflow: 'hidden',
+    width: '100%',
   },
   leftActions: {
     ...StyleSheet.absoluteFillObject,

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -21,6 +21,7 @@ import Animated, {
   SharedValue,
   interpolate,
   runOnJS,
+  runOnUI,
   useAnimatedStyle,
   useSharedValue,
   withSpring,
@@ -256,19 +257,8 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
     const leftWidth = useSharedValue<number>(0);
     const rightWidth = useSharedValue<number>(0);
 
-    // used for synchronizing layout measurements between JS and UI
-    const rightOffset = useSharedValue<number | null>(null);
-
     const showLeftProgress = useSharedValue<number>(0);
     const showRightProgress = useSharedValue<number>(0);
-
-    const updateRightElementWidth = useCallback(() => {
-      'worklet';
-      if (rightOffset.value === null) {
-        rightOffset.value = rowWidth.value;
-      }
-      rightWidth.value = Math.max(0, rowWidth.value - rightOffset.value);
-    }, [rightOffset, rightWidth, rowWidth]);
 
     const updateAnimatedEvent = useCallback(() => {
       'worklet';
@@ -451,8 +441,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         },
         openRight() {
           'worklet';
-          // rightOffset and rowWidth are already much sooner than rightWidth
-          animateRow((rightOffset.value ?? 0) - rowWidth.value);
+          animateRow(-rightWidth.value);
         },
         reset() {
           'worklet';
@@ -464,8 +453,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       }),
       [
         leftWidth,
-        rightOffset,
-        rowWidth,
+        rightWidth,
         userDrag,
         showLeftProgress,
         appliedTranslation,
@@ -515,7 +503,13 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           )}
           <View
             onLayout={({ nativeEvent }) => {
-              rightOffset.value = nativeEvent.layout.x;
+              runOnUI(
+                () =>
+                  (rightWidth.value = Math.max(
+                    rowWidth.value - nativeEvent.layout.x,
+                    0
+                  ))
+              )();
             }}
           />
         </Animated.View>
@@ -523,7 +517,8 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       [
         appliedTranslation,
         renderRightActions,
-        rightOffset,
+        rightWidth,
+        rowWidth.value,
         showRightProgress,
         swipeableMethods,
       ]
@@ -534,8 +529,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         'worklet';
         const { velocityX } = event;
         userDrag.value = event.translationX;
-
-        updateRightElementWidth();
 
         const leftThresholdProp = leftThreshold ?? leftWidth.value / 2;
         const rightThresholdProp = rightThreshold ?? rightWidth.value / 2;
@@ -574,7 +567,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         rightWidth,
         rowState,
         userDrag,
-        updateRightElementWidth,
       ]
     );
 
@@ -603,9 +595,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           .enabled(enabled !== false)
           .enableTrackpadTwoFingerGesture(enableTrackpadTwoFingerGesture)
           .activeOffsetX([-dragOffsetFromRightEdge, dragOffsetFromLeftEdge])
-          .onStart(() => {
-            updateRightElementWidth();
-          })
           .onUpdate(
             (event: GestureUpdateEvent<PanGestureHandlerEventPayload>) => {
               userDrag.value = event.translationX;
@@ -650,7 +639,6 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
         onSwipeableOpenStartDrag,
         rowState,
         updateAnimatedEvent,
-        updateRightElementWidth,
         userDrag,
       ]
     );

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -18,6 +18,7 @@ import {
 import type { PanGestureHandlerProps } from '../handlers/PanGestureHandler';
 import type { PanGestureHandlerEventPayload } from '../handlers/GestureHandlerEventPayload';
 import Animated, {
+  ReduceMotion,
   SharedValue,
   interpolate,
   measure,
@@ -363,11 +364,12 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           'worklet';
 
           const translationSpringConfig = {
-            duration: 1000,
-            dampingRatio: 0.9,
-            stiffness: 500,
+            mass: 2,
+            damping: 1000,
+            stiffness: 700,
             velocity: velocityX,
             overshootClamping: true,
+            reduceMotion: ReduceMotion.System,
             ...animationOptions,
           };
 

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -8,6 +8,7 @@ import React, {
   useCallback,
   useImperativeHandle,
   useMemo,
+  useRef,
 } from 'react';
 import { GestureObjects as Gesture } from '../handlers/gestures/gestureObjects';
 import { GestureDetector } from '../handlers/gestures/GestureDetector';
@@ -462,11 +463,20 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       ]
     );
 
+    const leftLayoutRef = useRef<View>(null);
+    const rightLayoutRef = useRef<View>(null);
+
     const onRowLayout = useCallback(
       ({ nativeEvent }: LayoutChangeEvent) => {
         rowWidth.value = nativeEvent.layout.width;
+        leftLayoutRef.current?.measure((x) =>
+          runOnUI(() => (leftWidth.value = x))()
+        );
+        rightLayoutRef.current?.measure((x) =>
+          runOnUI(() => (rightWidth.value = Math.max(rowWidth.value - x, 0)))()
+        );
       },
-      [rowWidth]
+      [leftWidth, rightWidth, rowWidth]
     );
 
     const leftElement = useCallback(
@@ -478,8 +488,9 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             swipeableMethods
           )}
           <View
+            ref={leftLayoutRef}
             onLayout={({ nativeEvent }) =>
-              (leftWidth.value = nativeEvent.layout.x)
+              runOnUI(() => (leftWidth.value = nativeEvent.layout.x))()
             }
           />
         </Animated.View>
@@ -502,6 +513,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
             swipeableMethods
           )}
           <View
+            ref={rightLayoutRef}
             onLayout={({ nativeEvent }) => {
               runOnUI(
                 () =>


### PR DESCRIPTION
## Description

This PR allows Swipeable to be dynamically resized.

Fixes #3333

## Test plan

- open any swipeable example on web
- resize window
- see how the `ReanimatedSwipeable` still works, while the legacy `Swipeable` is misaligned