### PR TITLE
Remove `dispatchesAnimatedEvents` from the native detector

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
@@ -14,7 +14,6 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
   private var handlersToAttach: List<Int>? = null
   private var attachedHandlers = listOf<Int>()
   private var moduleId: Int = -1
-  private var dispatchesAnimatedEvents: Boolean = false
 
   fun setHandlerTags(handlerTags: ReadableArray?) {
     val newHandlers = handlerTags?.toArrayList()?.map { (it as Double).toInt() } ?: emptyList()
@@ -34,10 +33,6 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
     this.moduleId = id
     this.attachHandlers(handlersToAttach ?: return)
     handlersToAttach = null
-  }
-
-  fun setDispatchesAnimatedEvents(dispatchesAnimatedEvents: Boolean) {
-    this.dispatchesAnimatedEvents = dispatchesAnimatedEvents
   }
 
   private fun attachHandlers(newHandlers: List<Int>) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorViewManager.kt
@@ -36,8 +36,4 @@ class RNGestureHandlerDetectorViewManager :
   override fun setModuleId(view: RNGestureHandlerDetectorView, value: Int) {
     view.setModuleId(value)
   }
-
-  override fun setDispatchesAnimatedEvents(view: RNGestureHandlerDetectorView, value: Boolean) {
-    view.setDispatchesAnimatedEvents(value)
-  }
 }

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts
@@ -49,7 +49,6 @@ export interface NativeProps extends ViewProps {
   onGestureHandlerTouchEvent?: DirectEventHandler<GestureHandlerTouchEvent>;
 
   handlerTags: Int32[];
-  dispatchesAnimatedEvents: boolean;
   moduleId: Int32;
 }
 

--- a/packages/react-native-gesture-handler/src/v3/NativeDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/NativeDetector.tsx
@@ -48,9 +48,6 @@ export function NativeDetector({ gesture, children }: NativeDetectorProps) {
       onGestureHandlerTouchEvent={
         gesture.gestureEvents.onGestureHandlerTouchEvent
       }
-      dispatchesAnimatedEvents={
-        gesture.config.dispatchesAnimatedEvents as boolean
-      }
       moduleId={globalThis._RNGH_MODULE_ID}
       handlerTags={[gesture.tag]}
       style={styles.detector}>


### PR DESCRIPTION
## Description

https://github.com/software-mansion/react-native-gesture-handler/pull/3646 removed the Animated action type, but there are still references left to `dispatchesAnimatedEvents` in the native detector, while the property has been moved to the config of individual gestures.

This PR removes those references.

## Test plan

Check the native detector examples
