### PR TITLE
Fix `needs-more-info` action

### DIFF
--- a/.github/workflows/needs-more-info.yml
+++ b/.github/workflows/needs-more-info.yml
@@ -33,7 +33,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           needs-more-info-label: 'Missing info'
-          required-sections: 'Description;Steps to reproduce;Snack or a link to a repository;Gesture Handler version;React Native version;Platforms'
+          required-sections: 'Description;Steps to reproduce;A link to a [Gist](https://gist.github.com/), an [Expo Snack](https://snack.expo.io/) or a link to a repository based on [this template](https://github.com/react-native-community/reproducer-react-native) that reproduces the bug.;Gesture Handler version;React Native version;Platforms'
           needs-more-info-response: "Hey! 👋 \n\nIt looks like you've omitted a few important sections from the issue template."
           # This action also appends something like: "Please complete X, Y and Z sections." to the response.
           # Code responsible for this can be found here: https://github.com/software-mansion-labs/swmansion-bot/blob/main/needs-more-info/MissingSectionsFormatter.js


### PR DESCRIPTION
## Description

#3508 introduced enhanced issue template. However, it did not changed github action responsible for checking issues. I've spotted it in [this issue](https://github.com/software-mansion/react-native-gesture-handler/issues/3543).

## Test plan

Well... I guess we should create test issues 🤷‍♀️ 
