### PR TITLE
[Monorepo] Move `bob build` to `build` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "apps/common-app"
   ],
   "scripts": {
-    "postinstall": "husky",
+    "postinstall": "yarn build",
+    "build": "husky && yarn workspaces foreach --all --parallel --topological-dev run build",
     "ts-check": "yarn workspaces foreach --all --parallel --topological-dev run ts-check",
     "lint-js": "yarn workspaces foreach --all --parallel --topological-dev run lint-js",
     "format-js": "yarn workspaces foreach --all --parallel --topological-dev run format-js",

--- a/packages/react-native-gesture-handler/package.json
+++ b/packages/react-native-gesture-handler/package.json
@@ -3,9 +3,8 @@
   "version": "2.25.0",
   "description": "Declarative API exposing native platform touch and gesture system to React Native",
   "scripts": {
-    "postinstall": "bob build",
     "test": "jest",
-    "build": "yarn tsc -p tsconfig.build.json",
+    "build": "yarn tsc -p tsconfig.build.json && bob build",
     "ts-check": "yarn tsc --noEmit",
     "format-js": "prettier --write --list-different './src/**/*.{js,jsx,ts,tsx}'",
     "format:js": "yarn format-js",

--- a/yarn.lock
+++ b/yarn.lock
@@ -13723,13 +13723,23 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-safe-area-context@npm:5.4.0, react-native-safe-area-context@npm:^5.4.0":
+"react-native-safe-area-context@npm:5.4.0":
   version: 5.4.0
   resolution: "react-native-safe-area-context@npm:5.4.0"
   peerDependencies:
     react: "*"
     react-native: "*"
   checksum: 10c0/729fef1f768d57b905f51882374aa93b209d54576b8a0cf328e0a349c8dc9705ae8f9032e572fd7a7c9e94b588105f44760c0bb15ab9911b7977073d6754b54d
+  languageName: node
+  linkType: hard
+
+"react-native-safe-area-context@npm:^5.4.0":
+  version: 5.4.1
+  resolution: "react-native-safe-area-context@npm:5.4.1"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/6da614f4e9318c784700f0586d19d866f565ae08029c9a38cb1b03fd578af3838f2a6d5321c4a220dc7d698d919faf544536b60e45b7cc97f985349328041de2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

When I tried to install _**GestureHandler**_ from newly created package, it fails with message:

```
command not found: bob
```

This PR moves `bob build` into `build` script (as it is already done in [Reanimated](https://github.com/software-mansion/react-native-reanimated/blob/30f397ff4851029ee10c39283b2893fb231af63e/packages/react-native-reanimated/package.json#L33)), so that `postinstall` no longer fails.
 
## Test plan

Generate new package and add it to newly created app.
