### PR TITLE
Update link in the error message

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/createHandler.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/createHandler.tsx
@@ -446,7 +446,7 @@ export default function createHandler<
       if (__DEV__ && !this.context && !isTestEnv() && Platform.OS !== 'web') {
         throw new Error(
           name +
-            ' must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/installation for more details.'
+            ' must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation for more details.'
         );
       }
 

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx
@@ -96,7 +96,7 @@ export const GestureDetector = (props: GestureDetectorProps) => {
   const rootViewContext = useContext(GestureHandlerRootViewContext);
   if (__DEV__ && !rootViewContext && !isTestEnv() && Platform.OS !== 'web') {
     throw new Error(
-      'GestureDetector must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/installation for more details.'
+      'GestureDetector must be used as a descendant of GestureHandlerRootView. Otherwise the gestures will not be recognized. See https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/installation for more details.'
     );
   }
 


### PR DESCRIPTION
## Description

The link in the error message about the missing `GestureHandlerRootView` was outdated, and the page no longer exists.

## Test plan

Open the new link
