### PR TITLE
Refactor RNGestureHandlerModule on android

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -852,7 +852,11 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   abstract class Factory<T : GestureHandler<T>> {
     abstract val type: Class<T>
     abstract val name: String
-    abstract fun create(context: Context?): T
+
+    protected abstract fun create(context: Context?): T
+
+    fun create(context: Context?, handlerTag: Int): T = create(context).also { it.tag = handlerTag }
+
     open fun setConfig(handler: T, config: ReadableMap) {
       handler.resetConfig()
       if (config.hasKey(KEY_SHOULD_CANCEL_WHEN_OUTSIDE)) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEventDispatcher.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEventDispatcher.kt
@@ -1,0 +1,148 @@
+package com.swmansion.gesturehandler.react
+
+import android.view.MotionEvent
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.swmansion.gesturehandler.BuildConfig
+import com.swmansion.gesturehandler.ReanimatedEventDispatcher
+import com.swmansion.gesturehandler.core.GestureHandler
+import com.swmansion.gesturehandler.core.OnTouchEventListener
+import com.swmansion.gesturehandler.dispatchEvent
+
+class RNGestureHandlerEventDispatcher(private val reactApplicationContext: ReactApplicationContext) : OnTouchEventListener {
+  private val reanimatedEventDispatcher = ReanimatedEventDispatcher()
+
+  override fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, event: MotionEvent) {
+    this.dispatchHandlerUpdateEvent(handler)
+  }
+
+  override fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int) {
+    this.dispatchStateChangeEvent(handler, newState, oldState)
+  }
+
+  override fun <T : GestureHandler<T>> onTouchEvent(handler: T) {
+    this.dispatchTouchEvent(handler)
+  }
+
+  private fun <T : GestureHandler<T>> dispatchHandlerUpdateEvent(handler: T) {
+    // triggers onUpdate and onChange callbacks on the JS side
+
+    if (handler.tag < 0) {
+      // root containers use negative tags, we don't need to dispatch events for them to the JS
+      return
+    }
+    if (handler.state == GestureHandler.STATE_ACTIVE) {
+      val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
+
+      if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
+        // Reanimated worklet
+        val event = RNGestureHandlerEvent.obtain(handler, handlerFactory.createEventBuilder(handler))
+        sendEventForReanimated(event)
+      } else if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT) {
+        // Animated with useNativeDriver: true
+        val event = RNGestureHandlerEvent.obtain(
+          handler,
+          handlerFactory.createEventBuilder(handler),
+          true
+        )
+        sendEventForNativeAnimatedEvent(event)
+      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API) {
+        // JS function, Animated.event with useNativeDriver: false using old API
+        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+          val data = RNGestureHandlerEvent.createEventData(handlerFactory.createEventBuilder(handler))
+          sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
+        } else {
+          val event = RNGestureHandlerEvent.obtain(handler, handlerFactory.createEventBuilder(handler))
+          sendEventForDirectEvent(event)
+        }
+      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
+        // JS function, Animated.event with useNativeDriver: false using new API
+        val data = RNGestureHandlerEvent.createEventData(handlerFactory.createEventBuilder(handler))
+        sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
+      }
+    }
+  }
+
+  private fun <T : GestureHandler<T>> dispatchStateChangeEvent(handler: T, newState: Int, oldState: Int) {
+    // triggers onBegin, onStart, onEnd, onFinalize callbacks on the JS side
+
+    if (handler.tag < 0) {
+      // root containers use negative tags, we don't need to dispatch events for them to the JS
+      return
+    }
+    val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
+
+    if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
+      // Reanimated worklet
+      val event = RNGestureHandlerStateChangeEvent.obtain(handler, newState, oldState, handlerFactory.createEventBuilder(handler))
+      sendEventForReanimated(event)
+    } else if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT ||
+      handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API
+    ) {
+      // JS function or Animated.event with useNativeDriver: false with old API
+      if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+        val data = RNGestureHandlerStateChangeEvent.createEventData(handlerFactory.createEventBuilder(handler), newState, oldState)
+        sendEventForDeviceEvent(RNGestureHandlerStateChangeEvent.EVENT_NAME, data)
+      } else {
+        val event = RNGestureHandlerStateChangeEvent.obtain(handler, newState, oldState, handlerFactory.createEventBuilder(handler))
+        sendEventForDirectEvent(event)
+      }
+    } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
+      // JS function or Animated.event with useNativeDriver: false with new API
+      val data = RNGestureHandlerStateChangeEvent.createEventData(handlerFactory.createEventBuilder(handler), newState, oldState)
+      sendEventForDeviceEvent(RNGestureHandlerStateChangeEvent.EVENT_NAME, data)
+    }
+  }
+
+  private fun <T : GestureHandler<T>> dispatchTouchEvent(handler: T) {
+    // triggers onTouchesDown, onTouchesMove, onTouchesUp, onTouchesCancelled callbacks on the JS side
+
+    if (handler.tag < 0) {
+      // root containers use negative tags, we don't need to dispatch events for them to the JS
+      return
+    }
+    if (handler.state == GestureHandler.STATE_BEGAN || handler.state == GestureHandler.STATE_ACTIVE ||
+      handler.state == GestureHandler.STATE_UNDETERMINED || handler.view != null
+    ) {
+      if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
+        // Reanimated worklet
+        val event = RNGestureHandlerTouchEvent.obtain(handler)
+        sendEventForReanimated(event)
+      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
+        // JS function, Animated.event with useNativeDriver: false with new API
+        val data = RNGestureHandlerTouchEvent.createEventData(handler)
+        sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
+      }
+    }
+  }
+
+  private fun <T : Event<T>>sendEventForReanimated(event: T) {
+    // Delivers the event to Reanimated.
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // Send event directly to Reanimated
+      reanimatedEventDispatcher.sendEvent(event, reactApplicationContext)
+    } else {
+      // In the old architecture, Reanimated subscribes for specific direct events.
+      sendEventForDirectEvent(event)
+    }
+  }
+
+  private fun sendEventForNativeAnimatedEvent(event: RNGestureHandlerEvent) {
+    // Delivers the event to NativeAnimatedModule.
+    // TODO: send event directly to NativeAnimated[Turbo]Module
+    // ReactContext.dispatchEvent is an extension function, depending on the architecture it will
+    // dispatch event using UIManagerModule or FabricUIManager.
+    reactApplicationContext.dispatchEvent(event)
+  }
+
+  private fun <T : Event<T>>sendEventForDirectEvent(event: T) {
+    // Delivers the event to JS as a direct event. This method is called only on Paper.
+    reactApplicationContext.dispatchEvent(event)
+  }
+
+  private fun sendEventForDeviceEvent(eventName: String, data: WritableMap) {
+    // Delivers the event to JS as a device event.
+    reactApplicationContext.deviceEventEmitter.emit(eventName, data)
+  }
+}

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerFactoryUtil.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerFactoryUtil.kt
@@ -1,0 +1,34 @@
+package com.swmansion.gesturehandler.react
+
+import com.swmansion.gesturehandler.core.FlingGestureHandler
+import com.swmansion.gesturehandler.core.GestureHandler
+import com.swmansion.gesturehandler.core.HoverGestureHandler
+import com.swmansion.gesturehandler.core.LongPressGestureHandler
+import com.swmansion.gesturehandler.core.ManualGestureHandler
+import com.swmansion.gesturehandler.core.NativeViewGestureHandler
+import com.swmansion.gesturehandler.core.PanGestureHandler
+import com.swmansion.gesturehandler.core.PinchGestureHandler
+import com.swmansion.gesturehandler.core.RotationGestureHandler
+import com.swmansion.gesturehandler.core.TapGestureHandler
+
+object RNGestureHandlerFactoryUtil {
+  private val handlerFactories = arrayOf<GestureHandler.Factory<*>>(
+    NativeViewGestureHandler.Factory(),
+    TapGestureHandler.Factory(),
+    LongPressGestureHandler.Factory(),
+    PanGestureHandler.Factory(),
+    PinchGestureHandler.Factory(),
+    RotationGestureHandler.Factory(),
+    FlingGestureHandler.Factory(),
+    ManualGestureHandler.Factory(),
+    HoverGestureHandler.Factory(),
+  )
+
+  @Suppress("UNCHECKED_CAST")
+  fun <T : GestureHandler<T>> findFactoryForHandler(handler: GestureHandler<T>): GestureHandler.Factory<T>? =
+    handlerFactories.firstOrNull { it.type == handler.javaClass } as GestureHandler.Factory<T>?
+
+  @Suppress("UNCHECKED_CAST")
+  fun <T : GestureHandler<T>> findFactoryForName(handlerName: String): GestureHandler.Factory<T>? =
+    handlerFactories.firstOrNull { it.name == handlerName } as GestureHandler.Factory<T>?
+}

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -20,10 +20,11 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   NativeRNGestureHandlerModuleSpec(reactContext),
   GestureHandlerStateManager {
 
-  private val eventDispatcher = RNGestureHandlerEventDispatcher(reactApplicationContext)
   val registry: RNGestureHandlerRegistry = RNGestureHandlerRegistry()
+  private val eventDispatcher = RNGestureHandlerEventDispatcher(reactApplicationContext)
   private val interactionManager = RNGestureHandlerInteractionManager()
   private val roots: MutableList<RNGestureHandlerRootHelper> = ArrayList()
+
   override fun getName() = NAME
 
   @Suppress("UNCHECKED_CAST")

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -105,12 +105,10 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   }
 
   @ReactMethod
