### PR TITLE
Update how handler configuration is handled on Android

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
@@ -1,9 +1,12 @@
 package com.swmansion.gesturehandler.core
 
+import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.view.MotionEvent
 import android.view.VelocityTracker
+import com.facebook.react.bridge.ReadableMap
+import com.swmansion.gesturehandler.react.eventbuilders.FlingGestureHandlerEventDataBuilder
 
 class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
   var numberOfPointersRequired = DEFAULT_NUMBER_OF_TOUCHES_REQUIRED
@@ -124,6 +127,32 @@ class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
     event.offsetLocation(offsetX, offsetY)
     tracker!!.addMovement(event)
     event.offsetLocation(-offsetX, -offsetY)
+  }
+
+  class Factory : GestureHandler.Factory<FlingGestureHandler>() {
+    override val type = FlingGestureHandler::class.java
+    override val name = "FlingGestureHandler"
+
+    override fun create(context: Context?): FlingGestureHandler {
+      return FlingGestureHandler()
+    }
+
+    override fun configure(handler: FlingGestureHandler, config: ReadableMap) {
+      super.configure(handler, config)
+      if (config.hasKey(KEY_NUMBER_OF_POINTERS)) {
+        handler.numberOfPointersRequired = config.getInt(KEY_NUMBER_OF_POINTERS)
+      }
+      if (config.hasKey(KEY_DIRECTION)) {
+        handler.direction = config.getInt(KEY_DIRECTION)
+      }
+    }
+
+    override fun createEventBuilder(handler: FlingGestureHandler) = FlingGestureHandlerEventDataBuilder(handler)
+
+    companion object {
+      private const val KEY_NUMBER_OF_POINTERS = "numberOfPointers"
+      private const val KEY_DIRECTION = "direction"
+    }
   }
 
   companion object {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
@@ -137,8 +137,8 @@ class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
       return FlingGestureHandler()
     }
 
-    override fun configure(handler: FlingGestureHandler, config: ReadableMap) {
-      super.configure(handler, config)
+    override fun setConfig(handler: FlingGestureHandler, config: ReadableMap) {
+      super.setConfig(handler, config)
       if (config.hasKey(KEY_NUMBER_OF_POINTERS)) {
         handler.numberOfPointersRequired = config.getInt(KEY_NUMBER_OF_POINTERS)
       }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -829,7 +829,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     abstract val type: Class<T>
     abstract val name: String
     abstract fun create(context: Context?): T
-    open fun configure(handler: T, config: ReadableMap) {
+    open fun setConfig(handler: T, config: ReadableMap) {
       handler.resetConfig()
       if (config.hasKey(KEY_SHOULD_CANCEL_WHEN_OUTSIDE)) {
         handler.setShouldCancelWhenOutside(config.getBoolean(KEY_SHOULD_CANCEL_WHEN_OUTSIDE))

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -39,7 +39,17 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   var isWithinBounds = false
     private set
   var isEnabled = true
-    private set
+    private set(enabled) {
+      // Don't cancel handler when not changing the value of the isEnabled, executing it always caused
+      // handlers to be cancelled on re-render because that's the moment when the config is updated.
+      // If the enabled prop "changed" from true to true the handler would get cancelled.
+      if (view != null && isEnabled != enabled) {
+        // If view is set then handler is in "active" state. In that case we want to "cancel" handler
+        // when it changes enabled state so that it gets cleared from the orchestrator
+        UiThreadUtil.runOnUiThread { cancel() }
+      }
+      field = enabled
+    }
   var actionType = 0
 
   var changedTouchesPayload: WritableArray? = null
@@ -65,9 +75,9 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
 
   private var lastEventOffsetX = 0f
   private var lastEventOffsetY = 0f
-  private var shouldCancelWhenOutside = false
   var numberOfPointers = 0
-    private set
+    protected set
+  protected var shouldCancelWhenOutside = false
   protected var orchestrator: GestureHandlerOrchestrator? = null
   private var onTouchEventListener: OnTouchEventListener? = null
   private var interactionController: GestureHandlerInteractionController? = null
@@ -103,11 +113,12 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   }
 
   open fun resetConfig() {
-    needsPointerData = false
-    manualActivation = false
-    shouldCancelWhenOutside = false
-    isEnabled = true
-    hitSlop = null
+    needsPointerData = DEFAULT_NEEDS_POINTER_DATA
+    manualActivation = DEFAULT_MANUAL_ACTIVATION
+    shouldCancelWhenOutside = DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE
+    isEnabled = DEFAULT_IS_ENABLED
+    hitSlop = DEFAULT_HIT_SLOP
+    mouseButton = DEFAULT_MOUSE_BUTTON
   }
 
   fun hasCommonPointers(other: GestureHandler<*>): Boolean {
@@ -118,24 +129,6 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     }
     return false
   }
-
-  fun setShouldCancelWhenOutside(shouldCancelWhenOutside: Boolean): ConcreteGestureHandlerT =
-    applySelf { this.shouldCancelWhenOutside = shouldCancelWhenOutside }
-
-  fun setEnabled(enabled: Boolean): ConcreteGestureHandlerT = applySelf {
-    // Don't cancel handler when not changing the value of the isEnabled, executing it always caused
-    // handlers to be cancelled on re-render because that's the moment when the config is updated.
-    // If the enabled prop "changed" from true to true the handler would get cancelled.
-    if (view != null && isEnabled != enabled) {
-      // If view is set then handler is in "active" state. In that case we want to "cancel" handler
-      // when it changes enabled state so that it gets cleared from the orchestrator
-      UiThreadUtil.runOnUiThread { cancel() }
-    }
-    isEnabled = enabled
-  }
-
-  fun setManualActivation(manualActivation: Boolean): ConcreteGestureHandlerT =
-    applySelf { this.manualActivation = manualActivation }
 
   fun setHitSlop(
     leftPad: Float,
@@ -166,10 +159,6 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
 
   fun setInteractionController(controller: GestureHandlerInteractionController?): ConcreteGestureHandlerT =
     applySelf { interactionController = controller }
-
-  fun setMouseButton(mouseButton: Int) = apply {
-    this.mouseButton = mouseButton
-  }
 
   fun prepare(view: View?, orchestrator: GestureHandlerOrchestrator?) {
     check(!(this.view != null || this.orchestrator != null)) { "Already prepared or hasn't been reset" }
@@ -832,10 +821,10 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     open fun setConfig(handler: T, config: ReadableMap) {
       handler.resetConfig()
       if (config.hasKey(KEY_SHOULD_CANCEL_WHEN_OUTSIDE)) {
-        handler.setShouldCancelWhenOutside(config.getBoolean(KEY_SHOULD_CANCEL_WHEN_OUTSIDE))
+        handler.shouldCancelWhenOutside = config.getBoolean(KEY_SHOULD_CANCEL_WHEN_OUTSIDE)
       }
       if (config.hasKey(KEY_ENABLED)) {
-        handler.setEnabled(config.getBoolean(KEY_ENABLED))
+        handler.isEnabled = config.getBoolean(KEY_ENABLED)
       }
       if (config.hasKey(KEY_HIT_SLOP)) {
         handleHitSlopProperty(handler, config)
@@ -844,10 +833,10 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
         handler.needsPointerData = config.getBoolean(KEY_NEEDS_POINTER_DATA)
       }
       if (config.hasKey(KEY_MANUAL_ACTIVATION)) {
-        handler.setManualActivation(config.getBoolean(KEY_MANUAL_ACTIVATION))
+        handler.manualActivation = config.getBoolean(KEY_MANUAL_ACTIVATION)
       }
       if (config.hasKey(KEY_MOUSE_BUTTON)) {
-        handler.setMouseButton(config.getInt(KEY_MOUSE_BUTTON))
+        handler.mouseButton = config.getInt(KEY_MOUSE_BUTTON)
       }
     }
 
@@ -916,6 +905,13 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   }
 
   companion object {
+    private const val DEFAULT_NEEDS_POINTER_DATA = false
+    private const val DEFAULT_MANUAL_ACTIVATION = false
+    private const val DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE = false
+    private const val DEFAULT_IS_ENABLED = true
+    private val DEFAULT_HIT_SLOP = null
+    private const val DEFAULT_MOUSE_BUTTON = 0
+
     const val STATE_UNDETERMINED = 0
     const val STATE_FAILED = 1
     const val STATE_BEGAN = 2

--- a/android/src/main/java/com/swmansion/gesturehandler/core/HoverGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/HoverGestureHandler.kt
@@ -1,5 +1,6 @@
 package com.swmansion.gesturehandler.core
 
+import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.view.MotionEvent
@@ -7,6 +8,7 @@ import android.view.View
 import android.view.ViewGroup
 import com.swmansion.gesturehandler.react.RNGestureHandlerRootHelper
 import com.swmansion.gesturehandler.react.RNViewConfigurationHelper
+import com.swmansion.gesturehandler.react.eventbuilders.HoverGestureHandlerEventDataBuilder
 
 class HoverGestureHandler : GestureHandler<HoverGestureHandler>() {
   private var handler: Handler? = null
@@ -128,6 +130,17 @@ class HoverGestureHandler : GestureHandler<HoverGestureHandler>() {
       STATE_BEGAN -> fail()
       STATE_ACTIVE -> end()
     }
+  }
+
+  class Factory : GestureHandler.Factory<HoverGestureHandler>() {
+    override val type = HoverGestureHandler::class.java
+    override val name = "HoverGestureHandler"
+
+    override fun create(context: Context?): HoverGestureHandler {
+      return HoverGestureHandler()
+    }
+
+    override fun createEventBuilder(handler: HoverGestureHandler) = HoverGestureHandlerEventDataBuilder(handler)
   }
 
   companion object {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -186,11 +186,11 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
 
     override fun configure(handler: LongPressGestureHandler, config: ReadableMap) {
       super.configure(handler, config)
-      if (config.hasKey(KEY_LONG_PRESS_MIN_DURATION_MS)) {
-        handler.minDurationMs = config.getInt(KEY_LONG_PRESS_MIN_DURATION_MS).toLong()
+      if (config.hasKey(KEY_MIN_DURATION_MS)) {
+        handler.minDurationMs = config.getInt(KEY_MIN_DURATION_MS).toLong()
       }
-      if (config.hasKey(KEY_LONG_PRESS_MAX_DIST)) {
-        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_LONG_PRESS_MAX_DIST)))
+      if (config.hasKey(KEY_MAX_DIST)) {
+        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DIST)))
       }
       if (config.hasKey(KEY_NUMBER_OF_POINTERS)) {
         handler.setNumberOfPointers(config.getInt(KEY_NUMBER_OF_POINTERS))
@@ -200,8 +200,8 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
     override fun createEventBuilder(handler: LongPressGestureHandler) = LongPressGestureHandlerEventDataBuilder(handler)
 
     companion object {
-      private const val KEY_LONG_PRESS_MIN_DURATION_MS = "minDurationMs"
-      private const val KEY_LONG_PRESS_MAX_DIST = "maxDist"
+      private const val KEY_MIN_DURATION_MS = "minDurationMs"
+      private const val KEY_MAX_DIST = "maxDist"
       private const val KEY_NUMBER_OF_POINTERS = "numberOfPointers"
     }
   }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -13,8 +13,8 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
   var minDurationMs = DEFAULT_MIN_DURATION_MS
   val duration: Int
     get() = (previousTime - startTime).toInt()
-  private val defaultMaxDistSq: Float
-  private var maxDistSq: Float
+  private val defaultMaxDist: Float
+  private var maxDist: Float
   private var numberOfPointersRequired: Int
   private var startX = 0f
   private var startY = 0f
@@ -24,28 +24,19 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
   private var currentPointers = 0
 
   init {
-    setShouldCancelWhenOutside(true)
+    shouldCancelWhenOutside = true
 
-    val defaultMaxDist = DEFAULT_MAX_DIST_DP * context.resources.displayMetrics.density
-    defaultMaxDistSq = defaultMaxDist * defaultMaxDist
-    maxDistSq = defaultMaxDistSq
+    val systemDefaultMaxDist = DEFAULT_MAX_DIST_DP * context.resources.displayMetrics.density
+    defaultMaxDist = systemDefaultMaxDist
+    maxDist = defaultMaxDist
     numberOfPointersRequired = 1
   }
 
   override fun resetConfig() {
     super.resetConfig()
     minDurationMs = DEFAULT_MIN_DURATION_MS
-    maxDistSq = defaultMaxDistSq
-  }
-
-  fun setMaxDist(maxDist: Float): LongPressGestureHandler {
-    maxDistSq = maxDist * maxDist
-    return this
-  }
-
-  fun setNumberOfPointers(numberOfPointers: Int): LongPressGestureHandler {
-    numberOfPointersRequired = numberOfPointers
-    return this
+    maxDist = defaultMaxDist
+    shouldCancelWhenOutside = DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE
   }
 
   private fun getAverageCoords(ev: MotionEvent, excludePointer: Boolean = false): Pair<Float, Float> {
@@ -144,7 +135,7 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
       val deltaY = y - startY
       val distSq = deltaX * deltaX + deltaY * deltaY
 
-      if (distSq > maxDistSq) {
+      if (distSq > maxDist * maxDist) {
         if (state == STATE_ACTIVE) {
           cancel()
         } else {
@@ -190,10 +181,10 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
         handler.minDurationMs = config.getInt(KEY_MIN_DURATION_MS).toLong()
       }
       if (config.hasKey(KEY_MAX_DIST)) {
-        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DIST)))
+        handler.maxDist = PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DIST))
       }
       if (config.hasKey(KEY_NUMBER_OF_POINTERS)) {
-        handler.setNumberOfPointers(config.getInt(KEY_NUMBER_OF_POINTERS))
+        handler.numberOfPointers = config.getInt(KEY_NUMBER_OF_POINTERS)
       }
     }
 
