### PR TITLE
[Android] Add check for `ScrollView` in `ReactViewGroupHook`

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -313,6 +313,12 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     // inside a `<View />` component in JS). In such cases, calling `onTouchEvent` wouldn't work as those are
     // ignored by the wrapper view. Instead `dispatchTouchEvent` can be used, which causes the view to dispatch
     // the event to its children.
-    override fun sendTouchEvent(view: View?, event: MotionEvent) = view?.dispatchTouchEvent(event)
+    override fun sendTouchEvent(view: View?, event: MotionEvent): Boolean? {
+      return if ((view as ReactViewGroup).getChildAt(0) is ScrollView) {
+        view?.onTouchEvent(event)
+      } else {
+        view?.dispatchTouchEvent(event)
+      }
+    }
   }
 }


### PR DESCRIPTION
## Description

In #3244 I've changed `onTouchEvent` into `dispatchTouchEvent` when dealing with `ReactViewGroup`. Turns out that [FlashList](https://github.com/Shopify/flash-list) wraps `ScrollView` into additional `ReactViewGroup`, which resulted in `Invalid pointerId=-1 in onTouchEvent` error. 

This PR checks if first child of `ReactViewGroup` is `ScrollView`. If so, we use `onTouchEvent` instead of `dispatchTouchEvent`.

Fixes #3382

## Test plan

<details>
<summary>Tested on the following reproduction from issue:</summary>

```jsx
import React from 'react';
import { Text } from 'react-native';
import {
  GestureHandlerRootView,
  ScrollView,
  createNativeWrapper,
} from 'react-native-gesture-handler';
import { FlashList } from '@shopify/flash-list';
import Animated from 'react-native-reanimated';

const GestureFlashList = createNativeWrapper(FlashList);
const AnimatedFlashList = Animated.createAnimatedComponent(GestureFlashList);

export default () => {
  return (
    <GestureHandlerRootView>
      <AnimatedFlashList
        data={Array.from(Array(100).keys())}
        renderItem={({ item }) => <Text>{item}</Text>}
        renderScrollComponent={ScrollView}
      />
    </GestureHandlerRootView>
  );
};
```

</details>
