### PR TITLE
[Android] Handle `hover` events in `RNGestureHandlerRootHelper`

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -6,6 +6,7 @@ import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
 import android.widget.EditText
+import com.swmansion.gesturehandler.react.RNGestureHandlerRootHelper
 import java.util.*
 import kotlin.collections.HashSet
 
@@ -470,6 +471,13 @@ class GestureHandlerOrchestrator(
     return found
   }
 
+  private fun shouldHandlerSkipHoverEvents(handler: GestureHandler<*>, action: Int): Boolean {
+    val shouldSkipEvents =
+      handler !is HoverGestureHandler && handler !is RNGestureHandlerRootHelper.RootViewGestureHandler
+
+    return action in listOf(MotionEvent.ACTION_HOVER_EXIT, MotionEvent.ACTION_HOVER_ENTER, MotionEvent.ACTION_HOVER_MOVE) && shouldSkipEvents
+  }
+
   private fun recordViewHandlersForPointer(view: View, coords: FloatArray, pointerId: Int, event: MotionEvent): Boolean {
     var found = false
     handlerRegistry.getHandlersForView(view)?.let {
@@ -480,8 +488,11 @@ class GestureHandlerOrchestrator(
             continue
           }
 
-          // we don't want to extract gestures other than hover when processing hover events
-          if (event.action in listOf(MotionEvent.ACTION_HOVER_EXIT, MotionEvent.ACTION_HOVER_ENTER, MotionEvent.ACTION_HOVER_MOVE) && handler !is HoverGestureHandler) {
+          // We don't want to extract gestures other than hover when processing hover events.
+          // There's only one exception - RootViewGestureHandler. TalkBack uses hover events,
+          // so we need to pass them into RootViewGestureHandler, otherwise press and hold
+          // gesture stops working correctly (see https://github.com/software-mansion/react-native-gesture-handler/issues/3407)
+          if (shouldHandlerSkipHoverEvents(handler, event.action)) {
             continue
           }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -8,7 +8,6 @@ import android.view.ViewGroup
 import android.widget.EditText
 import com.swmansion.gesturehandler.react.RNGestureHandlerRootHelper
 import java.util.*
-import kotlin.collections.HashSet
 
 class GestureHandlerOrchestrator(
   private val wrapperView: ViewGroup,
@@ -476,10 +475,10 @@ class GestureHandlerOrchestrator(
   // so we need to pass them into RootViewGestureHandler, otherwise press and hold
   // gesture stops working correctly (see https://github.com/software-mansion/react-native-gesture-handler/issues/3407)
   private fun shouldHandlerSkipHoverEvents(handler: GestureHandler<*>, action: Int): Boolean {
-    val shouldSkipEvents =
+    val shouldSkipHoverEvents =
       handler !is HoverGestureHandler && handler !is RNGestureHandlerRootHelper.RootViewGestureHandler
 
-    return shouldSkipEvents && action in listOf(MotionEvent.ACTION_HOVER_EXIT, MotionEvent.ACTION_HOVER_ENTER, MotionEvent.ACTION_HOVER_MOVE)
+    return shouldSkipHoverEvents && action in listOf(MotionEvent.ACTION_HOVER_EXIT, MotionEvent.ACTION_HOVER_ENTER, MotionEvent.ACTION_HOVER_MOVE)
   }
 
   private fun recordViewHandlersForPointer(view: View, coords: FloatArray, pointerId: Int, event: MotionEvent): Boolean {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -471,11 +471,15 @@ class GestureHandlerOrchestrator(
     return found
   }
 
+  // We don't want to extract gestures other than hover when processing hover events.
+  // There's only one exception - RootViewGestureHandler. TalkBack uses hover events,
+  // so we need to pass them into RootViewGestureHandler, otherwise press and hold
+  // gesture stops working correctly (see https://github.com/software-mansion/react-native-gesture-handler/issues/3407)
   private fun shouldHandlerSkipHoverEvents(handler: GestureHandler<*>, action: Int): Boolean {
     val shouldSkipEvents =
       handler !is HoverGestureHandler && handler !is RNGestureHandlerRootHelper.RootViewGestureHandler
 
-    return action in listOf(MotionEvent.ACTION_HOVER_EXIT, MotionEvent.ACTION_HOVER_ENTER, MotionEvent.ACTION_HOVER_MOVE) && shouldSkipEvents
+    return shouldSkipEvents && action in listOf(MotionEvent.ACTION_HOVER_EXIT, MotionEvent.ACTION_HOVER_ENTER, MotionEvent.ACTION_HOVER_MOVE)
   }
 
   private fun recordViewHandlersForPointer(view: View, coords: FloatArray, pointerId: Int, event: MotionEvent): Boolean {
@@ -488,10 +492,6 @@ class GestureHandlerOrchestrator(
             continue
           }
 
-          // We don't want to extract gestures other than hover when processing hover events.
-          // There's only one exception - RootViewGestureHandler. TalkBack uses hover events,
-          // so we need to pass them into RootViewGestureHandler, otherwise press and hold
-          // gesture stops working correctly (see https://github.com/software-mansion/react-native-gesture-handler/issues/3407)
           if (shouldHandlerSkipHoverEvents(handler, event.action)) {
             continue
           }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -50,7 +50,9 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
       ReactConstants.TAG,
       "[GESTURE HANDLER] Tearing down gesture handler registered for root view $rootView"
     )
-    val module = (context as ThemedReactContext).reactApplicationContext.getNativeModule(RNGestureHandlerModule::class.java)!!
+    val module = (context as ThemedReactContext).reactApplicationContext.getNativeModule(
+      RNGestureHandlerModule::class.java
+    )!!
     with(module) {
       registry.dropHandler(jsGestureHandler!!.tag)
       unregisterRootHelper(this@RNGestureHandlerRootHelper)
@@ -58,17 +60,28 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
   }
 
   internal inner class RootViewGestureHandler : GestureHandler<RootViewGestureHandler>() {
-    override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
+
+    private fun handleEvent(event: MotionEvent) {
       val currentState = state
+
       // we shouldn't stop intercepting events when there is an active handler already, which could happen when
       // adding a new pointer to the screen after a handler activates
       if (currentState == STATE_UNDETERMINED && (!shouldIntercept || orchestrator?.isAnyHandlerActive() != true)) {
         begin()
         shouldIntercept = false
       }
-      if (event.actionMasked == MotionEvent.ACTION_UP) {
+
+      if (event.actionMasked == MotionEvent.ACTION_UP || event.actionMasked == MotionEvent.ACTION_HOVER_EXIT) {
         end()
       }
+    }
+
+    override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
+      handleEvent(event)
+    }
+
+    override fun onHandleHover(event: MotionEvent, sourceEvent: MotionEvent) {
+      handleEvent(event)
     }
 
     override fun onCancel() {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -73,13 +73,9 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
       }
     }
 
-    override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
-      handleEvent(event)
-    }
+    override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) = handleEvent(event)
 
-    override fun onHandleHover(event: MotionEvent, sourceEvent: MotionEvent) {
-      handleEvent(event)
-    }
+    override fun onHandleHover(event: MotionEvent, sourceEvent: MotionEvent) = handleEvent(event)
 
     override fun onCancel() {
       shouldIntercept = true

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -50,9 +50,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
       ReactConstants.TAG,
       "[GESTURE HANDLER] Tearing down gesture handler registered for root view $rootView"
     )
-    val module = (context as ThemedReactContext).reactApplicationContext.getNativeModule(
-      RNGestureHandlerModule::class.java
-    )!!
+    val module = (context as ThemedReactContext).reactApplicationContext.getNativeModule(RNGestureHandlerModule::class.java)!!
     with(module) {
       registry.dropHandler(jsGestureHandler!!.tag)
       unregisterRootHelper(this@RNGestureHandlerRootHelper)
@@ -60,7 +58,6 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
   }
 
   internal inner class RootViewGestureHandler : GestureHandler<RootViewGestureHandler>() {
-
     private fun handleEvent(event: MotionEvent) {
       val currentState = state
 


### PR DESCRIPTION
## Description

As stated in [this comment](https://github.com/software-mansion/react-native-gesture-handler/issues/3407#issuecomment-2658466924), `TalkBack` uses `Hover` events. The fact that they were not handled in `RNGestureHandlerRootHelper` resulted in buttons being unresponsive after other gesture had been activated. 

Fixes #3407 

## Test plan

Tested on the reproduction code from issue
