### PR TITLE
Fix `yarn format:apple` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "ts-check": "yarn tsc --noEmit",
     "format:js": "prettier --write --list-different './{src,example,FabricExample,MacOSExample}/**/*.{js,jsx,ts,tsx}'",
     "format:android": "node ./scripts/format-android.js",
-    "format:apple": "find apple/ -iname *.h -o -iname *.m -o -iname *.cpp -o -iname *.mm | xargs clang-format -i",
+    "format:apple": "find apple/ -iname '*.h' -o -iname '*.m' -o -iname '*.cpp' -o -iname '*.mm' | xargs clang-format -i",
     "lint:js": "eslint --ext '.js,.ts,.tsx' src/ example/src FabricExample/src MacOSExample/src && yarn prettier --check './{src,example,FabricExample,MacOSExample}/**/*.{js,jsx,ts,tsx}'",
     "lint:js-root": "eslint --ext '.js,.ts,.tsx' src/ && yarn prettier --check './src/**/*.{js,jsx,ts,tsx}'",
     "lint:android": "./android/gradlew -p android spotlessCheck -q",


### PR DESCRIPTION
## Description

For some reason running `yarn format:apple` was working fine, even though running `apple/ -iname *.h` resulted in an error. This confusing behavior seems to be fixed in `yarn 4`, so now trying to run this script results in error:

```
No matches found: "*.h"
```

This PR fixes this error.

## Test plan

Run `yarn format:apple`
