### PR TITLE
[Monorepo] Fix hoisting

### DIFF
--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,5 +1,5 @@
 {
-  "apps/BasicExample/package.json": "node scripts/check-rn-versions.js",
+  "{apps/BasicExample,packages/react-native-gesture-handler}/package.json": "node scripts/check-rn-versions.js",
   "**/*.{ts,tsx}": ["prettier --write", "eslint"],
   "packages/react-native-gesture-handler/android/**/*.kt": [
     "node scripts/check-android-dirs.js",

--- a/.lintstagedrc.json
+++ b/.lintstagedrc.json
@@ -1,4 +1,5 @@
 {
+  "apps/BasicExample/package.json": "node scripts/check-rn-versions.js",
   "**/*.{ts,tsx}": ["prettier --write", "eslint"],
   "packages/react-native-gesture-handler/android/**/*.kt": [
     "node scripts/check-android-dirs.js",

--- a/apps/BasicExample/package.json
+++ b/apps/BasicExample/package.json
@@ -50,5 +50,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "installConfig": {
+    "selfReferences": false
   }
 }

--- a/apps/CommonApp/package.json
+++ b/apps/CommonApp/package.json
@@ -12,14 +12,16 @@
     "lint-js": "eslint --ext '.js,.ts,.tsx' src/ && yarn prettier --check './src/**/*.{js,jsx,ts,tsx}'",
     "format-js": "prettier --write --list-different App.tsx './src/**/*.{js,jsx,ts,tsx}'"
   },
+  "peerDependencies": {
+    "react": "*",
+    "react-native": "*"
+  },
   "dependencies": {
     "@react-native-async-storage/async-storage": "^2.1.2",
     "@react-navigation/elements": "^2.3.8",
     "@react-navigation/native": "^7.1.6",
     "@react-navigation/stack": "^7.2.10",
     "@swmansion/icons": "^0.0.1",
-    "react": "19.0.0",
-    "react-native": "0.79.0",
     "react-native-gesture-handler": "workspace:*",
     "react-native-reanimated": "^3.17.4",
     "react-native-safe-area-context": "^5.4.0"
@@ -57,5 +59,8 @@
   },
   "engines": {
     "node": ">=18"
+  },
+  "installConfig": {
+    "selfReferences": false
   }
 }

--- a/apps/ExpoExample/package.json
+++ b/apps/ExpoExample/package.json
@@ -40,6 +40,7 @@
   },
   "private": true,
   "installConfig": {
-    "hoistingLimits": "workspaces"
+    "hoistingLimits": "workspaces",
+    "selfReferences": false
   }
 }

--- a/apps/MacOSExample/package.json
+++ b/apps/MacOSExample/package.json
@@ -49,6 +49,7 @@
     "node": ">=18"
   },
   "installConfig": {
-    "hoistingLimits": "workspaces"
+    "hoistingLimits": "workspaces",
+    "selfReferences": false
   }
 }

