### PR TITLE
[Android] Add support for 16KB page size.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -125,7 +125,8 @@ android {
                     cppFlags "-O2", "-frtti", "-fexceptions", "-Wall", "-Werror", "-std=c++20", "-DANDROID"
                     arguments "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
                         "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
-                        "-DANDROID_STL=c++_shared"
+                        "-DANDROID_STL=c++_shared",
+                        "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                     abiFilters (*reactNativeArchitectures())
                 }
             }


### PR DESCRIPTION
## Description

Starting from Android 15 devices can use 16KB page size instead of 4KB. Apps that take advantage of this require additional linker flag.

This PR adds aforementioned flag so that apps that use Gesture Handler don't crash.

Fixes #3410

>[!NOTE]
> More info can be found [here](https://developer.android.com/guide/practices/page-sizes)

## Test plan

Tested on AVD with 16KB page size.