### PR TITLE
Automatically assign `dispatchesAnimatedEvents`

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/NativeDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/NativeDetector.tsx
@@ -20,7 +20,7 @@ const ReanimatedNativeDetector = Reanimated?.default.createAnimatedComponent(
 );
 
 export function NativeDetector({ gesture, children }: NativeDetectorProps) {
-  const NativeDetectorComponent = gesture.dispatchesAnimatedEvents
+  const NativeDetectorComponent = gesture.config.dispatchesAnimatedEvents
     ? AnimatedNativeDetector
     : gesture.shouldUseReanimated
       ? ReanimatedNativeDetector
@@ -47,7 +47,9 @@ export function NativeDetector({ gesture, children }: NativeDetectorProps) {
       onGestureHandlerTouchEvent={
         gesture.gestureEvents.onGestureHandlerTouchEvent
       }
-      dispatchesAnimatedEvents={gesture.dispatchesAnimatedEvents}
+      dispatchesAnimatedEvents={
+        gesture.config.dispatchesAnimatedEvents as boolean
+      }
       moduleId={globalThis._RNGH_MODULE_ID}
       handlerTags={[gesture.tag]}
       style={styles.detector}>

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -30,7 +30,6 @@ export interface NativeGesture {
   config: Record<string, unknown>;
   gestureEvents: GestureEvents;
   shouldUseReanimated: boolean;
-  dispatchesAnimatedEvents: boolean;
 }
 
 function hasWorkletEventHandlers(config: Record<string, unknown>) {
@@ -65,7 +64,6 @@ export function useGesture(
 
   const shouldUseReanimated =
     Reanimated !== undefined && hasWorkletEventHandlers(config);
-  config.needsPointerData = shouldHandleTouchEvents(config);
 
   const {
     onGestureHandlerStateChange,
@@ -84,6 +82,11 @@ export function useGesture(
   ) {
     throw new Error(tagMessage('Failed to create event handlers.'));
   }
+
+  config.needsPointerData = shouldHandleTouchEvents(config);
+  config.dispatchesAnimatedEvents =
+    !!onGestureHandlerAnimatedEvent &&
+    '__isNative' in onGestureHandlerAnimatedEvent;
 
   useMemo(() => {
     RNGestureHandlerModule.createGestureHandler(type, tag, {});
@@ -119,8 +122,5 @@ export function useGesture(
       onGestureHandlerAnimatedEvent,
     },
     shouldUseReanimated,
-    dispatchesAnimatedEvents:
-      !!onGestureHandlerAnimatedEvent &&
-      '__isNative' in onGestureHandlerAnimatedEvent,
   };
 }


### PR DESCRIPTION
## Description

#3646 removed _animated native detector_ action type. However, now we have to pass `dispatchesAnimatedEvents` to gesture config, what was not done automatically. This PR fixes it.

## Test plan

Tested on `basic-example`
