### PR TITLE
Add relation props to `Pressable` and `ReanimatedSwipeable`

### DIFF
--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -29,6 +29,11 @@ import {
 import { PressabilityDebugView } from '../../handlers/PressabilityDebugView';
 import { GestureTouchEvent } from '../../handlers/gestureHandlerCommon';
 import { INT32_MAX, isFabric, isTestEnv } from '../../utils';
+import {
+  applyRelationProp,
+  RelationPropName,
+  RelationPropType,
+} from '../utils';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;
 const IS_TEST_ENV = isTestEnv();
@@ -58,8 +63,16 @@ const Pressable = forwardRef(
       disabled,
       accessible,
       simultaneousWithExternalGesture,
+      requireExternalGestureToFail,
+      blocksExternalGesture,
       ...remainingProps
     } = props;
+
+    const relationProps = {
+      simultaneousWithExternalGesture,
+      requireExternalGestureToFail,
+      blocksExternalGesture,
+    };
 
     const [pressedState, setPressedState] = useState(testOnly_pressed ?? false);
 
@@ -408,19 +421,13 @@ const Pressable = forwardRef(
       gesture.hitSlop(appliedHitSlop);
       gesture.shouldCancelWhenOutside(Platform.OS === 'web' ? false : true);
 
-      if (!simultaneousWithExternalGesture) {
-        continue;
-      }
-
-      if (Array.isArray(simultaneousWithExternalGesture)) {
-        gesture.simultaneousWithExternalGesture(
-          ...simultaneousWithExternalGesture
+      Object.entries(relationProps).forEach(([key, value]) => {
+        applyRelationProp(
+          gesture,
+          key as RelationPropName,
+          value as RelationPropType
         );
-      } else {
-        gesture.simultaneousWithExternalGesture(
-          simultaneousWithExternalGesture
-        );
-      }
+      });
     }
 
     // Uses different hitSlop, to activate on hitSlop area instead of pressRetentionOffset area

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -421,11 +421,11 @@ const Pressable = forwardRef(
       gesture.hitSlop(appliedHitSlop);
       gesture.shouldCancelWhenOutside(Platform.OS === 'web' ? false : true);
 
-      Object.entries(relationProps).forEach(([key, value]) => {
+      Object.entries(relationProps).forEach(([relationName, relation]) => {
         applyRelationProp(
           gesture,
-          key as RelationPropName,
-          value as RelationPropType
+          relationName as RelationPropName,
+          relation as RelationPropType
         );
       });
     }

--- a/src/components/Pressable/Pressable.tsx
+++ b/src/components/Pressable/Pressable.tsx
@@ -57,6 +57,7 @@ const Pressable = forwardRef(
       android_ripple,
       disabled,
       accessible,
+      simultaneousWithExternalGesture,
       ...remainingProps
     } = props;
 
@@ -406,6 +407,20 @@ const Pressable = forwardRef(
       gesture.runOnJS(true);
       gesture.hitSlop(appliedHitSlop);
       gesture.shouldCancelWhenOutside(Platform.OS === 'web' ? false : true);
+
+      if (!simultaneousWithExternalGesture) {
+        continue;
+      }
+
+      if (Array.isArray(simultaneousWithExternalGesture)) {
+        gesture.simultaneousWithExternalGesture(
+          ...simultaneousWithExternalGesture
+        );
+      } else {
+        gesture.simultaneousWithExternalGesture(
+          simultaneousWithExternalGesture
+        );
+      }
     }
 
     // Uses different hitSlop, to activate on hitSlop area instead of pressRetentionOffset area

--- a/src/components/Pressable/PressableProps.tsx
+++ b/src/components/Pressable/PressableProps.tsx
@@ -148,4 +148,20 @@ export interface PressableProps
   simultaneousWithExternalGesture?:
     | Exclude<GestureRef, number>
     | Exclude<GestureRef, number>[];
+
+  /**
+   * A gesture object or an array of gesture objects containing the configuration and callbacks to be
+   * used with the Pressable's gesture handlers.
+   */
+  requireExternalGestureToFail?:
+    | Exclude<GestureRef, number>
+    | Exclude<GestureRef, number>[];
+
+  /**
+   * A gesture object or an array of gesture objects containing the configuration and callbacks to be
+   * used with the Pressable's gesture handlers.
+   */
+  blocksExternalGesture?:
+    | Exclude<GestureRef, number>
+    | Exclude<GestureRef, number>[];
 }

--- a/src/components/Pressable/PressableProps.tsx
+++ b/src/components/Pressable/PressableProps.tsx
@@ -7,6 +7,7 @@ import {
   PressableStateCallbackType as RNPressableStateCallbackType,
   PressableAndroidRippleConfig as RNPressableAndroidRippleConfig,
 } from 'react-native';
+import type { GestureRef } from '../../handlers/gestures/gesture';
 
 export type PressableStateCallbackType = RNPressableStateCallbackType;
 export type PressableAndroidRippleConfig = RNPressableAndroidRippleConfig;
@@ -139,4 +140,12 @@ export interface PressableProps
    * Duration (in milliseconds) to wait after press down before calling onPressIn.
    */
   unstable_pressDelay?: number;
+
+  /**
+   * A gesture object or an array of gesture objects containing the configuration and callbacks to be
+   * used with the Pressable's gesture handlers.
+   */
+  simultaneousWithExternalGesture?:
+    | Exclude<GestureRef, number>
+    | Exclude<GestureRef, number>[];
 }

--- a/src/components/Pressable/PressableProps.tsx
+++ b/src/components/Pressable/PressableProps.tsx
@@ -7,7 +7,7 @@ import {
   PressableStateCallbackType as RNPressableStateCallbackType,
   PressableAndroidRippleConfig as RNPressableAndroidRippleConfig,
 } from 'react-native';
-import type { GestureRef } from '../../handlers/gestures/gesture';
+import { RelationPropType } from '../utils';
 
 export type PressableStateCallbackType = RNPressableStateCallbackType;
 export type PressableAndroidRippleConfig = RNPressableAndroidRippleConfig;
@@ -145,23 +145,17 @@ export interface PressableProps
    * A gesture object or an array of gesture objects containing the configuration and callbacks to be
    * used with the Pressable's gesture handlers.
    */
-  simultaneousWithExternalGesture?:
-    | Exclude<GestureRef, number>
-    | Exclude<GestureRef, number>[];
+  simultaneousWithExternalGesture?: RelationPropType;
 
   /**
    * A gesture object or an array of gesture objects containing the configuration and callbacks to be
    * used with the Pressable's gesture handlers.
    */
-  requireExternalGestureToFail?:
-    | Exclude<GestureRef, number>
-    | Exclude<GestureRef, number>[];
+  requireExternalGestureToFail?: RelationPropType;
 
   /**
    * A gesture object or an array of gesture objects containing the configuration and callbacks to be
    * used with the Pressable's gesture handlers.
    */
-  blocksExternalGesture?:
-    | Exclude<GestureRef, number>
-    | Exclude<GestureRef, number>[];
+  blocksExternalGesture?: RelationPropType;
 }

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -38,6 +38,7 @@ import {
   View,
   ViewStyle,
 } from 'react-native';
+import { applyRelationProp, RelationPropName, RelationPropType } from './utils';
 
 const DRAG_TOSS = 0.05;
 
@@ -211,6 +212,22 @@ export interface SwipeableProps
   simultaneousWithExternalGesture?:
     | Exclude<GestureRef, number>
     | Exclude<GestureRef, number>[];
+
+  /**
+   * A gesture object or an array of gesture objects containing the configuration and callbacks to be
+   * used with the swipeable's gesture handler.
+   */
+  requireExternalGestureToFail?:
+    | Exclude<GestureRef, number>
+    | Exclude<GestureRef, number>[];
+
+  /**
+   * A gesture object or an array of gesture objects containing the configuration and callbacks to be
+   * used with the swipeable's gesture handler.
+   */
+  blocksExternalGesture?:
+    | Exclude<GestureRef, number>
+    | Exclude<GestureRef, number>[];
 }
 
 export interface SwipeableMethods {
@@ -257,8 +274,16 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
       renderLeftActions,
       renderRightActions,
       simultaneousWithExternalGesture,
+      requireExternalGestureToFail,
+      blocksExternalGesture,
       ...remainingProps
     } = props;
