### PR TITLE
[android] Fix compilation with react-native 0.80

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/jni/CMakeLists.txt
+++ b/packages/react-native-gesture-handler/android/src/main/jni/CMakeLists.txt
@@ -26,7 +26,15 @@ target_include_directories(
 )
 
 find_package(ReactAndroid REQUIRED CONFIG)
-if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
+if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+  find_package(fbjni REQUIRED CONFIG)
+  target_link_libraries(
+    ${PACKAGE_NAME}
+    ReactAndroid::reactnative
+    ReactAndroid::jsi
+    fbjni::fbjni
+  )
+elseif (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
   target_link_libraries(
     ${PACKAGE_NAME}
     ReactAndroid::reactnative


### PR DESCRIPTION
## Description

React native 0.80 is getting out today, and it would be great to have day 1 support

## Test plan

Create an expo project using `npx create-expo-app my-app --template blank@canary` and add gesture-handler