-  override fun handleClearJSResponder() {
-  }
+  override fun handleClearJSResponder() = Unit
 
   @ReactMethod
-  override fun flushOperations() {
-  }
+  override fun flushOperations() = Unit
 
   override fun setGestureHandlerState(handlerTag: Int, newState: Int) {
     registry.getHandler(handlerTag)?.let { handler ->

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -27,7 +27,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
   override fun getName() = NAME
 
-  @Suppress("UNCHECKED_CAST")
   private fun <T : GestureHandler<T>> createGestureHandlerHelper(
     handlerName: String,
     handlerTag: Int,

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -1,35 +1,16 @@
 package com.swmansion.gesturehandler.react
 
 import android.util.Log
-import android.view.MotionEvent
 import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.WritableMap
 import com.facebook.react.module.annotations.ReactModule
-import com.facebook.react.uimanager.events.Event
 import com.facebook.soloader.SoLoader
 import com.swmansion.common.GestureHandlerStateManager
-import com.swmansion.gesturehandler.BuildConfig
 import com.swmansion.gesturehandler.NativeRNGestureHandlerModuleSpec
-import com.swmansion.gesturehandler.ReanimatedEventDispatcher
-import com.swmansion.gesturehandler.core.FlingGestureHandler
 import com.swmansion.gesturehandler.core.GestureHandler
-import com.swmansion.gesturehandler.core.HoverGestureHandler
-import com.swmansion.gesturehandler.core.LongPressGestureHandler
-import com.swmansion.gesturehandler.core.ManualGestureHandler
-import com.swmansion.gesturehandler.core.NativeViewGestureHandler
-import com.swmansion.gesturehandler.core.OnTouchEventListener
-import com.swmansion.gesturehandler.core.PanGestureHandler
-import com.swmansion.gesturehandler.core.PinchGestureHandler
-import com.swmansion.gesturehandler.core.RotationGestureHandler
-import com.swmansion.gesturehandler.core.TapGestureHandler
-import com.swmansion.gesturehandler.dispatchEvent
-
-// NativeModule.onCatalystInstanceDestroy() was deprecated in favor of NativeModule.invalidate()
-// ref: https://github.com/facebook/react-native/commit/18c8417290823e67e211bde241ae9dde27b72f17
 
 // UIManagerModule.resolveRootTagFromReactTag() was deprecated and will be removed in the next RN release
 // ref: https://github.com/facebook/react-native/commit/acbf9e18ea666b07c1224a324602a41d0a66985e
@@ -39,34 +20,10 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   NativeRNGestureHandlerModuleSpec(reactContext),
   GestureHandlerStateManager {
 
-  private val eventListener = object : OnTouchEventListener {
-    override fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, event: MotionEvent) {
-      this@RNGestureHandlerModule.onHandlerUpdate(handler)
-    }
-
-    override fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int) {
-      this@RNGestureHandlerModule.onStateChange(handler, newState, oldState)
-    }
-
-    override fun <T : GestureHandler<T>> onTouchEvent(handler: T) {
-      this@RNGestureHandlerModule.onTouchEvent(handler)
-    }
-  }
-  private val handlerFactories = arrayOf<GestureHandler.Factory<*>>(
-    NativeViewGestureHandler.Factory(),
-    TapGestureHandler.Factory(),
-    LongPressGestureHandler.Factory(),
-    PanGestureHandler.Factory(),
-    PinchGestureHandler.Factory(),
-    RotationGestureHandler.Factory(),
-    FlingGestureHandler.Factory(),
-    ManualGestureHandler.Factory(),
-    HoverGestureHandler.Factory(),
-  )
+  private val eventDispatcher = RNGestureHandlerEventDispatcher(reactApplicationContext)
   val registry: RNGestureHandlerRegistry = RNGestureHandlerRegistry()
   private val interactionManager = RNGestureHandlerInteractionManager()
   private val roots: MutableList<RNGestureHandlerRootHelper> = ArrayList()
-  private val reanimatedEventDispatcher = ReanimatedEventDispatcher()
   override fun getName() = NAME
 
   @Suppress("UNCHECKED_CAST")
@@ -81,19 +38,16 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
       )
     }
 
