### PR TITLE
[Android] Add missing paper files

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "android/src/main/jni/",
     "android/fabric/src/main/java",
     "android/paper/src/main/java",
+    "android/paper77/src/main/java",
     "android/common/src/main/java/",
     "android/reanimated/src/main/java/",
     "android/noreanimated/src/main/java/",


### PR DESCRIPTION
## Description

In #3354 we introduced `paper77` subdirectory, however we didn't include it in `package.json`, thus builds break.

## Test plan

Build app on 0.77 with paper.