@@ -207,6 +198,7 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
   }
 
   companion object {
+    private const val DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE = true
     private const val DEFAULT_MIN_DURATION_MS: Long = 500
     private const val DEFAULT_MAX_DIST_DP = 10f
   }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -5,6 +5,9 @@ import android.os.Handler
 import android.os.Looper
 import android.os.SystemClock
 import android.view.MotionEvent
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.PixelUtil
+import com.swmansion.gesturehandler.react.eventbuilders.LongPressGestureHandlerEventDataBuilder
 
 class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestureHandler>() {
   var minDurationMs = DEFAULT_MIN_DURATION_MS
@@ -171,6 +174,36 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
   override fun onReset() {
     super.onReset()
     currentPointers = 0
+  }
+
+  class Factory : GestureHandler.Factory<LongPressGestureHandler>() {
+    override val type = LongPressGestureHandler::class.java
+    override val name = "LongPressGestureHandler"
+
+    override fun create(context: Context?): LongPressGestureHandler {
+      return LongPressGestureHandler((context)!!)
+    }
+
+    override fun configure(handler: LongPressGestureHandler, config: ReadableMap) {
+      super.configure(handler, config)
+      if (config.hasKey(KEY_LONG_PRESS_MIN_DURATION_MS)) {
+        handler.minDurationMs = config.getInt(KEY_LONG_PRESS_MIN_DURATION_MS).toLong()
+      }
+      if (config.hasKey(KEY_LONG_PRESS_MAX_DIST)) {
+        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_LONG_PRESS_MAX_DIST)))
+      }
+      if (config.hasKey(KEY_NUMBER_OF_POINTERS)) {
+        handler.setNumberOfPointers(config.getInt(KEY_NUMBER_OF_POINTERS))
+      }
+    }
+
+    override fun createEventBuilder(handler: LongPressGestureHandler) = LongPressGestureHandlerEventDataBuilder(handler)
+
+    companion object {
+      private const val KEY_LONG_PRESS_MIN_DURATION_MS = "minDurationMs"
+      private const val KEY_LONG_PRESS_MAX_DIST = "maxDist"
+      private const val KEY_NUMBER_OF_POINTERS = "numberOfPointers"
+    }
   }
 
   companion object {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -184,8 +184,8 @@ class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestur
       return LongPressGestureHandler((context)!!)
     }
 
