### PR TITLE
[iOS] Pass `accessibility` props to button view

### DIFF
--- a/apple/RNGestureHandlerButtonComponentView.h
+++ b/apple/RNGestureHandlerButtonComponentView.h
@@ -13,7 +13,8 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface RNGestureHandlerButtonComponentView : RCTViewComponentView
-
+- (void)setAccessibilityProps:(const facebook::react::Props::Shared &)props
+                     oldProps:(const facebook::react::Props::Shared &)oldProps;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Description

Currently adding `accessibility` props to `Pressable` component doesn't work. It happens because on `fabric` those props are assigned to `RNGestureHandlerButtonComponentView` instead of `RNGestureHandlerButton`. 

This PR adds [logic from react-native](https://github.com/facebook/react-native/blob/b226049a4a28ea3f7f32266269fb76340c324d42/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm#L343) to assign props to `_buttonView` instead of `ComponentView`.

Fixes #3428 

>[!NOTE]
> I've skipped one part of this logic, namely [accessibilityElements](https://github.com/facebook/react-native/blob/b226049a4a28ea3f7f32266269fb76340c324d42/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm#L394C2-L399C4) because of type errors (compiler says that `accessibilityElements` doesn't exist on `props`), but it shouldn't change the behavior.

## Test plan

<details>
<summary>Tested on the following example:</summary>

```jsx
import React from 'react';
import { StyleSheet, Text, View, Pressable as RNPressable } from 'react-native';
import {
  GestureHandlerRootView,
  RectButton,
  Pressable,
} from 'react-native-gesture-handler';

// Not accessible:
const NotAccessibleButton = () => (
  <RectButton
    style={styles.button}
    onPress={() => console.log('Not accessible')}>
    <Text>Foo</Text>
  </RectButton>
);
// Accessible:
const AccessibleButton = () => (
  <RectButton style={styles.button} onPress={() => console.log('Accessible')}>
    <View accessible accessibilityRole="button">
      <Text>Bar</Text>
    </View>
  </RectButton>
);

export default function EmptyExample() {
  return (
    <GestureHandlerRootView style={styles.container}>
      <NotAccessibleButton />
      <AccessibleButton />
      <Pressable
        style={styles.button}
        accessible
        testID="RNGH"
        accessibilityLabel="RNGH"
        onPress={() => console.log('RNGH')}>
        <Text>Pressable</Text>
      </Pressable>
      <RNPressable
        style={styles.button}
        accessible
        accessibilityLabel="RN"
        onPress={() => console.log('RN')}>
        <Text>RNPressable</Text>
      </RNPressable>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
    gap: 20,
  },

  button: {
    width: 100,
    height: 25,
    backgroundColor: 'crimson',
    alignItems: 'center',
    justifyContent: 'space-around',
  },
});
```

</details>
