### PR TITLE
Fix `Pressable` requiring `dimensionsAfterResize`

### DIFF
--- a/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
+++ b/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
@@ -58,9 +58,7 @@ export interface RawButtonProps
   style?: StyleProp<ViewStyle>;
 
   /**
-   * Invoked on mount and layout changes with
-   *
-   * {nativeEvent: { layout: {x, y, width, height}}}.
+   * Invoked on mount and layout changes.
    */
   onLayout?: (event: LayoutChangeEvent) => void;
 

--- a/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
+++ b/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
@@ -62,7 +62,7 @@ export interface RawButtonProps
    *
    * {nativeEvent: { layout: {x, y, width, height}}}.
    */
-  onLayout?: ((event: LayoutChangeEvent) => void) | undefined;
+  onLayout?: (event: LayoutChangeEvent) => void;
 
   /**
    * Used for testing-library compatibility, not passed to the native component.

--- a/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
+++ b/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
@@ -2,6 +2,7 @@ import * as React from 'react';
 import {
   AccessibilityProps,
   ColorValue,
+  LayoutChangeEvent,
   StyleProp,
   ViewStyle,
 } from 'react-native';
@@ -55,6 +56,13 @@ export interface RawButtonProps
    * Style object, use it to set additional styles.
    */
   style?: StyleProp<ViewStyle>;
+
+  /**
+   * Invoked on mount and layout changes with
+   *
+   * {nativeEvent: { layout: {x, y, width, height}}}.
+   */
+  onLayout?: ((event: LayoutChangeEvent) => void) | undefined;
 
   /**
    * Used for testing-library compatibility, not passed to the native component.

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -14,6 +14,7 @@ import {
 } from './PressableProps';
 import {
   Insets,
+  LayoutChangeEvent,
   Platform,
   StyleProp,
   ViewStyle,
@@ -355,11 +356,15 @@ const Pressable = (props: PressableProps) => {
       : processColor(unprocessedRippleColor);
   }, [android_ripple]);
 
+  const setDimensions = useCallback((event: LayoutChangeEvent) => {
+    dimensions.current = event.nativeEvent.layout;
+  }, []);
+
   return (
     <GestureDetector gesture={gesture}>
       <NativeButton
         {...remainingProps}
-        onLayout={(e) => (dimensions.current = e.nativeEvent.layout)}
+        onLayout={setDimensions}
         accessible={accessible !== false}
         hitSlop={appliedHitSlop}
         enabled={isPressableEnabled}

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -364,7 +364,6 @@ const Pressable = (props: PressableProps) => {
     <GestureDetector gesture={gesture}>
       <NativeButton
         {...remainingProps}
-        // @ts-ignore Prop `onLayout` always works. Todo: Define it's availability on NativeButton
         onLayout={(e) => (dimensions.current = e.nativeEvent.layout)}
         ref={ref ?? fallbackRef}
         accessible={accessible !== false}

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -16,7 +16,6 @@ import {
   Insets,
   Platform,
   StyleProp,
-  View,
   ViewStyle,
   processColor,
 } from 'react-native';
@@ -45,7 +44,6 @@ let IS_FABRIC: null | boolean = null;
 
 const Pressable = (props: PressableProps) => {
   const {
-    ref,
     testOnly_pressed,
     hitSlop,
     pressRetentionOffset,
@@ -76,9 +74,6 @@ const Pressable = (props: PressableProps) => {
     requireExternalGestureToFail,
     blocksExternalGesture,
   };
-
-  // used only if `ref` is undefined
-  const fallbackRef = useRef<View>(null);
 
   const [pressedState, setPressedState] = useState(testOnly_pressed ?? false);
 
@@ -365,7 +360,6 @@ const Pressable = (props: PressableProps) => {
       <NativeButton
         {...remainingProps}
         onLayout={(e) => (dimensions.current = e.nativeEvent.layout)}
-        ref={ref ?? fallbackRef}
         accessible={accessible !== false}
         hitSlop={appliedHitSlop}
         enabled={isPressableEnabled}

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -1,7 +1,6 @@
 import React, {
   useCallback,
   useEffect,
-  useLayoutEffect,
   useMemo,
   useRef,
   useState,
@@ -69,7 +68,6 @@ const Pressable = (props: PressableProps) => {
     simultaneousWithExternalGesture,
     requireExternalGestureToFail,
     blocksExternalGesture,
-    dimensionsAfterResize,
     ...remainingProps
   } = props;
 
@@ -108,21 +106,6 @@ const Pressable = (props: PressableProps) => {
     normalizedHitSlop,
     normalizedPressRetentionOffset
   );
-
-  useLayoutEffect(() => {
-    if (dimensionsAfterResize) {
-      dimensions.current = dimensionsAfterResize;
-    } else {
-      requestAnimationFrame(() => {
-        (ref ?? fallbackRef).current?.measure((_x, _y, width, height) => {
-          dimensions.current = {
-            width,
-            height,
-          };
-        });
-      });
-    }
-  }, [dimensionsAfterResize, ref]);
 
   const cancelLongPress = useCallback(() => {
     if (longPressTimeoutRef.current) {
@@ -377,10 +360,14 @@ const Pressable = (props: PressableProps) => {
       : processColor(unprocessedRippleColor);
   }, [android_ripple]);
 
+  console.log('render');
+
   return (
     <GestureDetector gesture={gesture}>
       <NativeButton
         {...remainingProps}
+        // @ts-ignore Prop `onLayout` always works. Todo: Define it's availability on NativeButton
+        onLayout={(e) => (dimensions.current = e.nativeEvent.layout)}
         ref={ref ?? fallbackRef}
         accessible={accessible !== false}
         hitSlop={appliedHitSlop}

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -58,6 +58,7 @@ const Pressable = (props: PressableProps) => {
     onPressIn,
     onPressOut,
     onLongPress,
+    onLayout,
     style,
     children,
     android_disableSound,
@@ -356,9 +357,13 @@ const Pressable = (props: PressableProps) => {
       : processColor(unprocessedRippleColor);
   }, [android_ripple]);
 
-  const setDimensions = useCallback((event: LayoutChangeEvent) => {
-    dimensions.current = event.nativeEvent.layout;
-  }, []);
+  const setDimensions = useCallback(
+    (event: LayoutChangeEvent) => {
+      onLayout?.(event);
+      dimensions.current = event.nativeEvent.layout;
+    },
+    [onLayout]
+  );
 
   return (
     <GestureDetector gesture={gesture}>

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -360,8 +360,6 @@ const Pressable = (props: PressableProps) => {
       : processColor(unprocessedRippleColor);
   }, [android_ripple]);
 
-  console.log('render');
-
   return (
     <GestureDetector gesture={gesture}>
       <NativeButton

--- a/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
@@ -168,11 +168,7 @@ export interface PressableProps
   blocksExternalGesture?: RelationPropType;
 
   /**
-   * Defines the dimensions of the Pressable after it's been resized.
-   * This property does not affect Pressable's physical appearance.
-   * Required when the Pressable is resized **and** uses pressRetentionOffset.
-   *
-   * @deprecated This property is no longer used. It can be safely removed.
+   * @deprecated This property is no longer used, and will be removed in the future. It can be safely removed.
    */
   dimensionsAfterResize?: PressableDimensions;
 }

