### PR TITLE
Release 2.28.0

### DIFF
--- a/apps/basic-example/ios/Podfile.lock
+++ b/apps/basic-example/ios/Podfile.lock
@@ -2223,7 +2223,7 @@ PODS:
     - React-perflogger (= 0.81.0-rc.5)
     - React-utils (= 0.81.0-rc.5)
     - SocketRocket
-  - RNGestureHandler (2.27.2):
+  - RNGestureHandler (2.28.0):
     - boost
     - DoubleConversion
     - fast_float
@@ -2552,7 +2552,7 @@ SPEC CHECKSUMS:
   ReactAppDependencyProvider: 3b7ece00025ce3482570139b0dbe115e639688ca
   ReactCodegen: e94ec7f44191aec5bc53b17e141a5c393731f2ea
   ReactCommon: 61fd53636b15a5dc300d5e31105a76f773a918fd
-  RNGestureHandler: eeb519bb8f93a48e91d3b8848446ba123203b530
+  RNGestureHandler: 226975d40048f7186ecc974fd5796bfba857aba1
   SocketRocket: d4aabe649be1e368d1318fdf28a022d714d65748
   Yoga: 72ab8318e9f1910fbdd236b045eb5455c8415d92
 

--- a/packages/react-native-gesture-handler/package.json
+++ b/packages/react-native-gesture-handler/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-gesture-handler",
-  "version": "2.27.2",
+  "version": "2.28.0",
   "description": "Declarative API exposing native platform touch and gesture system to React Native",
   "scripts": {
     "test": "jest",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7581,12 +7581,12 @@ __metadata:
   linkType: hard
 
 "enhanced-resolve@npm:^5.8.3":
-  version: 5.18.2
-  resolution: "enhanced-resolve@npm:5.18.2"
+  version: 5.18.3
+  resolution: "enhanced-resolve@npm:5.18.3"
   dependencies:
     graceful-fs: "npm:^4.2.4"
     tapable: "npm:^2.2.0"
-  checksum: 10c0/2a45105daded694304b0298d1c0351a981842249a9867513d55e41321a4ccf37dfd35b0c1e9ceae290eab73654b09aa7a910d618ea6f9441e97c52bc424a2372
+  checksum: 10c0/d413c23c2d494e4c1c9c9ac7d60b812083dc6d446699ed495e69c920988af0a3c66bf3f8d0e7a45cb1686c2d4c1df9f4e7352d973f5b56fe63d8d711dd0ccc54
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Release 2.28.0

> [!WARNING]
> `Podfile.lock` in `macos-example` is not changed since latest `react-native-macos` fails to install `pods`. Moreover, for now they only support `react-native` up to 0.78, which will be dropped in this release. 

## Test plan

🚀 
