### PR TITLE
Fix combo example crashing.

### DIFF
--- a/apps/common-app/src/release_tests/combo/index.tsx
+++ b/apps/common-app/src/release_tests/combo/index.tsx
@@ -28,8 +28,6 @@ import { PressBox } from '../../basic/multitap';
 
 import { LoremIpsum } from '../../common';
 
-const CHILD_REF = 'CHILD_REF';
-
 const WrappedSlider = createNativeWrapper(Slider, {
   shouldCancelWhenOutside: false,
   shouldActivateOnStart: true,
@@ -85,9 +83,7 @@ class TouchableHighlight extends Component<
                   : 1,
             }}>
             {/* @ts-ignore not typed properly? */}
-            {React.cloneElement(React.Children.only(this.props.children), {
-              ref: CHILD_REF,
-            })}
+            {React.cloneElement(React.Children.only(this.props.children))}
           </View>
         </View>
       </TapGestureHandler>


### PR DESCRIPTION
## Description

Combo example is crashing due to an invalid prop being passed down to one of the components.
This code was always invalid, but wasn't crashing up until recently.
The invalid part of the code was removed in this PR - this removal does not change any expected behaviour.

## Test plan

Open combo example