### PR TITLE
fix: Crash on Android 10 due to pointerIndex out of range in ReactScrollView with react-native-gesture-handler

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
@@ -32,11 +32,17 @@ class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {
     rootHelper?.tearDown()
   }
 
-  override fun dispatchTouchEvent(ev: MotionEvent) = if (rootViewEnabled && rootHelper!!.dispatchTouchEvent(ev)) {
-    true
-  } else {
-    super.dispatchTouchEvent(ev)
-  }
+  override fun dispatchTouchEvent(ev: MotionEvent) =
+    try {
+      if (rootViewEnabled && rootHelper!!.dispatchTouchEvent(ev)) {
+        true
+      } else {
+        super.dispatchTouchEvent(ev)
+      }
+    } catch (IllegalArgumentException e) {
+      e.printStackTrace();
+      false
+    }
 
   override fun dispatchGenericMotionEvent(event: MotionEvent) =
     if (rootViewEnabled && rootHelper!!.dispatchTouchEvent(event)) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
@@ -39,7 +39,7 @@ class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {
       } else {
         super.dispatchTouchEvent(ev)
       }
-    } catch (IllegalArgumentException e) {
+    } catch (e: IllegalArgumentException) {
       e.printStackTrace();
       false
     }


### PR DESCRIPTION
### WHAT IS THE DRIVING SCENARIO?

This crash, Fatal Exception: java.lang.IllegalArgumentException with message pointerIndex out of range , occurring in com.facebook.react.views.scroll.ReactScrollView.onTouchEvent , indicates a problem with how touch events are being handled in the Android native layer by the ReactScrollView component.
Given the information about react-native-gesture-handler and the forum post, the cause is an integration issue between ReactScrollView and react-native-gesture-handler , where intercepting the latter's event disrupts the former's expectations regarding pointer indices.

### HOW TO REPRODUCE?

Use an Android 10 device.
Access a screen with ReactScrollView active.
End up with an input field activated with the keyboard showing. Repeatedly scrolling
The app may crash and close unexpectedly.

### WHAT WAS DONE IN THIS PR?

Applied a mitigation patch related to the pointerIndex out of range issue, inspired by discussions and solutions in the react-native-gesture-handler repository

Ensured compatibility between ReactScrollView and react-native-gesture-handler to avoid conflicts in touch events.

Added additional protections in native handlers to prevent invalid pointer exceptions.

### HOW TO TEST LOCALLY?

Run a production app because the issue doesn't occur with a debug app.
Install the app on a device with Android 10.
Keep an input field activated with the keyboard showing.
Keep scrolling up and down until it crashes.
