### PR TITLE
[Monorepo] Add `husky install` to `build` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "postinstall": "yarn build",
-    "build": "husky && yarn workspaces foreach --all --parallel --topological-dev run build",
+    "build": "husky install && yarn workspaces foreach --all --parallel --topological-dev run build",
     "ts-check": "yarn workspaces foreach --all --parallel --topological-dev run ts-check",
     "lint-js": "yarn workspaces foreach --all --parallel --topological-dev run lint-js",
     "format-js": "yarn workspaces foreach --all --parallel --topological-dev run format-js",


### PR DESCRIPTION
## Description

`yarn build` was missing `install` command when running `husky`. This resulted in `_` directory not being generated.

## Test plan

Checked that after `yarn build` `_` is present.