### PR TITLE
[iOS] Avoid unnecessary string allocations

### DIFF
--- a/apple/RNGestureHandlerButton.mm
+++ b/apple/RNGestureHandlerButton.mm
@@ -135,13 +135,16 @@
 // Vendored from RCTView.m to infer accessibility label from children
 static NSString *RNGHRecursiveAccessibilityLabel(UIView *view)
 {
-  NSMutableString *str = [NSMutableString stringWithString:@""];
+  NSMutableString *str = nil;
   for (UIView *subview in view.subviews) {
     NSString *label = subview.accessibilityLabel;
     if (!label) {
       label = RNGHRecursiveAccessibilityLabel(subview);
     }
     if (label && label.length > 0) {
+      if (str == nil) {
+        str = [NSMutableString string];
+      }
       if (str.length > 0) {
         [str appendString:@" "];
       }

--- a/apple/RNGestureHandlerButton.mm
+++ b/apple/RNGestureHandlerButton.mm
@@ -151,7 +151,8 @@ static NSString *RNGHRecursiveAccessibilityLabel(UIView *view)
       [str appendString:label];
     }
   }
-  return str.length == 0 ? nil : str;
+
+  return str;
 }
 #endif
 


### PR DESCRIPTION
## Description

#3290 introduced recursive algorithm to obtain accessibility label from children. However, unlike in React Native, it allocates `String` at every recursive call. This may lower the performance as those allocations come at high cost. 

## Test plan

Accessibility labels are inferred as before.