### PR TITLE
[Android] Suppress `UIManagerType` error

### DIFF
--- a/android/fabric/src/main/java/com/swmansion/gesturehandler/ReactContextExtensions.kt
+++ b/android/fabric/src/main/java/com/swmansion/gesturehandler/ReactContextExtensions.kt
@@ -5,8 +5,10 @@ import com.facebook.react.fabric.FabricUIManager
 import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.react.uimanager.events.Event
+import android.annotation.SuppressLint
 
 fun ReactContext.dispatchEvent(event: Event<*>) {
+  @SuppressLint("WrongConstant")
   val fabricUIManager = UIManagerHelper.getUIManager(this, UIManagerType.FABRIC) as FabricUIManager
   fabricUIManager.eventDispatcher.dispatchEvent(event)
 }


### PR DESCRIPTION
## Description

When building app with `react-native` 0.78.1, _**Gesture Handler**_ build fails with the following error message:

```
react-native-gesture-handler/android/fabric/src/main/java/com/swmansion/gesturehandler/ReactContextExtensions.kt:10:
Error: Must be one of: UIManagerType.DEFAULT, UIManagerType.FABRIC [WrongConstant]
    val fabricUIManager = UIManagerHelper.getUIManager(this, UIManagerType.FABRIC) as FabricUIManager
```

As stated in the error above, constant passed to `getUIManager` should be either `UIManagerType.DEFAULT` or `UIManagerType.FABRIC`, but this condition is clearly met. In that case, I've added `SuppressLint` annotation to get rid of the error.

Fixes #3464

## Test plan

Function above is called in specific condition, i.e. if `onGestureEvent` is `Animated.Event`. In order to check if we can suppress this error without problems, I've used the following code:

<details>
<summary>Test code</summary>

```jsx
import React, {useRef} from 'react';
import {View, Animated, StyleSheet} from 'react-native';
import {
  PanGestureHandler,
  GestureHandlerRootView,
  State,
} from 'react-native-gesture-handler';

export default function App() {
  const translateX = useRef(new Animated.Value(0)).current;
  const translateY = useRef(new Animated.Value(0)).current;

  const onGestureEvent = Animated.event(
    [{nativeEvent: {translationX: translateX, translationY: translateY}}],
    {useNativeDriver: true},
  );

  const onHandlerStateChange = event => {
    if (event.nativeEvent.state === State.END) {
      Animated.spring(translateX, {
        toValue: 0,
        useNativeDriver: true,
      }).start();
      Animated.spring(translateY, {
        toValue: 0,
        useNativeDriver: true,
      }).start();
    }
  };

  return (
    <GestureHandlerRootView style={styles.container}>
      <PanGestureHandler
        onGestureEvent={onGestureEvent}
        onHandlerStateChange={onHandlerStateChange}>
        <Animated.View
          style={[
            styles.box,
            {
              transform: [{translateX}, {translateY}],
            },
          ]}
        />
      </PanGestureHandler>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
  box: {
    width: 100,
    height: 100,
    backgroundColor: 'tomato',
    borderRadius: 10,
  },
});
```

</details>

and added a breakpoint to check whether we get correct `UIManager` instance:

![Zrzut ekranu 2025-03-28 o 11 55 13](https://github.com/user-attachments/assets/13925cc1-fb8d-4ad4-a8af-f9746e70c769)