--- a/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
@@ -168,7 +168,7 @@ export interface PressableProps
   blocksExternalGesture?: RelationPropType;
 
   /**
-   * @deprecated This property is no longer used, and will be removed in the future. It can be safely removed.
+   * @deprecated This property is no longer used, and will be removed in the future.
    */
   dimensionsAfterResize?: PressableDimensions;
 }

--- a/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
@@ -171,6 +171,8 @@ export interface PressableProps
    * Defines the dimensions of the Pressable after it's been resized.
    * This property does not affect Pressable's physical appearance.
    * Required when the Pressable is resized **and** uses pressRetentionOffset.
+   *
+   * @deprecated This property is no longer used. It can be safely removed.
    */
   dimensionsAfterResize?: PressableDimensions;
 }

--- a/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
@@ -66,7 +66,7 @@ export interface PressableProps
   /**
    * A reference to the pressable element.
    */
-  ref?: React.RefObject<View>;
+  ref?: React.Ref<View>;
 
   /**
    * Either children or a render prop that receives a boolean reflecting whether


### PR DESCRIPTION
## Description

The `Pressable` was developed with an incorrect assumption that the `onLayout` prop is not available on the `NativeButton`.

This PR defines the `onLayout` on `RawButtonProps`, and makes use of said prop in `Pressable` to remove the need for the `dimensionsAfterResize` property.

This PR also marks `dimensionsAfterResize` as deprecated.

Fixes #3600

## Test plan

1. Use the provided test code.
2. Notice how the `Pressable`, despite starting out with `0, 0` dimensions, responds correctly to all press events.
3. Use the `Pressable` examples in our example app to confirm there are no new issues with the component.

## Test code

<details>

```tsx
import React, { useEffect } from 'react';
import { StyleSheet } from 'react-native';
import {
  Pressable,
  GestureHandlerRootView,
} from 'react-native-gesture-handler';
import Animated, {
  useSharedValue,
  useAnimatedStyle,
  withTiming,
} from 'react-native-reanimated';

export default function EmptyExample() {
  const opacity = useSharedValue(0);

  const containerAnimatedStyle = useAnimatedStyle(() => {
    'worklet';
    return {
      opacity: opacity.value,
      transform: [{ scale: opacity.value }],
    };
  });

  useEffect(() => {
    opacity.value = withTiming(1, { duration: 200 });
  }, [opacity]);

  return (
    <GestureHandlerRootView style={styles.container}>
      <Animated.View style={containerAnimatedStyle}>
        <Pressable style={styles.box} onPress={() => console.log('press')} />
      </Animated.View>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
    gap: 10,
  },
  box: {
    width: 150,
    height: 150,
    backgroundColor: 'red',
    alignItems: 'center',
    justifyContent: 'center',
  },
});


```

</details>