+
+    const relationProps = {
+      simultaneousWithExternalGesture,
+      requireExternalGestureToFail,
+      blocksExternalGesture,
+    };
 
     const rowState = useSharedValue<number>(0);
 
@@ -654,15 +679,13 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           }
         });
 
-      if (!simultaneousWithExternalGesture) {
-        return tap;
-      }
-
-      if (Array.isArray(simultaneousWithExternalGesture)) {
-        tap.simultaneousWithExternalGesture(...simultaneousWithExternalGesture);
-      } else {
-        tap.simultaneousWithExternalGesture(simultaneousWithExternalGesture);
-      }
+      Object.entries(relationProps).forEach(([key, value]) => {
+        applyRelationProp(
+          tap,
+          key as RelationPropName,
+          value as RelationPropType
+        );
+      });
 
       return tap;
     }, [close, rowState, simultaneousWithExternalGesture]);
@@ -707,15 +730,13 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           dragStarted.value = false;
         });
 
-      if (!simultaneousWithExternalGesture) {
-        return pan;
-      }
-
-      if (Array.isArray(simultaneousWithExternalGesture)) {
-        pan.simultaneousWithExternalGesture(...simultaneousWithExternalGesture);
-      } else {
-        pan.simultaneousWithExternalGesture(simultaneousWithExternalGesture);
-      }
+      Object.entries(relationProps).forEach(([key, value]) => {
+        applyRelationProp(
+          pan,
+          key as RelationPropName,
+          value as RelationPropType
+        );
+      });
 
       return pan;
     }, [

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -679,11 +679,11 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           }
         });
 
