### PR TITLE
[Android] Use `asReversed` instead of `reversed`

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -207,7 +207,7 @@ class GestureHandlerOrchestrator(
     }
 
     // Clear all awaiting handlers waiting for the current handler to fail
-    for (otherHandler in awaitingHandlers.reversed()) {
+    for (otherHandler in awaitingHandlers.asReversed()) {
       if (shouldHandlerBeCancelledBy(otherHandler, handler)) {
         otherHandler.isAwaiting = false
       }
@@ -255,15 +255,16 @@ class GestureHandlerOrchestrator(
   }
 
   private fun cancelAll() {
-    for (handler in awaitingHandlers.reversed()) {
+    for (handler in awaitingHandlers.asReversed().toList()) {
       handler.cancel()
     }
+
     // Copy handlers to "prepared handlers" array, because the list of active handlers can change
     // as a result of state updates
     preparedHandlers.clear()
     preparedHandlers.addAll(gestureHandlers)
 
-    for (handler in gestureHandlers.reversed()) {
+    for (handler in gestureHandlers.asReversed()) {
       handler.cancel()
     }
   }
@@ -281,7 +282,7 @@ class GestureHandlerOrchestrator(
     val event = transformEventToViewCoords(handler.view, MotionEvent.obtain(sourceEvent))
 
     // Touch events are sent before the handler itself has a chance to process them,
-    // mainly because `onTouchesUp` shoul be send befor gesture finishes. This means that
+    // mainly because `onTouchesUp` should be send before gesture finishes. This means that
     // the first `onTouchesDown` event is sent before a gesture begins, activation in
     // callback for this event causes problems because the handler doesn't have a chance
     // to initialize itself with starting values of pointer (in pan this causes translation

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -255,6 +255,8 @@ class GestureHandlerOrchestrator(
   }
 
   private fun cancelAll() {
+    // We need `toList` as `awaitingHandlers` can be modified by `cancel`:
+    // `onHandlerStateChange` -> `tryActivate` -> `addAwaitingHandler`
     for (handler in awaitingHandlers.asReversed().toList()) {
       handler.cancel()
     }


### PR DESCRIPTION
## Description

Some of our users experience crashes that `reversed` is not defined:

```
java.lang.NoSuchMethodError: No virtual method reversed()Ljava/util/List;
```

This PR changes `reversed` occurrences to either `asReversed` (if possible), or `asReversed().toList()`, if array can be modified.

Closes #3594 

## Test plan

Tested on expo-example (mostly _transformations_, _multitap_).