### PR TITLE
fix: replace 'transparent' string with 0x00000000 double to support Fabric

### DIFF
--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -455,7 +455,7 @@ const Pressable = forwardRef(
         IS_FABRIC = isFabric();
       }
 
-      const defaultRippleColor = android_ripple ? undefined : 'transparent';
+      const defaultRippleColor = android_ripple ? undefined : Number(0x00000000); // transparent
       const unprocessedRippleColor =
         android_ripple?.color ?? defaultRippleColor;
       return IS_FABRIC


### PR DESCRIPTION
## Description

Fabric doesn't run processColor on props, so passing 'transparent' as a string causes a crash in ColorPropConverter.getColor. This change replaces it with the equivalent numeric double (0x00000000), which works both when passed raw and when processed via processColor in non-Fabric environments.
