### PR TITLE
Make base `GestureHandler` on Android non generic

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
@@ -8,7 +8,7 @@ import android.view.VelocityTracker
 import com.facebook.react.bridge.ReadableMap
 import com.swmansion.gesturehandler.react.eventbuilders.FlingGestureHandlerEventDataBuilder
 
-class FlingGestureHandler : GestureHandler<FlingGestureHandler>() {
+class FlingGestureHandler : GestureHandler() {
   var numberOfPointersRequired = DEFAULT_NUMBER_OF_TOUCHES_REQUIRED
   var direction = DEFAULT_DIRECTION
 

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -817,7 +817,11 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   abstract class Factory<T : GestureHandler<T>> {
     abstract val type: Class<T>
     abstract val name: String
-    abstract fun create(context: Context?): T
+
+    protected abstract fun create(context: Context?): T
+
+    fun create(context: Context?, handlerTag: Int): T = create(context).also { it.tag = handlerTag }
+
     open fun setConfig(handler: T, config: ReadableMap) {
       handler.resetConfig()
       if (config.hasKey(KEY_SHOULD_CANCEL_WHEN_OUTSIDE)) {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -23,7 +23,7 @@ import com.swmansion.gesturehandler.react.eventbuilders.GestureHandlerEventDataB
 import java.lang.IllegalStateException
 import java.util.*
 
-open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestureHandlerT>> {
+open class GestureHandler {
   private val trackedPointerIDs = IntArray(MAX_POINTERS_COUNT)
   private var trackedPointersIDsCount = 0
   private val windowOffset = IntArray(2) { 0 }
@@ -79,18 +79,12 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     protected set
   protected var shouldCancelWhenOutside = false
   protected var orchestrator: GestureHandlerOrchestrator? = null
-  private var onTouchEventListener: OnTouchEventListener? = null
+  var onTouchEventListener: OnTouchEventListener? = null
   private var interactionController: GestureHandlerInteractionController? = null
   var pointerType: Int = POINTER_TYPE_OTHER
     private set
 
   protected var mouseButton = 0
-
-  @Suppress("UNCHECKED_CAST")
-  protected fun self(): ConcreteGestureHandlerT = this as ConcreteGestureHandlerT
-
-  protected inline fun applySelf(block: ConcreteGestureHandlerT.() -> Unit): ConcreteGestureHandlerT =
-    self().apply { block() }
 
   // properties set and accessed only by the orchestrator
   var activationIndex = 0
@@ -99,16 +93,16 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   var shouldResetProgress = false
 
   open fun dispatchStateChange(newState: Int, prevState: Int) {
-    onTouchEventListener?.onStateChange(self(), newState, prevState)
+    onTouchEventListener?.onStateChange(this, newState, prevState)
   }
 
   open fun dispatchHandlerUpdate(event: MotionEvent) {
-    onTouchEventListener?.onHandlerUpdate(self(), event)
+    onTouchEventListener?.onHandlerUpdate(this, event)
   }
 
   open fun dispatchTouchEvent() {
     if (changedTouchesPayload != null) {
-      onTouchEventListener?.onTouchEvent(self())
+      onTouchEventListener?.onTouchEvent(this)
     }
   }
 
@@ -121,7 +115,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     mouseButton = DEFAULT_MOUSE_BUTTON
   }
 
-  fun hasCommonPointers(other: GestureHandler<*>): Boolean {
+  fun hasCommonPointers(other: GestureHandler): Boolean {
     for (i in trackedPointerIDs.indices) {
       if (trackedPointerIDs[i] != -1 && other.trackedPointerIDs[i] != -1) {
         return true
@@ -137,7 +131,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     bottomPad: Float,
     width: Float,
     height: Float,
-  ): ConcreteGestureHandlerT = applySelf {
+  ) {
     if (hitSlop == null) {
       hitSlop = FloatArray(6)
     }
@@ -153,12 +147,11 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     require(!(hitSlopSet(height) && !hitSlopSet(bottomPad) && !hitSlopSet(topPad))) { "When height is set one of top or bottom pads need to be defined" }
   }
 
-  fun setHitSlop(padding: Float): ConcreteGestureHandlerT {
+  fun setHitSlop(padding: Float) {
     return setHitSlop(padding, padding, padding, padding, HIT_SLOP_NONE, HIT_SLOP_NONE)
   }
 
-  fun setInteractionController(controller: GestureHandlerInteractionController?): ConcreteGestureHandlerT =
-    applySelf { interactionController = controller }
+  fun setInteractionController(controller: GestureHandlerInteractionController?) { interactionController = controller }
 
   fun prepare(view: View?, orchestrator: GestureHandlerOrchestrator?) {
     check(!(this.view != null || this.orchestrator != null)) { "Already prepared or hasn't been reset" }
@@ -312,7 +305,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
 
   // exception to help debug https://github.com/software-mansion/react-native-gesture-handler/issues/1188
   class AdaptEventException(
-    handler: GestureHandler<*>,
+    handler: GestureHandler,
     event: MotionEvent,
     e: IllegalArgumentException
   ) : Exception(
@@ -570,7 +563,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
       trackedPointersIDsCount > 0
   }
 
-  open fun shouldRequireToWaitForFailure(handler: GestureHandler<*>): Boolean {
+  open fun shouldRequireToWaitForFailure(handler: GestureHandler): Boolean {
     if (handler === this) {
       return false
     }
@@ -578,7 +571,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     return interactionController?.shouldRequireHandlerToWaitForFailure(this, handler) ?: false
   }
 
-  fun shouldWaitForHandlerFailure(handler: GestureHandler<*>): Boolean {
+  fun shouldWaitForHandlerFailure(handler: GestureHandler): Boolean {
     if (handler === this) {
       return false
     }
@@ -586,7 +579,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     return interactionController?.shouldWaitForHandlerFailure(this, handler) ?: false
   }
 
-  open fun shouldRecognizeSimultaneously(handler: GestureHandler<*>): Boolean {
+  open fun shouldRecognizeSimultaneously(handler: GestureHandler): Boolean {
     if (handler === this) {
       return true
     }
@@ -594,7 +587,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     return interactionController?.shouldRecognizeSimultaneously(this, handler) ?: false
   }
 
-  open fun shouldBeCancelledBy(handler: GestureHandler<*>): Boolean {
+  open fun shouldBeCancelledBy(handler: GestureHandler): Boolean {
     if (handler === this) {
       return false
     }
@@ -685,7 +678,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   * Returns true if the view this handler is attached to is a descendant of the view the other handler
   * is attached to and false otherwise.
   */
-  fun isDescendantOf(of: GestureHandler<*>): Boolean {
+  fun isDescendantOf(of: GestureHandler): Boolean {
     var view = this.view?.parent as? View
     while (view != null) {
       if (view == of.view) {
@@ -794,11 +787,6 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
     }
   }
 
-  fun setOnTouchEventListener(listener: OnTouchEventListener?): GestureHandler<*> {
-    onTouchEventListener = listener
-    return this
-  }
-
   override fun toString(): String {
     val viewString = if (view == null) null else view!!.javaClass.simpleName
     return this.javaClass.simpleName + "@[" + tag + "]:" + viewString
@@ -814,7 +802,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   val lastPositionInWindowY: Float
     get() = lastAbsolutePositionY + lastEventOffsetY - windowOffset[1]
 
-  abstract class Factory<T : GestureHandler<T>> {
+  abstract class Factory<T : GestureHandler> {
     abstract val type: Class<T>
     abstract val name: String
 
@@ -862,7 +850,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
       private const val KEY_HIT_SLOP_WIDTH = "width"
       private const val KEY_HIT_SLOP_HEIGHT = "height"
 
-      private fun handleHitSlopProperty(handler: GestureHandler<*>, config: ReadableMap) {
+      private fun handleHitSlopProperty(handler: GestureHandler, config: ReadableMap) {
         if (config.getType(KEY_HIT_SLOP) == ReadableType.Number) {
           val hitSlop = PixelUtil.toPixelFromDIP(config.getDouble(KEY_HIT_SLOP))
           handler.setHitSlop(hitSlop, hitSlop, hitSlop, hitSlop, GestureHandler.HIT_SLOP_NONE, GestureHandler.HIT_SLOP_NONE)

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerInteractionController.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerInteractionController.kt
@@ -1,8 +1,8 @@
 package com.swmansion.gesturehandler.core
 
 interface GestureHandlerInteractionController {
-  fun shouldWaitForHandlerFailure(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
-  fun shouldRequireHandlerToWaitForFailure(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
-  fun shouldRecognizeSimultaneously(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
-  fun shouldHandlerBeCancelledBy(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean
+  fun shouldWaitForHandlerFailure(handler: GestureHandler, otherHandler: GestureHandler): Boolean
+  fun shouldRequireHandlerToWaitForFailure(handler: GestureHandler, otherHandler: GestureHandler): Boolean
+  fun shouldRecognizeSimultaneously(handler: GestureHandler, otherHandler: GestureHandler): Boolean
+  fun shouldHandlerBeCancelledBy(handler: GestureHandler, otherHandler: GestureHandler): Boolean
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -20,9 +20,9 @@ class GestureHandlerOrchestrator(
    * traversing view hierarchy and looking for gesture handlers.
    */
   var minimumAlphaForTraversal = DEFAULT_MIN_ALPHA_FOR_TRAVERSAL
-  private val gestureHandlers = arrayListOf<GestureHandler<*>>()
-  private val awaitingHandlers = arrayListOf<GestureHandler<*>>()
-  private val preparedHandlers = arrayListOf<GestureHandler<*>>()
+  private val gestureHandlers = arrayListOf<GestureHandler>()
+  private val awaitingHandlers = arrayListOf<GestureHandler>()
+  private val preparedHandlers = arrayListOf<GestureHandler>()
 
   // In `onHandlerStateChange` method we iterate through `awaitingHandlers`, but calling `tryActivate` may modify this list.
   // To avoid `ConcurrentModificationException` we iterate through copy. There is one more problem though - if handler was
@@ -82,16 +82,16 @@ class GestureHandlerOrchestrator(
     finishedHandlersCleanupScheduled = false
   }
 
-  private fun hasOtherHandlerToWaitFor(handler: GestureHandler<*>) =
+  private fun hasOtherHandlerToWaitFor(handler: GestureHandler) =
     gestureHandlers.any { !isFinished(it.state) && shouldHandlerWaitForOther(handler, it) }
 
-  private fun shouldBeCancelledByFinishedHandler(handler: GestureHandler<*>) =
+  private fun shouldBeCancelledByFinishedHandler(handler: GestureHandler) =
     gestureHandlers.any { shouldHandlerWaitForOther(handler, it) && it.state == GestureHandler.STATE_END }
 
-  private fun shouldBeCancelledByActiveHandler(handler: GestureHandler<*>) =
+  private fun shouldBeCancelledByActiveHandler(handler: GestureHandler) =
     gestureHandlers.any { handler.hasCommonPointers(it) && it.state == GestureHandler.STATE_ACTIVE && !canRunSimultaneously(handler, it) && handler.isDescendantOf(it) }
 
-  private fun tryActivate(handler: GestureHandler<*>) {
+  private fun tryActivate(handler: GestureHandler) {
     // If we are waiting for a gesture that has successfully finished, we should cancel handler
     if (shouldBeCancelledByFinishedHandler(handler) || shouldBeCancelledByActiveHandler(handler)) {
       handler.cancel()
@@ -120,7 +120,7 @@ class GestureHandlerOrchestrator(
   }
 
   /*package*/
-  fun onHandlerStateChange(handler: GestureHandler<*>, newState: Int, prevState: Int) {
+  fun onHandlerStateChange(handler: GestureHandler, newState: Int, prevState: Int) {
     handlingChangeSemaphore += 1
     if (isFinished(newState)) {
       // We have to loop through copy in order to avoid modifying collection
@@ -178,7 +178,7 @@ class GestureHandlerOrchestrator(
     scheduleFinishedHandlersCleanup()
   }
 
-  private fun makeActive(handler: GestureHandler<*>) {
+  private fun makeActive(handler: GestureHandler) {
     val currentState = handler.state
     with(handler) {
       isAwaiting = false
@@ -253,7 +253,7 @@ class GestureHandlerOrchestrator(
     }
   }
 
-  private fun deliverEventToGestureHandler(handler: GestureHandler<*>, sourceEvent: MotionEvent) {
+  private fun deliverEventToGestureHandler(handler: GestureHandler, sourceEvent: MotionEvent) {
     if (!isViewAttachedUnderWrapper(handler.view)) {
       handler.cancel()
       return
@@ -404,7 +404,7 @@ class GestureHandlerOrchestrator(
     return point
   }
 
-  private fun addAwaitingHandler(handler: GestureHandler<*>) {
+  private fun addAwaitingHandler(handler: GestureHandler) {
     if (awaitingHandlers.contains(handler)) {
       return
     }
@@ -418,7 +418,7 @@ class GestureHandlerOrchestrator(
     }
   }
 
-  private fun recordHandlerIfNotPresent(handler: GestureHandler<*>, view: View) {
+  private fun recordHandlerIfNotPresent(handler: GestureHandler, view: View) {
     if (gestureHandlers.contains(handler)) {
       return
     }
@@ -474,7 +474,7 @@ class GestureHandlerOrchestrator(
   // There's only one exception - RootViewGestureHandler. TalkBack uses hover events,
   // so we need to pass them into RootViewGestureHandler, otherwise press and hold
   // gesture stops working correctly (see https://github.com/software-mansion/react-native-gesture-handler/issues/3407)
-  private fun shouldHandlerSkipHoverEvents(handler: GestureHandler<*>, action: Int): Boolean {
+  private fun shouldHandlerSkipHoverEvents(handler: GestureHandler, action: Int): Boolean {
     val shouldSkipHoverEvents =
       handler !is HoverGestureHandler && handler !is RNGestureHandlerRootHelper.RootViewGestureHandler
 
@@ -629,7 +629,7 @@ class GestureHandlerOrchestrator(
     private val matrixTransformCoords = FloatArray(2)
     private val inverseMatrix = Matrix()
     private val tempCoords = FloatArray(2)
-    private val handlersComparator = Comparator<GestureHandler<*>> { a, b ->
+    private val handlersComparator = Comparator<GestureHandler> { a, b ->
       return@Comparator if (a.isActive && b.isActive || a.isAwaiting && b.isAwaiting) {
         // both A and B are either active or awaiting activation, in which case we prefer one that
         // has activated (or turned into "awaiting" state) earlier
@@ -683,17 +683,17 @@ class GestureHandlerOrchestrator(
     private fun isTransformedTouchPointInView(x: Float, y: Float, child: View) =
       x in 0f..child.width.toFloat() && y in 0f..child.height.toFloat()
 
-    private fun shouldHandlerWaitForOther(handler: GestureHandler<*>, other: GestureHandler<*>): Boolean {
+    private fun shouldHandlerWaitForOther(handler: GestureHandler, other: GestureHandler): Boolean {
       return handler !== other && (
         handler.shouldWaitForHandlerFailure(other) ||
           other.shouldRequireToWaitForFailure(handler)
         )
     }
 
-    private fun canRunSimultaneously(a: GestureHandler<*>, b: GestureHandler<*>) =
+    private fun canRunSimultaneously(a: GestureHandler, b: GestureHandler) =
       a === b || a.shouldRecognizeSimultaneously(b) || b.shouldRecognizeSimultaneously(a)
 
-    private fun shouldHandlerBeCancelledBy(handler: GestureHandler<*>, other: GestureHandler<*>): Boolean {
+    private fun shouldHandlerBeCancelledBy(handler: GestureHandler, other: GestureHandler): Boolean {
       if (!handler.hasCommonPointers(other)) {
         // if two handlers share no common pointer one can never trigger cancel for the other
         return false

--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerRegistry.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerRegistry.kt
@@ -4,5 +4,5 @@ import android.view.View
 import java.util.*
 
 interface GestureHandlerRegistry {
-  fun getHandlersForView(view: View): ArrayList<GestureHandler<*>>?
+  fun getHandlersForView(view: View): ArrayList<GestureHandler>?
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/HoverGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/HoverGestureHandler.kt
@@ -10,13 +10,13 @@ import com.swmansion.gesturehandler.react.RNGestureHandlerRootHelper
 import com.swmansion.gesturehandler.react.RNViewConfigurationHelper
 import com.swmansion.gesturehandler.react.eventbuilders.HoverGestureHandlerEventDataBuilder
 
-class HoverGestureHandler : GestureHandler<HoverGestureHandler>() {
+class HoverGestureHandler : GestureHandler() {
   private var handler: Handler? = null
   private var finishRunnable = Runnable { finish() }
   var stylusData: StylusData = StylusData()
     private set
 
-  private infix fun isAncestorOf(other: GestureHandler<*>): Boolean {
+  private infix fun isAncestorOf(other: GestureHandler): Boolean {
     var current: View? = other.view
 
     while (current != null) {
@@ -50,7 +50,7 @@ class HoverGestureHandler : GestureHandler<HoverGestureHandler>() {
     return null
   }
 
-  override fun shouldBeCancelledBy(handler: GestureHandler<*>): Boolean {
+  override fun shouldBeCancelledBy(handler: GestureHandler): Boolean {
     if (handler is HoverGestureHandler && !(handler isAncestorOf this)) {
       return isViewDisplayedOverAnother(handler.view!!, this.view!!)!!
     }
@@ -58,7 +58,7 @@ class HoverGestureHandler : GestureHandler<HoverGestureHandler>() {
     return super.shouldBeCancelledBy(handler)
   }
 
-  override fun shouldRequireToWaitForFailure(handler: GestureHandler<*>): Boolean {
+  override fun shouldRequireToWaitForFailure(handler: GestureHandler): Boolean {
     if (handler is HoverGestureHandler) {
       if (!(this isAncestorOf handler) && !(handler isAncestorOf this)) {
         isViewDisplayedOverAnother(this.view!!, handler.view!!)?.let {
@@ -70,7 +70,7 @@ class HoverGestureHandler : GestureHandler<HoverGestureHandler>() {
     return super.shouldRequireToWaitForFailure(handler)
   }
 
-  override fun shouldRecognizeSimultaneously(handler: GestureHandler<*>): Boolean {
+  override fun shouldRecognizeSimultaneously(handler: GestureHandler): Boolean {
     if (handler is HoverGestureHandler && (this isAncestorOf handler || handler isAncestorOf this)) {
       return true
     }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -9,7 +9,7 @@ import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.uimanager.PixelUtil
 import com.swmansion.gesturehandler.react.eventbuilders.LongPressGestureHandlerEventDataBuilder
 
-class LongPressGestureHandler(context: Context) : GestureHandler<LongPressGestureHandler>() {
+class LongPressGestureHandler(context: Context) : GestureHandler() {
   var minDurationMs = DEFAULT_MIN_DURATION_MS
   val duration: Int
     get() = (previousTime - startTime).toInt()

--- a/android/src/main/java/com/swmansion/gesturehandler/core/ManualGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/ManualGestureHandler.kt
@@ -4,7 +4,7 @@ import android.content.Context
 import android.view.MotionEvent
 import com.swmansion.gesturehandler.react.eventbuilders.ManualGestureHandlerEventDataBuilder
 
-class ManualGestureHandler : GestureHandler<ManualGestureHandler>() {
+class ManualGestureHandler : GestureHandler() {
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
     if (state == STATE_UNDETERMINED) {
       begin()

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -18,7 +18,7 @@ import com.swmansion.gesturehandler.react.RNGestureHandlerButtonViewManager
 import com.swmansion.gesturehandler.react.eventbuilders.NativeGestureHandlerEventDataBuilder
 import com.swmansion.gesturehandler.react.isScreenReaderOn
 
-class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
+class NativeViewGestureHandler : GestureHandler() {
   private var shouldActivateOnStart = false
 
   /**
@@ -42,7 +42,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     shouldCancelWhenOutside = DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE
   }
 
-  override fun shouldRecognizeSimultaneously(handler: GestureHandler<*>): Boolean {
+  override fun shouldRecognizeSimultaneously(handler: GestureHandler): Boolean {
     // if the gesture is marked by user as simultaneous with other or the hook return true
     hook.shouldRecognizeSimultaneously(handler)?.let {
       return@shouldRecognizeSimultaneously it
@@ -73,7 +73,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     // otherwise we can only return `true` if already in an active state
   }
 
-  override fun shouldBeCancelledBy(handler: GestureHandler<*>): Boolean {
+  override fun shouldBeCancelledBy(handler: GestureHandler): Boolean {
     return !disallowInterruption
   }
 
@@ -222,7 +222,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
      * @return Boolean value signalling whether the gesture can be recognized simultaneously with
      * other (handler). Returning false doesn't necessarily prevent it from happening.
      */
-    fun shouldRecognizeSimultaneously(handler: GestureHandler<*>): Boolean? = null
+    fun shouldRecognizeSimultaneously(handler: GestureHandler): Boolean? = null
 
     /**
      * shouldActivateOnStart and tryIntercept have priority over this method
@@ -250,7 +250,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
   }
 
   private class TextViewHook() : NativeViewGestureHandlerHook {
-    override fun shouldRecognizeSimultaneously(handler: GestureHandler<*>) = false
+    override fun shouldRecognizeSimultaneously(handler: GestureHandler) = false
 
     // We have to explicitly check for ReactTextView, since its `isPressed` flag is not set to `true`,
     // in contrast to e.g. Touchable
@@ -279,7 +279,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     // recognize alongside every handler besides RootViewGestureHandler, which is a private inner class
     // of RNGestureHandlerRootHelper so no explicit type checks, but its tag is always negative
     // also if other handler is NativeViewGestureHandler then don't override the default implementation
-    override fun shouldRecognizeSimultaneously(handler: GestureHandler<*>) =
+    override fun shouldRecognizeSimultaneously(handler: GestureHandler) =
       handler.tag > 0 && handler !is NativeViewGestureHandler
 
     override fun wantsToHandleEventBeforeActivation() = true

--- a/android/src/main/java/com/swmansion/gesturehandler/core/OnTouchEventListener.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/OnTouchEventListener.kt
@@ -3,7 +3,7 @@ package com.swmansion.gesturehandler.core
 import android.view.MotionEvent
 
 interface OnTouchEventListener {
-  fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, event: MotionEvent)
-  fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int)
-  fun <T : GestureHandler<T>> onTouchEvent(handler: T)
+  fun <T : GestureHandler> onHandlerUpdate(handler: T, event: MotionEvent)
+  fun <T : GestureHandler> onStateChange(handler: T, newState: Int, oldState: Int)
+  fun <T : GestureHandler> onTouchEvent(handler: T)
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
@@ -12,7 +12,7 @@ import com.swmansion.gesturehandler.core.GestureUtils.getLastPointerX
 import com.swmansion.gesturehandler.core.GestureUtils.getLastPointerY
 import com.swmansion.gesturehandler.react.eventbuilders.PanGestureHandlerEventDataBuilder
 
-class PanGestureHandler(context: Context?) : GestureHandler<PanGestureHandler>() {
+class PanGestureHandler(context: Context?) : GestureHandler() {
   var velocityX = 0f
     private set
   var velocityY = 0f

--- a/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
@@ -7,7 +7,7 @@ import android.view.ViewConfiguration
 import com.swmansion.gesturehandler.react.eventbuilders.PinchGestureHandlerEventDataBuilder
 import kotlin.math.abs
 
-class PinchGestureHandler : GestureHandler<PinchGestureHandler>() {
+class PinchGestureHandler : GestureHandler() {
   var scale = 0.0
     private set
   var velocity = 0.0

--- a/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/RotationGestureHandler.kt
@@ -7,7 +7,7 @@ import com.swmansion.gesturehandler.core.RotationGestureDetector.OnRotationGestu
 import com.swmansion.gesturehandler.react.eventbuilders.RotationGestureHandlerEventDataBuilder
 import kotlin.math.abs
 
-class RotationGestureHandler : GestureHandler<RotationGestureHandler>() {
+class RotationGestureHandler : GestureHandler() {
   private var rotationGestureDetector: RotationGestureDetector? = null
   var rotation = 0.0
     private set

--- a/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
@@ -11,7 +11,7 @@ import com.swmansion.gesturehandler.core.GestureUtils.getLastPointerY
 import com.swmansion.gesturehandler.react.eventbuilders.TapGestureHandlerEventDataBuilder
 import kotlin.math.abs
 
-class TapGestureHandler : GestureHandler<TapGestureHandler>() {
+class TapGestureHandler : GestureHandler() {
   private var maxDeltaX = MAX_VALUE_IGNORE
   private var maxDeltaY = MAX_VALUE_IGNORE
   private var maxDist = MAX_VALUE_IGNORE

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEvent.kt
@@ -25,7 +25,7 @@ class RNGestureHandlerEvent private constructor() : Event<RNGestureHandlerEvent>
   // how GH sends events (which needs to be done, but maybe wait until the RN's apis stop changing)
   private var useTopPrefixedName: Boolean = false
 
-  private fun <T : GestureHandler<T>> init(
+  private fun <T : GestureHandler> init(
     handler: T,
     dataBuilder: GestureHandlerEventDataBuilder<T>,
     useNativeAnimatedName: Boolean
@@ -56,7 +56,7 @@ class RNGestureHandlerEvent private constructor() : Event<RNGestureHandlerEvent>
     private const val TOUCH_EVENTS_POOL_SIZE = 7 // magic
     private val EVENTS_POOL = Pools.SynchronizedPool<RNGestureHandlerEvent>(TOUCH_EVENTS_POOL_SIZE)
 
-    fun <T : GestureHandler<T>> obtain(
+    fun <T : GestureHandler> obtain(
       handler: T,
       dataBuilder: GestureHandlerEventDataBuilder<T>,
       useTopPrefixedName: Boolean = false

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEventDispatcher.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEventDispatcher.kt
@@ -1,0 +1,148 @@
+package com.swmansion.gesturehandler.react
+
+import android.view.MotionEvent
+import com.facebook.react.bridge.ReactApplicationContext
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.events.Event
+import com.swmansion.gesturehandler.BuildConfig
+import com.swmansion.gesturehandler.ReanimatedEventDispatcher
+import com.swmansion.gesturehandler.core.GestureHandler
+import com.swmansion.gesturehandler.core.OnTouchEventListener
+import com.swmansion.gesturehandler.dispatchEvent
+
+class RNGestureHandlerEventDispatcher(private val reactApplicationContext: ReactApplicationContext) : OnTouchEventListener {
+  private val reanimatedEventDispatcher = ReanimatedEventDispatcher()
+
+  override fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, event: MotionEvent) {
+    this.dispatchHandlerUpdateEvent(handler)
+  }
+
+  override fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int) {
+    this.dispatchStateChangeEvent(handler, newState, oldState)
+  }
+
+  override fun <T : GestureHandler<T>> onTouchEvent(handler: T) {
+    this.dispatchTouchEvent(handler)
+  }
+
+  private fun <T : GestureHandler<T>> dispatchHandlerUpdateEvent(handler: T) {
+    // triggers onUpdate and onChange callbacks on the JS side
+
+    if (handler.tag < 0) {
+      // root containers use negative tags, we don't need to dispatch events for them to the JS
+      return
+    }
+    if (handler.state == GestureHandler.STATE_ACTIVE) {
+      val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
+
+      if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
+        // Reanimated worklet
+        val event = RNGestureHandlerEvent.obtain(handler, handlerFactory.createEventBuilder(handler))
+        sendEventForReanimated(event)
+      } else if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT) {
+        // Animated with useNativeDriver: true
+        val event = RNGestureHandlerEvent.obtain(
+          handler,
+          handlerFactory.createEventBuilder(handler),
+          true
+        )
+        sendEventForNativeAnimatedEvent(event)
+      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API) {
+        // JS function, Animated.event with useNativeDriver: false using old API
+        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+          val data = RNGestureHandlerEvent.createEventData(handlerFactory.createEventBuilder(handler))
+          sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
+        } else {
+          val event = RNGestureHandlerEvent.obtain(handler, handlerFactory.createEventBuilder(handler))
+          sendEventForDirectEvent(event)
+        }
+      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
+        // JS function, Animated.event with useNativeDriver: false using new API
+        val data = RNGestureHandlerEvent.createEventData(handlerFactory.createEventBuilder(handler))
+        sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
+      }
+    }
+  }
+
+  private fun <T : GestureHandler<T>> dispatchStateChangeEvent(handler: T, newState: Int, oldState: Int) {
+    // triggers onBegin, onStart, onEnd, onFinalize callbacks on the JS side
+
+    if (handler.tag < 0) {
+      // root containers use negative tags, we don't need to dispatch events for them to the JS
+      return
+    }
+    val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
+
+    if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
+      // Reanimated worklet
+      val event = RNGestureHandlerStateChangeEvent.obtain(handler, newState, oldState, handlerFactory.createEventBuilder(handler))
+      sendEventForReanimated(event)
+    } else if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT ||
+      handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API
+    ) {
+      // JS function or Animated.event with useNativeDriver: false with old API
+      if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+        val data = RNGestureHandlerStateChangeEvent.createEventData(handlerFactory.createEventBuilder(handler), newState, oldState)
+        sendEventForDeviceEvent(RNGestureHandlerStateChangeEvent.EVENT_NAME, data)
+      } else {
+        val event = RNGestureHandlerStateChangeEvent.obtain(handler, newState, oldState, handlerFactory.createEventBuilder(handler))
+        sendEventForDirectEvent(event)
+      }
+    } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
+      // JS function or Animated.event with useNativeDriver: false with new API
+      val data = RNGestureHandlerStateChangeEvent.createEventData(handlerFactory.createEventBuilder(handler), newState, oldState)
+      sendEventForDeviceEvent(RNGestureHandlerStateChangeEvent.EVENT_NAME, data)
+    }
+  }
+
+  private fun <T : GestureHandler<T>> dispatchTouchEvent(handler: T) {
+    // triggers onTouchesDown, onTouchesMove, onTouchesUp, onTouchesCancelled callbacks on the JS side
+
+    if (handler.tag < 0) {
+      // root containers use negative tags, we don't need to dispatch events for them to the JS
+      return
+    }
+    if (handler.state == GestureHandler.STATE_BEGAN || handler.state == GestureHandler.STATE_ACTIVE ||
+      handler.state == GestureHandler.STATE_UNDETERMINED || handler.view != null
+    ) {
+      if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
+        // Reanimated worklet
+        val event = RNGestureHandlerTouchEvent.obtain(handler)
+        sendEventForReanimated(event)
+      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
+        // JS function, Animated.event with useNativeDriver: false with new API
+        val data = RNGestureHandlerTouchEvent.createEventData(handler)
+        sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
+      }
+    }
+  }
+
+  private fun <T : Event<T>>sendEventForReanimated(event: T) {
+    // Delivers the event to Reanimated.
+    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
+      // Send event directly to Reanimated
+      reanimatedEventDispatcher.sendEvent(event, reactApplicationContext)
+    } else {
+      // In the old architecture, Reanimated subscribes for specific direct events.
+      sendEventForDirectEvent(event)
+    }
+  }
+
+  private fun sendEventForNativeAnimatedEvent(event: RNGestureHandlerEvent) {
+    // Delivers the event to NativeAnimatedModule.
+    // TODO: send event directly to NativeAnimated[Turbo]Module
+    // ReactContext.dispatchEvent is an extension function, depending on the architecture it will
+    // dispatch event using UIManagerModule or FabricUIManager.
+    reactApplicationContext.dispatchEvent(event)
+  }
+
+  private fun <T : Event<T>>sendEventForDirectEvent(event: T) {
+    // Delivers the event to JS as a direct event. This method is called only on Paper.
+    reactApplicationContext.dispatchEvent(event)
+  }
+
+  private fun sendEventForDeviceEvent(eventName: String, data: WritableMap) {
+    // Delivers the event to JS as a device event.
+    reactApplicationContext.deviceEventEmitter.emit(eventName, data)
+  }
+}

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEventDispatcher.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerEventDispatcher.kt
@@ -13,19 +13,19 @@ import com.swmansion.gesturehandler.dispatchEvent
 class RNGestureHandlerEventDispatcher(private val reactApplicationContext: ReactApplicationContext) : OnTouchEventListener {
   private val reanimatedEventDispatcher = ReanimatedEventDispatcher()
 
-  override fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, event: MotionEvent) {
+  override fun <T : GestureHandler> onHandlerUpdate(handler: T, event: MotionEvent) {
     this.dispatchHandlerUpdateEvent(handler)
   }
 
-  override fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int) {
+  override fun <T : GestureHandler> onStateChange(handler: T, newState: Int, oldState: Int) {
     this.dispatchStateChangeEvent(handler, newState, oldState)
   }
 
-  override fun <T : GestureHandler<T>> onTouchEvent(handler: T) {
+  override fun <T : GestureHandler> onTouchEvent(handler: T) {
     this.dispatchTouchEvent(handler)
   }
 
-  private fun <T : GestureHandler<T>> dispatchHandlerUpdateEvent(handler: T) {
+  private fun <T : GestureHandler> dispatchHandlerUpdateEvent(handler: T) {
     // triggers onUpdate and onChange callbacks on the JS side
 
     if (handler.tag < 0) {
@@ -33,7 +33,7 @@ class RNGestureHandlerEventDispatcher(private val reactApplicationContext: React
       return
     }
     if (handler.state == GestureHandler.STATE_ACTIVE) {
-      val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
+      val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForHandler<GestureHandler>(handler) ?: return
 
       if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
         // Reanimated worklet
@@ -64,14 +64,14 @@ class RNGestureHandlerEventDispatcher(private val reactApplicationContext: React
     }
   }
 
-  private fun <T : GestureHandler<T>> dispatchStateChangeEvent(handler: T, newState: Int, oldState: Int) {
+  private fun <T : GestureHandler> dispatchStateChangeEvent(handler: T, newState: Int, oldState: Int) {
     // triggers onBegin, onStart, onEnd, onFinalize callbacks on the JS side
 
     if (handler.tag < 0) {
       // root containers use negative tags, we don't need to dispatch events for them to the JS
       return
     }
-    val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
+    val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForHandler<GestureHandler>(handler) ?: return
 
     if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
       // Reanimated worklet
@@ -95,7 +95,7 @@ class RNGestureHandlerEventDispatcher(private val reactApplicationContext: React
     }
   }
 
-  private fun <T : GestureHandler<T>> dispatchTouchEvent(handler: T) {
+  private fun <T : GestureHandler> dispatchTouchEvent(handler: T) {
     // triggers onTouchesDown, onTouchesMove, onTouchesUp, onTouchesCancelled callbacks on the JS side
 
     if (handler.tag < 0) {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerFactoryUtil.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerFactoryUtil.kt
@@ -25,10 +25,10 @@ object RNGestureHandlerFactoryUtil {
   )
 
   @Suppress("UNCHECKED_CAST")
-  fun <T : GestureHandler<T>> findFactoryForHandler(handler: GestureHandler<T>): GestureHandler.Factory<T>? =
-    handlerFactories.firstOrNull { it.type == handler.javaClass } as GestureHandler.Factory<T>?
+  fun <T : GestureHandler> findFactoryForHandler(handler: GestureHandler): GestureHandler.Factory<GestureHandler>? =
+    handlerFactories.firstOrNull { it.type == handler.javaClass } as GestureHandler.Factory<GestureHandler>?
 
   @Suppress("UNCHECKED_CAST")
-  fun <T : GestureHandler<T>> findFactoryForName(handlerName: String): GestureHandler.Factory<T>? =
-    handlerFactories.firstOrNull { it.name == handlerName } as GestureHandler.Factory<T>?
+  fun <T : GestureHandler> findFactoryForName(handlerName: String): GestureHandler.Factory<GestureHandler>? =
+    handlerFactories.firstOrNull { it.name == handlerName } as GestureHandler.Factory<GestureHandler>?
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerFactoryUtil.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerFactoryUtil.kt
@@ -1,0 +1,34 @@
+package com.swmansion.gesturehandler.react
+
+import com.swmansion.gesturehandler.core.FlingGestureHandler
+import com.swmansion.gesturehandler.core.GestureHandler
+import com.swmansion.gesturehandler.core.HoverGestureHandler
+import com.swmansion.gesturehandler.core.LongPressGestureHandler
+import com.swmansion.gesturehandler.core.ManualGestureHandler
+import com.swmansion.gesturehandler.core.NativeViewGestureHandler
+import com.swmansion.gesturehandler.core.PanGestureHandler
+import com.swmansion.gesturehandler.core.PinchGestureHandler
+import com.swmansion.gesturehandler.core.RotationGestureHandler
+import com.swmansion.gesturehandler.core.TapGestureHandler
+
+object RNGestureHandlerFactoryUtil {
+  private val handlerFactories = arrayOf<GestureHandler.Factory<*>>(
+    NativeViewGestureHandler.Factory(),
+    TapGestureHandler.Factory(),
+    LongPressGestureHandler.Factory(),
+    PanGestureHandler.Factory(),
+    PinchGestureHandler.Factory(),
+    RotationGestureHandler.Factory(),
+    FlingGestureHandler.Factory(),
+    ManualGestureHandler.Factory(),
+    HoverGestureHandler.Factory(),
+  )
+
+  @Suppress("UNCHECKED_CAST")
+  fun <T : GestureHandler<T>> findFactoryForHandler(handler: GestureHandler<T>): GestureHandler.Factory<T>? =
+    handlerFactories.firstOrNull { it.type == handler.javaClass } as GestureHandler.Factory<T>?
+
+  @Suppress("UNCHECKED_CAST")
+  fun <T : GestureHandler<T>> findFactoryForName(handlerName: String): GestureHandler.Factory<T>? =
+    handlerFactories.firstOrNull { it.name == handlerName } as GestureHandler.Factory<T>?
+}

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerInteractionManager.kt
@@ -25,7 +25,7 @@ class RNGestureHandlerInteractionManager : GestureHandlerInteractionController {
     }
   }
 
-  fun configureInteractions(handler: GestureHandler<*>, config: ReadableMap) {
+  fun configureInteractions(handler: GestureHandler, config: ReadableMap) {
     handler.setInteractionController(this)
     if (config.hasKey(KEY_WAIT_FOR)) {
       val tags = convertHandlerTagsArray(config, KEY_WAIT_FOR)
@@ -41,15 +41,15 @@ class RNGestureHandlerInteractionManager : GestureHandlerInteractionController {
     }
   }
 
-  override fun shouldWaitForHandlerFailure(handler: GestureHandler<*>, otherHandler: GestureHandler<*>) =
+  override fun shouldWaitForHandlerFailure(handler: GestureHandler, otherHandler: GestureHandler) =
     waitForRelations[handler.tag]?.any { tag -> tag == otherHandler.tag } ?: false
 
   override fun shouldRequireHandlerToWaitForFailure(
-    handler: GestureHandler<*>,
-    otherHandler: GestureHandler<*>,
+    handler: GestureHandler,
+    otherHandler: GestureHandler,
   ) = blockingRelations[handler.tag]?.any { tag -> tag == otherHandler.tag } ?: false
 
-  override fun shouldHandlerBeCancelledBy(handler: GestureHandler<*>, otherHandler: GestureHandler<*>): Boolean {
+  override fun shouldHandlerBeCancelledBy(handler: GestureHandler, otherHandler: GestureHandler): Boolean {
     if (otherHandler is NativeViewGestureHandler) {
       return otherHandler.disallowInterruption
     }
@@ -61,8 +61,8 @@ class RNGestureHandlerInteractionManager : GestureHandlerInteractionController {
     return false
   }
   override fun shouldRecognizeSimultaneously(
-    handler: GestureHandler<*>,
-    otherHandler: GestureHandler<*>,
+    handler: GestureHandler,
+    otherHandler: GestureHandler,
   ) = simultaneousRelations[handler.tag]?.any { tag -> tag == otherHandler.tag } ?: false
 
   fun reset() {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -19,10 +19,11 @@ import com.swmansion.gesturehandler.core.GestureHandler
 class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   NativeRNGestureHandlerModuleSpec(reactContext), GestureHandlerStateManager {
 
-  private val eventDispatcher = RNGestureHandlerEventDispatcher(reactApplicationContext)
   val registry: RNGestureHandlerRegistry = RNGestureHandlerRegistry()
+  private val eventDispatcher = RNGestureHandlerEventDispatcher(reactApplicationContext)
   private val interactionManager = RNGestureHandlerInteractionManager()
   private val roots: MutableList<RNGestureHandlerRootHelper> = ArrayList()
+
   override fun getName() = NAME
 
   @Suppress("UNCHECKED_CAST")

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -26,7 +26,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
   override fun getName() = NAME
 
-  @Suppress("UNCHECKED_CAST")
   private fun <T : GestureHandler<T>> createGestureHandlerHelper(
     handlerName: String,
     handlerTag: Int,

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -41,10 +41,8 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
     val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForName<T>(handlerName)
       ?: throw JSApplicationIllegalArgumentException("Invalid handler name $handlerName")
 
-    val handler = handlerFactory.create(reactApplicationContext).apply {
-      tag = handlerTag
-      setOnTouchEventListener(eventDispatcher)
-    }
+    val handler = handlerFactory.create(reactApplicationContext, handlerTag)
+    handler.setOnTouchEventListener(eventDispatcher)
     registry.registerHandler(handler)
     interactionManager.configureInteractions(handler, config)
     handlerFactory.setConfig(handler, config)
@@ -77,13 +75,11 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
   @Suppress("UNCHECKED_CAST")
   private fun <T : GestureHandler<T>> updateGestureHandlerHelper(handlerTag: Int, config: ReadableMap) {
-    val handler = registry.getHandler(handlerTag) as T?
-    if (handler != null) {
-      val factory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
-      interactionManager.dropRelationsForHandlerWithTag(handlerTag)
-      interactionManager.configureInteractions(handler, config)
-      factory.setConfig(handler, config)
-    }
+    val handler = registry.getHandler(handlerTag) as T? ?: return
+    val factory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
+    interactionManager.dropRelationsForHandlerWithTag(handlerTag)
+    interactionManager.configureInteractions(handler, config)
+    factory.setConfig(handler, config)
   }
 
   @ReactMethod
@@ -161,9 +157,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
   fun registerRootHelper(root: RNGestureHandlerRootHelper) {
     synchronized(roots) {
-      if (root in roots) {
-        throw IllegalStateException("Root helper$root already registered")
-      }
+      assert(root !in roots) { "Root helper$root already registered" }
       roots.add(root)
     }
   }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -32,7 +32,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
     handlerTag: Int,
     config: ReadableMap,
   ) {
-
     if (registry.getHandler(handlerTag) !== null) {
       throw IllegalStateException(
         "Handler with tag $handlerTag already exists. Please ensure that no Gesture instance is used across multiple GestureDetectors."
@@ -109,12 +108,10 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   }
 
   @ReactMethod
-  override fun handleClearJSResponder() {
-  }
+  override fun handleClearJSResponder() = Unit
 
   @ReactMethod
-  override fun flushOperations() {
-  }
+  override fun flushOperations() = Unit
 
   override fun setGestureHandlerState(handlerTag: Int, newState: Int) {
     registry.getHandler(handlerTag)?.let { handler ->

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -1,35 +1,16 @@
 package com.swmansion.gesturehandler.react
 
 import android.util.Log
-import android.view.MotionEvent
 import com.facebook.react.ReactRootView
 import com.facebook.react.bridge.JSApplicationIllegalArgumentException
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.bridge.ReactMethod
 import com.facebook.react.bridge.ReadableMap
-import com.facebook.react.bridge.WritableMap
 import com.facebook.react.module.annotations.ReactModule
-import com.facebook.react.uimanager.events.Event
 import com.facebook.soloader.SoLoader
 import com.swmansion.common.GestureHandlerStateManager
-import com.swmansion.gesturehandler.BuildConfig
 import com.swmansion.gesturehandler.NativeRNGestureHandlerModuleSpec
-import com.swmansion.gesturehandler.ReanimatedEventDispatcher
-import com.swmansion.gesturehandler.core.FlingGestureHandler
 import com.swmansion.gesturehandler.core.GestureHandler
-import com.swmansion.gesturehandler.core.HoverGestureHandler
-import com.swmansion.gesturehandler.core.LongPressGestureHandler
-import com.swmansion.gesturehandler.core.ManualGestureHandler
-import com.swmansion.gesturehandler.core.NativeViewGestureHandler
-import com.swmansion.gesturehandler.core.OnTouchEventListener
-import com.swmansion.gesturehandler.core.PanGestureHandler
-import com.swmansion.gesturehandler.core.PinchGestureHandler
-import com.swmansion.gesturehandler.core.RotationGestureHandler
-import com.swmansion.gesturehandler.core.TapGestureHandler
-import com.swmansion.gesturehandler.dispatchEvent
-
-// NativeModule.onCatalystInstanceDestroy() was deprecated in favor of NativeModule.invalidate()
-// ref: https://github.com/facebook/react-native/commit/18c8417290823e67e211bde241ae9dde27b72f17
 
 // UIManagerModule.resolveRootTagFromReactTag() was deprecated and will be removed in the next RN release
 // ref: https://github.com/facebook/react-native/commit/acbf9e18ea666b07c1224a324602a41d0a66985e
@@ -38,34 +19,10 @@ import com.swmansion.gesturehandler.dispatchEvent
 class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   NativeRNGestureHandlerModuleSpec(reactContext), GestureHandlerStateManager {
 
-  private val eventListener = object : OnTouchEventListener {
-    override fun <T : GestureHandler<T>> onHandlerUpdate(handler: T, event: MotionEvent) {
-      this@RNGestureHandlerModule.onHandlerUpdate(handler)
-    }
-
-    override fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int) {
-      this@RNGestureHandlerModule.onStateChange(handler, newState, oldState)
-    }
-
-    override fun <T : GestureHandler<T>> onTouchEvent(handler: T) {
-      this@RNGestureHandlerModule.onTouchEvent(handler)
-    }
-  }
-  private val handlerFactories = arrayOf<GestureHandler.Factory<*>>(
-    NativeViewGestureHandler.Factory(),
-    TapGestureHandler.Factory(),
-    LongPressGestureHandler.Factory(),
-    PanGestureHandler.Factory(),
-    PinchGestureHandler.Factory(),
-    RotationGestureHandler.Factory(),
-    FlingGestureHandler.Factory(),
-    ManualGestureHandler.Factory(),
-    HoverGestureHandler.Factory(),
-  )
+  private val eventDispatcher = RNGestureHandlerEventDispatcher(reactApplicationContext)
   val registry: RNGestureHandlerRegistry = RNGestureHandlerRegistry()
   private val interactionManager = RNGestureHandlerInteractionManager()
   private val roots: MutableList<RNGestureHandlerRootHelper> = ArrayList()
-  private val reanimatedEventDispatcher = ReanimatedEventDispatcher()
   override fun getName() = NAME
 
   @Suppress("UNCHECKED_CAST")
@@ -81,19 +38,16 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
       )
     }
 
-    for (handlerFactory in handlerFactories as Array<GestureHandler.Factory<T>>) {
-      if (handlerFactory.name == handlerName) {
-        val handler = handlerFactory.create(reactApplicationContext).apply {
-          tag = handlerTag
-          setOnTouchEventListener(eventListener)
-        }
-        registry.registerHandler(handler)
-        interactionManager.configureInteractions(handler, config)
-        handlerFactory.setConfig(handler, config)
-        return
-      }
+    val handlerFactory = RNGestureHandlerFactoryUtil.findFactoryForName<T>(handlerName)
+      ?: throw JSApplicationIllegalArgumentException("Invalid handler name $handlerName")
+
+    val handler = handlerFactory.create(reactApplicationContext).apply {
+      tag = handlerTag
+      setOnTouchEventListener(eventDispatcher)
     }
-    throw JSApplicationIllegalArgumentException("Invalid handler name $handlerName")
+    registry.registerHandler(handler)
+    interactionManager.configureInteractions(handler, config)
+    handlerFactory.setConfig(handler, config)
   }
 
   @ReactMethod
@@ -125,12 +79,10 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   private fun <T : GestureHandler<T>> updateGestureHandlerHelper(handlerTag: Int, config: ReadableMap) {
     val handler = registry.getHandler(handlerTag) as T?
     if (handler != null) {
-      val factory = findFactoryForHandler(handler)
-      if (factory != null) {
-        interactionManager.dropRelationsForHandlerWithTag(handlerTag)
-        interactionManager.configureInteractions(handler, config)
-        factory.setConfig(handler, config)
-      }
+      val factory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
+      interactionManager.dropRelationsForHandlerWithTag(handlerTag)
+      interactionManager.configureInteractions(handler, config)
+      factory.setConfig(handler, config)
     }
   }
 
@@ -192,25 +144,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
   private external fun decorateRuntime(jsiPtr: Long)
 
-  override fun getConstants(): Map<String, Any> {
-    return mapOf(
-      "State" to mapOf(
-        "UNDETERMINED" to GestureHandler.STATE_UNDETERMINED,
-        "BEGAN" to GestureHandler.STATE_BEGAN,
-        "ACTIVE" to GestureHandler.STATE_ACTIVE,
-        "CANCELLED" to GestureHandler.STATE_CANCELLED,
-        "FAILED" to GestureHandler.STATE_FAILED,
-        "END" to GestureHandler.STATE_END
-      ),
-      "Direction" to mapOf(
-        "RIGHT" to GestureHandler.DIRECTION_RIGHT,
-        "LEFT" to GestureHandler.DIRECTION_LEFT,
-        "UP" to GestureHandler.DIRECTION_UP,
-        "DOWN" to GestureHandler.DIRECTION_DOWN
-      )
-    )
-  }
-
   override fun invalidate() {
     registry.dropAllHandlers()
     interactionManager.reset()
@@ -219,8 +152,9 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
         val sizeBefore: Int = roots.size
         val root: RNGestureHandlerRootHelper = roots[0]
         root.tearDown()
-        if (roots.size >= sizeBefore) {
-          throw IllegalStateException("Expected root helper to get unregistered while tearing down")
+
+        assert(roots.size < sizeBefore) {
+          "Expected root helper to get unregistered while tearing down"
         }
       }
     }
@@ -252,131 +186,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
         it.rootView is ReactRootView && it.rootView.rootViewTag == rootViewTag
       }
     }
-  }
-
-  @Suppress("UNCHECKED_CAST")
-  private fun <T : GestureHandler<T>> findFactoryForHandler(handler: GestureHandler<T>): GestureHandler.Factory<T>? =
-    handlerFactories.firstOrNull { it.type == handler.javaClass } as GestureHandler.Factory<T>?
-
-  private fun <T : GestureHandler<T>> onHandlerUpdate(handler: T) {
-    // triggers onUpdate and onChange callbacks on the JS side
-
-    if (handler.tag < 0) {
-      // root containers use negative tags, we don't need to dispatch events for them to the JS
-      return
-    }
-    if (handler.state == GestureHandler.STATE_ACTIVE) {
-      val handlerFactory = findFactoryForHandler(handler) ?: return
-
-      if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
-        // Reanimated worklet
-        val event = RNGestureHandlerEvent.obtain(handler, handlerFactory.createEventBuilder(handler))
-        sendEventForReanimated(event)
-      } else if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT) {
-        // Animated with useNativeDriver: true
-        val event = RNGestureHandlerEvent.obtain(
-          handler,
-          handlerFactory.createEventBuilder(handler),
-          true
-        )
-        sendEventForNativeAnimatedEvent(event)
-      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API) {
-        // JS function, Animated.event with useNativeDriver: false using old API
-        if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-          val data = RNGestureHandlerEvent.createEventData(handlerFactory.createEventBuilder(handler))
-          sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
-        } else {
-          val event = RNGestureHandlerEvent.obtain(handler, handlerFactory.createEventBuilder(handler))
-          sendEventForDirectEvent(event)
-        }
-      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
-        // JS function, Animated.event with useNativeDriver: false using new API
-        val data = RNGestureHandlerEvent.createEventData(handlerFactory.createEventBuilder(handler))
-        sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
-      }
-    }
-  }
-
-  private fun <T : GestureHandler<T>> onStateChange(handler: T, newState: Int, oldState: Int) {
-    // triggers onBegin, onStart, onEnd, onFinalize callbacks on the JS side
-
-    if (handler.tag < 0) {
-      // root containers use negative tags, we don't need to dispatch events for them to the JS
-      return
-    }
-    val handlerFactory = findFactoryForHandler(handler) ?: return
-
-    if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
-      // Reanimated worklet
-      val event = RNGestureHandlerStateChangeEvent.obtain(handler, newState, oldState, handlerFactory.createEventBuilder(handler))
-      sendEventForReanimated(event)
-    } else if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT ||
-      handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API
-    ) {
-      // JS function or Animated.event with useNativeDriver: false with old API
-      if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-        val data = RNGestureHandlerStateChangeEvent.createEventData(handlerFactory.createEventBuilder(handler), newState, oldState)
-        sendEventForDeviceEvent(RNGestureHandlerStateChangeEvent.EVENT_NAME, data)
-      } else {
-        val event = RNGestureHandlerStateChangeEvent.obtain(handler, newState, oldState, handlerFactory.createEventBuilder(handler))
-        sendEventForDirectEvent(event)
-      }
-    } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
-      // JS function or Animated.event with useNativeDriver: false with new API
-      val data = RNGestureHandlerStateChangeEvent.createEventData(handlerFactory.createEventBuilder(handler), newState, oldState)
-      sendEventForDeviceEvent(RNGestureHandlerStateChangeEvent.EVENT_NAME, data)
-    }
-  }
-
-  private fun <T : GestureHandler<T>> onTouchEvent(handler: T) {
-    // triggers onTouchesDown, onTouchesMove, onTouchesUp, onTouchesCancelled callbacks on the JS side
-
-    if (handler.tag < 0) {
-      // root containers use negative tags, we don't need to dispatch events for them to the JS
-      return
-    }
-    if (handler.state == GestureHandler.STATE_BEGAN || handler.state == GestureHandler.STATE_ACTIVE ||
-      handler.state == GestureHandler.STATE_UNDETERMINED || handler.view != null
-    ) {
-      if (handler.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET) {
-        // Reanimated worklet
-        val event = RNGestureHandlerTouchEvent.obtain(handler)
-        sendEventForReanimated(event)
-      } else if (handler.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API) {
-        // JS function, Animated.event with useNativeDriver: false with new API
-        val data = RNGestureHandlerTouchEvent.createEventData(handler)
-        sendEventForDeviceEvent(RNGestureHandlerEvent.EVENT_NAME, data)
-      }
-    }
-  }
-
-  private fun <T : Event<T>>sendEventForReanimated(event: T) {
-    // Delivers the event to Reanimated.
-    if (BuildConfig.IS_NEW_ARCHITECTURE_ENABLED) {
-      // Send event directly to Reanimated
-      reanimatedEventDispatcher.sendEvent(event, reactApplicationContext)
-    } else {
-      // In the old architecture, Reanimated subscribes for specific direct events.
-      sendEventForDirectEvent(event)
-    }
-  }
-
-  private fun sendEventForNativeAnimatedEvent(event: RNGestureHandlerEvent) {
-    // Delivers the event to NativeAnimatedModule.
-    // TODO: send event directly to NativeAnimated[Turbo]Module
-    // ReactContext.dispatchEvent is an extension function, depending on the architecture it will
-    // dispatch event using UIManagerModule or FabricUIManager.
-    reactApplicationContext.dispatchEvent(event)
-  }
-
-  private fun <T : Event<T>>sendEventForDirectEvent(event: T) {
-    // Delivers the event to JS as a direct event. This method is called only on Paper.
-    reactApplicationContext.dispatchEvent(event)
-  }
-
-  private fun sendEventForDeviceEvent(eventName: String, data: WritableMap) {
-    // Delivers the event to JS as a device event.
-    reactApplicationContext.deviceEventEmitter.emit(eventName, data)
   }
 
   companion object {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -26,7 +26,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
   override fun getName() = NAME
 
-  private fun <T : GestureHandler<T>> createGestureHandlerHelper(
+  private fun <T : GestureHandler> createGestureHandlerHelper(
     handlerName: String,
     handlerTag: Int,
     config: ReadableMap,
@@ -41,7 +41,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
       ?: throw JSApplicationIllegalArgumentException("Invalid handler name $handlerName")
 
     val handler = handlerFactory.create(reactApplicationContext, handlerTag)
-    handler.setOnTouchEventListener(eventDispatcher)
+    handler.onTouchEventListener = eventDispatcher
     registry.registerHandler(handler)
     interactionManager.configureInteractions(handler, config)
     handlerFactory.setConfig(handler, config)
@@ -55,7 +55,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   ) {
     val handlerTag = handlerTagDouble.toInt()
 
-    createGestureHandlerHelper(handlerName, handlerTag, config)
+    createGestureHandlerHelper<GestureHandler>(handlerName, handlerTag, config)
   }
 
   @ReactMethod
@@ -72,10 +72,9 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
     }
   }
 
-  @Suppress("UNCHECKED_CAST")
-  private fun <T : GestureHandler<T>> updateGestureHandlerHelper(handlerTag: Int, config: ReadableMap) {
-    val handler = registry.getHandler(handlerTag) as T? ?: return
-    val factory = RNGestureHandlerFactoryUtil.findFactoryForHandler(handler) ?: return
+  private fun <T : GestureHandler> updateGestureHandlerHelper(handlerTag: Int, config: ReadableMap) {
+    val handler = registry.getHandler(handlerTag) ?: return
+    val factory = RNGestureHandlerFactoryUtil.findFactoryForHandler<GestureHandler>(handler) ?: return
     interactionManager.dropRelationsForHandlerWithTag(handlerTag)
     interactionManager.configureInteractions(handler, config)
     factory.setConfig(handler, config)
@@ -85,7 +84,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   override fun updateGestureHandler(handlerTagDouble: Double, config: ReadableMap) {
     val handlerTag = handlerTagDouble.toInt()
 
-    updateGestureHandlerHelper(handlerTag, config)
+    updateGestureHandlerHelper<GestureHandler>(handlerTag, config)
   }
 
   @ReactMethod

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
@@ -8,17 +8,17 @@ import com.swmansion.gesturehandler.core.GestureHandlerRegistry
 import java.util.*
 
 class RNGestureHandlerRegistry : GestureHandlerRegistry {
-  private val handlers = SparseArray<GestureHandler<*>>()
+  private val handlers = SparseArray<GestureHandler>()
   private val attachedTo = SparseArray<Int?>()
-  private val handlersForView = SparseArray<ArrayList<GestureHandler<*>>>()
+  private val handlersForView = SparseArray<ArrayList<GestureHandler>>()
 
   @Synchronized
-  fun registerHandler(handler: GestureHandler<*>) {
+  fun registerHandler(handler: GestureHandler) {
     handlers.put(handler.tag, handler)
   }
 
   @Synchronized
-  fun getHandler(handlerTag: Int): GestureHandler<*>? {
+  fun getHandler(handlerTag: Int): GestureHandler? {
     return handlers[handlerTag]
   }
 
@@ -34,7 +34,7 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
   }
 
   @Synchronized
-  private fun registerHandlerForViewWithTag(viewTag: Int, handler: GestureHandler<*>) {
+  private fun registerHandlerForViewWithTag(viewTag: Int, handler: GestureHandler) {
     check(attachedTo[handler.tag] == null) { "Handler $handler already attached" }
     attachedTo.put(handler.tag, viewTag)
     var listToAdd = handlersForView[viewTag]
@@ -50,7 +50,7 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
   }
 
   @Synchronized
-  private fun detachHandler(handler: GestureHandler<*>) {
+  private fun detachHandler(handler: GestureHandler) {
     val attachedToView = attachedTo[handler.tag]
     if (attachedToView != null) {
       attachedTo.remove(handler.tag)
@@ -89,12 +89,12 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
   }
 
   @Synchronized
-  fun getHandlersForViewWithTag(viewTag: Int): ArrayList<GestureHandler<*>>? {
+  fun getHandlersForViewWithTag(viewTag: Int): ArrayList<GestureHandler>? {
     return handlersForView[viewTag]
   }
 
   @Synchronized
-  override fun getHandlersForView(view: View): ArrayList<GestureHandler<*>>? {
+  override fun getHandlersForView(view: View): ArrayList<GestureHandler>? {
     return getHandlersForViewWithTag(view.id)
   }
 }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -24,8 +24,8 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
   init {
     UiThreadUtil.assertOnUiThread()
     val wrappedViewTag = wrappedView.id
-    check(wrappedViewTag >= 1) { "Expect view tag to be set for $wrappedView" }
-    val module = (context as ThemedReactContext).reactApplicationContext.getNativeModule(RNGestureHandlerModule::class.java)!!
+    assert(wrappedViewTag >= 1) { "Expect view tag to be set for $wrappedView" }
+    val module = context.getNativeModule(RNGestureHandlerModule::class.java)!!
     val registry = module.registry
     rootView = findRootViewTag(wrappedView)
     Log.i(
@@ -37,11 +37,9 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     ).apply {
       minimumAlphaForTraversal = MIN_ALPHA_FOR_TOUCH
     }
-    jsGestureHandler = RootViewGestureHandler().apply { tag = -wrappedViewTag }
-    with(registry) {
-      registerHandler(jsGestureHandler)
-      attachHandlerToView(jsGestureHandler.tag, wrappedViewTag, GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API)
-    }
+    jsGestureHandler = RootViewGestureHandler(handlerTag = -wrappedViewTag)
+    registry.registerHandler(jsGestureHandler)
+    registry.attachHandlerToView(jsGestureHandler.tag, wrappedViewTag, GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API)
     module.registerRootHelper(this)
   }
 
@@ -57,7 +55,11 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     }
   }
 
-  internal inner class RootViewGestureHandler : GestureHandler<RootViewGestureHandler>() {
+  internal inner class RootViewGestureHandler(handlerTag: Int) : GestureHandler<RootViewGestureHandler>() {
+    init {
+        this.tag = handlerTag
+    }
+
     private fun handleEvent(event: MotionEvent) {
       val currentState = state
 

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -57,7 +57,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
 
   internal inner class RootViewGestureHandler(handlerTag: Int) : GestureHandler<RootViewGestureHandler>() {
     init {
-        this.tag = handlerTag
+      this.tag = handlerTag
     }
 
     private fun handleEvent(event: MotionEvent) {

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -16,7 +16,7 @@ import com.swmansion.gesturehandler.core.GestureHandlerOrchestrator
 
 class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView: ViewGroup) {
   private val orchestrator: GestureHandlerOrchestrator?
-  private val jsGestureHandler: GestureHandler<*>?
+  private val jsGestureHandler: GestureHandler?
   val rootView: ViewGroup
   private var shouldIntercept = false
   private var passingTouch = false
@@ -55,7 +55,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     }
   }
 
-  internal inner class RootViewGestureHandler(handlerTag: Int) : GestureHandler<RootViewGestureHandler>() {
+  internal inner class RootViewGestureHandler(handlerTag: Int) : GestureHandler() {
     init {
       this.tag = handlerTag
     }

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerStateChangeEvent.kt
@@ -19,7 +19,7 @@ class RNGestureHandlerStateChangeEvent private constructor() : Event<RNGestureHa
   private var newState: Int = GestureHandler.STATE_UNDETERMINED
   private var oldState: Int = GestureHandler.STATE_UNDETERMINED
 
-  private fun <T : GestureHandler<T>> init(
+  private fun <T : GestureHandler> init(
     handler: T,
     newState: Int,
     oldState: Int,
@@ -54,7 +54,7 @@ class RNGestureHandlerStateChangeEvent private constructor() : Event<RNGestureHa
     private const val TOUCH_EVENTS_POOL_SIZE = 7 // magic
     private val EVENTS_POOL = Pools.SynchronizedPool<RNGestureHandlerStateChangeEvent>(TOUCH_EVENTS_POOL_SIZE)
 
-    fun <T : GestureHandler<T>> obtain(
+    fun <T : GestureHandler> obtain(
       handler: T,
       newState: Int,
       oldState: Int,

--- a/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
@@ -10,7 +10,7 @@ import com.swmansion.gesturehandler.core.GestureHandler
 class RNGestureHandlerTouchEvent private constructor() : Event<RNGestureHandlerTouchEvent>() {
   private var extraData: WritableMap? = null
   private var coalescingKey: Short = 0
-  private fun <T : GestureHandler<T>> init(handler: T) {
+  private fun <T : GestureHandler> init(handler: T) {
     val view = handler.view!!
     super.init(UIManagerHelper.getSurfaceId(view), view.id)
     extraData = createEventData(handler)
@@ -40,12 +40,12 @@ class RNGestureHandlerTouchEvent private constructor() : Event<RNGestureHandlerT
     private const val TOUCH_EVENTS_POOL_SIZE = 7 // magic
     private val EVENTS_POOL = Pools.SynchronizedPool<RNGestureHandlerTouchEvent>(TOUCH_EVENTS_POOL_SIZE)
 
-    fun <T : GestureHandler<T>> obtain(handler: T): RNGestureHandlerTouchEvent =
+    fun <T : GestureHandler> obtain(handler: T): RNGestureHandlerTouchEvent =
       (EVENTS_POOL.acquire() ?: RNGestureHandlerTouchEvent()).apply {
         init(handler)
       }
 
-    fun <T : GestureHandler<T>> createEventData(handler: T): WritableMap = Arguments.createMap().apply {
+    fun <T : GestureHandler> createEventData(handler: T): WritableMap = Arguments.createMap().apply {
       putInt("handlerTag", handler.tag)
       putInt("state", handler.state)
       putInt("numberOfTouches", handler.trackedPointersCount)

--- a/android/src/main/java/com/swmansion/gesturehandler/react/eventbuilders/GestureHandlerEventDataBuilder.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/react/eventbuilders/GestureHandlerEventDataBuilder.kt
@@ -3,7 +3,7 @@ package com.swmansion.gesturehandler.react.eventbuilders
 import com.facebook.react.bridge.WritableMap
 import com.swmansion.gesturehandler.core.GestureHandler
 
-abstract class GestureHandlerEventDataBuilder<T : GestureHandler<T>>(handler: T) {
+abstract class GestureHandlerEventDataBuilder<T : GestureHandler>(handler: T) {
   private val numberOfPointers: Int
   private val handlerTag: Int
   private val state: Int


### PR DESCRIPTION
## Description

Depends on https://github.com/software-mansion/react-native-gesture-handler/pull/3489

On Android, `GestureHandler` was a generic class specialized by the concrete type of the handler. The only place it was used was `applySelf` method, which allowed for inherited methods to return the concrete handler:

```
tapHandler.setEnabled(true) // returns TapGestureHandler instead of GestureHandler
```

...but we don't use this pattern anywhere. It made much more sense in Java, than it does in Kotlin, where we can simply use `apply`, `let`, etc. when there's a need to do multiple operations on the same object. Now, it simply makes the logic dealing with gesture handlers more complicated as it also needs to keep track of the generic type, which in most cases is `*` so it doesn't give us more type safety.

This PR makes it so that the base `GestureHandler` class is no longer generic, which should make life easier when dealing with non-concrete gesture handlers in the future.

## Test plan

Build Example and FabricExample apps