-    override fun configure(handler: LongPressGestureHandler, config: ReadableMap) {
-      super.configure(handler, config)
+    override fun setConfig(handler: LongPressGestureHandler, config: ReadableMap) {
+      super.setConfig(handler, config)
       if (config.hasKey(KEY_MIN_DURATION_MS)) {
         handler.minDurationMs = config.getInt(KEY_MIN_DURATION_MS).toLong()
       }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/ManualGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/ManualGestureHandler.kt
@@ -1,11 +1,24 @@
 package com.swmansion.gesturehandler.core
 
+import android.content.Context
 import android.view.MotionEvent
+import com.swmansion.gesturehandler.react.eventbuilders.ManualGestureHandlerEventDataBuilder
 
 class ManualGestureHandler : GestureHandler<ManualGestureHandler>() {
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
     if (state == STATE_UNDETERMINED) {
       begin()
     }
+  }
+
+  class Factory : GestureHandler.Factory<ManualGestureHandler>() {
+    override val type = ManualGestureHandler::class.java
+    override val name = "ManualGestureHandler"
+
+    override fun create(context: Context?): ManualGestureHandler {
+      return ManualGestureHandler()
+    }
+
+    override fun createEventBuilder(handler: ManualGestureHandler) = ManualGestureHandlerEventDataBuilder(handler)
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -177,21 +177,21 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
 
     override fun configure(handler: NativeViewGestureHandler, config: ReadableMap) {
       super.configure(handler, config)
-      if (config.hasKey(KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START)) {
+      if (config.hasKey(KEY_SHOULD_ACTIVATE_ON_START)) {
         handler.setShouldActivateOnStart(
-          config.getBoolean(KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START)
+          config.getBoolean(KEY_SHOULD_ACTIVATE_ON_START)
         )
       }
-      if (config.hasKey(KEY_NATIVE_VIEW_DISALLOW_INTERRUPTION)) {
-        handler.setDisallowInterruption(config.getBoolean(KEY_NATIVE_VIEW_DISALLOW_INTERRUPTION))
+      if (config.hasKey(KEY_DISALLOW_INTERRUPTION)) {
+        handler.setDisallowInterruption(config.getBoolean(KEY_DISALLOW_INTERRUPTION))
       }
     }
 
     override fun createEventBuilder(handler: NativeViewGestureHandler) = NativeGestureHandlerEventDataBuilder(handler)
 
     companion object {
-      private const val KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START = "shouldActivateOnStart"
-      private const val KEY_NATIVE_VIEW_DISALLOW_INTERRUPTION = "disallowInterruption"
+      private const val KEY_SHOULD_ACTIVATE_ON_START = "shouldActivateOnStart"
+      private const val KEY_DISALLOW_INTERRUPTION = "disallowInterruption"
     }
   }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -175,8 +175,8 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
       return NativeViewGestureHandler()
     }
 
-    override fun configure(handler: NativeViewGestureHandler, config: ReadableMap) {
-      super.configure(handler, config)
+    override fun setConfig(handler: NativeViewGestureHandler, config: ReadableMap) {
+      super.setConfig(handler, config)
       if (config.hasKey(KEY_SHOULD_ACTIVATE_ON_START)) {
         handler.setShouldActivateOnStart(
           config.getBoolean(KEY_SHOULD_ACTIVATE_ON_START)

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -1,11 +1,13 @@
 package com.swmansion.gesturehandler.core
 
+import android.content.Context
 import android.os.SystemClock
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewConfiguration
 import android.view.ViewGroup
 import android.widget.ScrollView
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.views.scroll.ReactHorizontalScrollView
 import com.facebook.react.views.scroll.ReactScrollView
 import com.facebook.react.views.swiperefresh.ReactSwipeRefreshLayout
@@ -13,6 +15,7 @@ import com.facebook.react.views.text.ReactTextView
 import com.facebook.react.views.textinput.ReactEditText
 import com.facebook.react.views.view.ReactViewGroup
 import com.swmansion.gesturehandler.react.RNGestureHandlerButtonViewManager
+import com.swmansion.gesturehandler.react.eventbuilders.NativeGestureHandlerEventDataBuilder
 import com.swmansion.gesturehandler.react.isScreenReaderOn
 
 class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
@@ -162,6 +165,34 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
 
   override fun onReset() {
     this.hook = defaultHook
+  }
+
+  class Factory : GestureHandler.Factory<NativeViewGestureHandler>() {
+    override val type = NativeViewGestureHandler::class.java
+    override val name = "NativeViewGestureHandler"
+
+    override fun create(context: Context?): NativeViewGestureHandler {
+      return NativeViewGestureHandler()
+    }
+
+    override fun configure(handler: NativeViewGestureHandler, config: ReadableMap) {
+      super.configure(handler, config)
+      if (config.hasKey(KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START)) {
+        handler.setShouldActivateOnStart(
+          config.getBoolean(KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START)
+        )
+      }
+      if (config.hasKey(KEY_NATIVE_VIEW_DISALLOW_INTERRUPTION)) {
+        handler.setDisallowInterruption(config.getBoolean(KEY_NATIVE_VIEW_DISALLOW_INTERRUPTION))
+      }
+    }
+
+    override fun createEventBuilder(handler: NativeViewGestureHandler) = NativeGestureHandlerEventDataBuilder(handler)
+
+    companion object {
+      private const val KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START = "shouldActivateOnStart"
+      private const val KEY_NATIVE_VIEW_DISALLOW_INTERRUPTION = "disallowInterruption"
+    }
   }
 
   companion object {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -20,32 +20,26 @@ import com.swmansion.gesturehandler.react.isScreenReaderOn
 
 class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   private var shouldActivateOnStart = false
-  var disallowInterruption = false
-    private set
-
-  private var hook: NativeViewGestureHandlerHook = defaultHook
-
-  init {
-    setShouldCancelWhenOutside(true)
-  }
-
-  override fun resetConfig() {
-    super.resetConfig()
-    shouldActivateOnStart = false
-    disallowInterruption = false
-  }
-
-  fun setShouldActivateOnStart(shouldActivateOnStart: Boolean) = apply {
-    this.shouldActivateOnStart = shouldActivateOnStart
-  }
 
   /**
    * Set this to `true` when wrapping native components that are supposed to be an exclusive
    * target for a touch stream. Like for example switch or slider component which when activated
    * aren't supposed to be cancelled by scrollview or other container that may also handle touches.
    */
-  fun setDisallowInterruption(disallowInterruption: Boolean) = apply {
-    this.disallowInterruption = disallowInterruption
+  var disallowInterruption = false
+    private set
+
+  private var hook: NativeViewGestureHandlerHook = defaultHook
+
+  init {
+    shouldCancelWhenOutside = true
+  }
+
+  override fun resetConfig() {
+    super.resetConfig()
+    shouldActivateOnStart = DEFAULT_SHOULD_ACTIVATE_ON_START
+    disallowInterruption = DEFAULT_DISALLOW_INTERRUPTION
+    shouldCancelWhenOutside = DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE
   }
 
   override fun shouldRecognizeSimultaneously(handler: GestureHandler<*>): Boolean {
@@ -178,12 +172,10 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     override fun setConfig(handler: NativeViewGestureHandler, config: ReadableMap) {
       super.setConfig(handler, config)
       if (config.hasKey(KEY_SHOULD_ACTIVATE_ON_START)) {
-        handler.setShouldActivateOnStart(
-          config.getBoolean(KEY_SHOULD_ACTIVATE_ON_START)
-        )
+        handler.shouldActivateOnStart = config.getBoolean(KEY_SHOULD_ACTIVATE_ON_START)
       }
       if (config.hasKey(KEY_DISALLOW_INTERRUPTION)) {
-        handler.setDisallowInterruption(config.getBoolean(KEY_DISALLOW_INTERRUPTION))
+        handler.disallowInterruption = config.getBoolean(KEY_DISALLOW_INTERRUPTION)
       }
     }
 
@@ -196,6 +188,10 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   }
 
   companion object {
+    private const val DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE = true
+    private const val DEFAULT_SHOULD_ACTIVATE_ON_START = false
+    private const val DEFAULT_DISALLOW_INTERRUPTION = false
+
     private fun tryIntercept(view: View, event: MotionEvent) =
       view is ViewGroup && view.onInterceptTouchEvent(event)
 

--- a/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
@@ -321,8 +321,8 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       return PanGestureHandler(context)
     }
 
-    override fun configure(handler: PanGestureHandler, config: ReadableMap) {
-      super.configure(handler, config)
+    override fun setConfig(handler: PanGestureHandler, config: ReadableMap) {
+      super.setConfig(handler, config)
       var hasCustomActivationCriteria = false
       if (config.hasKey(KEY_ACTIVE_OFFSET_X_START)) {
         handler.setActiveOffsetXStart(

--- a/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
@@ -22,8 +22,8 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
   val translationY: Float
     get() = lastY - startY + offsetY
 
-  private val defaultMinDistSq: Float
-  private var minDistSq = MAX_VALUE_IGNORE
+  private val defaultMinDist: Float
+  private var minDist = MAX_VALUE_IGNORE
   private var activeOffsetXStart = MIN_VALUE_IGNORE
   private var activeOffsetXEnd = MAX_VALUE_IGNORE
   private var failOffsetXStart = MAX_VALUE_IGNORE
@@ -32,9 +32,12 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
   private var activeOffsetYEnd = MAX_VALUE_IGNORE
   private var failOffsetYStart = MAX_VALUE_IGNORE
   private var failOffsetYEnd = MIN_VALUE_IGNORE
+  /**
+   * in pixels per second
+   */
   private var minVelocityX = MIN_VALUE_IGNORE
   private var minVelocityY = MIN_VALUE_IGNORE
-  private var minVelocitySq = MIN_VALUE_IGNORE
+  private var minVelocity = MIN_VALUE_IGNORE
   private var minPointers = DEFAULT_MIN_POINTERS
   private var maxPointers = DEFAULT_MAX_POINTERS
   private var startX = 0f
@@ -65,96 +68,28 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
    */
   init {
     val vc = ViewConfiguration.get(context!!)
-    val touchSlop = vc.scaledTouchSlop
-    defaultMinDistSq = (touchSlop * touchSlop).toFloat()
-    minDistSq = defaultMinDistSq
+    defaultMinDist = vc.scaledTouchSlop.toFloat()
+    minDist = defaultMinDist
   }
 
   override fun resetConfig() {
     super.resetConfig()
-    activeOffsetXStart = MIN_VALUE_IGNORE
-    activeOffsetXEnd = MAX_VALUE_IGNORE
-    failOffsetXStart = MAX_VALUE_IGNORE
-    failOffsetXEnd = MIN_VALUE_IGNORE
-    activeOffsetYStart = MIN_VALUE_IGNORE
-    activeOffsetYEnd = MAX_VALUE_IGNORE
-    failOffsetYStart = MAX_VALUE_IGNORE
-    failOffsetYEnd = MIN_VALUE_IGNORE
-    minVelocityX = MIN_VALUE_IGNORE
-    minVelocityY = MIN_VALUE_IGNORE
-    minVelocitySq = MIN_VALUE_IGNORE
-    minDistSq = defaultMinDistSq
+    activeOffsetXStart = DEFAULT_ACTIVE_OFFSET_X_START
+    activeOffsetXEnd = DEFAULT_ACTIVE_OFFSET_X_END
+    failOffsetXStart = DEFAULT_FAIL_OFFSET_X_START
+    failOffsetXEnd = DEFAULT_FAIL_OFFSET_X_END
+    activeOffsetYStart = DEFAULT_ACTIVE_OFFSET_Y_START
+    activeOffsetYEnd = DEFAULT_ACTIVE_OFFSET_Y_END
+    failOffsetYStart = DEFAULT_FAIL_OFFSET_Y_START
+    failOffsetYEnd = DEFAULT_FAIL_OFFSET_Y_END
+    minVelocityX = DEFAULT_MIN_VELOCITY_X
+    minVelocityY = DEFAULT_MIN_VELOCITY_Y
+    minVelocity = DEFAULT_MIN_VELOCITY
+    minDist = defaultMinDist
     minPointers = DEFAULT_MIN_POINTERS
     maxPointers = DEFAULT_MAX_POINTERS
     activateAfterLongPress = DEFAULT_ACTIVATE_AFTER_LONG_PRESS
-    averageTouches = false
-  }
-
-  fun setActiveOffsetXStart(activeOffsetXStart: Float) = apply {
-    this.activeOffsetXStart = activeOffsetXStart
-  }
-
-  fun setActiveOffsetXEnd(activeOffsetXEnd: Float) = apply {
-    this.activeOffsetXEnd = activeOffsetXEnd
-  }
-
-  fun setFailOffsetXStart(failOffsetXStart: Float) = apply {
-    this.failOffsetXStart = failOffsetXStart
-  }
-
-  fun setFailOffsetXEnd(failOffsetXEnd: Float) = apply {
-    this.failOffsetXEnd = failOffsetXEnd
-  }
-
-  fun setActiveOffsetYStart(activeOffsetYStart: Float) = apply {
-    this.activeOffsetYStart = activeOffsetYStart
-  }
-
-  fun setActiveOffsetYEnd(activeOffsetYEnd: Float) = apply {
-    this.activeOffsetYEnd = activeOffsetYEnd
-  }
-
-  fun setFailOffsetYStart(failOffsetYStart: Float) = apply {
-    this.failOffsetYStart = failOffsetYStart
-  }
-
-  fun setFailOffsetYEnd(failOffsetYEnd: Float) = apply {
-    this.failOffsetYEnd = failOffsetYEnd
-  }
-
-  fun setMinDist(minDist: Float) = apply {
-    minDistSq = minDist * minDist
-  }
-
-  fun setMinPointers(minPointers: Int) = apply {
-    this.minPointers = minPointers
-  }
-
-  fun setMaxPointers(maxPointers: Int) = apply {
-    this.maxPointers = maxPointers
-  }
-
-  fun setAverageTouches(averageTouches: Boolean) = apply {
-    this.averageTouches = averageTouches
-  }
-
-  fun setActivateAfterLongPress(time: Long) = apply {
-    this.activateAfterLongPress = time
-  }
-
-  /**
-   * @param minVelocity in pixels per second
-   */
-  fun setMinVelocity(minVelocity: Float) = apply {
-    minVelocitySq = minVelocity * minVelocity
-  }
-
-  fun setMinVelocityX(minVelocityX: Float) = apply {
-    this.minVelocityX = minVelocityX
-  }
-
-  fun setMinVelocityY(minVelocityY: Float) = apply {
-    this.minVelocityY = minVelocityY
+    averageTouches = DEFAULT_AVERAGE_TOUCHES
   }
 
   private fun shouldActivate(): Boolean {
@@ -173,7 +108,7 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       return true
     }
     val distSq = dx * dx + dy * dy
-    if (minDistSq != MIN_VALUE_IGNORE && distSq >= minDistSq) {
+    if (minDist != MIN_VALUE_IGNORE && distSq >= minDist * minDist) {
       return true
     }
     val vx = velocityX
@@ -189,14 +124,14 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       return true
     }
     val velocitySq = vx * vx + vy * vy
-    return minVelocitySq != MIN_VALUE_IGNORE && velocitySq >= minVelocitySq
+    return minVelocity != MIN_VALUE_IGNORE && velocitySq >= minVelocity * minVelocity
   }
 
   private fun shouldFail(): Boolean {
     val dx = lastX - startX + offsetX
     val dy = lastY - startY + offsetY
 
-    if (activateAfterLongPress > 0 && dx * dx + dy * dy > defaultMinDistSq) {
+    if (activateAfterLongPress > 0 && dx * dx + dy * dy > defaultMinDist * defaultMinDist) {
       handler?.removeCallbacksAndMessages(null)
       return true
     }
@@ -325,94 +260,110 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
       super.setConfig(handler, config)
       var hasCustomActivationCriteria = false
       if (config.hasKey(KEY_ACTIVE_OFFSET_X_START)) {
-        handler.setActiveOffsetXStart(
-          PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_ACTIVE_OFFSET_X_START
-          )))
+        handler.activeOffsetXStart =
+          PixelUtil.toPixelFromDIP(
+            config.getDouble(
+              KEY_ACTIVE_OFFSET_X_START
+            )
+          )
         hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_ACTIVE_OFFSET_X_END)) {
-        handler.setActiveOffsetXEnd(
-          PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_ACTIVE_OFFSET_X_END
-          )))
+        handler.activeOffsetXEnd =
+          PixelUtil.toPixelFromDIP(
+            config.getDouble(
+              KEY_ACTIVE_OFFSET_X_END
+            )
+          )
         hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_FAIL_OFFSET_RANGE_X_START)) {
-        handler.setFailOffsetXStart(
-          PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_FAIL_OFFSET_RANGE_X_START
-          )))
+        handler.failOffsetXStart =
+          PixelUtil.toPixelFromDIP(
+            config.getDouble(
+              KEY_FAIL_OFFSET_RANGE_X_START
+            )
+          )
         hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_FAIL_OFFSET_RANGE_X_END)) {
-        handler.setFailOffsetXEnd(
-          PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_FAIL_OFFSET_RANGE_X_END
-          )))
+        handler.failOffsetXEnd =
+          PixelUtil.toPixelFromDIP(
+            config.getDouble(
+              KEY_FAIL_OFFSET_RANGE_X_END
+            )
+          )
         hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_ACTIVE_OFFSET_Y_START)) {
-        handler.setActiveOffsetYStart(
-          PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_ACTIVE_OFFSET_Y_START
-          )))
+        handler.activeOffsetYStart =
+          PixelUtil.toPixelFromDIP(
+            config.getDouble(
+              KEY_ACTIVE_OFFSET_Y_START
+            )
+          )
         hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_ACTIVE_OFFSET_Y_END)) {
-        handler.setActiveOffsetYEnd(
-          PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_ACTIVE_OFFSET_Y_END
-          )))
+        handler.activeOffsetYEnd =
+          PixelUtil.toPixelFromDIP(
+            config.getDouble(
+              KEY_ACTIVE_OFFSET_Y_END
+            )
+          )
         hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_FAIL_OFFSET_RANGE_Y_START)) {
-        handler.setFailOffsetYStart(
-          PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_FAIL_OFFSET_RANGE_Y_START
-          )))
+        handler.failOffsetYStart =
+          PixelUtil.toPixelFromDIP(
+            config.getDouble(
+              KEY_FAIL_OFFSET_RANGE_Y_START
+            )
+          )
         hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_FAIL_OFFSET_RANGE_Y_END)) {
-        handler.setFailOffsetYEnd(
-          PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_FAIL_OFFSET_RANGE_Y_END
-          )))
+        handler.failOffsetYEnd =
+          PixelUtil.toPixelFromDIP(
+            config.getDouble(
+              KEY_FAIL_OFFSET_RANGE_Y_END
+            )
+          )
         hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_MIN_VELOCITY)) {
         // This value is actually in DPs/ms, but we can use the same function as for converting
         // from DPs to pixels as the unit we're converting is in the numerator
-        handler.setMinVelocity(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_VELOCITY)))
+        handler.minVelocity = PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_VELOCITY))
         hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_MIN_VELOCITY_X)) {
-        handler.setMinVelocityX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_VELOCITY_X)))
+        handler.minVelocityX = PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_VELOCITY_X))
         hasCustomActivationCriteria = true
       }
       if (config.hasKey(KEY_MIN_VELOCITY_Y)) {
-        handler.setMinVelocityY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_VELOCITY_Y)))
+        handler.minVelocityY = PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_VELOCITY_Y))
         hasCustomActivationCriteria = true
       }
 
       // PanGestureHandler sets minDist by default, if there are custom criteria specified we want
       // to reset that setting and use provided criteria instead.
       if (config.hasKey(KEY_MIN_DIST)) {
-        handler.setMinDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_DIST)))
+        handler.minDist = PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_DIST))
       } else if (hasCustomActivationCriteria) {
-        handler.setMinDist(Float.MAX_VALUE)
+        handler.minDist = Float.MAX_VALUE
       }
       if (config.hasKey(KEY_MIN_POINTERS)) {
-        handler.setMinPointers(config.getInt(KEY_MIN_POINTERS))
+        handler.minPointers = config.getInt(KEY_MIN_POINTERS)
       }
       if (config.hasKey(KEY_MAX_POINTERS)) {
-        handler.setMaxPointers(config.getInt(KEY_MAX_POINTERS))
+        handler.maxPointers = config.getInt(KEY_MAX_POINTERS)
       }
       if (config.hasKey(KEY_AVG_TOUCHES)) {
-        handler.setAverageTouches(config.getBoolean(KEY_AVG_TOUCHES))
+        handler.averageTouches = config.getBoolean(KEY_AVG_TOUCHES)
       }
       if (config.hasKey(KEY_ACTIVATE_AFTER_LONG_PRESS)) {
-        handler.setActivateAfterLongPress(config.getInt(KEY_ACTIVATE_AFTER_LONG_PRESS).toLong())
+        handler.activateAfterLongPress = config.getInt(KEY_ACTIVATE_AFTER_LONG_PRESS).toLong()
       }
     }
 
