### PR TITLE
Remove `ref` type from props in `Pressable` Example

### DIFF
--- a/example/src/release_tests/gesturizedPressable/testingBase.tsx
+++ b/example/src/release_tests/gesturizedPressable/testingBase.tsx
@@ -11,9 +11,7 @@ import {
   PressableProps as GHPressableProps,
 } from 'react-native-gesture-handler';
 
-const TestingBase = (
-  props: GHPressableProps & RNPressableProps & React.RefAttributes<View>
-) => (
+const TestingBase = (props: GHPressableProps & RNPressableProps) => (
   <>
     <GesturizedPressable {...props}>
       <View style={styles.textWrapper}>


### PR DESCRIPTION
## Description

Our CI fails on `tsc` check in example, probably becauseof #3431. I've removed `RefAttributes` from `props` type as `ref` is not used anyway in this example.

## Test plan

Run `yarn tsc --noEmit`