### PR TITLE
Fixed Android build on RN 0.78

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNViewConfigurationHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNViewConfigurationHelper.kt
@@ -14,7 +14,11 @@ class RNViewConfigurationHelper : ViewConfigurationHelper {
   override fun getPointerEventsConfigForView(view: View): PointerEventsConfig {
     val pointerEvents: PointerEvents =
       if (view is ReactPointerEventsView) {
-        (view as ReactPointerEventsView).pointerEvents
+        #if REACT_NATIVE_MINOR_VERSION >= 78
+          (view as ReactPointerEventsView).getPointerEvents()
+        #else
+          (view as ReactPointerEventsView).pointerEvents
+        #endif
       } else PointerEvents.AUTO
 
     // Views that are disabled should never be the target of pointer events. However, their children


### PR DESCRIPTION
## Description

pointerEvents in RN 0.78 changes from .pointerEvents to .getPointerEvents()

https://github.com/facebook/react-native/commit/45e4a3afceb4be3047cd01a60ec2c9f806ed30fe

There is a similar [PR](https://github.com/software-mansion/react-native-gesture-handler/pull/3354) but it includes a lot more changes and doesn't check for RN versions so would break with older versions of RN.

## Test plan

Didn't test as it's a simple change to fix the build
