### PR TITLE
Add functionality to track subsequent taps

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/TapGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/TapGestureHandler.ts
@@ -9,6 +9,7 @@ export const tapGestureHandlerProps = [
   'maxDurationMs',
   'maxDelayMs',
   'numberOfTaps',
+  'maxNumberOfTaps',
   'maxDeltaX',
   'maxDeltaY',
   'maxDist',
@@ -40,6 +41,12 @@ export interface TapGestureConfig {
    * is 1.
    */
   numberOfTaps?: number;
+
+  /**
+   * Maximum number of sequential taps before the handler finalizes the gesture.
+   * To track unlimited number of taps, set to `Math.Infinity`.The default value is 1.
+   */
+  maxNumberOfTaps?: number;
 
   /**
    * Maximum distance, expressed in points, that defines how far the finger is

--- a/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
@@ -7,6 +7,7 @@ const DEFAULT_MAX_DURATION_MS = 500;
 const DEFAULT_MAX_DELAY_MS = 500;
 const DEFAULT_NUMBER_OF_TAPS = 1;
 const DEFAULT_MIN_NUMBER_OF_POINTERS = 1;
+const DEFAULT_MAX_NUMBER_OF_TAPS = 1;
 
 export default class TapGestureHandler extends GestureHandler {
   private maxDeltaX = Number.MIN_SAFE_INTEGER;
@@ -16,6 +17,7 @@ export default class TapGestureHandler extends GestureHandler {
   private maxDelayMs = DEFAULT_MAX_DELAY_MS;
 
   private numberOfTaps = DEFAULT_NUMBER_OF_TAPS;
+  private maxNumberOfTaps = DEFAULT_MAX_NUMBER_OF_TAPS;
   private minNumberOfPointers = DEFAULT_MIN_NUMBER_OF_POINTERS;
   private currentMaxNumberOfPointers = 1;
 
@@ -36,6 +38,10 @@ export default class TapGestureHandler extends GestureHandler {
 
     if (this.config.numberOfTaps !== undefined) {
       this.numberOfTaps = this.config.numberOfTaps;
+    }
+
+    if (this.config.maxNumberOfTaps !== undefined) {
+      this.maxNumberOfTaps = this.config.maxNumberOfTaps;
     }
 
     if (this.config.maxDurationMs !== undefined) {
@@ -72,6 +78,7 @@ export default class TapGestureHandler extends GestureHandler {
     this.maxDurationMs = DEFAULT_MAX_DURATION_MS;
     this.maxDelayMs = DEFAULT_MAX_DELAY_MS;
     this.numberOfTaps = DEFAULT_NUMBER_OF_TAPS;
+    this.maxNumberOfTaps = DEFAULT_MAX_NUMBER_OF_TAPS;
     this.minNumberOfPointers = DEFAULT_MIN_NUMBER_OF_POINTERS;
   }
 
@@ -89,13 +96,20 @@ export default class TapGestureHandler extends GestureHandler {
   private endTap(): void {
     this.clearTimeouts();
 
-    if (
-      ++this.tapsSoFar === this.numberOfTaps &&
-      this.currentMaxNumberOfPointers >= this.minNumberOfPointers
-    ) {
+    if (this.tapsSoFar < this.numberOfTaps) {
+      if (
+        ++this.tapsSoFar === this.numberOfTaps &&
+        this.currentMaxNumberOfPointers >= this.minNumberOfPointers
+      ) {
+        this.activate();
+      } else {
+        this.delayTimeout = setTimeout(() => this.fail(), this.maxDelayMs);
+      }
+    } else if (this.tapsSoFar < this.maxNumberOfTaps) {
+      this.tapsSoFar++;
       this.activate();
     } else {
-      this.delayTimeout = setTimeout(() => this.fail(), this.maxDelayMs);
+      this.fail();
     }
   }
 

--- a/packages/react-native-gesture-handler/src/web/interfaces.ts
+++ b/packages/react-native-gesture-handler/src/web/interfaces.ts
@@ -71,6 +71,7 @@ export interface Config extends Record<string, ConfigArgs> {
   numberOfPointers?: number;
   minDurationMs?: number;
   numberOfTaps?: number;
+  maxNumberOfTaps?: number;
   maxDurationMs?: number;
   maxDelayMs?: number;
   maxDeltaX?: number;


### PR DESCRIPTION
## Description

This PR adds support for tracking multiple sequential taps in the Tap Gesture Handler by introducing a new `maxNumberOfTaps` property. This specific use case I was trying to cover are more discrete video interactions, such as skipping forwards or backwards in a video over and over.

Key changes:
- Added new `maxNumberOfTaps` property to the Tap Gesture Handler configuration
- Added support for unlimited taps by allowing `Math.Infinity` as a value

The implementation maintains the existing behavior when `maxNumberOfTaps` is not specified, ensuring backward compatibility with existing code.

## Test plan

Tested on both iOS (iPhone 14 Pro 18.3 - Device) and Android (Pixel 9 13 API 33 - Simulator) platforms the following tap patterns
- Single tap (default behavior)
- Double tap with max 3 taps
- Triple tap with unlimited taps

The changes are exclusively within typescript utilising existing features for the most part, I don't forsee too many issues