### PR TITLE
[Web] Fix `Text` with `Touchables`

### DIFF
--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -35,6 +35,9 @@ export const Text = forwardRef(
       }
     };
 
+    // This is a special case for `Text` component. After https://github.com/software-mansion/react-native-gesture-handler/pull/3379 we check for
+    // `displayName` field. However, `Text` from RN has this field set to `Text`, but is also present in `RNSVGElements` set.
+    // We don't want to treat our `Text` as the one from `SVG`, therefore we add special field to ref.
     refHandler.rngh = true;
 
     useEffect(() => {

--- a/src/components/Text.tsx
+++ b/src/components/Text.tsx
@@ -35,6 +35,8 @@ export const Text = forwardRef(
       }
     };
 
+    refHandler.rngh = true;
+
     useEffect(() => {
       if (Platform.OS !== 'web') {
         return;

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -280,6 +280,8 @@ export function isRNSVGElement(viewRef: SVGRef | GestureHandlerRef) {
 // Second condition was introduced to handle case where SVG element was wrapped with
 // `createAnimatedComponent` from Reanimated.
 export function isRNSVGNode(node: any) {
+  // If `ref` has `rngh` field, it means that component comes from Gesture Handler. This is a special case for
+  // `Text` component, which is present in `RNSVGElements` set, yet we don't want to treat it as SVG.
   if (node.ref?.rngh) {
     return false;
   }

--- a/src/web/utils.ts
+++ b/src/web/utils.ts
@@ -280,6 +280,10 @@ export function isRNSVGElement(viewRef: SVGRef | GestureHandlerRef) {
 // Second condition was introduced to handle case where SVG element was wrapped with
 // `createAnimatedComponent` from Reanimated.
 export function isRNSVGNode(node: any) {
+  if (node.ref?.rngh) {
+    return false;
+  }
+
   return (
     Object.getPrototypeOf(node?.type)?.name === 'WebShape' ||
     RNSVGElements.has(node?.type?.displayName)


### PR DESCRIPTION
## Description

#3379 introduced new check for `SVG`. However, `Text` is present in `RNSVGElements` list - it resulted in `Text` component not working correctly with `Touchables` 

## Test plan

Tested on **_NestedText_** example
