### PR TITLE
[Web] Fix bottom hitslop

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -685,8 +685,9 @@ export default abstract class GestureHandler implements IGestureHandler {
     }
 
     if (this.config.hitSlop.bottom !== undefined) {
-      bottom = width + this.config.hitSlop.bottom;
+      bottom = height + this.config.hitSlop.bottom;
     }
+
     if (this.config.hitSlop.width !== undefined) {
       if (this.config.hitSlop.left !== undefined) {
         right = left + this.config.hitSlop.width;


### PR DESCRIPTION
## Description

Currently `hitSlop` on web uses `width` instead of `height` to calculate `bottom` property. This is incorrect.

Fixes #3633 

## Test plan

Trust our intuition 🤓 

<details>
<summary>Tested on the following example:</summary>

```jsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import { Gesture, GestureDetector } from 'react-native-gesture-handler';

export default function EmptyExample() {
  const gesture = Gesture.Pan().hitSlop({ bottom: -20 }).onUpdate(console.log);

  return (
    <GestureDetector gesture={gesture}>
      <View style={styles.box} />
    </GestureDetector>
  );
}

const styles = StyleSheet.create({
  box: {
    width: 10,
    height: 100,
    backgroundColor: 'red',
  },
});
```

</details>