### PR TITLE
chore(docs): add actionable advice to deprecation warnings

### DIFF
--- a/docs/docs/components/touchables.md
+++ b/docs/docs/components/touchables.md
@@ -5,7 +5,7 @@ sidebar_label: Touchables
 ---
 
 :::warning
-Touchables will be removed in the future version of Gesture Handler.
+Touchables will be removed in the future version of Gesture Handler. Use Pressable instead.
 :::
 
 Gesture Handler library provides an implementation of RN's touchable components that are based on [native buttons](buttons.mdx) and does not rely on JS responder system utilized by RN. Our touchable implementation follows the same API and aims to be a drop-in replacement for touchables available in React Native.

--- a/src/components/touchables/TouchableHighlight.tsx
+++ b/src/components/touchables/TouchableHighlight.tsx
@@ -20,13 +20,13 @@ interface State {
 }
 
 /**
- * @deprecated TouchableHighlight will be removed in the future version of Gesture Handler.
+ * @deprecated TouchableHighlight will be removed in the future version of Gesture Handler. Use Pressable instead.
  */
 export type TouchableHighlightProps = RNTouchableHighlightProps &
   GenericTouchableProps;
 
 /**
- * @deprecated TouchableHighlight will be removed in the future version of Gesture Handler.
+ * @deprecated TouchableHighlight will be removed in the future version of Gesture Handler. Use Pressable instead.
  *
  * TouchableHighlight follows RN's implementation
  */

--- a/src/components/touchables/TouchableNativeFeedback.android.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.android.tsx
@@ -8,7 +8,7 @@ import {
 } from './TouchableNativeFeedbackProps';
 
 /**
- * @deprecated TouchableNativeFeedback will be removed in the future version of Gesture Handler.
+ * @deprecated TouchableNativeFeedback will be removed in the future version of Gesture Handler. Use Pressable instead.
  *
  * TouchableNativeFeedback behaves slightly different than RN's TouchableNativeFeedback.
  * There's small difference with handling long press ripple since RN's implementation calls

--- a/src/components/touchables/TouchableNativeFeedback.tsx
+++ b/src/components/touchables/TouchableNativeFeedback.tsx
@@ -1,7 +1,7 @@
 import { TouchableNativeFeedback as RNTouchableNativeFeedback } from 'react-native';
 
 /**
- * @deprecated TouchableNativeFeedback will be removed in the future version of Gesture Handler.
+ * @deprecated TouchableNativeFeedback will be removed in the future version of Gesture Handler. Use Pressable instead.
  */
 const TouchableNativeFeedback = RNTouchableNativeFeedback;
 

--- a/src/components/touchables/TouchableNativeFeedbackProps.tsx
+++ b/src/components/touchables/TouchableNativeFeedbackProps.tsx
@@ -9,7 +9,7 @@ export type TouchableNativeFeedbackExtraProps = {
 };
 
 /**
- * @deprecated TouchableNativeFeedback will be removed in the future version of Gesture Handler.
+ * @deprecated TouchableNativeFeedback will be removed in the future version of Gesture Handler. Use Pressable instead.
  */
 export type TouchableNativeFeedbackProps = RNTouchableNativeFeedbackProps &
   GenericTouchableProps;

--- a/src/components/touchables/TouchableOpacity.tsx
+++ b/src/components/touchables/TouchableOpacity.tsx
@@ -11,7 +11,7 @@ import * as React from 'react';
 import { Component } from 'react';
 
 /**
- * @deprecated TouchableOpacity will be removed in the future version of Gesture Handler.
+ * @deprecated TouchableOpacity will be removed in the future version of Gesture Handler. Use Pressable instead.
  */
 export type TouchableOpacityProps = RNTouchableOpacityProps &
   GenericTouchableProps & {
@@ -19,7 +19,7 @@ export type TouchableOpacityProps = RNTouchableOpacityProps &
   };
 
 /**
- * @deprecated TouchableOpacity will be removed in the future version of Gesture Handler.
+ * @deprecated TouchableOpacity will be removed in the future version of Gesture Handler. Use Pressable instead.
  *
  * TouchableOpacity bases on timing animation which has been used in RN's core
  */

--- a/src/components/touchables/TouchableWithoutFeedback.tsx
+++ b/src/components/touchables/TouchableWithoutFeedback.tsx
@@ -4,12 +4,12 @@ import GenericTouchable from './GenericTouchable';
 import type { GenericTouchableProps } from './GenericTouchableProps';
 
 /**
- * @deprecated TouchableWithoutFeedback will be removed in the future version of Gesture Handler.
+ * @deprecated TouchableWithoutFeedback will be removed in the future version of Gesture Handler. Use Pressable instead.
  */
 export type TouchableWithoutFeedbackProps = GenericTouchableProps;
 
 /**
- * @deprecated TouchableWithoutFeedback will be removed in the future version of Gesture Handler.
+ * @deprecated TouchableWithoutFeedback will be removed in the future version of Gesture Handler. Use Pressable instead.
  */
 const TouchableWithoutFeedback = React.forwardRef<
   GenericTouchable,


### PR DESCRIPTION
## Description

Add actionable advice to deprecation warnings.

See: https://github.com/software-mansion/react-native-gesture-handler/pull/3260

## Test plan

- None needed