### PR TITLE
[iOS] Fix `GestureDetector` on `Text`

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.h
@@ -72,7 +72,9 @@
 @property (nonatomic) BOOL needsPointerData;
 @property (nonatomic) BOOL manualActivation;
 
+#if RCT_NEW_ARCH_ENABLED
 - (BOOL)isViewParagraphComponent:(nullable RNGHUIView *)view;
+#endif
 - (nonnull RNGHUIView *)chooseViewForInteraction:(nonnull UIGestureRecognizer *)recognizer;
 - (void)bindToView:(nonnull RNGHUIView *)view;
 - (void)unbindFromView;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.h
@@ -72,6 +72,8 @@
 @property (nonatomic) BOOL needsPointerData;
 @property (nonatomic) BOOL manualActivation;
 
+- (BOOL)isViewParagraphComponent:(nullable RNGHUIView *)view;
+- (nonnull RNGHUIView *)chooseViewForInteraction:(nonnull UIGestureRecognizer *)recognizer;
 - (void)bindToView:(nonnull RNGHUIView *)view;
 - (void)unbindFromView;
 - (void)resetConfig NS_REQUIRES_SUPER;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -286,7 +286,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   // it may happen that the gesture recognizer is reset after it's been unbound from the view,
   // it that recognizer tried to send event, the app would crash because the target of the event
   // would be nil.
-  if (view == nil) {
+  if (view.reactTag == nil) {
     return;
   }
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -216,10 +216,12 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   return (UITouchType)_pointerType;
 }
 
+#if RCT_NEW_ARCH_ENABLED
 - (BOOL)isViewParagraphComponent:(RNGHUIView *)view
 {
   return [view isKindOfClass:[RCTParagraphComponentView class]];
 }
+#endif
 
 - (void)bindToView:(RNGHUIView *)view
 {
@@ -228,10 +230,14 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 #endif
   self.recognizer.delegate = self;
 
+#if RCT_NEW_ARCH_ENABLED
   // Starting from react-native 0.79 `RCTParagraphTextView` overrides `hitTest` method to return `nil`. This results in
   // native `UIGestureRecognizer` not responding to gestures. To fix this issue, we attach recognizer to its parent,
   // i.e. `RCTParagraphComponentView`.
   RNGHUIView *recognizerView = [self isViewParagraphComponent:view.superview] ? view.superview : view;
+#else
+  RNGHUIView *recognizerView = view;
+#endif
 
   [recognizerView addGestureRecognizer:self.recognizer];
   [self bindManualActivationToView:recognizerView];
@@ -266,7 +272,11 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
  */
 - (RNGHUIView *)chooseViewForInteraction:(UIGestureRecognizer *)recognizer
 {
+#if RCT_NEW_ARCH_ENABLED
   return [self isViewParagraphComponent:recognizer.view] ? recognizer.view.subviews[0] : recognizer.view;
+#else
+  return recognizer.view;
+#endif
 }
 
 - (void)handleGesture:(UIGestureRecognizer *)recognizer

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -225,9 +225,6 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 - (void)bindToView:(RNGHUIView *)view
 {
-#if !TARGET_OS_OSX
-  view.userInteractionEnabled = YES;
-#endif
   self.recognizer.delegate = self;
 
 #if RCT_NEW_ARCH_ENABLED
@@ -237,6 +234,10 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   RNGHUIView *recognizerView = [self isViewParagraphComponent:view.superview] ? view.superview : view;
 #else
   RNGHUIView *recognizerView = view;
+#endif
+
+#if !TARGET_OS_OSX
+  recognizerView.userInteractionEnabled = YES;
 #endif
 
   [recognizerView addGestureRecognizer:self.recognizer];


### PR DESCRIPTION
## Description

### Problem

Currently the following configuration:

```jsx
<GestureDetector ... >
  <Text> ... </Text>
</GestureDetector>
```

does not work on `iOS`. This is due to change `react-native` introduced in 0.79 - `hitTest` in `RCTParagraphTextView` now returns `nil` by default ([see here](https://github.com/facebook/react-native/blob/dcbbf275cbc4150820691a4fbc254b198cc92bdd/packages/react-native/React/Fabric/Mounting/ComponentViews/Text/RCTParagraphComponentView.mm#L379)). This results in native `UIGestureRecognizer` not responding to touches.

### Solution

We no longer attach native recognizer to `RCTParagraphTextView`, but to its parent - `RCTParagraphComponentView`. The problem with this approach is that `handleGesture` method uses `reactTag` property, which on `RCTParagraphComponentView` is `nil`. This is why we use `reactTag` from `RCTParagraphTextView` when sending event to `JS` side.

Fixes #3581

## Test plan

<details>
<summary>Tested on the following code:</summary>

```jsx
import React from 'react';
import { StyleSheet, Text } from 'react-native';
import {
  Gesture,
  GestureDetector,
  GestureHandlerRootView,
} from 'react-native-gesture-handler';

export default function EmptyExample() {
  const g = Gesture.Tap().onEnd(() => {
    console.log('Tapped!');
  });

  return (
    <GestureHandlerRootView style={styles.container}>
      <GestureDetector gesture={g}>
        <Text>
          Click me
          <Text> Me too! </Text>
        </Text>
      </GestureDetector>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```

</details>