-      Object.entries(relationProps).forEach(([key, value]) => {
+      Object.entries(relationProps).forEach(([relationName, relation]) => {
         applyRelationProp(
           tap,
-          key as RelationPropName,
-          value as RelationPropType
+          relationName as RelationPropName,
+          relation as RelationPropType
         );
       });
 
@@ -730,11 +730,11 @@ const Swipeable = forwardRef<SwipeableMethods, SwipeableProps>(
           dragStarted.value = false;
         });
 
-      Object.entries(relationProps).forEach(([key, value]) => {
+      Object.entries(relationProps).forEach(([relationName, relation]) => {
         applyRelationProp(
           pan,
-          key as RelationPropName,
-          value as RelationPropType
+          relationName as RelationPropName,
+          relation as RelationPropType
         );
       });
 

--- a/src/components/ReanimatedSwipeable.tsx
+++ b/src/components/ReanimatedSwipeable.tsx
@@ -9,7 +9,6 @@ import React, {
   useImperativeHandle,
   useMemo,
 } from 'react';
-import { GestureRef } from '../handlers/gestures/gesture';
 import { GestureObjects as Gesture } from '../handlers/gestures/gestureObjects';
 import { GestureDetector } from '../handlers/gestures/GestureDetector';
 import {
@@ -209,25 +208,19 @@ export interface SwipeableProps
    * A gesture object or an array of gesture objects containing the configuration and callbacks to be
    * used with the swipeable's gesture handler.
    */
-  simultaneousWithExternalGesture?:
-    | Exclude<GestureRef, number>
-    | Exclude<GestureRef, number>[];
+  simultaneousWithExternalGesture?: RelationPropType;
 
   /**
    * A gesture object or an array of gesture objects containing the configuration and callbacks to be
    * used with the swipeable's gesture handler.
    */
-  requireExternalGestureToFail?:
-    | Exclude<GestureRef, number>
-    | Exclude<GestureRef, number>[];
+  requireExternalGestureToFail?: RelationPropType;
 
   /**
    * A gesture object or an array of gesture objects containing the configuration and callbacks to be
    * used with the swipeable's gesture handler.
    */
-  blocksExternalGesture?:
-    | Exclude<GestureRef, number>
-    | Exclude<GestureRef, number>[];
+  blocksExternalGesture?: RelationPropType;
 }
 
 export interface SwipeableMethods {

--- a/src/components/utils.ts
+++ b/src/components/utils.ts
@@ -1,0 +1,26 @@
+import { BaseGesture, GestureRef } from '../handlers/gestures/gesture';
+
+export type RelationPropName =
+  | 'simultaneousWithExternalGesture'
+  | 'requireExternalGestureToFail'
+  | 'blocksExternalGesture';
+
+export type RelationPropType =
+  | Exclude<GestureRef, number>
+  | Exclude<GestureRef, number>[];
+
+export function applyRelationProp(
+  gesture: BaseGesture<any>,
+  relationPropName: RelationPropName,
+  relationProp: RelationPropType
+) {
+  if (!relationProp) {
+    return;
+  }
+
+  if (Array.isArray(relationProp)) {
+    gesture[relationPropName](...relationProp);
+  } else {
+    gesture[relationPropName](relationProp);
+  }
+}


### PR DESCRIPTION
## Description

It has been reported that if `Pressable` is placed under the view with attached `GestureDetector`, it doesn't work since it gets cancelled by other gestures. This PR adds relation properties to `Pressable` and `ReanimatedSwipeable`, so we can make interactions with external handlers possible.

> [!NOTE]
> This change was partially added into `ReanimatedSwipeable` in #3324 

## Test plan

<details>
<summary>Tested on the following example:</summary>

```jsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import {
  Gesture,
  Pressable,
  GestureDetector,
  GestureHandlerRootView,
} from 'react-native-gesture-handler';

export default function App() {
  const gesture = Gesture.Pan();

  return (
    <GestureHandlerRootView>
      <GestureDetector gesture={gesture}>
        <View style={styles.buttonContainer} collapsable={false}>
          <Pressable
            style={styles.button}
            onPressIn={() => console.log('Pressable onPressIn')}
            onPressOut={() => console.log('Pressable onPressOut')}
            simultaneousWithExternalGesture={gesture}
          />
        </View>
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  buttonContainer: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'space-around',
    backgroundColor: '#535353',
  },
  button: {
    width: 200,
    height: 200,
    borderRadius: 30,
    backgroundColor: '#1db954',
  },
});
```

</details>
