### PR TITLE
[Android] Fix `onTouches*` callbacks being called for all gestures

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -579,7 +579,7 @@ open class GestureHandler {
     onStateChange(newState, oldState)
   }
 
-  fun wantsEvents(event: MotionEvent): Boolean = isEnabled &&
+  fun wantsEvent(event: MotionEvent): Boolean = isEnabled &&
     state != STATE_FAILED &&
     state != STATE_CANCELLED &&
     state != STATE_END &&

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -583,7 +583,6 @@ open class GestureHandler {
     state != STATE_FAILED &&
     state != STATE_CANCELLED &&
     state != STATE_END &&
-    trackedPointersIDsCount > 0 &&
     isTrackingPointer(event.getPointerId(event.actionIndex))
 
   open fun shouldRequireToWaitForFailure(handler: GestureHandler): Boolean {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -220,7 +220,9 @@ open class GestureHandler {
     trackedPointersIDsCount--
   }
 
-  fun isTrackingPointer(pointerId: Int) = trackedPointerIDs[pointerId] != -1
+  private fun isTrackingPointer(pointerId: Int) = trackedPointerIDs[pointerId] != -1
+
+  fun shouldHandleTouchEvent(event: MotionEvent) = isTrackingPointer(event.getPointerId(event.actionIndex))
 
   private fun needAdapt(event: MotionEvent): Boolean {
     if (event.pointerCount != trackedPointersIDsCount) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -222,8 +222,6 @@ open class GestureHandler {
 
   private fun isTrackingPointer(pointerId: Int) = trackedPointerIDs[pointerId] != -1
 
-  fun shouldHandleTouchEvent(event: MotionEvent) = isTrackingPointer(event.getPointerId(event.actionIndex))
-
   private fun needAdapt(event: MotionEvent): Boolean {
     if (event.pointerCount != trackedPointersIDsCount) {
       return true
@@ -581,11 +579,12 @@ open class GestureHandler {
     onStateChange(newState, oldState)
   }
 
-  fun wantEvents(): Boolean = isEnabled &&
+  fun wantsEvents(event: MotionEvent): Boolean = isEnabled &&
     state != STATE_FAILED &&
     state != STATE_CANCELLED &&
     state != STATE_END &&
-    trackedPointersIDsCount > 0
+    trackedPointersIDsCount > 0 &&
+    isTrackingPointer(event.getPointerId(event.actionIndex))
 
   open fun shouldRequireToWaitForFailure(handler: GestureHandler): Boolean {
     if (handler === this) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -203,18 +203,24 @@ open class GestureHandler {
   }
 
   fun startTrackingPointer(pointerId: Int) {
-    if (trackedPointerIDs[pointerId] == -1) {
-      trackedPointerIDs[pointerId] = findNextLocalPointerId()
-      trackedPointersIDsCount++
+    if (isTrackingPointer(pointerId)) {
+      return
     }
+
+    trackedPointerIDs[pointerId] = findNextLocalPointerId()
+    trackedPointersIDsCount++
   }
 
   fun stopTrackingPointer(pointerId: Int) {
-    if (trackedPointerIDs[pointerId] != -1) {
-      trackedPointerIDs[pointerId] = -1
-      trackedPointersIDsCount--
+    if (!isTrackingPointer(pointerId)) {
+      return
     }
+
+    trackedPointerIDs[pointerId] = -1
+    trackedPointersIDsCount--
   }
+
+  fun isTrackingPointer(pointerId: Int) = trackedPointerIDs[pointerId] != -1
 
   private fun needAdapt(event: MotionEvent): Boolean {
     if (event.pointerCount != trackedPointersIDsCount) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -275,7 +275,7 @@ class GestureHandlerOrchestrator(
       return
     }
 
-    if (!handler.wantsEvents(sourceEvent)) {
+    if (!handler.wantsEvent(sourceEvent)) {
       return
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -251,7 +251,7 @@ class GestureHandlerOrchestrator(
     preparedHandlers.sortWith(handlersComparator)
 
     for (handler in preparedHandlers) {
-      if (handler.isTrackingPointer(event.getPointerId(event.actionIndex))) {
+      if (handler.shouldHandleTouchEvent(event)) {
         deliverEventToGestureHandler(handler, event)
       }
     }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -249,8 +249,11 @@ class GestureHandlerOrchestrator(
     // on Arrays.sort providing a stable sort (as children are registered in order in which they
     // should be tested)
     preparedHandlers.sortWith(handlersComparator)
+
     for (handler in preparedHandlers) {
-      deliverEventToGestureHandler(handler, event)
+      if (handler.isTrackingPointer(event.getPointerId(event.actionIndex))) {
+        deliverEventToGestureHandler(handler, event)
+      }
     }
   }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -251,9 +251,7 @@ class GestureHandlerOrchestrator(
     preparedHandlers.sortWith(handlersComparator)
 
     for (handler in preparedHandlers) {
-      if (handler.shouldHandleTouchEvent(event)) {
-        deliverEventToGestureHandler(handler, event)
-      }
+      deliverEventToGestureHandler(handler, event)
     }
   }
 
@@ -276,7 +274,8 @@ class GestureHandlerOrchestrator(
       handler.cancel()
       return
     }
-    if (!handler.wantEvents()) {
+
+    if (!handler.wantsEvents(sourceEvent)) {
       return
     }
 


### PR DESCRIPTION
## Description

Logic behind sending touch events on `android` dispatches events into all gesture handlers registered in the orchestrator. This means that interaction with one `GestureDetector` triggers callbacks on the others. This PR adds check for tracked pointer, so that handlers respond only to those that they are tracking.

Fixes #3543

## Test plan

<details>

<summary>Tested on the following example:</summary>

```jsx
import React from 'react';
import { StyleSheet, Text, View } from 'react-native';
import {
  Gesture,
  GestureDetector,
  GestureHandlerRootView,
} from 'react-native-gesture-handler';

type BoxProps = {
  label: string;
};

function Box({ label }: BoxProps) {
  const manual = Gesture.Manual()
    .onTouchesDown((e) => {
      console.log('down', label, e.handlerTag);
    })
    .onTouchesUp((e) => {
      console.log('up', label, e.handlerTag);
    })
    .onTouchesCancelled(() => {
      console.log('cancelled', label);
    });

  return (
    <GestureDetector gesture={manual}>
      <View style={styles.box}>
        <Text style={styles.text}>{label}</Text>
      </View>
    </GestureDetector>
  );
}

export default function EmptyExample() {
  return (
    <GestureHandlerRootView style={styles.container}>
      <Box label="1" />
      <Box label="2" />
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
    gap: 10,
  },
  box: {
    width: 100,
    height: 100,
    backgroundColor: 'red',
    alignItems: 'center',
    justifyContent: 'center',
  },
  text: {
    color: 'white',
    fontSize: 20,
    fontWeight: 'bold',
  },
});
```

</details>