### PR TITLE
Don't block `onPress` if `onLongPress` is not defined

### DIFF
--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -231,8 +231,8 @@ const Pressable = forwardRef(
           return;
         }
 
-        if (hasPassedBoundsChecks.current) {
-          onLongPress?.(gestureTouchToPressableEvent(event));
+        if (hasPassedBoundsChecks.current && onLongPress) {
+          onLongPress(gestureTouchToPressableEvent(event));
           isPressCallbackEnabled.current = false;
         }
 


### PR DESCRIPTION
## Description

Currently if `onLongPress` is not passed into `Pressable`, `onPress` will not be called anyway, opposed to react-native 

Fixes #3514 

## Test plan

<details>
<summary>Tested on the following example</summary>

```jsx
import React from 'react';
import { StyleSheet, View, Pressable as RNPressable } from 'react-native';
import { Pressable } from 'react-native-gesture-handler';

export default function EmptyExample() {
  return (
    <View style={styles.container}>
      <RNPressable
        style={styles.button}
        onPress={() => console.log('onPress')}
        onPressOut={() => console.log('onPressOut')}
      />

      <Pressable
        style={styles.button}
        onPress={() => console.log('onPress')}
        onPressOut={() => console.log('onPressOut')}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
    gap: 10,
  },

  button: {
    backgroundColor: 'blue',
    width: 200,
    height: 50,
    justifyContent: 'center',
    alignItems: 'center',
  },
});

```

</details>