-    for (handlerFactory in handlerFactories as Array<GestureHandler.Factory<T>>) {
-      if (handlerFactory.name == handlerName) {
-        val handler = handlerFactory.create(reactApplicationContext).apply {
-          tag = handlerTag
-          setOnTouchEventListener(eventListener)
-        }
-        registry.registerHandler(handler)
-        interactionManager.configureInteractions(handler, config)
-        handlerFactory.setConfig(handler, config)
-        return
-      }
+    val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForName<T>(handlerName)
+      ?: throw JSApplicationIllegalArgumentException("Invalid handler name $handlerName")
+
+    val handler = handlerFactory.create(reactApplicationContext).apply {
+      tag = handlerTag
+      setOnTouchEventListener(eventDispatcher)
     }
-    throw JSApplicationIllegalArgumentException("Invalid handler name $handlerName")
+    registry.registerHandler(handler)
+    interactionManager.configureInteractions(handler, config)
+    handlerFactory.setConfig(handler, config)
   }
 
   @ReactMethod
@@ -121,12 +75,10 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   private fun <T : GestureHandler<T>> updateGestureHandlerHelper(handlerTag: Int, config: ReadableMap) {
     val handler = registry.getHandler(handlerTag) as T?
     if (handler != null) {
-      val factory = findFactoryForHandler(handler)
-      if (factory != null) {
-        interactionManager.dropRelationsForHandlerWithTag(handlerTag)
-        interactionManager.configureInteractions(handler, config)
-        factory.setConfig(handler, config)
-      }
+      val factory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
+      interactionManager.dropRelationsForHandlerWithTag(handlerTag)
+      interactionManager.configureInteractions(handler, config)
+      factory.setConfig(handler, config)
     }
   }
 
