### PR TITLE
Fix `ReanimatedSwipeable` reanimated warnings 

### DIFF
--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -466,7 +466,7 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       rightLayoutRef,
       leftWidth,
       rightWidth,
-      rowWidth.value,
+      rowWidth,
     ]);
 
     const swipeableMethods = useMemo<SwipeableMethods>(


### PR DESCRIPTION

## Description

Fix -  WARN  [Reanimated] Reading from `value` during component render.  in react-native-gesture-handler version 2.22.1

This warning appear when you use Swipeable component.

Change : 
in src/components/ReanimatedSwipeable.tsx
replace rowWidth.value to rowWidth in the dependency array of updateElementWidths callback.

#3170 #3320

## Test plan

Tested on Samsung Galaxy A52, android emulator and Iphone 13