--- a/scripts/check-rn-versions.js
+++ b/scripts/check-rn-versions.js
@@ -1,0 +1,24 @@
+const { exit } = require('process');
+const path = require('path');
+
+const basicExamplePackageJsonPath = path.join(
+  __dirname,
+  '../apps/BasicExample/package.json'
+);
+const basicExamplePackageJson = require(basicExamplePackageJsonPath);
+
+const rnghPackageJsonPath = path.join(
+  __dirname,
+  '../packages/react-native-gesture-handler/package.json'
+);
+const rnghPackageJson = require(rnghPackageJsonPath);
+
+if (
+  rnghPackageJson.devDependencies['react-native'] !==
+  basicExamplePackageJson.dependencies['react-native']
+) {
+  console.error(
+    'There is a mismatch between the react-native version in the BasicExample and react-native-gesture-handler packages.\nIf you are bumping react-native version, make sure to also update react-native-gesture-handler package.json.'
+  );
+  exit(1);
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -2799,7 +2799,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@pkgr/core@npm:^0.2.3":
+"@pkgr/core@npm:^0.2.4":
   version: 0.2.4
   resolution: "@pkgr/core@npm:0.2.4"
   checksum: 10c0/2528a443bbbef5d4686614e1d73f834f19ccbc975f62b2a64974a6b97bcdf677b9c5e8948e04808ac4f0d853e2f422adfaae2a06e9e9f4f5cf8af76f1adf8dc1
@@ -4354,11 +4354,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 22.15.17
-  resolution: "@types/node@npm:22.15.17"
+  version: 22.15.18
+  resolution: "@types/node@npm:22.15.18"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/fb92aa10b628683c5b965749f955bc2322485ecb0ea6c2f4cae5f2c7537a16834607e67083a9e9281faaae8d7dee9ada8d6a5c0de9a52c17d82912ef00c0fdd4
+  checksum: 10c0/e23178c568e2dc6b93b6aa3b8dfb45f9556e527918c947fe7406a4c92d2184c7396558912400c3b1b8d0fa952ec63819aca2b8e4d3545455fc6f1e9623e09ca6
   languageName: node
   linkType: hard
 
@@ -4988,14 +4988,15 @@ __metadata:
     expo-camera: "npm:~16.1.1"
     jest: "npm:^29.6.3"
     prettier: "npm:3.3.3"
-    react: "npm:19.0.0"
-    react-native: "npm:0.79.0"
     react-native-gesture-handler: "workspace:*"
     react-native-reanimated: "npm:^3.17.4"
     react-native-safe-area-context: "npm:^5.4.0"
     react-native-svg: "npm:15.11.2"
     react-test-renderer: "npm:19.0.0"
     typescript: "npm:~5.8.3"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
   languageName: unknown
   linkType: soft
 
@@ -5071,7 +5072,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"acorn@npm:^8.8.2, acorn@npm:^8.9.0":
+"acorn@npm:^8.14.0, acorn@npm:^8.9.0":
   version: 8.14.1
   resolution: "acorn@npm:8.14.1"
   bin:
@@ -6507,14 +6508,14 @@ __metadata:
   linkType: hard
 
 "debug@npm:4, debug@npm:^4.0.0, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.1, debug@npm:^4.3.2, debug@npm:^4.3.3, debug@npm:^4.3.4, debug@npm:^4.3.5, debug@npm:^4.4.0":
-  version: 4.4.0
-  resolution: "debug@npm:4.4.0"
+  version: 4.4.1
+  resolution: "debug@npm:4.4.1"
   dependencies:
     ms: "npm:^2.1.3"
   peerDependenciesMeta:
     supports-color:
       optional: true
-  checksum: 10c0/db94f1a182bf886f57b4755f85b3a74c39b5114b9377b7ab375dc2cfa3454f09490cc6c30f829df3fc8042bc8b8995f6567ce5cd96f3bc3688bd24027197d9de
+  checksum: 10c0/d2b44bc1afd912b49bb7ebb0d50a860dc93a4dd7d946e8de94abc957bb63726b7dd5aa48c18c2386c379ec024c46692e15ed3ed97d481729f929201e671fcd55
   languageName: node
   linkType: hard
 
@@ -7007,9 +7008,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.149":
-  version: 1.5.152
-  resolution: "electron-to-chromium@npm:1.5.152"
-  checksum: 10c0/99c58dc8fc6b22ea64f118599663a0d336aa28693fbd275d06f3e2c1d1a6c954fcb88f5b2390223267bb3487940d3e587b6acac8b1b2ebc4dc65c44cd7739c7c
+  version: 1.5.155
+  resolution: "electron-to-chromium@npm:1.5.155"
+  checksum: 10c0/aee32a0b03282e488352370f6a910de37788b814031020a0e244943450e844e8a41f741d6e5ec70d553dfa4382ef80088034ddc400b48f45de95de331b9ec178
   languageName: node
   linkType: hard
 
@@ -8444,9 +8445,9 @@ __metadata:
   linkType: hard
 
 "flow-parser@npm:0.*":
-  version: 0.270.0
-  resolution: "flow-parser@npm:0.270.0"
-  checksum: 10c0/5eb9d0fa1e489c180264f03d72a244407f3f071651ae0da9ed3843ab0a75ebfa5ffa01b3639b88aeb9e31994eeb1e8d4525c7890f9abc5ae6ceda2202d9f1922
+  version: 0.271.0
+  resolution: "flow-parser@npm:0.271.0"
+  checksum: 10c0/e5a1f8062c873fae9dd7f390a3e439b9fe59ccf4602fc582ad5795a58f13e0e7d2c3f0f521ed91d3c051c2368eb6daf1581bacca000189e3c2765e0f95cf3c65
   languageName: node
   linkType: hard
 
@@ -15264,12 +15265,12 @@ __metadata:
   linkType: hard
 
 "synckit@npm:^0.11.0":
-  version: 0.11.4
-  resolution: "synckit@npm:0.11.4"
+  version: 0.11.5
+  resolution: "synckit@npm:0.11.5"
   dependencies:
-    "@pkgr/core": "npm:^0.2.3"
+    "@pkgr/core": "npm:^0.2.4"
     tslib: "npm:^2.8.1"
-  checksum: 10c0/dd2965a37c93c0b652bf07b1fd8d1639a803b65cf34c0cb1b827b8403044fc3b09ec87f681d922a324825127ee95b2e0394e7caccb502f407892d63e903c5276
+  checksum: 10c0/49cbd90c3f0ebe7ea6af2fe359e93ef737983b9aaaa605d63c3bf6ba7b31fd2d201e0d8c09f099a11d5ed2d5a7bf3a2ee865708f7f6795646317aac1266517aa
   languageName: node
   linkType: hard
 
@@ -15312,16 +15313,16 @@ __metadata:
   linkType: hard
 
 "terser@npm:^5.15.0":
-  version: 5.39.1
-  resolution: "terser@npm:5.39.1"
+  version: 5.39.2
+  resolution: "terser@npm:5.39.2"
   dependencies:
     "@jridgewell/source-map": "npm:^0.3.3"
-    acorn: "npm:^8.8.2"
+    acorn: "npm:^8.14.0"
     commander: "npm:^2.20.0"
     source-map-support: "npm:~0.5.20"
   bin:
     terser: bin/terser
-  checksum: 10c0/d49e06dd4dd03661dac41f45c9cf187b2aa3fe80775235e838398c29311705169387c007f398ab44cd1bd8f89b14a1eea383feaa95c1cae29e3f5b6b606b6b37
+  checksum: 10c0/f70462feddecf458ad2441b16b2969e0024f81c6e47207717a096cfa1d60b85e0c60a129b42c80bcb258c28ae16e4e6d875db8bb9df9be9b5bc748807c2916ba
   languageName: node
   linkType: hard
 
@@ -16271,11 +16272,11 @@ __metadata:
   linkType: hard
 
 "yaml@npm:^2.2.1":
-  version: 2.7.1
-  resolution: "yaml@npm:2.7.1"
+  version: 2.8.0
+  resolution: "yaml@npm:2.8.0"
   bin:
     yaml: bin.mjs
-  checksum: 10c0/ee2126398ab7d1fdde566b4013b68e36930b9e6d8e68b6db356875c99614c10d678b6f45597a145ff6d63814961221fc305bf9242af8bf7450177f8a68537590
+  checksum: 10c0/f6f7310cf7264a8107e72c1376f4de37389945d2fb4656f8060eca83f01d2d703f9d1b925dd8f39852a57034fafefde6225409ddd9f22aebfda16c6141b71858
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

When tried to update `react-native` to `0.80.0-rc.1` I've noticed that hoisting doesn't work as it should - `BasicExample` had version `0.80.0-rc.1` in its `node_modules`, but the version hoisted to root was `0.79.0`.  This resulted in errors during `pods` installation. To get rid of this problem we need to do 2 thing:

1. Change `react-native` to `peerDependency` in `CommonApp`,
2. Update both, `BasicExample` and `react-native-gesture-handler` `package.json` files at the same time. This ensures that version hoisted to root will be the same. 

Other apps should not be affected since they have `hoistingLimits: "workspaces"`.

This PR also adds `selfReferences: false` - with this change, apps won't be referenced in root `node_modules`

## Test plan

Checked how hoisting behaves with different react-native versions across monorepo.
