### PR TITLE
[iOS] Add FabricComponents to Podfile

### DIFF
--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -35,7 +35,6 @@ Pod::Spec.new do |s|
       "react/renderer/textlayoutmanager/platform/ios",
       "react/renderer/components/textinput/platform/ios",
     ])
-    add_dependency(s, "React-rendererconsistency")
   end
 
 end

--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -32,8 +32,10 @@ Pod::Spec.new do |s|
 
   if ENV['USE_FRAMEWORKS'] != nil && ENV['RCT_NEW_ARCH_ENABLED'] == '1'
     add_dependency(s, "React-FabricComponents", :additional_framework_paths => [
-      "react/renderer/components/text",
+      "react/renderer/textlayoutmanager/platform/ios",
+      "react/renderer/components/textinput/platform/ios",
     ])
+    add_dependency(s, "React-rendererconsistency")
   end
 
 end

--- a/RNGestureHandler.podspec
+++ b/RNGestureHandler.podspec
@@ -29,4 +29,11 @@ Pod::Spec.new do |s|
   else
     s.dependency "React-Core"
   end
+
+  if ENV['USE_FRAMEWORKS'] != nil && ENV['RCT_NEW_ARCH_ENABLED'] == '1'
+    add_dependency(s, "React-FabricComponents", :additional_framework_paths => [
+      "react/renderer/components/text",
+    ])
+  end
+
 end


### PR DESCRIPTION
## Description

This PR updates `RNGestureHandler.podspec` to fix builds on iOS, which broke after #3338.

Fixes #3385 

## Test plan

Verified by users (see [issue](https://github.com/software-mansion/react-native-gesture-handler/issues/3385))

Tested on fresh React Native 0.77 app with the following line in `Podfile`:

```rb
use_frameworks! :linkage => :static
```
