### PR TITLE
Fix Reanimated crashes in `ReanimatedDrawerLayout`

### DIFF
--- a/example/src/release_tests/reanimatedDrawerLayout/index.tsx
+++ b/example/src/release_tests/reanimatedDrawerLayout/index.tsx
@@ -72,7 +72,8 @@ export default function ReanimatedDrawerExample() {
       renderNavigationView={() => <DrawerPage />}
       drawerPosition={side}
       drawerType={type}
-      drawerLockMode={lock}>
+      drawerLockMode={lock}
+      hideStatusBar={true}>
       <View style={styles.innerContainer}>
         <GestureDetector gesture={tapGesture}>
           <View style={styles.box}>

--- a/src/components/ReanimatedDrawerLayout.tsx
+++ b/src/components/ReanimatedDrawerLayout.tsx
@@ -256,6 +256,7 @@ const defaultProps = {
   statusBarAnimation: 'slide' as StatusBarAnimation,
 };
 
+// StatusBar.setHidden and Keyboard.dismiss cannot be used directly in worklets, thus have to be copied beforehand.
 const setStatusBarHidden = StatusBar.setHidden;
 const dismissKeyboard = Keyboard.dismiss;
 

--- a/src/components/ReanimatedDrawerLayout.tsx
+++ b/src/components/ReanimatedDrawerLayout.tsx
@@ -256,7 +256,7 @@ const defaultProps = {
   statusBarAnimation: 'slide' as StatusBarAnimation,
 };
 
-// StatusBar.setHidden and Keyboard.dismiss cannot be used directly in worklets, thus have to be copied beforehand.
+// StatusBar.setHidden and Keyboard.dismiss cannot be directly referenced in worklets.
 const setStatusBarHidden = StatusBar.setHidden;
 const dismissKeyboard = Keyboard.dismiss;
 

--- a/src/components/ReanimatedDrawerLayout.tsx
+++ b/src/components/ReanimatedDrawerLayout.tsx
@@ -256,6 +256,9 @@ const defaultProps = {
   statusBarAnimation: 'slide' as StatusBarAnimation,
 };
 
+const setStatusBarHidden = StatusBar.setHidden;
+const dismissKeyboard = Keyboard.dismiss;
+
 const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
   function DrawerLayout(props: DrawerLayoutProps, ref) {
     const [containerWidth, setContainerWidth] = useState(0);
@@ -355,11 +358,6 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
           : { right: 0, width: edgeWidth }
       );
     }, [isFromLeft, edgeWidth]);
-
-    const setStatusBarHidden = (
-      hidden: boolean,
-      animation?: StatusBarAnimation | undefined
-    ) => StatusBar.setHidden(hidden, animation);
 
     const animateDrawer = useCallback(
       (toValue: number, initialVelocity: number, animationSpeed?: number) => {
@@ -513,8 +511,6 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
       () => (isFromLeft ? { left: drawerWidth } : { right: drawerWidth }),
       [drawerWidth, isFromLeft]
     );
-
-    const dismissKeyboard = () => Keyboard.dismiss();
 
     const panGesture = useMemo(() => {
       return Gesture.Pan()

--- a/src/components/ReanimatedDrawerLayout.tsx
+++ b/src/components/ReanimatedDrawerLayout.tsx
@@ -356,6 +356,11 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
       );
     }, [isFromLeft, edgeWidth]);
 
+    const setStatusBarHidden = (
+      hidden: boolean,
+      animation?: StatusBarAnimation | undefined
+    ) => StatusBar.setHidden(hidden, animation);
+
     const animateDrawer = useCallback(
       (toValue: number, initialVelocity: number, animationSpeed?: number) => {
         'worklet';
@@ -366,7 +371,7 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
         runOnJS(setDrawerState)(DrawerState.SETTLING);
 
         if (hideStatusBar) {
-          runOnJS(StatusBar.setHidden)(willShow, statusBarAnimation);
+          runOnJS(setStatusBarHidden)(willShow, statusBarAnimation);
         }
 
         const normalizedToValue = interpolate(
@@ -509,6 +514,8 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
       [drawerWidth, isFromLeft]
     );
 
+    const dismissKeyboard = () => Keyboard.dismiss();
+
     const panGesture = useMemo(() => {
       return Gesture.Pan()
         .activeCursor(activeCursor)
@@ -529,10 +536,10 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
           emitStateChanged(DrawerState.DRAGGING, false);
           runOnJS(setDrawerState)(DrawerState.DRAGGING);
           if (keyboardDismissMode === DrawerKeyboardDismissMode.ON_DRAG) {
-            runOnJS(Keyboard.dismiss)();
+            runOnJS(dismissKeyboard)();
           }
           if (hideStatusBar) {
-            runOnJS(StatusBar.setHidden)(true, statusBarAnimation);
+            runOnJS(setStatusBarHidden)(true, statusBarAnimation);
           }
         })
         .onUpdate((event) => {


### PR DESCRIPTION
## Description

Direct references of react JS-only functions and classes lead to reanimated crashes.
Converted those direct references into indirect calls, this fixes the crashes.

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/3386

## Test plan

- use the `Reanimated Drawer Layout` example app to see how the props are now used without crashing the app.
