### PR TITLE
Fix `onUpdate` crash 

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils.ts
@@ -93,7 +93,7 @@ export function isAnimatedEvent(
 ): callback is AnimatedEvent {
   'worklet';
 
-  return '_argMapping' in callback;
+  return !!callback && '_argMapping' in callback;
 }
 
 export function checkMappingForChangeProperties(obj: Animated.Mapping) {

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils.ts
@@ -89,7 +89,7 @@ export function isEventForHandlerWithTag(
 }
 
 export function isAnimatedEvent(
-  callback: ((event: any) => void) | AnimatedEvent
+  callback: ((event: any) => void) | AnimatedEvent | undefined
 ): callback is AnimatedEvent {
   'worklet';
 


### PR DESCRIPTION
## Description

#3630 introduced automatic support for `Animated.Event` in `onUpdate` callback. However, I've missed the fact that this callback may not be defined. This PR fixes this crash.

## Test plan

Tested on current basic-example without specifying `onUpdate`