@@ -188,23 +140,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
   private external fun decorateRuntime(jsiPtr: Long)
 
-  override fun getConstants(): Map<String, Any> = mapOf(
-    "State" to mapOf(
-      "UNDETERMINED" to GestureHandler.STATE_UNDETERMINED,
-      "BEGAN" to GestureHandler.STATE_BEGAN,
-      "ACTIVE" to GestureHandler.STATE_ACTIVE,
-      "CANCELLED" to GestureHandler.STATE_CANCELLED,
-      "FAILED" to GestureHandler.STATE_FAILED,
-      "END" to GestureHandler.STATE_END,
-    ),
-    "Direction" to mapOf(
-      "RIGHT" to GestureHandler.DIRECTION_RIGHT,
-      "LEFT" to GestureHandler.DIRECTION_LEFT,
-      "UP" to GestureHandler.DIRECTION_UP,
-      "DOWN" to GestureHandler.DIRECTION_DOWN,
-    ),
-  )
-
   override fun invalidate() {
     registry.dropAllHandlers()
     interactionManager.reset()
@@ -213,8 +148,9 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
         val sizeBefore: Int = roots.size
         val root: RNGestureHandlerRootHelper = roots[0]
         root.tearDown()
-        if (roots.size >= sizeBefore) {
-          throw IllegalStateException("Expected root helper to get unregistered while tearing down")
+
+        assert(roots.size < sizeBefore) {
+          "Expected root helper to get unregistered while tearing down"
         }
       }
     }
