### PR TITLE
Change prepare script to postinstall in the root `package.json`

### DIFF
--- a/.github/workflows/static-example-apps-checks.yml
+++ b/.github/workflows/static-example-apps-checks.yml
@@ -27,7 +27,7 @@ jobs:
           node-version: 18
           cache: 'yarn'
       - name: Install root node dependencies
-        run: yarn --immutable && yarn prepare
+        run: yarn --immutable
       - name: Install ${{ matrix.working-directory }} app node dependencies
         working-directory: ${{ matrix.working-directory }}
         run: yarn

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "2.25.0",
   "description": "Declarative API exposing native platform touch and gesture system to React Native",
   "scripts": {
-    "prepare": "bob build && husky install",
+    "postinstall": "bob build && husky install",
     "test": "jest",
     "build": "yarn tsc -p tsconfig.build.json",
     "precommit": "lint-staged",


### PR DESCRIPTION
## Description

It seems like `prepare` script is not available in [modern Yarn versions](https://yarnpkg.com/advanced/lifecycle-scripts). Replaces it with `postinstall`.

## Test plan

`yarn` and verify that `husky` is installed correctly
