### PR TITLE
Remove `onChange` callback references

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/events/useGestureHandlerEvent.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/events/useGestureHandlerEvent.ts
@@ -13,7 +13,6 @@ export function useGestureHandlerEvent(
   shouldUseReanimated: boolean
 ) {
   const handlers: CallbackHandlers = {
-    onChange: config.onChange,
     onUpdate: config.onUpdate,
   };
 

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils.ts
@@ -18,8 +18,6 @@ export function getHandler(type: CALLBACK_TYPE, config: CallbackHandlers) {
       return config.onStart;
     case CALLBACK_TYPE.UPDATE:
       return config.onUpdate;
-    case CALLBACK_TYPE.CHANGE:
-      return config.onChange;
     case CALLBACK_TYPE.END:
       return config.onEnd;
     case CALLBACK_TYPE.FINALIZE:

--- a/packages/react-native-gesture-handler/src/v3/types.ts
+++ b/packages/react-native-gesture-handler/src/v3/types.ts
@@ -34,5 +34,9 @@ export type TouchEvent =
 
 export type CallbackHandlers = Omit<
   HandlerCallbacks<Record<string, unknown>>,
-  'gestureId' | 'handlerTag' | 'isWorklet'
+  | 'gestureId'
+  | 'handlerTag'
+  | 'isWorklet'
+  | 'changeEventCalculator'
+  | 'onChange'
 >;


### PR DESCRIPTION
## Description

In #3617 we've merged `onUpdate` and `onChange` callbacks so `onUpdate` now contains information about changes (or better to say, it will when we implement it 😄). However, there are still places in code where you can see `onChange` being referenced. This PR cleans that up.

## Test plan

Tested on basic-example.