### PR TITLE
Set default `accessible` prop on `Pressable`

### DIFF
--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -56,6 +56,7 @@ const Pressable = forwardRef(
       android_disableSound,
       android_ripple,
       disabled,
+      accessible,
       ...remainingProps
     } = props;
 
@@ -442,6 +443,7 @@ const Pressable = forwardRef(
         <NativeButton
           {...remainingProps}
           ref={pressableRef ?? innerPressableRef}
+          accessible={accessible !== false}
           hitSlop={appliedHitSlop}
           enabled={isPressableEnabled}
           touchSoundDisabled={android_disableSound ?? undefined}


### PR DESCRIPTION
## Description

Currently to make `Pressable` accessible one has to pass `accessible` prop. As pointed out in [this comment](https://github.com/software-mansion/react-native-gesture-handler/issues/3428#issuecomment-2757511562), `Pressable` from `react-native` is accessible by default.

In order to ensure that our component is _**drop-in replacement**_, I've added default value to `true`, following [this logic](https://github.com/facebook/react-native/blob/041014b8de528644c4a2c50bd4cea6f764478009/packages/react-native/Libraries/Components/Pressable/Pressable.js#L236).

## Test plan


<details>
<summary>Tested on the following example:</summary>

```jsx
import React from 'react';
import { StyleSheet, Text, View, Pressable as RNPressable } from 'react-native';
import {
  GestureHandlerRootView,
  RectButton,
  Pressable,
} from 'react-native-gesture-handler';

// Not accessible:
const NotAccessibleButton = () => (
  <RectButton
    style={styles.button}
    onPress={() => console.log('Not accessible')}>
    <Text>Foo</Text>
  </RectButton>
);
// Accessible:
const AccessibleButton = () => (
  <RectButton style={styles.button} onPress={() => console.log('Accessible')}>
    <View accessible accessibilityRole="button">
      <Text>Bar</Text>
    </View>
  </RectButton>
);

export default function EmptyExample() {
  return (
    <GestureHandlerRootView style={styles.container}>
      <NotAccessibleButton />
      <AccessibleButton />
      <Pressable
        style={styles.button}
        accessible
        testID="RNGH"
        accessibilityLabel="RNGH"
        onPress={() => console.log('RNGH')}>
        <Text>Pressable</Text>
      </Pressable>
      <RNPressable
        style={styles.button}
        accessible
        accessibilityLabel="RN"
        onPress={() => console.log('RN')}>
        <Text>RNPressable</Text>
      </RNPressable>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    backgroundColor: '#F5FCFF',
    gap: 20,
  },

  button: {
    width: 100,
    height: 25,
    backgroundColor: 'crimson',
    alignItems: 'center',
    justifyContent: 'space-around',
  },
});
```

</details>

