### PR TITLE
Fix possible web crashes

### DIFF
--- a/packages/react-native-gesture-handler/src/web/tools/PointerEventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/PointerEventManager.ts
@@ -98,7 +98,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     // pointer moves until it succeeds.
     // God, I do love web development.
     if (
-      !target.hasPointerCapture(event.pointerId) &&
+      !target?.hasPointerCapture(event.pointerId) &&
       !POINTER_CAPTURE_EXCLUDE_LIST.has(target.tagName)
     ) {
       target.setPointerCapture(event.pointerId);


### PR DESCRIPTION
## Description

Without being able to reproduce, we saw some possible web crashed happening in react-native-gesture-handler.
So adding more guards to avoid that

Here are the sentry crashed :
<img width="874" alt="Screenshot 2025-06-12 at 10 53 08" src="https://github.com/user-attachments/assets/1a372727-6f6b-40b8-b45f-2d0c19c0d999" />
<img width="880" alt="Screenshot 2025-06-12 at 11 02 58" src="https://github.com/user-attachments/assets/07d038bd-d780-4e83-a61e-867a9e12356e" />
