### PR TITLE
[Android] Cleanup CMakeLists

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/jni/CMakeLists.txt
+++ b/packages/react-native-gesture-handler/android/src/main/jni/CMakeLists.txt
@@ -27,7 +27,7 @@ target_include_directories(
 
 find_package(ReactAndroid REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
-if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
+if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
   find_package(fbjni REQUIRED CONFIG)
   target_link_libraries(
     ${PACKAGE_NAME}
@@ -35,21 +35,6 @@ if (ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
     ReactAndroid::jsi
     fbjni::fbjni
   )
-elseif (ReactAndroid_VERSION_MINOR GREATER_EQUAL 76)
-  target_link_libraries(
-    ${PACKAGE_NAME}
-    ReactAndroid::reactnative
-    ReactAndroid::jsi
-  )
-elseif (ReactAndroid_VERSION_MINOR GREATER_EQUAL 75)
-  target_link_libraries(
-    ${PACKAGE_NAME}
-    ReactAndroid::react_render_core
-    ReactAndroid::react_render_uimanager
-    ReactAndroid::react_render_graphics
-    ReactAndroid::jsi
-    ReactAndroid::react_nativemodule_core
-  )
 else ()
-  message(FATAL_ERROR "react-native-gesture-handler on the New Architecture requires react-native 0.75 or newer.")
+  message(FATAL_ERROR "react-native-gesture-handler on the New Architecture requires react-native 0.76 or newer.")
 endif ()


### PR DESCRIPTION
## Description

Clean some remaining code from `CMakeLists.txt` after 2.26.0 release

## Test plan

Built _Gesture Handler_ on fabric on the following RN versions:

- 0.80 ✅ 
- 0.79 ✅ 
- 0.78 ✅ 