### PR TITLE
Fix Pressable `onPress` callback not working

### DIFF
--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -1,5 +1,6 @@
 import React, {
   useCallback,
+  useEffect,
   useLayoutEffect,
   useMemo,
   useRef,
@@ -35,10 +36,8 @@ import {
   RelationPropName,
   RelationPropType,
 } from '../utils';
-import {
-  getConfiguredStateMachine,
-  StateMachineEvent,
-} from './stateDefinitions';
+import { getConfiguredStates, StateMachineEvent } from './stateDefinitions';
+import { PressableStateMachine } from './StateMachine';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;
 const IS_TEST_ENV = isTestEnv();
@@ -222,10 +221,12 @@ const Pressable = (props: PressableProps) => {
     [handleFinalize, innerHandlePressIn, onPress, onPressOut]
   );
 
-  const stateMachine = useMemo(
-    () => getConfiguredStateMachine(handlePressIn, handlePressOut),
-    [handlePressIn, handlePressOut]
-  );
+  const stateMachine = useMemo(() => new PressableStateMachine(), []);
+
+  useEffect(() => {
+    const configuration = getConfiguredStates(handlePressIn, handlePressOut);
+    stateMachine.setStates(configuration);
+  }, [handlePressIn, handlePressOut, stateMachine]);
 
   const hoverInTimeout = useRef<number | null>(null);
   const hoverOutTimeout = useRef<number | null>(null);

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -36,7 +36,7 @@ import {
   RelationPropName,
   RelationPropType,
 } from '../utils';
-import { getConfiguredStates, StateMachineEvent } from './stateDefinitions';
+import { getStatesConfig, StateMachineEvent } from './stateDefinitions';
 import { PressableStateMachine } from './StateMachine';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;
@@ -224,7 +224,7 @@ const Pressable = (props: PressableProps) => {
   const stateMachine = useMemo(() => new PressableStateMachine(), []);
 
   useEffect(() => {
-    const configuration = getConfiguredStates(handlePressIn, handlePressOut);
+    const configuration = getStatesConfig(handlePressIn, handlePressOut);
     stateMachine.setStates(configuration);
   }, [handlePressIn, handlePressOut, stateMachine]);
 

--- a/packages/react-native-gesture-handler/src/components/Pressable/StateMachine.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/StateMachine.tsx
@@ -1,19 +1,23 @@
 import { PressableEvent } from './PressableProps';
 
-interface StateDefinition {
+export interface StateDefinition {
   eventName: string;
   callback?: (event: PressableEvent) => void;
 }
 
 class PressableStateMachine {
-  private states: StateDefinition[];
+  private states: StateDefinition[] | null;
   private currentStepIndex: number;
   private eventPayload: PressableEvent | null;
 
-  constructor(steps: StateDefinition[]) {
-    this.states = steps;
+  constructor() {
+    this.states = null;
     this.currentStepIndex = 0;
     this.eventPayload = null;
+  }
+
+  public setStates(states: StateDefinition[]) {
+    this.states = states;
   }
 
   public reset() {
@@ -22,6 +26,10 @@ class PressableStateMachine {
   }
 
   public handleEvent(eventName: string, eventPayload?: PressableEvent) {
+    if (!this.states) {
+      return;
+    }
+
     const step = this.states[this.currentStepIndex];
     this.eventPayload = eventPayload || this.eventPayload;
 

--- a/packages/react-native-gesture-handler/src/components/Pressable/stateDefinitions.ts
+++ b/packages/react-native-gesture-handler/src/components/Pressable/stateDefinitions.ts
@@ -9,7 +9,7 @@ export enum StateMachineEvent {
   LONG_PRESS_TOUCHES_DOWN = 'longPressTouchesDown',
 }
 
-function getAndroidStateMachine(
+function getAndroidStatesConfig(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ) {
@@ -28,7 +28,7 @@ function getAndroidStateMachine(
   ];
 }
 
-function getIosStateMachine(
+function getIosStatesConfig(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ) {
@@ -47,7 +47,7 @@ function getIosStateMachine(
   ];
 }
 
-function getWebStateMachine(
+function getWebStatesConfig(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ) {
@@ -69,7 +69,7 @@ function getWebStateMachine(
   ];
 }
 
-function getMacosStateMachine(
+function getMacosStatesConfig(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ) {
@@ -91,7 +91,7 @@ function getMacosStateMachine(
   ];
 }
 
-function getUniversalStateMachine(
+function getUniversalStatesConfig(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ) {
@@ -106,20 +106,20 @@ function getUniversalStateMachine(
   ];
 }
 
-export function getConfiguredStates(
+export function getStatesConfig(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ): StateDefinition[] {
   if (Platform.OS === 'android') {
-    return getAndroidStateMachine(handlePressIn, handlePressOut);
+    return getAndroidStatesConfig(handlePressIn, handlePressOut);
   } else if (Platform.OS === 'ios') {
-    return getIosStateMachine(handlePressIn, handlePressOut);
+    return getIosStatesConfig(handlePressIn, handlePressOut);
   } else if (Platform.OS === 'web') {
-    return getWebStateMachine(handlePressIn, handlePressOut);
+    return getWebStatesConfig(handlePressIn, handlePressOut);
   } else if (Platform.OS === 'macos') {
-    return getMacosStateMachine(handlePressIn, handlePressOut);
+    return getMacosStatesConfig(handlePressIn, handlePressOut);
   } else {
     // Unknown platform - using minimal universal setup.
-    return getUniversalStateMachine(handlePressIn, handlePressOut);
+    return getUniversalStatesConfig(handlePressIn, handlePressOut);
   }
 }

--- a/packages/react-native-gesture-handler/src/components/Pressable/stateDefinitions.ts
+++ b/packages/react-native-gesture-handler/src/components/Pressable/stateDefinitions.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 import { PressableEvent } from './PressableProps';
-import { PressableStateMachine } from './StateMachine';
+import { StateDefinition } from './StateMachine';
 
 export enum StateMachineEvent {
   NATIVE_BEGIN = 'nativeBegin',
@@ -13,7 +13,7 @@ function getAndroidStateMachine(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ) {
-  return new PressableStateMachine([
+  return [
     {
       eventName: StateMachineEvent.NATIVE_BEGIN,
     },
@@ -25,14 +25,14 @@ function getAndroidStateMachine(
       eventName: StateMachineEvent.FINALIZE,
       callback: handlePressOut,
     },
-  ]);
+  ];
 }
 
 function getIosStateMachine(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ) {
-  return new PressableStateMachine([
+  return [
     {
       eventName: StateMachineEvent.LONG_PRESS_TOUCHES_DOWN,
     },
@@ -44,14 +44,14 @@ function getIosStateMachine(
       eventName: StateMachineEvent.FINALIZE,
       callback: handlePressOut,
     },
-  ]);
+  ];
 }
 
 function getWebStateMachine(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ) {
-  return new PressableStateMachine([
+  return [
     {
       eventName: StateMachineEvent.NATIVE_BEGIN,
     },
@@ -66,14 +66,14 @@ function getWebStateMachine(
       eventName: StateMachineEvent.FINALIZE,
       callback: handlePressOut,
     },
-  ]);
+  ];
 }
 
 function getMacosStateMachine(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ) {
-  return new PressableStateMachine([
+  return [
     {
       eventName: StateMachineEvent.LONG_PRESS_TOUCHES_DOWN,
     },
@@ -88,14 +88,14 @@ function getMacosStateMachine(
       eventName: StateMachineEvent.FINALIZE,
       callback: handlePressOut,
     },
-  ]);
+  ];
 }
 
 function getUniversalStateMachine(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
 ) {
-  return new PressableStateMachine([
+  return [
     {
       eventName: StateMachineEvent.FINALIZE,
       callback: (event: PressableEvent) => {
@@ -103,13 +103,13 @@ function getUniversalStateMachine(
         handlePressOut(event);
       },
     },
-  ]);
+  ];
 }
 
-export function getConfiguredStateMachine(
+export function getConfiguredStates(
   handlePressIn: (event: PressableEvent) => void,
   handlePressOut: (event: PressableEvent) => void
-) {
+): StateDefinition[] {
   if (Platform.OS === 'android') {
     return getAndroidStateMachine(handlePressIn, handlePressOut);
   } else if (Platform.OS === 'ios') {


### PR DESCRIPTION
## Description

Rendering `Pressable` during an active press resulted in `onPress` never being called.
This PR moves `StateMachine` dependencies, such that it is not reset when `handlePressIn` or `handlePressOut` change.

Fixes #3593

## Test plan

- Use the repro provided within #3593
- See how `onPress` is called correctly
