### PR TITLE
[Android] Add missing `SVG` files

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,8 @@
     "android/noreanimated/src/main/java/",
     "android/package77/",
     "android/packageDeprecated/",
+    "android/svg",
+    "android/nosvg",
     "apple/",
     "Swipeable/",
     "ReanimatedSwipeable/",


### PR DESCRIPTION
## Description

#3242 introduced new `SVG` interface for better hit tests. Added files were not specified in `package.json` which resulted in builds failing.

## Test plan

Checked that newly created app build when _**Gesture Handler**_ is added.