### PR TITLE
Don’t pass gesture handler wrapper props to child

### DIFF
--- a/src/handlers/createNativeWrapper.tsx
+++ b/src/handlers/createNativeWrapper.tsx
@@ -29,17 +29,23 @@ export default function createNativeWrapper<P>(
     P & NativeViewGestureHandlerProps
   >((props, ref) => {
     // Filter out props that should be passed to gesture handler wrapper
-    const gestureHandlerProps = Object.keys(props).reduce(
+    const { gestureHandlerProps, childProps } = Object.keys(props).reduce(
       (res, key) => {
         // TS being overly protective with it's types, see https://github.com/microsoft/TypeScript/issues/26255#issuecomment-458013731 for more info
         const allowedKeys: readonly string[] = NATIVE_WRAPPER_PROPS_FILTER;
         if (allowedKeys.includes(key)) {
           // @ts-ignore FIXME(TS)
-          res[key] = props[key];
+          res.gestureHandlerProps[key] = props[key];
+        } else {
+          // @ts-ignore FIXME(TS)
+          res.childProps[key] = props[key];
         }
         return res;
       },
-      { ...config } // Watch out not to modify config
+      {
+        gestureHandlerProps: { ...config }, // Watch out not to modify config
+        childProps: {} as P,
+      }
     );
     const _ref = useRef<React.ComponentType<P>>();
     const _gestureHandlerRef = useRef<React.ComponentType<P>>();
@@ -63,7 +69,7 @@ export default function createNativeWrapper<P>(
         {...gestureHandlerProps}
         // @ts-ignore TODO(TS)
         ref={_gestureHandlerRef}>
-        <Component {...props} ref={_ref} />
+        <Component {...childProps} ref={_ref} />
       </NativeViewGestureHandler>
     );
   });

--- a/src/handlers/createNativeWrapper.tsx
+++ b/src/handlers/createNativeWrapper.tsx
@@ -44,7 +44,7 @@ export default function createNativeWrapper<P>(
       },
       {
         gestureHandlerProps: { ...config }, // Watch out not to modify config
-        childProps: {} as P,
+        childProps: { enabled: props.enabled } as P,
       }
     );
     const _ref = useRef<React.ComponentType<P>>();


### PR DESCRIPTION
## Description

When using useEvent from Reanimated together with PureNativeButton, I noticed that I would receive duplicate events. Upon further investigation I found that this was because createHandler renames the handlers and when reanimated attaches the worklet it does so twice because the same handler is available under different props.

This PR fixes this problem by simply not passing wrapper specific props to the child.

## Test plan

<!--
Describe how did you test this change here.
-->
