### PR TITLE
Fix buttons getting stuck in scroll views during overscroll

### DIFF
--- a/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -657,6 +657,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
 
   fun fail() {
     if (state == STATE_ACTIVE || state == STATE_UNDETERMINED || state == STATE_BEGAN) {
+      onFail()
       moveToState(STATE_FAILED)
     }
   }
@@ -710,6 +711,7 @@ open class GestureHandler<ConcreteGestureHandlerT : GestureHandler<ConcreteGestu
   protected open fun onStateChange(newState: Int, previousState: Int) {}
   protected open fun onReset() {}
   protected open fun onCancel() {}
+  protected open fun onFail() {}
 
   private fun isButtonInConfig(clickedButton: Int): Boolean {
     if (mouseButton == 0) {

--- a/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -148,7 +148,7 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     }
   }
 
-  override fun onCancel() {
+  private fun dispatchCancelEventToView() {
     val time = SystemClock.uptimeMillis()
     val event = MotionEvent.obtain(time, time, MotionEvent.ACTION_CANCEL, 0f, 0f, 0).apply {
       action = MotionEvent.ACTION_CANCEL
@@ -156,6 +156,10 @@ class NativeViewGestureHandler : GestureHandler<NativeViewGestureHandler>() {
     hook.sendTouchEvent(view, event)
     event.recycle()
   }
+
+  override fun onCancel() = dispatchCancelEventToView()
+
+  override fun onFail() = dispatchCancelEventToView()
 
   override fun onReset() {
     this.hook = defaultHook


### PR DESCRIPTION
## Description

Addresses the issue reported in https://github.com/software-mansion/react-native-gesture-handler/pull/3350.

Conceptually, it's very similar to the above PR. The main difference is the timing - the above PR cancelled the button during `onReset`, while this one adds `onFail` method (analogous to `onCancel`). This method is called just before the state change, while the timing of `onReset` is dependent on the incoming touch stream and handling of other gestures.

With this change, I wasn't able to reproduce the issue anymore, though @latekvo mentioned that he was able to get into a situation where none of `onCancel`, `onFail`, and `onReset` were called. This would likely manifest in the same way, but it looks like an entirely different problem. Here, the gesture was canceled, while the underlying button was still kept as a touch responder, while in the above situation, the gesture would have never finished (or never activated).

## Test plan

Tested on the linked reproducer and on the Example app
