### PR TITLE
Unregister from oldGestureHandler when component unmounts

### DIFF
--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -8,7 +8,11 @@ import {
 import { customDirectEventTypes } from './customDirectEventTypes';
 import RNGestureHandlerModule from '../RNGestureHandlerModule';
 import { State } from '../State';
-import { handlerIDToTag, registerOldGestureHandler, unregisterOldGestureHandler } from './handlersRegistry';
+import {
+  handlerIDToTag,
+  registerOldGestureHandler,
+  unregisterOldGestureHandler,
+} from './handlersRegistry';
 import { getNextHandlerTag } from './getNextHandlerTag';
 
 import {
@@ -255,7 +259,7 @@ export default function createHandler<
     componentWillUnmount() {
       this.inspectorToggleListener?.remove();
       this.isMountedRef.current = false;
-      if (Platform.OS !== 'web')  {
+      if (Platform.OS !== 'web') {
         unregisterOldGestureHandler(this.handlerTag);
       }
       RNGestureHandlerModule.dropGestureHandler(this.handlerTag);

--- a/src/handlers/createHandler.tsx
+++ b/src/handlers/createHandler.tsx
@@ -8,7 +8,7 @@ import {
 import { customDirectEventTypes } from './customDirectEventTypes';
 import RNGestureHandlerModule from '../RNGestureHandlerModule';
 import { State } from '../State';
-import { handlerIDToTag, registerOldGestureHandler } from './handlersRegistry';
+import { handlerIDToTag, registerOldGestureHandler, unregisterOldGestureHandler } from './handlersRegistry';
 import { getNextHandlerTag } from './getNextHandlerTag';
 
 import {
@@ -255,6 +255,9 @@ export default function createHandler<
     componentWillUnmount() {
       this.inspectorToggleListener?.remove();
       this.isMountedRef.current = false;
+      if (Platform.OS !== 'web')  {
+        unregisterOldGestureHandler(this.handlerTag);
+      }
       RNGestureHandlerModule.dropGestureHandler(this.handlerTag);
       scheduleFlushOperations();
       // We can't use this.props.id directly due to TS generic type narrowing bug, see https://github.com/microsoft/TypeScript/issues/13995 for more context

--- a/src/handlers/handlersRegistry.ts
+++ b/src/handlers/handlersRegistry.ts
@@ -25,6 +25,10 @@ export function registerOldGestureHandler(
   oldHandlers.set(handlerTag, handler);
 }
 
+export function unregisterOldGestureHandler(handlerTag: number) {
+  oldHandlers.delete(handlerTag);
+}
+
 export function unregisterHandler(handlerTag: number, testID?: string) {
   gestures.delete(handlerTag);
   if (isTestEnv() && testID) {


### PR DESCRIPTION
## Description

We might have discovered a memory leak associated with oldGestureHandler registry. Nothing ever gets removed from it. We noticed a lot of hanging GenericTouchable components at runtime associated with this registry.

## Test plan

After applying this patch on our repo, the same profiling workflow did not show the same amount of hanging GenericTouchables. However, I don't know whats the proper way to verify and test this. 