@@ -444,6 +395,18 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
     private const val DEFAULT_MIN_POINTERS = 1
     private const val DEFAULT_MAX_POINTERS = 10
     private const val DEFAULT_ACTIVATE_AFTER_LONG_PRESS = 0L
+    private const val DEFAULT_AVERAGE_TOUCHES = false
+    private const val DEFAULT_ACTIVE_OFFSET_X_START = MIN_VALUE_IGNORE
+    private const val DEFAULT_ACTIVE_OFFSET_X_END = MAX_VALUE_IGNORE
+    private const val DEFAULT_FAIL_OFFSET_X_START = MAX_VALUE_IGNORE
+    private const val DEFAULT_FAIL_OFFSET_X_END = MIN_VALUE_IGNORE
+    private const val DEFAULT_ACTIVE_OFFSET_Y_START = MIN_VALUE_IGNORE
+    private const val DEFAULT_ACTIVE_OFFSET_Y_END = MAX_VALUE_IGNORE
+    private const val DEFAULT_FAIL_OFFSET_Y_START = MAX_VALUE_IGNORE
+    private const val DEFAULT_FAIL_OFFSET_Y_END = MIN_VALUE_IGNORE
+    private const val DEFAULT_MIN_VELOCITY_X = MIN_VALUE_IGNORE
+    private const val DEFAULT_MIN_VELOCITY_Y = MIN_VALUE_IGNORE
+    private const val DEFAULT_MIN_VELOCITY = MIN_VALUE_IGNORE
 
     /**
      * This method adds movement to {@class VelocityTracker} first resetting offset of the event so

--- a/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
@@ -6,8 +6,11 @@ import android.os.Looper
 import android.view.MotionEvent
 import android.view.VelocityTracker
 import android.view.ViewConfiguration
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.PixelUtil
 import com.swmansion.gesturehandler.core.GestureUtils.getLastPointerX
 import com.swmansion.gesturehandler.core.GestureUtils.getLastPointerY
+import com.swmansion.gesturehandler.react.eventbuilders.PanGestureHandlerEventDataBuilder
 
 class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>() {
   var velocityX = 0f
@@ -308,6 +311,131 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
   override fun resetProgress() {
     startX = lastX
     startY = lastY
+  }
+
+  class Factory : GestureHandler.Factory<PanGestureHandler>() {
+    override val type = PanGestureHandler::class.java
+    override val name = "PanGestureHandler"
+
+    override fun create(context: Context?): PanGestureHandler {
+      return PanGestureHandler(context)
+    }
+
+    override fun configure(handler: PanGestureHandler, config: ReadableMap) {
+      super.configure(handler, config)
+      var hasCustomActivationCriteria = false
+      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_START)) {
+        handler.setActiveOffsetXStart(
+          PixelUtil.toPixelFromDIP(config.getDouble(
+            KEY_PAN_ACTIVE_OFFSET_X_START
+          )))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_END)) {
+        handler.setActiveOffsetXEnd(
+          PixelUtil.toPixelFromDIP(config.getDouble(
+            KEY_PAN_ACTIVE_OFFSET_X_END
+          )))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_START)) {
+        handler.setFailOffsetXStart(
+          PixelUtil.toPixelFromDIP(config.getDouble(
+            KEY_PAN_FAIL_OFFSET_RANGE_X_START
+          )))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_END)) {
+        handler.setFailOffsetXEnd(
+          PixelUtil.toPixelFromDIP(config.getDouble(
+            KEY_PAN_FAIL_OFFSET_RANGE_X_END
+          )))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_START)) {
+        handler.setActiveOffsetYStart(
+          PixelUtil.toPixelFromDIP(config.getDouble(
+            KEY_PAN_ACTIVE_OFFSET_Y_START
+          )))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_END)) {
+        handler.setActiveOffsetYEnd(
+          PixelUtil.toPixelFromDIP(config.getDouble(
+            KEY_PAN_ACTIVE_OFFSET_Y_END
+          )))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)) {
+        handler.setFailOffsetYStart(
+          PixelUtil.toPixelFromDIP(config.getDouble(
+            KEY_PAN_FAIL_OFFSET_RANGE_Y_START
+          )))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)) {
+        handler.setFailOffsetYEnd(
+          PixelUtil.toPixelFromDIP(config.getDouble(
+            KEY_PAN_FAIL_OFFSET_RANGE_Y_END
+          )))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_MIN_VELOCITY)) {
+        // This value is actually in DPs/ms, but we can use the same function as for converting
+        // from DPs to pixels as the unit we're converting is in the numerator
+        handler.setMinVelocity(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY)))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_MIN_VELOCITY_X)) {
+        handler.setMinVelocityX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY_X)))
+        hasCustomActivationCriteria = true
+      }
+      if (config.hasKey(KEY_PAN_MIN_VELOCITY_Y)) {
+        handler.setMinVelocityY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY_Y)))
+        hasCustomActivationCriteria = true
+      }
+
+      // PanGestureHandler sets minDist by default, if there are custom criteria specified we want
+      // to reset that setting and use provided criteria instead.
+      if (config.hasKey(KEY_PAN_MIN_DIST)) {
+        handler.setMinDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_DIST)))
+      } else if (hasCustomActivationCriteria) {
+        handler.setMinDist(Float.MAX_VALUE)
+      }
+      if (config.hasKey(KEY_PAN_MIN_POINTERS)) {
+        handler.setMinPointers(config.getInt(KEY_PAN_MIN_POINTERS))
+      }
+      if (config.hasKey(KEY_PAN_MAX_POINTERS)) {
+        handler.setMaxPointers(config.getInt(KEY_PAN_MAX_POINTERS))
+      }
+      if (config.hasKey(KEY_PAN_AVG_TOUCHES)) {
+        handler.setAverageTouches(config.getBoolean(KEY_PAN_AVG_TOUCHES))
+      }
+      if (config.hasKey(KEY_PAN_ACTIVATE_AFTER_LONG_PRESS)) {
+        handler.setActivateAfterLongPress(config.getInt(KEY_PAN_ACTIVATE_AFTER_LONG_PRESS).toLong())
+      }
+    }
+
+    override fun createEventBuilder(handler: PanGestureHandler) = PanGestureHandlerEventDataBuilder(handler)
+
+    companion object {
+      private const val KEY_PAN_ACTIVE_OFFSET_X_START = "activeOffsetXStart"
+      private const val KEY_PAN_ACTIVE_OFFSET_X_END = "activeOffsetXEnd"
+      private const val KEY_PAN_FAIL_OFFSET_RANGE_X_START = "failOffsetXStart"
+      private const val KEY_PAN_FAIL_OFFSET_RANGE_X_END = "failOffsetXEnd"
+      private const val KEY_PAN_ACTIVE_OFFSET_Y_START = "activeOffsetYStart"
+      private const val KEY_PAN_ACTIVE_OFFSET_Y_END = "activeOffsetYEnd"
+      private const val KEY_PAN_FAIL_OFFSET_RANGE_Y_START = "failOffsetYStart"
+      private const val KEY_PAN_FAIL_OFFSET_RANGE_Y_END = "failOffsetYEnd"
+      private const val KEY_PAN_MIN_DIST = "minDist"
+      private const val KEY_PAN_MIN_VELOCITY = "minVelocity"
+      private const val KEY_PAN_MIN_VELOCITY_X = "minVelocityX"
+      private const val KEY_PAN_MIN_VELOCITY_Y = "minVelocityY"
+      private const val KEY_PAN_MIN_POINTERS = "minPointers"
+      private const val KEY_PAN_MAX_POINTERS = "maxPointers"
+      private const val KEY_PAN_AVG_TOUCHES = "avgTouches"
+      private const val KEY_PAN_ACTIVATE_AFTER_LONG_PRESS = "activateAfterLongPress"
+    }
   }
 
   companion object {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
@@ -324,117 +324,117 @@ class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>()
     override fun configure(handler: PanGestureHandler, config: ReadableMap) {
       super.configure(handler, config)
       var hasCustomActivationCriteria = false
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_START)) {
+      if (config.hasKey(KEY_ACTIVE_OFFSET_X_START)) {
         handler.setActiveOffsetXStart(
           PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_PAN_ACTIVE_OFFSET_X_START
+            KEY_ACTIVE_OFFSET_X_START
           )))
         hasCustomActivationCriteria = true
       }
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_END)) {
+      if (config.hasKey(KEY_ACTIVE_OFFSET_X_END)) {
         handler.setActiveOffsetXEnd(
           PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_PAN_ACTIVE_OFFSET_X_END
+            KEY_ACTIVE_OFFSET_X_END
           )))
         hasCustomActivationCriteria = true
       }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_START)) {
+      if (config.hasKey(KEY_FAIL_OFFSET_RANGE_X_START)) {
         handler.setFailOffsetXStart(
           PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_PAN_FAIL_OFFSET_RANGE_X_START
+            KEY_FAIL_OFFSET_RANGE_X_START
           )))
         hasCustomActivationCriteria = true
       }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_END)) {
+      if (config.hasKey(KEY_FAIL_OFFSET_RANGE_X_END)) {
         handler.setFailOffsetXEnd(
           PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_PAN_FAIL_OFFSET_RANGE_X_END
+            KEY_FAIL_OFFSET_RANGE_X_END
           )))
         hasCustomActivationCriteria = true
       }
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_START)) {
+      if (config.hasKey(KEY_ACTIVE_OFFSET_Y_START)) {
         handler.setActiveOffsetYStart(
           PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_PAN_ACTIVE_OFFSET_Y_START
+            KEY_ACTIVE_OFFSET_Y_START
           )))
         hasCustomActivationCriteria = true
       }
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_END)) {
+      if (config.hasKey(KEY_ACTIVE_OFFSET_Y_END)) {
         handler.setActiveOffsetYEnd(
           PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_PAN_ACTIVE_OFFSET_Y_END
+            KEY_ACTIVE_OFFSET_Y_END
           )))
         hasCustomActivationCriteria = true
       }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)) {
+      if (config.hasKey(KEY_FAIL_OFFSET_RANGE_Y_START)) {
         handler.setFailOffsetYStart(
           PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_PAN_FAIL_OFFSET_RANGE_Y_START
+            KEY_FAIL_OFFSET_RANGE_Y_START
           )))
         hasCustomActivationCriteria = true
       }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)) {
+      if (config.hasKey(KEY_FAIL_OFFSET_RANGE_Y_END)) {
         handler.setFailOffsetYEnd(
           PixelUtil.toPixelFromDIP(config.getDouble(
-            KEY_PAN_FAIL_OFFSET_RANGE_Y_END
+            KEY_FAIL_OFFSET_RANGE_Y_END
           )))
         hasCustomActivationCriteria = true
       }
-      if (config.hasKey(KEY_PAN_MIN_VELOCITY)) {
+      if (config.hasKey(KEY_MIN_VELOCITY)) {
         // This value is actually in DPs/ms, but we can use the same function as for converting
         // from DPs to pixels as the unit we're converting is in the numerator
-        handler.setMinVelocity(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY)))
+        handler.setMinVelocity(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_VELOCITY)))
         hasCustomActivationCriteria = true
       }
-      if (config.hasKey(KEY_PAN_MIN_VELOCITY_X)) {
-        handler.setMinVelocityX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY_X)))
+      if (config.hasKey(KEY_MIN_VELOCITY_X)) {
+        handler.setMinVelocityX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_VELOCITY_X)))
         hasCustomActivationCriteria = true
       }
-      if (config.hasKey(KEY_PAN_MIN_VELOCITY_Y)) {
-        handler.setMinVelocityY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY_Y)))
+      if (config.hasKey(KEY_MIN_VELOCITY_Y)) {
+        handler.setMinVelocityY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_VELOCITY_Y)))
         hasCustomActivationCriteria = true
       }
 
       // PanGestureHandler sets minDist by default, if there are custom criteria specified we want
       // to reset that setting and use provided criteria instead.
-      if (config.hasKey(KEY_PAN_MIN_DIST)) {
-        handler.setMinDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_DIST)))
+      if (config.hasKey(KEY_MIN_DIST)) {
+        handler.setMinDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MIN_DIST)))
       } else if (hasCustomActivationCriteria) {
         handler.setMinDist(Float.MAX_VALUE)
       }
-      if (config.hasKey(KEY_PAN_MIN_POINTERS)) {
-        handler.setMinPointers(config.getInt(KEY_PAN_MIN_POINTERS))
+      if (config.hasKey(KEY_MIN_POINTERS)) {
+        handler.setMinPointers(config.getInt(KEY_MIN_POINTERS))
       }
-      if (config.hasKey(KEY_PAN_MAX_POINTERS)) {
-        handler.setMaxPointers(config.getInt(KEY_PAN_MAX_POINTERS))
+      if (config.hasKey(KEY_MAX_POINTERS)) {
+        handler.setMaxPointers(config.getInt(KEY_MAX_POINTERS))
       }
-      if (config.hasKey(KEY_PAN_AVG_TOUCHES)) {
-        handler.setAverageTouches(config.getBoolean(KEY_PAN_AVG_TOUCHES))
+      if (config.hasKey(KEY_AVG_TOUCHES)) {
+        handler.setAverageTouches(config.getBoolean(KEY_AVG_TOUCHES))
       }
-      if (config.hasKey(KEY_PAN_ACTIVATE_AFTER_LONG_PRESS)) {
-        handler.setActivateAfterLongPress(config.getInt(KEY_PAN_ACTIVATE_AFTER_LONG_PRESS).toLong())
+      if (config.hasKey(KEY_ACTIVATE_AFTER_LONG_PRESS)) {
+        handler.setActivateAfterLongPress(config.getInt(KEY_ACTIVATE_AFTER_LONG_PRESS).toLong())
       }
     }
 
     override fun createEventBuilder(handler: PanGestureHandler) = PanGestureHandlerEventDataBuilder(handler)
 
     companion object {
-      private const val KEY_PAN_ACTIVE_OFFSET_X_START = "activeOffsetXStart"
-      private const val KEY_PAN_ACTIVE_OFFSET_X_END = "activeOffsetXEnd"
-      private const val KEY_PAN_FAIL_OFFSET_RANGE_X_START = "failOffsetXStart"
-      private const val KEY_PAN_FAIL_OFFSET_RANGE_X_END = "failOffsetXEnd"
-      private const val KEY_PAN_ACTIVE_OFFSET_Y_START = "activeOffsetYStart"
-      private const val KEY_PAN_ACTIVE_OFFSET_Y_END = "activeOffsetYEnd"
-      private const val KEY_PAN_FAIL_OFFSET_RANGE_Y_START = "failOffsetYStart"
-      private const val KEY_PAN_FAIL_OFFSET_RANGE_Y_END = "failOffsetYEnd"
-      private const val KEY_PAN_MIN_DIST = "minDist"
-      private const val KEY_PAN_MIN_VELOCITY = "minVelocity"
-      private const val KEY_PAN_MIN_VELOCITY_X = "minVelocityX"
-      private const val KEY_PAN_MIN_VELOCITY_Y = "minVelocityY"
-      private const val KEY_PAN_MIN_POINTERS = "minPointers"
-      private const val KEY_PAN_MAX_POINTERS = "maxPointers"
-      private const val KEY_PAN_AVG_TOUCHES = "avgTouches"
-      private const val KEY_PAN_ACTIVATE_AFTER_LONG_PRESS = "activateAfterLongPress"
+      private const val KEY_ACTIVE_OFFSET_X_START = "activeOffsetXStart"
+      private const val KEY_ACTIVE_OFFSET_X_END = "activeOffsetXEnd"
+      private const val KEY_FAIL_OFFSET_RANGE_X_START = "failOffsetXStart"
+      private const val KEY_FAIL_OFFSET_RANGE_X_END = "failOffsetXEnd"
+      private const val KEY_ACTIVE_OFFSET_Y_START = "activeOffsetYStart"
+      private const val KEY_ACTIVE_OFFSET_Y_END = "activeOffsetYEnd"
+      private const val KEY_FAIL_OFFSET_RANGE_Y_START = "failOffsetYStart"
+      private const val KEY_FAIL_OFFSET_RANGE_Y_END = "failOffsetYEnd"
+      private const val KEY_MIN_DIST = "minDist"
+      private const val KEY_MIN_VELOCITY = "minVelocity"
+      private const val KEY_MIN_VELOCITY_X = "minVelocityX"
+      private const val KEY_MIN_VELOCITY_Y = "minVelocityY"
+      private const val KEY_MIN_POINTERS = "minPointers"
+      private const val KEY_MAX_POINTERS = "maxPointers"
+      private const val KEY_AVG_TOUCHES = "avgTouches"
+      private const val KEY_ACTIVATE_AFTER_LONG_PRESS = "activateAfterLongPress"
     }
   }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
@@ -1,8 +1,10 @@
 package com.swmansion.gesturehandler.core
 
+import android.content.Context
 import android.graphics.PointF
 import android.view.MotionEvent
 import android.view.ViewConfiguration
+import com.swmansion.gesturehandler.react.eventbuilders.PinchGestureHandlerEventDataBuilder
 import kotlin.math.abs
 
 class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
@@ -99,5 +101,16 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
   override fun resetProgress() {
     velocity = 0.0
     scale = 1.0
+  }
+
+  class Factory : GestureHandler.Factory<PinchGestureHandler>() {
+    override val type = PinchGestureHandler::class.java
+    override val name = "PinchGestureHandler"
+
+    override fun create(context: Context?): PinchGestureHandler {
+      return PinchGestureHandler()
+    }
+
+    override fun createEventBuilder(handler: PinchGestureHandler) = PinchGestureHandlerEventDataBuilder(handler)
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
@@ -38,10 +38,6 @@ class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
       return true
     }
 
-    init {
-      setShouldCancelWhenOutside(false)
-    }
-
     override fun onScaleBegin(detector: ScaleGestureDetector): Boolean {
       startingSpan = detector.currentSpan
       return true

--- a/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
@@ -18,10 +18,6 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
   var anchorY: Float = Float.NaN
     private set
 
-  init {
-    setShouldCancelWhenOutside(false)
-  }
-
   private val gestureListener: OnRotationGestureListener = object : OnRotationGestureListener {
     override fun onRotation(detector: RotationGestureDetector): Boolean {
       val prevRotation: Double = rotation

--- a/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
@@ -1,8 +1,10 @@
 package com.swmansion.gesturehandler.core
 
+import android.content.Context
 import android.graphics.PointF
 import android.view.MotionEvent
 import com.swmansion.gesturehandler.core.RotationGestureDetector.OnRotationGestureListener
+import com.swmansion.gesturehandler.react.eventbuilders.RotationGestureHandlerEventDataBuilder
 import kotlin.math.abs
 
 class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
@@ -85,6 +87,17 @@ class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
   override fun resetProgress() {
     velocity = 0.0
     rotation = 0.0
+  }
+
+  class Factory : GestureHandler.Factory<RotationGestureHandler>() {
+    override val type = RotationGestureHandler::class.java
+    override val name = "RotationGestureHandler"
+
+    override fun create(context: Context?): RotationGestureHandler {
+      return RotationGestureHandler()
+    }
+
+    override fun createEventBuilder(handler: RotationGestureHandler) = RotationGestureHandlerEventDataBuilder(handler)
   }
 
   companion object {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
@@ -174,8 +174,8 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
       return TapGestureHandler()
     }
 
-    override fun configure(handler: TapGestureHandler, config: ReadableMap) {
-      super.configure(handler, config)
+    override fun setConfig(handler: TapGestureHandler, config: ReadableMap) {
+      super.setConfig(handler, config)
       if (config.hasKey(KEY_NUMBER_OF_TAPS)) {
         handler.setNumberOfTaps(config.getInt(KEY_NUMBER_OF_TAPS))
       }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
@@ -14,7 +14,7 @@ import kotlin.math.abs
 class TapGestureHandler : GestureHandler<TapGestureHandler>() {
   private var maxDeltaX = MAX_VALUE_IGNORE
   private var maxDeltaY = MAX_VALUE_IGNORE
-  private var maxDistSq = MAX_VALUE_IGNORE
+  private var maxDist = MAX_VALUE_IGNORE
   private var maxDurationMs = DEFAULT_MAX_DURATION_MS
   private var maxDelayMs = DEFAULT_MAX_DELAY_MS
   private var numberOfTaps = DEFAULT_NUMBER_OF_TAPS
@@ -31,46 +31,19 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
   private val failDelayed = Runnable { fail() }
 
   init {
-    setShouldCancelWhenOutside(true)
+    shouldCancelWhenOutside = true
   }
 
   override fun resetConfig() {
     super.resetConfig()
     maxDeltaX = MAX_VALUE_IGNORE
     maxDeltaY = MAX_VALUE_IGNORE
-    maxDistSq = MAX_VALUE_IGNORE
+    maxDist = MAX_VALUE_IGNORE
     maxDurationMs = DEFAULT_MAX_DURATION_MS
     maxDelayMs = DEFAULT_MAX_DELAY_MS
     numberOfTaps = DEFAULT_NUMBER_OF_TAPS
     minNumberOfPointers = DEFAULT_MIN_NUMBER_OF_POINTERS
-  }
-
-  fun setNumberOfTaps(numberOfTaps: Int) = apply {
-    this.numberOfTaps = numberOfTaps
-  }
-
-  fun setMaxDelayMs(maxDelayMs: Long) = apply {
-    this.maxDelayMs = maxDelayMs
-  }
-
-  fun setMaxDurationMs(maxDurationMs: Long) = apply {
-    this.maxDurationMs = maxDurationMs
-  }
-
-  fun setMaxDx(deltaX: Float) = apply {
-    maxDeltaX = deltaX
-  }
-
-  fun setMaxDy(deltaY: Float) = apply {
-    maxDeltaY = deltaY
-  }
-
-  fun setMaxDist(maxDist: Float) = apply {
-    maxDistSq = maxDist * maxDist
-  }
-
-  fun setMinNumberOfPointers(minNumberOfPointers: Int) = apply {
-    this.minNumberOfPointers = minNumberOfPointers
+    shouldCancelWhenOutside = DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE
   }
 
   private fun startTap() {
@@ -105,7 +78,7 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
       return true
     }
     val dist = dy * dy + dx * dx
-    return maxDistSq != MAX_VALUE_IGNORE && dist > maxDistSq
+    return maxDist != MAX_VALUE_IGNORE && dist > maxDist * maxDist
   }
 
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
@@ -177,25 +150,25 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
     override fun setConfig(handler: TapGestureHandler, config: ReadableMap) {
       super.setConfig(handler, config)
       if (config.hasKey(KEY_NUMBER_OF_TAPS)) {
-        handler.setNumberOfTaps(config.getInt(KEY_NUMBER_OF_TAPS))
+        handler.numberOfTaps = config.getInt(KEY_NUMBER_OF_TAPS)
       }
       if (config.hasKey(KEY_MAX_DURATION_MS)) {
-        handler.setMaxDurationMs(config.getInt(KEY_MAX_DURATION_MS).toLong())
+        handler.maxDurationMs = config.getInt(KEY_MAX_DURATION_MS).toLong()
       }
       if (config.hasKey(KEY_MAX_DELAY_MS)) {
-        handler.setMaxDelayMs(config.getInt(KEY_MAX_DELAY_MS).toLong())
+        handler.maxDelayMs = config.getInt(KEY_MAX_DELAY_MS).toLong()
       }
       if (config.hasKey(KEY_MAX_DELTA_X)) {
-        handler.setMaxDx(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DELTA_X)))
+        handler.maxDeltaX = PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DELTA_X))
       }
       if (config.hasKey(KEY_MAX_DELTA_Y)) {
-        handler.setMaxDy(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DELTA_Y)))
+        handler.maxDeltaY = PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DELTA_Y))
       }
       if (config.hasKey(KEY_MAX_DIST)) {
-        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DIST)))
+        handler.maxDist = PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DIST))
       }
       if (config.hasKey(KEY_MIN_POINTERS)) {
-        handler.setMinNumberOfPointers(config.getInt(KEY_MIN_POINTERS))
+        handler.minNumberOfPointers = config.getInt(KEY_MIN_POINTERS)
       }
     }
 
@@ -218,5 +191,6 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
     private const val DEFAULT_MAX_DELAY_MS: Long = 200
     private const val DEFAULT_NUMBER_OF_TAPS = 1
     private const val DEFAULT_MIN_NUMBER_OF_POINTERS = 1
+    private const val DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE = true
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
@@ -1,10 +1,14 @@
 package com.swmansion.gesturehandler.core
 
+import android.content.Context
 import android.os.Handler
 import android.os.Looper
 import android.view.MotionEvent
+import com.facebook.react.bridge.ReadableMap
+import com.facebook.react.uimanager.PixelUtil
 import com.swmansion.gesturehandler.core.GestureUtils.getLastPointerX
 import com.swmansion.gesturehandler.core.GestureUtils.getLastPointerY
+import com.swmansion.gesturehandler.react.eventbuilders.TapGestureHandlerEventDataBuilder
 import kotlin.math.abs
 
 class TapGestureHandler : GestureHandler<TapGestureHandler>() {
@@ -160,6 +164,52 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
     tapsSoFar = 0
     currentMaxNumberOfPointers = 0
     handler?.removeCallbacksAndMessages(null)
+  }
+
+  class Factory : GestureHandler.Factory<TapGestureHandler>() {
+    override val type = TapGestureHandler::class.java
+    override val name = "TapGestureHandler"
+
+    override fun create(context: Context?): TapGestureHandler {
+      return TapGestureHandler()
+    }
+
+    override fun configure(handler: TapGestureHandler, config: ReadableMap) {
+      super.configure(handler, config)
+      if (config.hasKey(KEY_TAP_NUMBER_OF_TAPS)) {
+        handler.setNumberOfTaps(config.getInt(KEY_TAP_NUMBER_OF_TAPS))
+      }
+      if (config.hasKey(KEY_TAP_MAX_DURATION_MS)) {
+        handler.setMaxDurationMs(config.getInt(KEY_TAP_MAX_DURATION_MS).toLong())
+      }
+      if (config.hasKey(KEY_TAP_MAX_DELAY_MS)) {
+        handler.setMaxDelayMs(config.getInt(KEY_TAP_MAX_DELAY_MS).toLong())
+      }
+      if (config.hasKey(KEY_TAP_MAX_DELTA_X)) {
+        handler.setMaxDx(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DELTA_X)))
+      }
+      if (config.hasKey(KEY_TAP_MAX_DELTA_Y)) {
+        handler.setMaxDy(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DELTA_Y)))
+      }
+      if (config.hasKey(KEY_TAP_MAX_DIST)) {
+        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DIST)))
+      }
+      if (config.hasKey(KEY_TAP_MIN_POINTERS)) {
+        handler.setMinNumberOfPointers(config.getInt(KEY_TAP_MIN_POINTERS))
+      }
+    }
+
+    override fun createEventBuilder(handler: TapGestureHandler) = TapGestureHandlerEventDataBuilder(handler)
+
+    companion object {
+      private const val KEY_TAP_NUMBER_OF_TAPS = "numberOfTaps"
+      private const val KEY_TAP_MAX_DURATION_MS = "maxDurationMs"
+      private const val KEY_TAP_MAX_DELAY_MS = "maxDelayMs"
+      private const val KEY_TAP_MAX_DELTA_X = "maxDeltaX"
+      private const val KEY_TAP_MAX_DELTA_Y = "maxDeltaY"
+      private const val KEY_TAP_MAX_DIST = "maxDist"
+      private const val KEY_TAP_MIN_POINTERS = "minPointers"
+    }
   }
 
   companion object {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
@@ -176,39 +176,39 @@ class TapGestureHandler : GestureHandler<TapGestureHandler>() {
 
     override fun configure(handler: TapGestureHandler, config: ReadableMap) {
       super.configure(handler, config)
-      if (config.hasKey(KEY_TAP_NUMBER_OF_TAPS)) {
-        handler.setNumberOfTaps(config.getInt(KEY_TAP_NUMBER_OF_TAPS))
+      if (config.hasKey(KEY_NUMBER_OF_TAPS)) {
+        handler.setNumberOfTaps(config.getInt(KEY_NUMBER_OF_TAPS))
       }
-      if (config.hasKey(KEY_TAP_MAX_DURATION_MS)) {
-        handler.setMaxDurationMs(config.getInt(KEY_TAP_MAX_DURATION_MS).toLong())
+      if (config.hasKey(KEY_MAX_DURATION_MS)) {
+        handler.setMaxDurationMs(config.getInt(KEY_MAX_DURATION_MS).toLong())
       }
-      if (config.hasKey(KEY_TAP_MAX_DELAY_MS)) {
-        handler.setMaxDelayMs(config.getInt(KEY_TAP_MAX_DELAY_MS).toLong())
+      if (config.hasKey(KEY_MAX_DELAY_MS)) {
+        handler.setMaxDelayMs(config.getInt(KEY_MAX_DELAY_MS).toLong())
       }
-      if (config.hasKey(KEY_TAP_MAX_DELTA_X)) {
-        handler.setMaxDx(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DELTA_X)))
+      if (config.hasKey(KEY_MAX_DELTA_X)) {
+        handler.setMaxDx(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DELTA_X)))
       }
-      if (config.hasKey(KEY_TAP_MAX_DELTA_Y)) {
-        handler.setMaxDy(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DELTA_Y)))
+      if (config.hasKey(KEY_MAX_DELTA_Y)) {
+        handler.setMaxDy(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DELTA_Y)))
       }
-      if (config.hasKey(KEY_TAP_MAX_DIST)) {
-        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DIST)))
+      if (config.hasKey(KEY_MAX_DIST)) {
+        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DIST)))
       }
-      if (config.hasKey(KEY_TAP_MIN_POINTERS)) {
-        handler.setMinNumberOfPointers(config.getInt(KEY_TAP_MIN_POINTERS))
+      if (config.hasKey(KEY_MIN_POINTERS)) {
+        handler.setMinNumberOfPointers(config.getInt(KEY_MIN_POINTERS))
       }
     }
 
     override fun createEventBuilder(handler: TapGestureHandler) = TapGestureHandlerEventDataBuilder(handler)
 
     companion object {
-      private const val KEY_TAP_NUMBER_OF_TAPS = "numberOfTaps"
-      private const val KEY_TAP_MAX_DURATION_MS = "maxDurationMs"
-      private const val KEY_TAP_MAX_DELAY_MS = "maxDelayMs"
-      private const val KEY_TAP_MAX_DELTA_X = "maxDeltaX"
-      private const val KEY_TAP_MAX_DELTA_Y = "maxDeltaY"
-      private const val KEY_TAP_MAX_DIST = "maxDist"
-      private const val KEY_TAP_MIN_POINTERS = "minPointers"
+      private const val KEY_NUMBER_OF_TAPS = "numberOfTaps"
+      private const val KEY_MAX_DURATION_MS = "maxDurationMs"
+      private const val KEY_MAX_DELAY_MS = "maxDelayMs"
+      private const val KEY_MAX_DELTA_X = "maxDeltaX"
+      private const val KEY_MAX_DELTA_Y = "maxDeltaY"
+      private const val KEY_MAX_DIST = "maxDist"
+      private const val KEY_MIN_POINTERS = "minPointers"
     }
   }
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -1,6 +1,5 @@
 package com.swmansion.gesturehandler.react
 
-import android.content.Context
 import android.util.Log
 import android.view.MotionEvent
 import com.facebook.react.ReactRootView
@@ -8,10 +7,8 @@ import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.ReadableType
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.module.annotations.ReactModule
-import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.events.Event
 import com.facebook.soloader.SoLoader
 import com.swmansion.common.GestureHandlerStateManager
@@ -30,16 +27,6 @@ import com.swmansion.gesturehandler.core.PinchGestureHandler
 import com.swmansion.gesturehandler.core.RotationGestureHandler
 import com.swmansion.gesturehandler.core.TapGestureHandler
 import com.swmansion.gesturehandler.dispatchEvent
-import com.swmansion.gesturehandler.react.eventbuilders.FlingGestureHandlerEventDataBuilder
-import com.swmansion.gesturehandler.react.eventbuilders.GestureHandlerEventDataBuilder
-import com.swmansion.gesturehandler.react.eventbuilders.HoverGestureHandlerEventDataBuilder
-import com.swmansion.gesturehandler.react.eventbuilders.LongPressGestureHandlerEventDataBuilder
-import com.swmansion.gesturehandler.react.eventbuilders.ManualGestureHandlerEventDataBuilder
-import com.swmansion.gesturehandler.react.eventbuilders.NativeGestureHandlerEventDataBuilder
-import com.swmansion.gesturehandler.react.eventbuilders.PanGestureHandlerEventDataBuilder
-import com.swmansion.gesturehandler.react.eventbuilders.PinchGestureHandlerEventDataBuilder
-import com.swmansion.gesturehandler.react.eventbuilders.RotationGestureHandlerEventDataBuilder
-import com.swmansion.gesturehandler.react.eventbuilders.TapGestureHandlerEventDataBuilder
 
 // NativeModule.onCatalystInstanceDestroy() was deprecated in favor of NativeModule.invalidate()
 // ref: https://github.com/facebook/react-native/commit/18c8417290823e67e211bde241ae9dde27b72f17
@@ -50,264 +37,6 @@ import com.swmansion.gesturehandler.react.eventbuilders.TapGestureHandlerEventDa
 @ReactModule(name = RNGestureHandlerModule.NAME)
 class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   NativeRNGestureHandlerModuleSpec(reactContext), GestureHandlerStateManager {
-  private abstract class HandlerFactory<T : GestureHandler<T>> {
-    abstract val type: Class<T>
-    abstract val name: String
-    abstract fun create(context: Context?): T
-    open fun configure(handler: T, config: ReadableMap) {
-      handler.resetConfig()
-      if (config.hasKey(KEY_SHOULD_CANCEL_WHEN_OUTSIDE)) {
-        handler.setShouldCancelWhenOutside(config.getBoolean(KEY_SHOULD_CANCEL_WHEN_OUTSIDE))
-      }
-      if (config.hasKey(KEY_ENABLED)) {
-        handler.setEnabled(config.getBoolean(KEY_ENABLED))
-      }
-      if (config.hasKey(KEY_HIT_SLOP)) {
-        handleHitSlopProperty(handler, config)
-      }
-      if (config.hasKey(KEY_NEEDS_POINTER_DATA)) {
-        handler.needsPointerData = config.getBoolean(KEY_NEEDS_POINTER_DATA)
-      }
-      if (config.hasKey(KEY_MANUAL_ACTIVATION)) {
-        handler.setManualActivation(config.getBoolean(KEY_MANUAL_ACTIVATION))
-      }
-      if (config.hasKey("mouseButton")) {
-        handler.setMouseButton(config.getInt("mouseButton"))
-      }
-    }
-
-    abstract fun createEventBuilder(handler: T): GestureHandlerEventDataBuilder<T>
-  }
-
-  private class NativeViewGestureHandlerFactory : HandlerFactory<NativeViewGestureHandler>() {
-    override val type = NativeViewGestureHandler::class.java
-    override val name = "NativeViewGestureHandler"
-
-    override fun create(context: Context?): NativeViewGestureHandler {
-      return NativeViewGestureHandler()
-    }
-
-    override fun configure(handler: NativeViewGestureHandler, config: ReadableMap) {
-      super.configure(handler, config)
-      if (config.hasKey(KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START)) {
-        handler.setShouldActivateOnStart(
-          config.getBoolean(KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START)
-        )
-      }
-      if (config.hasKey(KEY_NATIVE_VIEW_DISALLOW_INTERRUPTION)) {
-        handler.setDisallowInterruption(config.getBoolean(KEY_NATIVE_VIEW_DISALLOW_INTERRUPTION))
-      }
-    }
-
-    override fun createEventBuilder(handler: NativeViewGestureHandler) = NativeGestureHandlerEventDataBuilder(handler)
-  }
-
-  private class TapGestureHandlerFactory : HandlerFactory<TapGestureHandler>() {
-    override val type = TapGestureHandler::class.java
-    override val name = "TapGestureHandler"
-
-    override fun create(context: Context?): TapGestureHandler {
-      return TapGestureHandler()
-    }
-
-    override fun configure(handler: TapGestureHandler, config: ReadableMap) {
-      super.configure(handler, config)
-      if (config.hasKey(KEY_TAP_NUMBER_OF_TAPS)) {
-        handler.setNumberOfTaps(config.getInt(KEY_TAP_NUMBER_OF_TAPS))
-      }
-      if (config.hasKey(KEY_TAP_MAX_DURATION_MS)) {
-        handler.setMaxDurationMs(config.getInt(KEY_TAP_MAX_DURATION_MS).toLong())
-      }
-      if (config.hasKey(KEY_TAP_MAX_DELAY_MS)) {
-        handler.setMaxDelayMs(config.getInt(KEY_TAP_MAX_DELAY_MS).toLong())
-      }
-      if (config.hasKey(KEY_TAP_MAX_DELTA_X)) {
-        handler.setMaxDx(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DELTA_X)))
-      }
-      if (config.hasKey(KEY_TAP_MAX_DELTA_Y)) {
-        handler.setMaxDy(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DELTA_Y)))
-      }
-      if (config.hasKey(KEY_TAP_MAX_DIST)) {
-        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_TAP_MAX_DIST)))
-      }
-      if (config.hasKey(KEY_TAP_MIN_POINTERS)) {
-        handler.setMinNumberOfPointers(config.getInt(KEY_TAP_MIN_POINTERS))
-      }
-    }
-
-    override fun createEventBuilder(handler: TapGestureHandler) = TapGestureHandlerEventDataBuilder(handler)
-  }
-
-  private class LongPressGestureHandlerFactory : HandlerFactory<LongPressGestureHandler>() {
-    override val type = LongPressGestureHandler::class.java
-    override val name = "LongPressGestureHandler"
-
-    override fun create(context: Context?): LongPressGestureHandler {
-      return LongPressGestureHandler((context)!!)
-    }
-
-    override fun configure(handler: LongPressGestureHandler, config: ReadableMap) {
-      super.configure(handler, config)
-      if (config.hasKey(KEY_LONG_PRESS_MIN_DURATION_MS)) {
-        handler.minDurationMs = config.getInt(KEY_LONG_PRESS_MIN_DURATION_MS).toLong()
-      }
-      if (config.hasKey(KEY_LONG_PRESS_MAX_DIST)) {
-        handler.setMaxDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_LONG_PRESS_MAX_DIST)))
-      }
-      if (config.hasKey(KEY_NUMBER_OF_POINTERS)) {
-        handler.setNumberOfPointers(config.getInt(KEY_NUMBER_OF_POINTERS))
-      }
-    }
-
-    override fun createEventBuilder(handler: LongPressGestureHandler) = LongPressGestureHandlerEventDataBuilder(handler)
-  }
-
-  private class PanGestureHandlerFactory : HandlerFactory<PanGestureHandler>() {
-    override val type = PanGestureHandler::class.java
-    override val name = "PanGestureHandler"
-
-    override fun create(context: Context?): PanGestureHandler {
-      return PanGestureHandler(context)
-    }
-
-    override fun configure(handler: PanGestureHandler, config: ReadableMap) {
-      super.configure(handler, config)
-      var hasCustomActivationCriteria = false
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_START)) {
-        handler.setActiveOffsetXStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_X_START)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_X_END)) {
-        handler.setActiveOffsetXEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_X_END)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_START)) {
-        handler.setFailOffsetXStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_X_START)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_X_END)) {
-        handler.setFailOffsetXEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_X_END)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_START)) {
-        handler.setActiveOffsetYStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_Y_START)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_ACTIVE_OFFSET_Y_END)) {
-        handler.setActiveOffsetYEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_ACTIVE_OFFSET_Y_END)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)) {
-        handler.setFailOffsetYStart(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_Y_START)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)) {
-        handler.setFailOffsetYEnd(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_FAIL_OFFSET_RANGE_Y_END)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_MIN_VELOCITY)) {
-        // This value is actually in DPs/ms, but we can use the same function as for converting
-        // from DPs to pixels as the unit we're converting is in the numerator
-        handler.setMinVelocity(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_MIN_VELOCITY_X)) {
-        handler.setMinVelocityX(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY_X)))
-        hasCustomActivationCriteria = true
-      }
-      if (config.hasKey(KEY_PAN_MIN_VELOCITY_Y)) {
-        handler.setMinVelocityY(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_VELOCITY_Y)))
-        hasCustomActivationCriteria = true
-      }
-
-      // PanGestureHandler sets minDist by default, if there are custom criteria specified we want
-      // to reset that setting and use provided criteria instead.
-      if (config.hasKey(KEY_PAN_MIN_DIST)) {
-        handler.setMinDist(PixelUtil.toPixelFromDIP(config.getDouble(KEY_PAN_MIN_DIST)))
-      } else if (hasCustomActivationCriteria) {
-        handler.setMinDist(Float.MAX_VALUE)
-      }
-      if (config.hasKey(KEY_PAN_MIN_POINTERS)) {
-        handler.setMinPointers(config.getInt(KEY_PAN_MIN_POINTERS))
-      }
-      if (config.hasKey(KEY_PAN_MAX_POINTERS)) {
-        handler.setMaxPointers(config.getInt(KEY_PAN_MAX_POINTERS))
-      }
-      if (config.hasKey(KEY_PAN_AVG_TOUCHES)) {
-        handler.setAverageTouches(config.getBoolean(KEY_PAN_AVG_TOUCHES))
-      }
-      if (config.hasKey(KEY_PAN_ACTIVATE_AFTER_LONG_PRESS)) {
-        handler.setActivateAfterLongPress(config.getInt(KEY_PAN_ACTIVATE_AFTER_LONG_PRESS).toLong())
-      }
-    }
-
-    override fun createEventBuilder(handler: PanGestureHandler) = PanGestureHandlerEventDataBuilder(handler)
-  }
-
-  private class PinchGestureHandlerFactory : HandlerFactory<PinchGestureHandler>() {
-    override val type = PinchGestureHandler::class.java
-    override val name = "PinchGestureHandler"
-
-    override fun create(context: Context?): PinchGestureHandler {
-      return PinchGestureHandler()
-    }
-
-    override fun createEventBuilder(handler: PinchGestureHandler) = PinchGestureHandlerEventDataBuilder(handler)
-  }
-
-  private class FlingGestureHandlerFactory : HandlerFactory<FlingGestureHandler>() {
-    override val type = FlingGestureHandler::class.java
-    override val name = "FlingGestureHandler"
-
-    override fun create(context: Context?): FlingGestureHandler {
-      return FlingGestureHandler()
-    }
-
-    override fun configure(handler: FlingGestureHandler, config: ReadableMap) {
-      super.configure(handler, config)
-      if (config.hasKey(KEY_NUMBER_OF_POINTERS)) {
-        handler.numberOfPointersRequired = config.getInt(KEY_NUMBER_OF_POINTERS)
-      }
-      if (config.hasKey(KEY_DIRECTION)) {
-        handler.direction = config.getInt(KEY_DIRECTION)
-      }
-    }
-
-    override fun createEventBuilder(handler: FlingGestureHandler) = FlingGestureHandlerEventDataBuilder(handler)
-  }
-
-  private class RotationGestureHandlerFactory : HandlerFactory<RotationGestureHandler>() {
-    override val type = RotationGestureHandler::class.java
-    override val name = "RotationGestureHandler"
-
-    override fun create(context: Context?): RotationGestureHandler {
-      return RotationGestureHandler()
-    }
-
-    override fun createEventBuilder(handler: RotationGestureHandler) = RotationGestureHandlerEventDataBuilder(handler)
-  }
-
-  private class ManualGestureHandlerFactory : HandlerFactory<ManualGestureHandler>() {
-    override val type = ManualGestureHandler::class.java
-    override val name = "ManualGestureHandler"
-
-    override fun create(context: Context?): ManualGestureHandler {
-      return ManualGestureHandler()
-    }
-
-    override fun createEventBuilder(handler: ManualGestureHandler) = ManualGestureHandlerEventDataBuilder(handler)
-  }
-
-  private class HoverGestureHandlerFactory : HandlerFactory<HoverGestureHandler>() {
-    override val type = HoverGestureHandler::class.java
-    override val name = "HoverGestureHandler"
-
-    override fun create(context: Context?): HoverGestureHandler {
-      return HoverGestureHandler()
-    }
-
-    override fun createEventBuilder(handler: HoverGestureHandler) = HoverGestureHandlerEventDataBuilder(handler)
-  }
 
   private val eventListener = object : OnTouchEventListener {
     override fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, event: MotionEvent) {
@@ -322,16 +51,16 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
       this@RNGestureHandlerModule.onTouchEvent(handler)
     }
   }
-  private val handlerFactories = arrayOf<HandlerFactory<*>>(
-    NativeViewGestureHandlerFactory(),
-    TapGestureHandlerFactory(),
-    LongPressGestureHandlerFactory(),
-    PanGestureHandlerFactory(),
-    PinchGestureHandlerFactory(),
-    RotationGestureHandlerFactory(),
-    FlingGestureHandlerFactory(),
-    ManualGestureHandlerFactory(),
-    HoverGestureHandlerFactory(),
+  private val handlerFactories = arrayOf<GestureHandler.Factory<*>>(
+    NativeViewGestureHandler.Factory(),
+    TapGestureHandler.Factory(),
+    LongPressGestureHandler.Factory(),
+    PanGestureHandler.Factory(),
+    PinchGestureHandler.Factory(),
+    RotationGestureHandler.Factory(),
+    FlingGestureHandler.Factory(),
+    ManualGestureHandler.Factory(),
+    HoverGestureHandler.Factory(),
   )
   val registry: RNGestureHandlerRegistry = RNGestureHandlerRegistry()
   private val interactionManager = RNGestureHandlerInteractionManager()
@@ -352,7 +81,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
       )
     }
 
-    for (handlerFactory in handlerFactories as Array<HandlerFactory<T>>) {
+    for (handlerFactory in handlerFactories as Array<GestureHandler.Factory<T>>) {
       if (handlerFactory.name == handlerName) {
         val handler = handlerFactory.create(reactApplicationContext).apply {
           tag = handlerTag
@@ -526,8 +255,8 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   }
 
   @Suppress("UNCHECKED_CAST")
-  private fun <T : GestureHandler<T>> findFactoryForHandler(handler: GestureHandler<T>): HandlerFactory<T>? =
-    handlerFactories.firstOrNull { it.type == handler.javaClass } as HandlerFactory<T>?
+  private fun <T : GestureHandler<T>> findFactoryForHandler(handler: GestureHandler<T>): GestureHandler.Factory<T>? =
+    handlerFactories.firstOrNull { it.type == handler.javaClass } as GestureHandler.Factory<T>?
 
   private fun <T : GestureHandler<T>> onHandlerUpdate(handler: T) {
     // triggers onUpdate and onChange callbacks on the JS side
@@ -652,91 +381,5 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
   companion object {
     const val NAME = "RNGestureHandlerModule"
-    private const val KEY_SHOULD_CANCEL_WHEN_OUTSIDE = "shouldCancelWhenOutside"
-    private const val KEY_ENABLED = "enabled"
-    private const val KEY_NEEDS_POINTER_DATA = "needsPointerData"
-    private const val KEY_MANUAL_ACTIVATION = "manualActivation"
-    private const val KEY_HIT_SLOP = "hitSlop"
-    private const val KEY_HIT_SLOP_LEFT = "left"
-    private const val KEY_HIT_SLOP_TOP = "top"
-    private const val KEY_HIT_SLOP_RIGHT = "right"
-    private const val KEY_HIT_SLOP_BOTTOM = "bottom"
-    private const val KEY_HIT_SLOP_VERTICAL = "vertical"
-    private const val KEY_HIT_SLOP_HORIZONTAL = "horizontal"
-    private const val KEY_HIT_SLOP_WIDTH = "width"
-    private const val KEY_HIT_SLOP_HEIGHT = "height"
-    private const val KEY_NATIVE_VIEW_SHOULD_ACTIVATE_ON_START = "shouldActivateOnStart"
-    private const val KEY_NATIVE_VIEW_DISALLOW_INTERRUPTION = "disallowInterruption"
-    private const val KEY_TAP_NUMBER_OF_TAPS = "numberOfTaps"
-    private const val KEY_TAP_MAX_DURATION_MS = "maxDurationMs"
-    private const val KEY_TAP_MAX_DELAY_MS = "maxDelayMs"
-    private const val KEY_TAP_MAX_DELTA_X = "maxDeltaX"
-    private const val KEY_TAP_MAX_DELTA_Y = "maxDeltaY"
-    private const val KEY_TAP_MAX_DIST = "maxDist"
-    private const val KEY_TAP_MIN_POINTERS = "minPointers"
-    private const val KEY_LONG_PRESS_MIN_DURATION_MS = "minDurationMs"
-    private const val KEY_LONG_PRESS_MAX_DIST = "maxDist"
-    private const val KEY_PAN_ACTIVE_OFFSET_X_START = "activeOffsetXStart"
-    private const val KEY_PAN_ACTIVE_OFFSET_X_END = "activeOffsetXEnd"
-    private const val KEY_PAN_FAIL_OFFSET_RANGE_X_START = "failOffsetXStart"
-    private const val KEY_PAN_FAIL_OFFSET_RANGE_X_END = "failOffsetXEnd"
-    private const val KEY_PAN_ACTIVE_OFFSET_Y_START = "activeOffsetYStart"
-    private const val KEY_PAN_ACTIVE_OFFSET_Y_END = "activeOffsetYEnd"
-    private const val KEY_PAN_FAIL_OFFSET_RANGE_Y_START = "failOffsetYStart"
-    private const val KEY_PAN_FAIL_OFFSET_RANGE_Y_END = "failOffsetYEnd"
-    private const val KEY_PAN_MIN_DIST = "minDist"
-    private const val KEY_PAN_MIN_VELOCITY = "minVelocity"
-    private const val KEY_PAN_MIN_VELOCITY_X = "minVelocityX"
-    private const val KEY_PAN_MIN_VELOCITY_Y = "minVelocityY"
-    private const val KEY_PAN_MIN_POINTERS = "minPointers"
-    private const val KEY_PAN_MAX_POINTERS = "maxPointers"
-    private const val KEY_PAN_AVG_TOUCHES = "avgTouches"
-    private const val KEY_PAN_ACTIVATE_AFTER_LONG_PRESS = "activateAfterLongPress"
-    private const val KEY_NUMBER_OF_POINTERS = "numberOfPointers"
-    private const val KEY_DIRECTION = "direction"
-
-    private fun handleHitSlopProperty(handler: GestureHandler<*>, config: ReadableMap) {
-      if (config.getType(KEY_HIT_SLOP) == ReadableType.Number) {
-        val hitSlop = PixelUtil.toPixelFromDIP(config.getDouble(KEY_HIT_SLOP))
-        handler.setHitSlop(hitSlop, hitSlop, hitSlop, hitSlop, GestureHandler.HIT_SLOP_NONE, GestureHandler.HIT_SLOP_NONE)
-      } else {
-        val hitSlop = config.getMap(KEY_HIT_SLOP)!!
-        var left = GestureHandler.HIT_SLOP_NONE
-        var top = GestureHandler.HIT_SLOP_NONE
-        var right = GestureHandler.HIT_SLOP_NONE
-        var bottom = GestureHandler.HIT_SLOP_NONE
-        var width = GestureHandler.HIT_SLOP_NONE
-        var height = GestureHandler.HIT_SLOP_NONE
-        if (hitSlop.hasKey(KEY_HIT_SLOP_HORIZONTAL)) {
-          val horizontalPad = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_HORIZONTAL))
-          right = horizontalPad
-          left = right
-        }
-        if (hitSlop.hasKey(KEY_HIT_SLOP_VERTICAL)) {
-          val verticalPad = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_VERTICAL))
-          bottom = verticalPad
-          top = bottom
-        }
-        if (hitSlop.hasKey(KEY_HIT_SLOP_LEFT)) {
-          left = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_LEFT))
-        }
-        if (hitSlop.hasKey(KEY_HIT_SLOP_TOP)) {
-          top = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_TOP))
-        }
-        if (hitSlop.hasKey(KEY_HIT_SLOP_RIGHT)) {
-          right = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_RIGHT))
-        }
-        if (hitSlop.hasKey(KEY_HIT_SLOP_BOTTOM)) {
-          bottom = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_BOTTOM))
-        }
-        if (hitSlop.hasKey(KEY_HIT_SLOP_WIDTH)) {
-          width = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_WIDTH))
-        }
-        if (hitSlop.hasKey(KEY_HIT_SLOP_HEIGHT)) {
-          height = PixelUtil.toPixelFromDIP(hitSlop.getDouble(KEY_HIT_SLOP_HEIGHT))
-        }
-        handler.setHitSlop(left, top, right, bottom, width, height)
-      }
-    }
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -89,7 +89,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
         }
         registry.registerHandler(handler)
         interactionManager.configureInteractions(handler, config)
-        handlerFactory.configure(handler, config)
+        handlerFactory.setConfig(handler, config)
         return
       }
     }
@@ -129,7 +129,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
       if (factory != null) {
         interactionManager.dropRelationsForHandlerWithTag(handlerTag)
         interactionManager.configureInteractions(handler, config)
-        factory.configure(handler, config)
+        factory.setConfig(handler, config)
       }
     }
   }


### PR DESCRIPTION
## Description

All handler factories were stored in the `RNGestureHandlerModule` which always seemed like an odd place to keep them in to me. This PR moves each factory to be a nested class of the relevant gesture handler. This gives us private access to the handler inside the factory, which in turn allows to get rid of the setter methods and assign directly instead. Those were with use since RNGH was written in java, but we have Kotlin now. It's time to let go and use proper syntax.

It also adds default constants for each config property that didn't have it before.

## Test plan

Example app
