### PR TITLE
Fix border styling issues in `RNGestureHandlerButton`

### DIFF
--- a/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerDelegate.java
+++ b/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerDelegate.java
@@ -47,8 +47,44 @@ public class RNGestureHandlerButtonManagerDelegate<T extends View, U extends Bas
       case "borderWidth":
         mViewManager.setBorderWidth(view, value == null ? 0f : ((Double) value).floatValue());
         break;
+      case "borderLeftWidth":
+        mViewManager.setBorderLeftWidth(view, value == null ? 0f : ((Double) value).floatValue());
+        break;
+      case "borderRightWidth":
+        mViewManager.setBorderRightWidth(view, value == null ? 0f : ((Double) value).floatValue());
+        break;
+      case "borderTopWidth":
+        mViewManager.setBorderTopWidth(view, value == null ? 0f : ((Double) value).floatValue());
+        break;
+      case "borderBottomWidth":
+        mViewManager.setBorderBottomWidth(view, value == null ? 0f : ((Double) value).floatValue());
+        break;
+      case "borderStartWidth":
+        mViewManager.setBorderStartWidth(view, value == null ? 0f : ((Double) value).floatValue());
+        break;
+      case "borderEndWidth":
+        mViewManager.setBorderEndWidth(view, value == null ? 0f : ((Double) value).floatValue());
+        break;
       case "borderColor":
         mViewManager.setBorderColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "borderLeftColor":
+        mViewManager.setBorderLeftColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "borderRightColor":
+        mViewManager.setBorderRightColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "borderTopColor":
+        mViewManager.setBorderTopColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "borderBottomColor":
+        mViewManager.setBorderBottomColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "borderStartColor":
+        mViewManager.setBorderStartColor(view, ColorPropConverter.getColor(value, view.getContext()));
+        break;
+      case "borderEndColor":
+        mViewManager.setBorderEndColor(view, ColorPropConverter.getColor(value, view.getContext()));
         break;
       case "borderStyle":
         mViewManager.setBorderStyle(view, value == null ? "solid" : (String) value);

