### PR TITLE
[Monorepo] Add missing `react-native-screens`

### DIFF
--- a/apps/common-app/package.json
+++ b/apps/common-app/package.json
@@ -24,7 +24,8 @@
     "@swmansion/icons": "^0.0.1",
     "react-native-gesture-handler": "workspace:*",
     "react-native-reanimated": "^3.17.4",
-    "react-native-safe-area-context": "^5.4.0"
+    "react-native-safe-area-context": "^5.4.0",
+    "react-native-screens": "^4.10.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/apps/expo-example/package.json
+++ b/apps/expo-example/package.json
@@ -30,6 +30,7 @@
     "react-native-gesture-handler": "workspace:*",
     "react-native-reanimated": "3.17.5",
     "react-native-safe-area-context": "5.4.0",
+    "react-native-screens": "^4.10.0",
     "react-native-svg": "15.11.2",
     "react-native-web": "^0.20.0"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6199,6 +6199,7 @@ __metadata:
     react-native-gesture-handler: "workspace:*"
     react-native-reanimated: "npm:^3.17.4"
     react-native-safe-area-context: "npm:^5.4.0"
+    react-native-screens: "npm:^4.10.0"
     react-native-svg: "npm:15.11.2"
     react-test-renderer: "npm:19.0.0"
     typescript: "npm:~5.8.3"
@@ -6971,9 +6972,9 @@ __metadata:
   linkType: hard
 
 "electron-to-chromium@npm:^1.5.149":
-  version: 1.5.155
-  resolution: "electron-to-chromium@npm:1.5.155"
-  checksum: 10c0/aee32a0b03282e488352370f6a910de37788b814031020a0e244943450e844e8a41f741d6e5ec70d553dfa4382ef80088034ddc400b48f45de95de331b9ec178
+  version: 1.5.157
+  resolution: "electron-to-chromium@npm:1.5.157"
+  checksum: 10c0/d22dc2603bdfb0d89c8e199bcc29a34995cc6e37261b5029b4e635ea536b843ed00dfc3b1dd2f69e1852031daee0c7cf3fb63cc70abf5312908328075b35e9af
   languageName: node
   linkType: hard
 
@@ -8034,6 +8035,7 @@ __metadata:
     react-native-gesture-handler: "workspace:*"
     react-native-reanimated: "npm:3.17.5"
     react-native-safe-area-context: "npm:5.4.0"
+    react-native-screens: "npm:^4.10.0"
     react-native-svg: "npm:15.11.2"
     react-native-web: "npm:^0.20.0"
     typescript: "npm:~5.8.3"
@@ -13504,6 +13506,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-freeze@npm:^1.0.0":
+  version: 1.0.4
+  resolution: "react-freeze@npm:1.0.4"
+  peerDependencies:
+    react: ">=17.0.0"
+  checksum: 10c0/8f51257c261bfefff86f618e958683536248f708019632d309ee5ebdd52f25d3c130660d06fb6f0f4fdef79f00f8ec7177233a872c2321f7d46b7e77ccc522a1
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1, react-is@npm:^16.7.0":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -13740,6 +13751,19 @@ __metadata:
     react: "*"
     react-native: "*"
   checksum: 10c0/6da614f4e9318c784700f0586d19d866f565ae08029c9a38cb1b03fd578af3838f2a6d5321c4a220dc7d698d919faf544536b60e45b7cc97f985349328041de2
+  languageName: node
+  linkType: hard
+
+"react-native-screens@npm:^4.10.0":
+  version: 4.10.0
+  resolution: "react-native-screens@npm:4.10.0"
+  dependencies:
+    react-freeze: "npm:^1.0.0"
+    warn-once: "npm:^0.1.0"
+  peerDependencies:
+    react: "*"
+    react-native: "*"
+  checksum: 10c0/09d1f55431b85e556ef7b5efd776ac5e85303e47d9138f910cb8c25ff3804effc43185f84e8842bcae2219e8fee12366b3725f955f638c109387efb82e0260f3
   languageName: node
   linkType: hard
 
@@ -15938,7 +15962,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"warn-once@npm:0.1.1":
+"warn-once@npm:0.1.1, warn-once@npm:^0.1.0":
   version: 0.1.1
   resolution: "warn-once@npm:0.1.1"
   checksum: 10c0/f531e7b2382124f51e6d8f97b8c865246db8ab6ff4e53257a2d274e0f02b97d7201eb35db481843dc155815e154ad7afb53b01c4d4db15fb5aa073562496aff7


### PR DESCRIPTION
## Description

Seems that I forgot to include `react-native-screens` during transition to monorepo. This resulted in strange bug - you could click buttons and navigate to another example, while being in an example.

## Test plan

Check that `expo-example` works on both platforms and architectures.
