### PR TITLE
Copy `README.md` to package

### DIFF
--- a/packages/react-native-gesture-handler/package.json
+++ b/packages/react-native-gesture-handler/package.json
@@ -16,7 +16,9 @@
     "circular-dependency-check": "yarn madge --extensions js,ts,tsx --circular src",
     "architectures-consistency-check": "node ../../scripts/codegen-check-consistency.js",
     "sync-architectures": "node ../../scripts/codegen-sync-archs.js",
-    "clean": "rm -rf node_modules android/build android/.cxx"
+    "clean": "rm -rf node_modules android/build android/.cxx",
+    "prepack": "cp ../../README.md ./README.md",
+    "postpack": "rm ./README.md"
   },
   "react-native": "src/index.ts",
   "main": "lib/commonjs/index.js",


### PR DESCRIPTION
## Description

After moving into monorepo setup main `README.md` was left in the root of the repository. It looks good on `github`, but unfortunately on `npm` you can no longer see readme since it is not present in the package.

## Test plan

Run `npm pack` and see that `README.md` is present in the package.
