### PR TITLE
fix: overlapping buttons cause buttons to stop being responsive

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -260,11 +260,12 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
     }
 
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
+      if (touchResponder != null && touchResponder !== this) {
+        return false
+      }
       if (super.onInterceptTouchEvent(ev)) {
         return true
       }
-      // We call `onTouchEvent` and wait until button changes state to `pressed`, if it's pressed
-      // we return true so that the gesture handler can activate.
       onTouchEvent(ev)
       return isPressed
     }
@@ -288,6 +289,16 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
      * [com.swmansion.gesturehandler.NativeViewGestureHandler.onHandle]  */
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
+
+      if (touchResponder != null && touchResponder !== this) {
+        if (isPressed) {
+          setPressed(false)
+        }
+        lastEventTime = event.eventTime
+        lastAction = event.action
+        return false
+      }
+      
       val eventTime = event.eventTime
       val action = event.action
 
@@ -435,7 +446,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       }
     }
 
-    private fun tryGrabbingResponder(): Boolean {
+        private fun tryGrabbingResponder(): Boolean {
       if (isChildTouched()) {
         return false
       }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -260,9 +260,6 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
     }
 
     override fun onInterceptTouchEvent(ev: MotionEvent): Boolean {
-      if (touchResponder != null && touchResponder !== this) {
-        return false
-      }
       if (super.onInterceptTouchEvent(ev)) {
         return true
       }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -288,18 +288,17 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
      * [com.swmansion.gesturehandler.NativeViewGestureHandler.onHandle]  */
     @SuppressLint("ClickableViewAccessibility")
     override fun onTouchEvent(event: MotionEvent): Boolean {
+      val eventTime = event.eventTime
+      val action = event.action
 
       if (touchResponder != null && touchResponder !== this) {
         if (isPressed) {
           setPressed(false)
         }
-        lastEventTime = event.eventTime
-        lastAction = event.action
+        lastEventTime = eventTime
+        lastAction = action
         return false
       }
-
-      val eventTime = event.eventTime
-      val action = event.action
 
       if (event.action == MotionEvent.ACTION_CANCEL) {
         tryFreeingResponder()

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -296,15 +296,13 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       val eventTime = event.eventTime
       val action = event.action
 
-      if (touchResponder != null && touchResponder !== this) {
-        if (touchResponder!!.exclusive) {
-          if (isPressed) {
-            setPressed(false)
-          }
-          lastEventTime = eventTime
-          lastAction = action
-          return false
+      if (touchResponder != null && touchResponder !== this && touchResponder!!.exclusive) {
+        if (isPressed) {
+          setPressed(false)
         }
+        lastEventTime = eventTime
+        lastAction = action
+        return false
       }
 
       if (event.action == MotionEvent.ACTION_CANCEL) {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -292,12 +292,14 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       val action = event.action
 
       if (touchResponder != null && touchResponder !== this) {
-        if (isPressed) {
-          setPressed(false)
+        if (touchResponder!!.exclusive) {
+          if (isPressed) {
+            setPressed(false)
+          }
+          lastEventTime = eventTime
+          lastAction = action
+          return false
         }
-        lastEventTime = eventTime
-        lastAction = action
-        return false
       }
 
       if (event.action == MotionEvent.ACTION_CANCEL) {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -266,6 +266,8 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       if (super.onInterceptTouchEvent(ev)) {
         return true
       }
+      // We call `onTouchEvent` and wait until button changes state to `pressed`, if it's pressed
+      // we return true so that the gesture handler can activate.
       onTouchEvent(ev)
       return isPressed
     }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -298,7 +298,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
         lastAction = event.action
         return false
       }
-      
+
       val eventTime = event.eventTime
       val action = event.action
 
@@ -446,7 +446,7 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
       }
     }
 
-        private fun tryGrabbingResponder(): Boolean {
+    private fun tryGrabbingResponder(): Boolean {
       if (isChildTouched()) {
         return false
       }


### PR DESCRIPTION
## Description

Partially resolves problem in #3370

This PR fixes an issue where a behind button could stay stuck in the "pressed" state if another overlapping button took the responder. By adding a check in onTouchEvent, we ensure that only one button can stay pressed at a time. If another button is already the responder, the behind button cancels itself and won't remain highlighted.

It will not solve the issue if both button are not exclusive. For this edge case better solution is needed.

## With this fix:
https://github.com/user-attachments/assets/b88ff1d1-cf1c-4a62-9967-7dd25e2f3dc0

## Without this fix:
https://github.com/user-attachments/assets/b69771d2-655c-4fa6-b5b2-9edd37d32e9c


## Test plan

https://snack.expo.dev/@oblador/gesture-handler-overlap-reproduction

<details>

<summary>Collapsed test code</summary>

```tsx
import { Text, View, StyleSheet, ScrollView } from 'react-native';
import {
  BaseButton,
  GestureHandlerRootView,
} from 'react-native-gesture-handler';

export default function App() {
  return (
    <GestureHandlerRootView>
      <View style={styles.container}>
        <BaseButton
          style={styles.button}
          shouldCancelWhenOutside={true}
          onHandlerStateChange={(event) => console.log(event.nativeEvent)}>
          <Text>Behind</Text>
        </BaseButton>
        <BaseButton
          style={[styles.button, styles.onTop]}
          shouldCancelWhenOutside={true}
          onHandlerStateChange={(event) => console.log(event.nativeEvent)}>
          <Text>On top</Text>
        </BaseButton>
      </View>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    backgroundColor: '#ecf0f1',
    justifyContent: 'center',
  },
  button: {
    padding: 30,
    borderWidth: 1,
    backgroundColor: '#ffffff99',
  },
  onTop: {
    position: 'relative',
    top: -40,
    left: 100,
    right: 20,
  },
});
```
</details>