@@ -246,159 +182,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
         it.rootView is ReactRootView && it.rootView.rootViewTag == rootViewTag
       }
     }
-  }
-
-  @Suppress("UNCHECKED_CAST")
-  private fun <T : GestureHandler<T>> findFactoryForHandler(handler: GestureHandler<T>): GestureHandler.Factory<T>? =
-    handlerFactories.firstOrNull { it.type == handler.javaClass } as GestureHandler.Factory<T>?
-
-  private fun <T : GestureHandler<T>> onHandlerUpdate(handler: T) {
-    // triggers onUpdate and onChange callbacks on the JS side
-
-    if (handler.tag < 0) {
-      // root containers use negative tags, we don't need to dispatch events for them to the JS
-      return
-    }
-    if (handler.state == GestureHandler.STATE_ACTIVE) {
-      val handlerFactory = findFactoryForHandler(handler) ?: return
-
-      if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
-        // Reanimated worklet
-        val event = RNGestureHandlerEvent.obtain(
-          handler,
-          handlerFactory.createEventBuilder(handler),
-        )
-        sendEventForReanimated(event)
-      } else if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT) {
-        // Animated with useNativeDriver: true
-        val event = RNGestureHandlerEvent.obtain(
-          handler,
-          handlerFactory.createEventBuilder(handler),
-          true,
-        )
-        sendEventForNativeAnimatedEvent(event)
-      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API) {
-        // JS function, Animated.event with useNativeDriver: false using old API
-        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-          val data = RNGestureHandlerEvent.createEventData(
-            handlerFactory.createEventBuilder(handler),
-          )
-          sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
-        } else {
-          val event = RNGestureHandlerEvent.obtain(
-            handler,
-            handlerFactory.createEventBuilder(handler),
-          )
-          sendEventForDirectEvent(event)
-        }
-      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
-        // JS function, Animated.event with useNativeDriver: false using new API
-        val data = RNGestureHandlerEvent.createEventData(handlerFactory.createEventBuilder(handler))
-        sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
-      }
-    }
-  }
-
-  private fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int) {
-    // triggers onBegin, onStart, onEnd, onFinalize callbacks on the JS side
-
-    if (handler.tag < 0) {
-      // root containers use negative tags, we don't need to dispatch events for them to the JS
-      return
-    }
-    val handlerFactory = findFactoryForHandler(handler) ?: return
-
-    if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
-      // Reanimated worklet
-      val event = RNGestureHandlerStateChangeEvent.obtain(
-        handler,
-        newState,
-        oldState,
-        handlerFactory.createEventBuilder(handler),
-      )
-      sendEventForReanimated(event)
-    } else if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT ||
-      handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API
-    ) {
-      // JS function or Animated.event with useNativeDriver: false with old API
-      if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-        val data = RNGestureHandlerStateChangeEvent.createEventData(
-          handlerFactory.createEventBuilder(handler),
-          newState,
-          oldState,
-        )
-        sendEventForDeviceEvent(RNGestureHandlerStateChangeEvent.EVENT_NAME, data)
-      } else {
-        val event = RNGestureHandlerStateChangeEvent.obtain(
-          handler,
-          newState,
-          oldState,
-          handlerFactory.createEventBuilder(handler),
-        )
-        sendEventForDirectEvent(event)
-      }
-    } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
-      // JS function or Animated.event with useNativeDriver: false with new API
-      val data = RNGestureHandlerStateChangeEvent.createEventData(
-        handlerFactory.createEventBuilder(handler),
-        newState,
-        oldState,
-      )
-      sendEventForDeviceEvent(RNGestureHandlerStateChangeEvent.EVENT_NAME, data)
-    }
-  }
-
-  private fun <T : GestureHandler<T>> onTouchEvent(handler: T) {
-    // triggers onTouchesDown, onTouchesMove, onTouchesUp, onTouchesCancelled callbacks on the JS side
-
-    if (handler.tag < 0) {
-      // root containers use negative tags, we don't need to dispatch events for them to the JS
-      return
-    }
-    if (handler.state == GestureHandler.STATE_BEGAN ||
-      handler.state == GestureHandler.STATE_ACTIVE ||
-      handler.state == GestureHandler.STATE_UNDETERMINED ||
-      handler.view != null
-    ) {
-      if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
-        // Reanimated worklet
-        val event = RNGestureHandlerTouchEvent.obtain(handler)
-        sendEventForReanimated(event)
-      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
-        // JS function, Animated.event with useNativeDriver: false with new API
-        val data = RNGestureHandlerTouchEvent.createEventData(handler)
-        sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
-      }
-    }
-  }
-
-  private fun <T : Event<T>> sendEventForReanimated(event: T) {
-    // Delivers the event to Reanimated.
-    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-      // Send event directly to Reanimated
-      reanimatedEventDispatcher.sendEvent(event, reactApplicationContext)
-    } else {
-      // In the old architecture, Reanimated subscribes for specific direct events.
-      sendEventForDirectEvent(event)
-    }
-  }
-
-  private fun sendEventForNativeAnimatedEvent(event: RNGestureHandlerEvent) {
-    // Delivers the event to NativeAnimatedModule.
-    // TODO: send event directly to NativeAnimated[Turbo]Module
-    // ReactContext.dispatchEvent is an extension function, depending on the architecture it will
-    // dispatch event using UIManagerModule or FabricUIManager.
-    reactApplicationContext.dispatchEvent(event)
-  }
-
-  private fun <T : Event<T>> sendEventForDirectEvent(event: T) {
-    // Delivers the event to JS as a direct event. This method is called only on Paper.
-    reactApplicationContext.dispatchEvent(event)
-  }
-
-  private fun sendEventForDeviceEvent(eventName: String, data: WritableMap) {
-    // Delivers the event to JS as a device event.
-    reactApplicationContext.deviceEventEmitter.emit(eventName, data)
   }
 
   companion object {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -61,7 +61,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
 
   internal inner class RootViewGestureHandler(handlerTag: Int) : GestureHandler<RootViewGestureHandler>() {
     init {
-        this.tag = handlerTag
+      this.tag = handlerTag
     }
 
     private fun handleEvent(event: MotionEvent) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -24,10 +24,8 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
   init {
     UiThreadUtil.assertOnUiThread()
     val wrappedViewTag = wrappedView.id
-    check(wrappedViewTag >= 1) { "Expect view tag to be set for $wrappedView" }
-    val module = (context as ThemedReactContext).reactApplicationContext.getNativeModule(
-      RNGestureHandlerModule::class.java,
-    )!!
+    assert(wrappedViewTag >= 1) { "Expect view tag to be set for $wrappedView" }
+    val module = context.getNativeModule(RNGestureHandlerModule::class.java)!!
     val registry = module.registry
     rootView = findRootViewTag(wrappedView)
     Log.i(
@@ -41,15 +39,9 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     ).apply {
       minimumAlphaForTraversal = MIN_ALPHA_FOR_TOUCH
     }
-    jsGestureHandler = RootViewGestureHandler().apply { tag = -wrappedViewTag }
-    with(registry) {
-      registerHandler(jsGestureHandler)
-      attachHandlerToView(
-        jsGestureHandler.tag,
-        wrappedViewTag,
-        GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API,
-      )
-    }
+    jsGestureHandler = RootViewGestureHandler(handlerTag = -wrappedViewTag)
+    registry.registerHandler(jsGestureHandler)
+    registry.attachHandlerToView(jsGestureHandler.tag, wrappedViewTag, GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API)
     module.registerRootHelper(this)
   }
 
@@ -67,7 +59,11 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     }
   }
 
-  internal inner class RootViewGestureHandler : GestureHandler<RootViewGestureHandler>() {
+  internal inner class RootViewGestureHandler(handlerTag: Int) : GestureHandler<RootViewGestureHandler>() {
+    init {
+        this.tag = handlerTag
+    }
+
     private fun handleEvent(event: MotionEvent) {
       val currentState = state
 


### PR DESCRIPTION
## Description

- simplifies `RNGestureHandlerRootHelper` a bit
- moves logic related to sending events to a separate class
- moves logic related to resolving handler factories to a separate class

## Test plan

Example & FabricExample apps
