### PR TITLE
[Web] fixed repeated listener registration

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -570,6 +570,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     if (this.enabled !== enabled) {
       this.delegate.onEnabledChange(enabled);
     }
+
     this.enabled = enabled;
 
     if (this.config.shouldCancelWhenOutside !== undefined) {

--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -566,9 +566,11 @@ export default abstract class GestureHandler implements IGestureHandler {
 
   public updateGestureConfig({ enabled = true, ...props }: Config): void {
     this._config = { enabled: enabled, ...props };
-    this.enabled = enabled;
 
-    this.delegate.onEnabledChange(enabled);
+    if (this.enabled !== enabled) {
+      this.delegate.onEnabledChange(enabled);
+    }
+    this.enabled = enabled;
 
     if (this.config.shouldCancelWhenOutside !== undefined) {
       this.shouldCancelWhenOutside = this.config.shouldCancelWhenOutside;

--- a/packages/react-native-gesture-handler/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureHandlerWebDelegate.ts
@@ -174,11 +174,6 @@ export class GestureHandlerWebDelegate
 
     if (enabled) {
       this.eventManagers.forEach((manager) => {
-        // It may look like managers will be registered twice when handler is mounted for the first time.
-        // However, `init` method is called AFTER `updateGestureConfig` - it means that delegate has not
-        // been initialized yet, so this code won't be executed.
-        //
-        // Also, because we use defined functions, not lambdas, they will not be registered multiple times.
         manager.registerListeners();
       });
     } else {


### PR DESCRIPTION
## Description

On web, In `EventManagers`, the `registerListeners` was called twice for each handler of a `Button`

## Test plan

* Add a console.log to both `registerListners()` and `unregisterListeners()` in `web/tools/KeyboardEventManager` (or any other event manager)
* Observe logs in the `Web styles reset` example in the example app