### PR TITLE
Fix `useLayoutEffect` throwing warnings when using SSR

### DIFF
--- a/src/handlers/gestures/GestureDetector/index.tsx
+++ b/src/handlers/gestures/GestureDetector/index.tsx
@@ -1,17 +1,11 @@
 /* eslint-disable react/no-unused-prop-types */
-import React, {
-  useContext,
-  useEffect,
-  useLayoutEffect,
-  useMemo,
-  useRef,
-} from 'react';
+import React, { useContext, useEffect, useMemo, useRef } from 'react';
 import { Platform } from 'react-native';
 import findNodeHandle from '../../../findNodeHandle';
 import { GestureType } from '../gesture';
 import { UserSelect, TouchAction } from '../../gestureHandlerCommon';
 import { ComposedGesture } from '../gestureComposition';
-import { isTestEnv } from '../../../utils';
+import { isTestEnv, useSafeLayoutEffect } from '../../../utils';
 
 import GestureHandlerRootViewContext from '../../../GestureHandlerRootViewContext';
 import { AttachedGestureState, GestureDetectorState } from './types';
@@ -149,7 +143,7 @@ export const GestureDetector = (props: GestureDetectorProps) => {
 
   useAnimatedGesture(preparedGesture, needsToRebuildReanimatedEvent);
 
-  useLayoutEffect(() => {
+  useSafeLayoutEffect(() => {
     const viewTag = findNodeHandle(state.viewRef) as number;
     preparedGesture.isMounted = true;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { useLayoutEffect, useEffect } from 'react';
+
 export function toArray<T>(object: T | T[]): T[] {
   if (!Array.isArray(object)) {
     return [object];
@@ -100,3 +102,6 @@ export function deepEqual(obj1: any, obj2: any) {
 }
 
 export const INT32_MAX = 2 ** 31 - 1;
+
+export const useSafeLayoutEffect =
+  typeof window !== 'undefined' ? useLayoutEffect : useEffect;


### PR DESCRIPTION
## Description

Using `useLayoutEffect` in combination with SSR results in a warning.
This PR adds a `useSafeLayoutEffect`, which acts as `useLayoutEffect` in regular apps, and defaults to `useEffect` when using SSR.

fixes https://github.com/software-mansion/react-native-gesture-handler/issues/3375

## Test plan

<!--
Describe how did you test this change here.
-->
