### PR TITLE
Update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -11,7 +11,7 @@ body:
         - Make sure to check whether there are similar issues in the repository
         - Make sure to clean cache in your project. Depending on your setup this could be done by:
           - `yarn start --reset-cache` or
-          - `npm start -- --reset-cache` or
+          - `npm run start -- --reset-cache` or
           - `expo start --clear`
 
   - type: markdown
@@ -41,9 +41,9 @@ body:
   - type: input
     id: repro
     attributes:
-      label: Snack or a link to a repository
+      label: A link to a [Gist](https://gist.github.com/), an [Expo Snack](https://snack.expo.io/) or a link to a repository based on [this template](https://github.com/react-native-community/reproducer-react-native) that reproduces the bug.
       description: |
-        Please provide a Snack (https://snack.expo.io/) or a link to a repository on GitHub under your username that reproduces the issue.
+        Please provide code snippet, a Snack or a link to a repository on GitHub under your username that reproduces the issue.
         Here are some tips for providing a minimal example: https://stackoverflow.com/help/mcve.
         Issues without a reproduction are likely to stale.
       placeholder: Link to a Snack or a GitHub repository
@@ -55,7 +55,7 @@ body:
     attributes:
       label: Gesture Handler version
       description: What version of react-native-gesture-handler are you using?
-      placeholder: 2.14.0
+      placeholder: 2.25.0
     validations:
       required: true
 
@@ -64,7 +64,7 @@ body:
     attributes:
       label: React Native version
       description: What version of react-native are you using?
-      placeholder: 0.73.0
+      placeholder: 0.79.0
     validations:
       required: true
 
@@ -95,28 +95,28 @@ body:
       label: JavaScript runtime
       description: What runtime is your application using?
       options:
-        - JSC
         - Hermes
+        - JSC
         - V8
 
   - type: dropdown
     id: workflow
     attributes:
       label: Workflow
-      description: How your application is managed? Not sure? Read [this part](https://docs.expo.dev/introduction/managed-vs-bare/) of Expo documentation
+      description: How your application is managed? Not sure? Read [this part](https://docs.expo.dev/develop/development-builds/introduction/) of Expo documentation.
       options:
         - React Native (without Expo)
-        - Expo bare workflow
-        - Expo managed workflow
+        - Using Expo Go
+        - Using Expo Prebuild or an Expo development build
 
   - type: dropdown
     id: architecture
     attributes:
       label: Architecture
-      description: What React Native architecture your application is running on? Currently, the default architecture on React Native is Paper so if you haven't changed it in your application select this option.
+      description: What React Native architecture your application is running on? Currently, the New Architecture is enabled by default for every new React Native project.
       options:
-        - Paper (Old Architecture)
-        - Fabric (New Architecture)
+        - New Architecture (Fabric)
+        - Old Architecture (Paper)
 
   - type: dropdown
     id: build-type


### PR DESCRIPTION
## Description

It's this time of year again - time to update the issue template 🎉 
- Updates the repro section also to mention Gists, points to RN issue template, and moves the snack link
  - I think we should require all issues with a custom reproducer to be based on [RN reproducer template](https://github.com/react-native-community/reproducer-react-native). This will allow us to clearly see all the changes and exact versions of dependencies that need to change compared to an established baseline (including transitive dependencies!) that are necessary for a repro.
- Bumps the placeholder versions to the current ones
- Updates the workflow section as the bare & managed workflows are a thing of the past (and the link was leading to a non-existent page)
- Updates the architecture section to say that the new arch is now enabled by default
  - I also moved the emphasis from codenames to the new/old arch, as it seems more widely used nowadays
