### PR TITLE
exports PressableStateCallbackType

### DIFF
--- a/src/components/Pressable/PressableProps.tsx
+++ b/src/components/Pressable/PressableProps.tsx
@@ -1,22 +1,15 @@
 import {
-  ColorValue,
   AccessibilityProps,
   ViewProps,
   Insets,
   StyleProp,
   ViewStyle,
+  PressableStateCallbackType as RNPressableStateCallbackType,
+  PressableAndroidRippleConfig as RNPressableAndroidRippleConfig,
 } from 'react-native';
 
-export interface PressableStateCallbackType {
-  readonly pressed: boolean;
-}
-
-export interface PressableAndroidRippleConfig {
-  color?: null | ColorValue | undefined;
-  borderless?: null | boolean | undefined;
-  radius?: null | number | undefined;
-  foreground?: null | boolean | undefined;
-}
+export type PressableStateCallbackType = RNPressableStateCallbackType;
+export type PressableAndroidRippleConfig = RNPressableAndroidRippleConfig;
 
 export type InnerPressableEvent = {
   changedTouches: InnerPressableEvent[];

--- a/src/components/Pressable/index.ts
+++ b/src/components/Pressable/index.ts
@@ -1,2 +1,5 @@
-export type { PressableProps } from './PressableProps';
+export type {
+  PressableProps,
+  PressableStateCallbackType,
+} from './PressableProps';
 export { default } from './Pressable';

--- a/src/index.ts
+++ b/src/index.ts
@@ -145,7 +145,10 @@ export type {
 
 export type { SwipeableProps } from './components/Swipeable';
 export { default as Swipeable } from './components/Swipeable';
-export type { PressableProps } from './components/Pressable';
+export type {
+  PressableProps,
+  PressableStateCallbackType,
+} from './components/Pressable';
 export { default as Pressable } from './components/Pressable';
 
 export type {


### PR DESCRIPTION
## Description

This is an absolute small fix, just exporting the `PressableStateCallbackType` type.

The type was already marked as `export` but not included in the other files.

## Test plan

<!--
Describe how did you test this change here.
-->
