### PR TITLE
[Android] Revert "fix: turn off build IDs for reproducibility (#3602)"

### DIFF
--- a/packages/react-native-gesture-handler/android/build.gradle
+++ b/packages/react-native-gesture-handler/android/build.gradle
@@ -158,15 +158,8 @@ android {
                     arguments "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
                             "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
                             "-DANDROID_STL=c++_shared",
-                            "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON",
-                            // Turn off build IDs for reproducibility (ensuring the same code will produce the same bundle when built)
-                            // See https://gitlab.com/IzzyOnDroid/repo/-/wikis/Reproducible-Builds/RB-Hints-for-Developers#no-funny-build-time-generated-ids
-                            // for more information
-                            "-DCMAKE_SHARED_LINKER_FLAGS=-Wl,--build-id=none"
+                            "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"
                     abiFilters(*reactNativeArchitectures())
-                }
-                ndkBuild {
-                    arguments "APP_LDFLAGS+=-Wl,--build-id=none"
                 }
             }
         }


### PR DESCRIPTION
## Description

Reverts #3602 as we want to stay consistent with **React Native**.

## Test plan

Trust me 😅 
