### PR TITLE
[Monorepo] Add `pod install` to `postinstall` script

### DIFF
--- a/.github/workflows/yarn-validation.yml
+++ b/.github/workflows/yarn-validation.yml
@@ -23,7 +23,7 @@ jobs:
   check:
     if: github.repository == 'software-mansion/react-native-gesture-handler'
 
-    runs-on: macos-14
+    runs-on: macos-15
     env:
       YARN_ENABLE_HARDENED_MODE: 1
 

--- a/.github/workflows/yarn-validation.yml
+++ b/.github/workflows/yarn-validation.yml
@@ -23,7 +23,7 @@ jobs:
   check:
     if: github.repository == 'software-mansion/react-native-gesture-handler'
 
-    runs-on: ubuntu-latest
+    runs-on: macos-14
     env:
       YARN_ENABLE_HARDENED_MODE: 1
 

--- a/apps/basic-example/package.json
+++ b/apps/basic-example/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "postinstall": "yarn pods",
+    "postinstall": "cd ios && bundle install && bundle exec pod install",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint .",

--- a/apps/basic-example/package.json
+++ b/apps/basic-example/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "yarn pods",
     "android": "react-native run-android",
     "ios": "react-native run-ios",
     "lint": "eslint .",

--- a/apps/macos-example/package.json
+++ b/apps/macos-example/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
+    "postinstall": "yarn pods",
     "macos": "npx react-native-macos run-macos",
     "lint": "eslint .",
     "start": "react-native start",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4354,11 +4354,11 @@ __metadata:
   linkType: hard
 
 "@types/node@npm:*":
-  version: 22.15.19
-  resolution: "@types/node@npm:22.15.19"
+  version: 22.15.21
+  resolution: "@types/node@npm:22.15.21"
   dependencies:
     undici-types: "npm:~6.21.0"
-  checksum: 10c0/8ef52fa1a91b1c8891616d46f3921a9f3c65ad1c6bb62db7899c8c28643c13bf9d607a2403b1e5aceb3e6fa6749efc9e0ba5c39618a4872da6946437b0edbfbe
+  checksum: 10c0/f092bbccda2131c2b2c8f720338080aa0ef1d928f5f1062c03954a4f7dafa7ee3ed29bc3e51bd4e2584473b3d943c637a2b39ad7174898970818270187cf10c1
   languageName: node
   linkType: hard
 
@@ -8644,11 +8644,11 @@ __metadata:
   linkType: hard
 
 "get-tsconfig@npm:^4.7.3":
-  version: 4.10.0
-  resolution: "get-tsconfig@npm:4.10.0"
+  version: 4.10.1
+  resolution: "get-tsconfig@npm:4.10.1"
   dependencies:
     resolve-pkg-maps: "npm:^1.0.0"
-  checksum: 10c0/c9b5572c5118923c491c04285c73bd55b19e214992af957c502a3be0fc0043bb421386ffd45ca3433c0a7fba81221ca300479e8393960acf15d0ed4563f38a86
+  checksum: 10c0/7f8e3dabc6a49b747920a800fb88e1952fef871cdf51b79e98db48275a5de6cdaf499c55ee67df5fa6fe7ce65f0063e26de0f2e53049b408c585aa74d39ffa21
   languageName: node
   linkType: hard
 
@@ -15276,9 +15276,9 @@ __metadata:
   linkType: hard
 
 "tapable@npm:^2.2.0":
-  version: 2.2.1
-  resolution: "tapable@npm:2.2.1"
-  checksum: 10c0/bc40e6efe1e554d075469cedaba69a30eeb373552aaf41caeaaa45bf56ffacc2674261b106245bd566b35d8f3329b52d838e851ee0a852120acae26e622925c9
+  version: 2.2.2
+  resolution: "tapable@npm:2.2.2"
+  checksum: 10c0/8ad130aa705cab6486ad89e42233569a1fb1ff21af115f59cebe9f2b45e9e7995efceaa9cc5062510cdb4ec673b527924b2ab812e3579c55ad659ae92117011e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

This PR adds `yarn pods` into `postinstall` script in order to preapre example apps during `yarn` in root.

## Test plan

Check that CI passes.