### PR TITLE
Fix android ripple color bug on fabric

### DIFF
--- a/src/components/GestureButtons.tsx
+++ b/src/components/GestureButtons.tsx
@@ -121,16 +121,16 @@ class InnerBaseButton extends React.Component<BaseButtonWithRefProps> {
   };
 
   render() {
-    const { rippleColor, style, ...rest } = this.props;
+    const { rippleColor: unprocessedRippleColor, style, ...rest } = this.props;
 
-    const processedRippleColor = isFabric()
-      ? rippleColor
-      : processColor(rippleColor ?? undefined);
+    const rippleColor = isFabric()
+      ? unprocessedRippleColor
+      : processColor(unprocessedRippleColor ?? undefined);
 
     return (
       <RawButton
         ref={this.props.innerRef}
-        rippleColor={processedRippleColor}
+        rippleColor={rippleColor}
         style={[style, Platform.OS === 'ios' && { cursor: undefined }]}
         {...rest}
         onGestureEvent={this.onGestureEvent}

--- a/src/components/GestureButtons.tsx
+++ b/src/components/GestureButtons.tsx
@@ -25,6 +25,8 @@ export const RawButton = createNativeWrapper(GestureHandlerButton, {
   shouldActivateOnStart: false,
 });
 
+let IS_FABRIC: null | boolean = null;
+
 class InnerBaseButton extends React.Component<BaseButtonWithRefProps> {
   static defaultProps = {
     delayLongPress: 600,
@@ -123,7 +125,11 @@ class InnerBaseButton extends React.Component<BaseButtonWithRefProps> {
   render() {
     const { rippleColor: unprocessedRippleColor, style, ...rest } = this.props;
 
-    const rippleColor = isFabric()
+    if (IS_FABRIC === null) {
+      IS_FABRIC = isFabric();
+    }
+
+    const rippleColor = IS_FABRIC
       ? unprocessedRippleColor
       : processColor(unprocessedRippleColor ?? undefined);
 

--- a/src/components/GestureButtons.tsx
+++ b/src/components/GestureButtons.tsx
@@ -18,6 +18,7 @@ import type {
   BorderlessButtonWithRefProps,
   BorderlessButtonProps,
 } from './GestureButtonsProps';
+import { isFabric } from '../utils';
 
 export const RawButton = createNativeWrapper(GestureHandlerButton, {
   shouldCancelWhenOutside: false,
@@ -122,10 +123,14 @@ class InnerBaseButton extends React.Component<BaseButtonWithRefProps> {
   render() {
     const { rippleColor, style, ...rest } = this.props;
 
+    const processedRippleColor = isFabric()
+      ? rippleColor
+      : processColor(rippleColor ?? undefined);
+
     return (
       <RawButton
         ref={this.props.innerRef}
-        rippleColor={processColor(rippleColor)}
+        rippleColor={processedRippleColor}
         style={[style, Platform.OS === 'ios' && { cursor: undefined }]}
         {...rest}
         onGestureEvent={this.onGestureEvent}

--- a/src/components/GestureButtonsProps.ts
+++ b/src/components/GestureButtonsProps.ts
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { AccessibilityProps, StyleProp, ViewStyle } from 'react-native';
+import {
+  AccessibilityProps,
+  ColorValue,
+  StyleProp,
+  ViewStyle,
+} from 'react-native';
 import type { NativeViewGestureHandlerProps } from '../handlers/NativeViewGestureHandler';
 
 export interface RawButtonProps
@@ -16,7 +21,7 @@ export interface RawButtonProps
    *
    * Defines color of native ripple animation used since API level 21.
    */
-  rippleColor?: any; // it was present in BaseButtonProps before but is used here in code
+  rippleColor?: number | ColorValue | null;
 
   /**
    * Android only.

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -379,15 +379,15 @@ export default function Pressable(props: PressableProps) {
       ? children({ pressed: pressedState })
       : children;
 
-  const memoIsFabric = useCallback(() => isFabric, []);
+  const isFabricValue = useMemo(() => isFabric(), []);
 
   const rippleColor = useMemo(() => {
     const defaultRippleColor = android_ripple ? undefined : 'transparent';
     const unprocessedRippleColor = android_ripple?.color ?? defaultRippleColor;
-    return memoIsFabric()
+    return isFabricValue
       ? unprocessedRippleColor
       : processColor(unprocessedRippleColor);
-  }, [android_ripple, memoIsFabric]);
+  }, [android_ripple, isFabricValue]);
 
   return (
     <GestureDetector gesture={gesture}>

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -366,8 +366,6 @@ export default function Pressable(props: PressableProps) {
 
   const gesture = Gesture.Simultaneous(...gestures);
 
-  const defaultRippleColor = android_ripple ? undefined : 'transparent';
-
   // `cursor: 'pointer'` on `RNButton` crashes iOS
   const pointerStyle: StyleProp<ViewStyle> =
     Platform.OS === 'web' ? { cursor: 'pointer' } : {};
@@ -380,10 +378,17 @@ export default function Pressable(props: PressableProps) {
       ? children({ pressed: pressedState })
       : children;
 
-  const unprocessedRippleColor = android_ripple?.color ?? defaultRippleColor;
-  const rippleColor = isFabric()
-    ? unprocessedRippleColor
-    : processColor(unprocessedRippleColor);
+  const defaultRippleColor = useMemo(
+    () => (android_ripple ? undefined : 'transparent'),
+    [android_ripple]
+  );
+
+  const rippleColor = useMemo(() => {
+    const unprocessedRippleColor = android_ripple?.color ?? defaultRippleColor;
+    return isFabric()
+      ? unprocessedRippleColor
+      : processColor(unprocessedRippleColor);
+  }, [android_ripple?.color, defaultRippleColor]);
 
   return (
     <GestureDetector gesture={gesture}>

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -20,7 +20,7 @@ import {
 } from './utils';
 import { PressabilityDebugView } from '../../handlers/PressabilityDebugView';
 import { GestureTouchEvent } from '../../handlers/gestureHandlerCommon';
-import { INT32_MAX } from '../../utils';
+import { INT32_MAX, isFabricUsed } from '../../utils';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;
 
@@ -380,6 +380,11 @@ export default function Pressable(props: PressableProps) {
       ? children({ pressed: pressedState })
       : children;
 
+  const fabricRippleColor = android_ripple?.color ?? defaultRippleColor;
+  const rippleColor = isFabricUsed()
+    ? fabricRippleColor
+    : processColor(fabricRippleColor);
+
   return (
     <GestureDetector gesture={gesture}>
       <NativeButton
@@ -388,7 +393,7 @@ export default function Pressable(props: PressableProps) {
         hitSlop={appliedHitSlop}
         enabled={isPressableEnabled}
         touchSoundDisabled={android_disableSound ?? undefined}
-        rippleColor={processColor(android_ripple?.color ?? defaultRippleColor)}
+        rippleColor={rippleColor}
         rippleRadius={android_ripple?.radius ?? undefined}
         style={[pointerStyle, styleProp]}>
         {childrenProp}

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -379,13 +379,15 @@ export default function Pressable(props: PressableProps) {
       ? children({ pressed: pressedState })
       : children;
 
+  const memoIsFabric = useCallback(() => isFabric, []);
+
   const rippleColor = useMemo(() => {
     const defaultRippleColor = android_ripple ? undefined : 'transparent';
     const unprocessedRippleColor = android_ripple?.color ?? defaultRippleColor;
-    return isFabric()
+    return memoIsFabric()
       ? unprocessedRippleColor
       : processColor(unprocessedRippleColor);
-  }, [android_ripple]);
+  }, [android_ripple, memoIsFabric]);
 
   return (
     <GestureDetector gesture={gesture}>

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -380,10 +380,10 @@ export default function Pressable(props: PressableProps) {
       ? children({ pressed: pressedState })
       : children;
 
-  const fabricRippleColor = android_ripple?.color ?? defaultRippleColor;
+  const unprocessedRippleColor = android_ripple?.color ?? defaultRippleColor;
   const rippleColor = isFabric()
-    ? fabricRippleColor
-    : processColor(fabricRippleColor);
+    ? unprocessedRippleColor
+    : processColor(unprocessedRippleColor);
 
   return (
     <GestureDetector gesture={gesture}>

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -20,7 +20,7 @@ import {
 } from './utils';
 import { PressabilityDebugView } from '../../handlers/PressabilityDebugView';
 import { GestureTouchEvent } from '../../handlers/gestureHandlerCommon';
-import { INT32_MAX, isFabricUsed } from '../../utils';
+import { INT32_MAX, isFabric } from '../../utils';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;
 
@@ -381,7 +381,7 @@ export default function Pressable(props: PressableProps) {
       : children;
 
   const fabricRippleColor = android_ripple?.color ?? defaultRippleColor;
-  const rippleColor = isFabricUsed()
+  const rippleColor = isFabric()
     ? fabricRippleColor
     : processColor(fabricRippleColor);
 

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -25,6 +25,8 @@ import { INT32_MAX, isFabric, isTestEnv } from '../../utils';
 const DEFAULT_LONG_PRESS_DURATION = 500;
 const IS_TEST_ENV = isTestEnv();
 
+let IS_FABRIC: null | boolean = null;
+
 export default function Pressable(props: PressableProps) {
   const {
     testOnly_pressed,
@@ -379,15 +381,17 @@ export default function Pressable(props: PressableProps) {
       ? children({ pressed: pressedState })
       : children;
 
-  const isFabricValue = useMemo(() => isFabric(), []);
-
   const rippleColor = useMemo(() => {
+    if (IS_FABRIC === null) {
+      IS_FABRIC = isFabric();
+    }
+
     const defaultRippleColor = android_ripple ? undefined : 'transparent';
     const unprocessedRippleColor = android_ripple?.color ?? defaultRippleColor;
-    return isFabricValue
+    return IS_FABRIC
       ? unprocessedRippleColor
       : processColor(unprocessedRippleColor);
-  }, [android_ripple, isFabricValue]);
+  }, [android_ripple]);
 
   return (
     <GestureDetector gesture={gesture}>

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -378,17 +378,13 @@ export default function Pressable(props: PressableProps) {
       ? children({ pressed: pressedState })
       : children;
 
-  const defaultRippleColor = useMemo(
-    () => (android_ripple ? undefined : 'transparent'),
-    [android_ripple]
-  );
-
   const rippleColor = useMemo(() => {
+    const defaultRippleColor = android_ripple ? undefined : 'transparent';
     const unprocessedRippleColor = android_ripple?.color ?? defaultRippleColor;
     return isFabric()
       ? unprocessedRippleColor
       : processColor(unprocessedRippleColor);
-  }, [android_ripple?.color, defaultRippleColor]);
+  }, [android_ripple]);
 
   return (
     <GestureDetector gesture={gesture}>

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -40,13 +40,6 @@ export function isJestEnv(): boolean {
   return hasProperty(global, 'process') && !!process.env.JEST_WORKER_ID;
 }
 
-export function isFabricUsed(): boolean {
-  return (
-    // @ts-ignore global is untyped, but always present, nativeFabricUIManager will be present when running on fabric
-    hasProperty(global, 'nativeFabricUIManager') && !!nativeFabricUIManager
-  );
-}
-
 export function tagMessage(msg: string) {
   return `[react-native-gesture-handler] ${msg}`;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,6 @@ export function hasProperty(object: object, key: string) {
 
 export function isJestEnv(): boolean {
   // @ts-ignore Do not use `@types/node` because it will prioritise Node types over RN types which breaks the types (ex. setTimeout) in React Native projects.
-  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   return hasProperty(global, 'process') && !!process.env.JEST_WORKER_ID;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -36,7 +36,15 @@ export function hasProperty(object: object, key: string) {
 
 export function isJestEnv(): boolean {
   // @ts-ignore Do not use `@types/node` because it will prioritise Node types over RN types which breaks the types (ex. setTimeout) in React Native projects.
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   return hasProperty(global, 'process') && !!process.env.JEST_WORKER_ID;
+}
+
+export function isFabricUsed(): boolean {
+  return (
+    // @ts-ignore global is untyped, but always present, nativeFabricUIManager will be present when running on fabric
+    hasProperty(global, 'nativeFabricUIManager') && !!nativeFabricUIManager
+  );
 }
 
 export function tagMessage(msg: string) {


### PR DESCRIPTION
## Description

Android ripple currently does not work on `Fabric`, as all values passed to `RawButton` and it's inheritors are passed through `processColor`, which is crucial on `Paper`, and broken on `Fabric`.

This PR disables usage of `processColor`, when running on `Fabric`.

Note: `isFabric` cannot be moved out of the body of the `Pressable`, as it likely won't be initialised before the `Pressable` starts being rendered. More details [here](https://github.com/software-mansion/react-native-gesture-handler/blob/b3d8fd91dca195267bdc33aa20fd6f5cd37d7fe2/src/utils.ts#L47).

Fixes #3246
Fixes #3312
Supersedes #3250
Likely could add a workaround for https://github.com/software-mansion/react-native-reanimated/issues/6935

## Test plan

<details>
<summary>
Collapsed test code
</summary>

```tsx
import React from 'react';
import { Pressable as RNPressable, StyleSheet, Text } from 'react-native';
import {
  BaseButton,
  GestureHandlerRootView,
  RectButton,
  Pressable,
} from 'react-native-gesture-handler';

const App = () => {
  return (
    <GestureHandlerRootView>
      <RectButton style={styles.wrapperCustom} rippleColor={'blue'}>
        <Text style={styles.text}>RectButton</Text>
      </RectButton>
      <BaseButton style={styles.wrapperCustom} rippleColor={'blue'}>
        <Text style={styles.text}>BaseButton</Text>
      </BaseButton>
      <Pressable
        style={styles.wrapperCustom}
        android_ripple={{ color: 'blue' }}>
        {({ pressed }) => (
          <Text style={styles.text}>
            {pressed ? 'Pressed!' : 'Pressable from react-native'}
          </Text>
        )}
      </Pressable>
      <RNPressable
        style={styles.wrapperCustom}
        android_ripple={{ color: 'blue' }}>
        {({ pressed }) => (
          <Text style={styles.text}>
            {pressed ? 'Pressed!' : 'Pressable from react-native'}
          </Text>
        )}
      </RNPressable>
      <Pressable
        style={styles.wrapperCustom}
        android_ripple={{ color: '#00f' }}>
        {({ pressed }) => (
          <Text style={styles.text}>
            {pressed ? 'Pressed!' : 'Pressable from react-native'}
          </Text>
        )}
      </Pressable>
      <RNPressable
        style={styles.wrapperCustom}
        android_ripple={{ color: '#00f' }}>
        {({ pressed }) => (
          <Text style={styles.text}>
            {pressed ? 'Pressed!' : 'Pressable from react-native'}
          </Text>
        )}
      </RNPressable>
    </GestureHandlerRootView>
  );
};

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    gap: 16,
    padding: 16,
  },
  text: {
    fontSize: 32,
  },
  wrapperCustom: {
    borderRadius: 8,
    padding: 6,
    flex: 1,
    backgroundColor: 'papayawhip',
    borderColor: 'red',
    borderWidth: 2,
  },
  logBox: {
    flex: 1,
    padding: 20,
    margin: 10,
    borderWidth: StyleSheet.hairlineWidth,
    borderColor: '#f0f0f0',
    backgroundColor: '#f9f9f9',
  },
});

export default App;

```

</details>
