### PR TITLE
Fix android new arch crash on RN 0.75

### DIFF
--- a/android/src/main/jni/cpp-adapter.cpp
+++ b/android/src/main/jni/cpp-adapter.cpp
@@ -1,8 +1,6 @@
 #include <jni.h>
 #include <jsi/jsi.h>
 
-#include <react/renderer/components/text/ParagraphShadowNode.h>
-#include <react/renderer/components/text/TextShadowNode.h>
 #include <react/renderer/uimanager/primitives.h>
 
 using namespace facebook;


### PR DESCRIPTION
## Description

Fixes build failure on android when using new architecture and RN 0.75.
Issue introduced here: https://github.com/software-mansion/react-native-gesture-handler/pull/3338

## Test plan

Build example app for android, with new arch and RN 0.75
