### PR TITLE
[Android] Move linker flags to cmake

### DIFF
--- a/packages/react-native-gesture-handler/android/build.gradle
+++ b/packages/react-native-gesture-handler/android/build.gradle
@@ -158,15 +158,8 @@ android {
                     arguments "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
                             "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
                             "-DANDROID_STL=c++_shared",
-                            "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON",
-                            // Turn off build IDs for reproducibility (ensuring the same code will produce the same bundle when built)
-                            // See https://gitlab.com/IzzyOnDroid/repo/-/wikis/Reproducible-Builds/RB-Hints-for-Developers#no-funny-build-time-generated-ids
-                            // for more information
-                            "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--build-id=none"
+                            "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                     abiFilters(*reactNativeArchitectures())
-                }
-                ndkBuild {
-                    arguments "APP_LDFLAGS+=-Wl,--build-id=none"
                 }
             }
         }

--- a/packages/react-native-gesture-handler/android/src/main/jni/CMakeLists.txt
+++ b/packages/react-native-gesture-handler/android/src/main/jni/CMakeLists.txt
@@ -12,6 +12,7 @@ set(PACKAGE_NAME "gesturehandler")
 set(REACT_ANDROID_DIR "${REACT_NATIVE_DIR}/ReactAndroid")
 
 include(${REACT_ANDROID_DIR}/cmake-utils/folly-flags.cmake)
+add_link_options(-Wl,--build-id=none)
 add_compile_options(${folly_FLAGS})
 
 add_library(${PACKAGE_NAME}


### PR DESCRIPTION
## Description

This PR moves build id flags from `build.gradle` to `CMakeLists.txt`

## Test plan

Checked that basic-example builds