--- a/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
+++ b/android/paper/src/main/java/com/facebook/react/viewmanagers/RNGestureHandlerButtonManagerInterface.java
@@ -21,6 +21,18 @@ public interface RNGestureHandlerButtonManagerInterface<T extends View> {
   void setRippleRadius(T view, int value);
   void setTouchSoundDisabled(T view, boolean value);
   void setBorderWidth(T view, float value);
+  void setBorderLeftWidth(T view, float value);
+  void setBorderRightWidth(T view, float value);
+  void setBorderTopWidth(T view, float value);
+  void setBorderBottomWidth(T view, float value);
+  void setBorderStartWidth(T view, float value);
+  void setBorderEndWidth(T view, float value);
   void setBorderColor(T view, @Nullable Integer value);
+  void setBorderLeftColor(T view, @Nullable Integer value);
+  void setBorderRightColor(T view, @Nullable Integer value);
+  void setBorderTopColor(T view, @Nullable Integer value);
+  void setBorderBottomColor(T view, @Nullable Integer value);
+  void setBorderStartColor(T view, @Nullable Integer value);
+  void setBorderEndColor(T view, @Nullable Integer value);
   void setBorderStyle(T view, @Nullable String value);
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -97,16 +97,79 @@ class RNGestureHandlerButtonViewManager : ViewGroupManager<ButtonViewGroup>(), R
 
   @ReactProp(name = "borderWidth")
   override fun setBorderWidth(view: ButtonViewGroup, borderWidth: Float) {
+    // view.setBorderWidth(Spacing.ALL, borderWidth)
     view.borderWidth = borderWidth
+  }
+
+  @ReactProp(name = "borderStartWidth")
+  override fun setBorderLeftWidth(view: ButtonViewGroup, borderStartWidth: Float) {
+    // view.setBorderWidth(Spacing.LEFT, borderStartWidth)
+  }
+
+  @ReactProp(name = "borderRightWidth")
+  override fun setBorderRightWidth(view: ButtonViewGroup, borderRightWidth: Float) {
+    // view.setBorderWidth(Spacing.RIGHT, borderRightWidth)
+  }
+
+  @ReactProp(name = "borderTopWidth")
+  override fun setBorderTopWidth(view: ButtonViewGroup, borderTopWidth: Float) {
+    // view.setBorderWidth(Spacing.TOP, borderTopWidth)
+  }
+
+  @ReactProp(name = "borderBottomWidth")
+  override fun setBorderBottomWidth(view: ButtonViewGroup, borderBottomWidth: Float) {
+    // view.setBorderWidth(Spacing.BOTTOM, borderBottomWidth)
+  }
+
+  @ReactProp(name = "borderStartWidth")
+  override fun setBorderStartWidth(view: ButtonViewGroup, borderStartWidth: Float) {
+    // view.setBorderWidth(Spacing.START, borderStartWidth)
+  }
+
+  @ReactProp(name = "borderEndWidth")
+  override fun setBorderEndWidth(view: ButtonViewGroup, borderEndWidth: Float) {
+    // view.setBorderWidth(Spacing.END, borderEndWidth)
   }
 
   @ReactProp(name = "borderColor")
   override fun setBorderColor(view: ButtonViewGroup, borderColor: Int?) {
+    // view.setBorderColor(Spacing.ALL, borderColor)
     view.borderColor = borderColor
+  }
+
+  @ReactProp(name = "borderLeftColor")
+  override fun setBorderLeftColor(view: ButtonViewGroup, borderLeftColor: Int?) {
+    // view.setBorderColor(Spacing.LEFT, borderLeftColor)
+  }
+
+  @ReactProp(name = "borderRightColor")
+  override fun setBorderRightColor(view: ButtonViewGroup, borderRightColor: Int?) {
+    // view.setBorderColor(Spacing.RIGHT, borderRightColor)
+  }
+
+  @ReactProp(name = "borderTopColor")
+  override fun setBorderTopColor(view: ButtonViewGroup, borderTopColor: Int?) {
+    // view.setBorderColor(Spacing.TOP, borderTopColor)
+  }
+
+  @ReactProp(name = "borderBottomColor")
+  override fun setBorderBottomColor(view: ButtonViewGroup, borderBottomColor: Int?) {
+    // view.setBorderColor(Spacing.BOTTOM, borderBottomColor)
+  }
+
+  @ReactProp(name = "borderStartColor")
+  override fun setBorderStartColor(view: ButtonViewGroup, borderStartColor: Int?) {
+    // view.setBorderColor(Spacing.START, borderStartColor)
+  }
+
+  @ReactProp(name = "borderEndColor")
+  override fun setBorderEndColor(view: ButtonViewGroup, borderEndColor: Int?) {
+    // view.setBorderColor(Spacing.END, borderEndColor)
   }
 
   @ReactProp(name = "borderStyle")
   override fun setBorderStyle(view: ButtonViewGroup, borderStyle: String?) {
+    // view.setBorderStyle(value)
     view.borderStyle = borderStyle
   }
 

--- a/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -14,8 +14,23 @@ interface NativeProps extends ViewProps {
   rippleColor?: ColorValue;
   rippleRadius?: Int32;
   touchSoundDisabled?: WithDefault<boolean, false>;
+
   borderWidth?: Float;
+  borderLeftWidth?: Float;
+  borderRightWidth?: Float;
+  borderTopWidth?: Float;
+  borderBottomWidth?: Float;
+  borderStartWidth?: Float;
+  borderEndWidth?: Float;
+
   borderColor?: ColorValue;
+  borderLeftColor?: ColorValue;
+  borderRightColor?: ColorValue;
+  borderTopColor?: ColorValue;
+  borderBottomColor?: ColorValue;
+  borderStartColor?: ColorValue;
+  borderEndColor?: ColorValue;
+
   borderStyle?: WithDefault<string, 'solid'>;
 }
 


### PR DESCRIPTION
## Description

This PR adds missing prop styles fields to the RNGestureHandlerButton delegate,
and rewrites `ButtonViewGroup` to use `ReactViewGroup` instead of `ViewGroup`.

## Test plan

<!--
Describe how did you test this change here.
-->
