### PR TITLE
Add `override` keyword to `TypeScript` part of codebase

### DIFF
--- a/apps/common-app/tsconfig.json
+++ b/apps/common-app/tsconfig.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": true,
     "baseUrl": ".",
+    "noImplicitOverride": false,
     "paths": {
       "@/*": ["./*"],
       "react-native-gesture-handler": [

--- a/packages/react-native-gesture-handler/src/components/DrawerLayout.tsx
+++ b/packages/react-native-gesture-handler/src/components/DrawerLayout.tsx
@@ -263,7 +263,10 @@ export default class DrawerLayout extends Component<
     this.updateAnimatedEvent(props, this.state);
   }
 
-  shouldComponentUpdate(props: DrawerLayoutProps, state: DrawerLayoutState) {
+  override shouldComponentUpdate(
+    props: DrawerLayoutProps,
+    state: DrawerLayoutState
+  ) {
     if (
       this.props.drawerPosition !== props.drawerPosition ||
       this.props.drawerWidth !== props.drawerWidth ||
@@ -719,7 +722,7 @@ export default class DrawerLayout extends Component<
     this.props.onGestureRef?.(ref);
   };
 
-  render() {
+  override render() {
     const { drawerPosition, drawerLockMode, edgeWidth, minSwipeDistance } =
       this.props;
 

--- a/packages/react-native-gesture-handler/src/components/GestureButtons.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureButtons.tsx
@@ -122,7 +122,7 @@ class InnerBaseButton extends React.Component<BaseButtonWithRefProps> {
     ); // TODO: maybe it is not correct
   };
 
-  render() {
+  override render() {
     const { rippleColor: unprocessedRippleColor, style, ...rest } = this.props;
 
     if (IS_FABRIC === null) {
@@ -190,7 +190,7 @@ class InnerRectButton extends React.Component<RectButtonWithRefProps> {
     this.props.onActiveStateChange?.(active);
   };
 
-  render() {
+  override render() {
     const { children, style, ...rest } = this.props;
 
     const resolvedStyle = StyleSheet.flatten(style) ?? {};
@@ -247,7 +247,7 @@ class InnerBorderlessButton extends React.Component<BorderlessButtonWithRefProps
     this.props.onActiveStateChange?.(active);
   };
 
-  render() {
+  override render() {
     const { children, style, innerRef, ...rest } = this.props;
 
     return (

--- a/packages/react-native-gesture-handler/src/components/Swipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Swipeable.tsx
@@ -257,7 +257,7 @@ export default class Swipeable extends Component<
     );
   }
 
-  shouldComponentUpdate(props: SwipeableProps, state: SwipeableState) {
+  override shouldComponentUpdate(props: SwipeableProps, state: SwipeableState) {
     if (
       this.props.friction !== props.friction ||
       this.props.overshootLeft !== props.overshootLeft ||
@@ -504,7 +504,7 @@ export default class Swipeable extends Component<
     this.setState({ rowState: 0 });
   };
 
-  render() {
+  override render() {
     const { rowState } = this.state;
     const {
       children,

--- a/packages/react-native-gesture-handler/src/components/touchables/GenericTouchable.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/GenericTouchable.tsx
@@ -115,7 +115,7 @@ export default class GenericTouchable extends Component<
     }
   }
 
-  componentDidMount() {
+  override componentDidMount() {
     this.reset();
   }
   // Reset timeout to prevent memory leaks.
@@ -204,7 +204,7 @@ export default class GenericTouchable extends Component<
     this.props.onLongPress?.();
   };
 
-  componentWillUnmount() {
+  override componentWillUnmount() {
     // To prevent memory leaks
     this.reset();
   }
@@ -225,7 +225,7 @@ export default class GenericTouchable extends Component<
     }
   }
 
-  render() {
+  override render() {
     const hitSlop =
       (typeof this.props.hitSlop === 'number'
         ? {

--- a/packages/react-native-gesture-handler/src/components/touchables/TouchableHighlight.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/TouchableHighlight.tsx
@@ -103,7 +103,7 @@ export default class TouchableHighlight extends Component<
     }
   };
 
-  render() {
+  override render() {
     const { style = {}, ...rest } = this.props;
     const { extraUnderlayStyle } = this.state;
     return (

--- a/packages/react-native-gesture-handler/src/components/touchables/TouchableNativeFeedback.android.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/TouchableNativeFeedback.android.tsx
@@ -70,7 +70,7 @@ export default class TouchableNativeFeedback extends Component<TouchableNativeFe
     extraProps['foreground'] = this.props.useForeground;
     return extraProps;
   }
-  render() {
+  override render() {
     const { style = {}, ...rest } = this.props;
     return (
       <GenericTouchable

--- a/packages/react-native-gesture-handler/src/components/touchables/TouchableOpacity.tsx
+++ b/packages/react-native-gesture-handler/src/components/touchables/TouchableOpacity.tsx
@@ -59,7 +59,7 @@ export default class TouchableOpacity extends Component<TouchableOpacityProps> {
     }
   };
 
-  render() {
+  override render() {
     const { style = {}, ...rest } = this.props;
     return (
       <GenericTouchable

--- a/packages/react-native-gesture-handler/src/handlers/ForceTouchGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/ForceTouchGestureHandler.ts
@@ -17,14 +17,14 @@ export const forceTouchGestureHandlerProps = [
 // implicit `children` prop has been removed in @types/react^18.0.0
 class ForceTouchFallback extends React.Component<PropsWithChildren<unknown>> {
   static forceTouchAvailable = false;
-  componentDidMount() {
+  override componentDidMount() {
     console.warn(
       tagMessage(
         'ForceTouchGestureHandler is not available on this platform. Please use ForceTouchGestureHandler.forceTouchAvailable to conditionally render other components that would provide a fallback behavior specific to your usecase'
       )
     );
   }
-  render() {
+  override render() {
     return this.props.children;
   }
 }

--- a/packages/react-native-gesture-handler/src/handlers/createHandler.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/createHandler.tsx
@@ -184,7 +184,7 @@ export default function createHandler<
     HandlerState
   > {
     static displayName = name;
-    static contextType = GestureHandlerRootViewContext;
+    static override contextType = GestureHandlerRootViewContext;
 
     private handlerTag = -1;
     private config: Record<string, unknown>;
@@ -208,7 +208,7 @@ export default function createHandler<
       }
     }
 
-    componentDidMount() {
+    override componentDidMount() {
       const props: HandlerProps<U> = this.props;
       this.isMountedRef.current = true;
 
@@ -250,7 +250,7 @@ export default function createHandler<
       this.attachGestureHandler(findNodeHandle(this.viewNode) as number); // TODO(TS) - check if this can be null
     }
 
-    componentDidUpdate() {
+    override componentDidUpdate() {
       const viewTag = findNodeHandle(this.viewNode);
       if (this.viewTag !== viewTag) {
         this.attachGestureHandler(viewTag as number); // TODO(TS) - check interaction between _viewTag & findNodeHandle
@@ -258,7 +258,7 @@ export default function createHandler<
       this.update(UNRESOLVED_REFS_RETRY_LIMIT);
     }
 
-    componentWillUnmount() {
+    override componentWillUnmount() {
       this.inspectorToggleListener?.remove();
       this.isMountedRef.current = false;
       if (Platform.OS !== 'web') {
@@ -442,7 +442,7 @@ export default function createHandler<
       this.updateGestureHandler(newConfig);
     }
 
-    render() {
+    override render() {
       if (__DEV__ && !this.context && !isTestEnv() && Platform.OS !== 'web') {
         throw new Error(
           name +

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/Wrap.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/Wrap.tsx
@@ -7,7 +7,7 @@ export class Wrap extends React.Component<{
   // Implicit `children` prop has been removed in @types/react^18.0.0
   children?: React.ReactNode;
 }> {
-  render() {
+  override render() {
     try {
       // I don't think that fighting with types over such a simple function is worth it
       // The only thing it does is add 'collapsable: false' to the child component

--- a/packages/react-native-gesture-handler/src/handlers/gestures/flingGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/flingGesture.ts
@@ -3,7 +3,7 @@ import { FlingGestureConfig } from '../FlingGestureHandler';
 import type { FlingGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
 
 export class FlingGesture extends BaseGesture<FlingGestureHandlerEventPayload> {
-  public config: BaseGestureConfig & FlingGestureConfig = {};
+  public override config: BaseGestureConfig & FlingGestureConfig = {};
 
   constructor() {
     super();

--- a/packages/react-native-gesture-handler/src/handlers/gestures/forceTouchGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/forceTouchGesture.ts
@@ -36,7 +36,7 @@ export class ForceTouchGesture extends ContinousBaseGesture<
   ForceTouchGestureHandlerEventPayload,
   ForceTouchGestureChangeEventPayload
 > {
-  public config: BaseGestureConfig & ForceTouchGestureConfig = {};
+  public override config: BaseGestureConfig & ForceTouchGestureConfig = {};
 
   constructor() {
     super();
@@ -73,7 +73,7 @@ export class ForceTouchGesture extends ContinousBaseGesture<
     return this;
   }
 
-  onChange(
+  override onChange(
     callback: (
       event: GestureUpdateEvent<
         GestureUpdateEvent<

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureComposition.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureComposition.ts
@@ -70,7 +70,7 @@ export class ComposedGesture extends Gesture {
 }
 
 export class SimultaneousGesture extends ComposedGesture {
-  prepare() {
+  override prepare() {
     // This piece of magic works something like this:
     // for every gesture in the array
     const simultaneousArrays = this.gestures.map((gesture) =>
@@ -96,7 +96,7 @@ export class SimultaneousGesture extends ComposedGesture {
 }
 
 export class ExclusiveGesture extends ComposedGesture {
-  prepare() {
+  override prepare() {
     // Transforms the array of gestures into array of grouped raw (not composed) gestures
     // i.e. [gesture1, gesture2, ComposedGesture(gesture3, gesture4)] -> [[gesture1], [gesture2], [gesture3, gesture4]]
     const gestureArrays = this.gestures.map((gesture) =>

--- a/packages/react-native-gesture-handler/src/handlers/gestures/hoverGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/hoverGesture.ts
@@ -44,7 +44,7 @@ export class HoverGesture extends ContinousBaseGesture<
   HoverGestureHandlerEventPayload,
   HoverGestureChangeEventPayload
 > {
-  public config: BaseGestureConfig & HoverGestureConfig = {};
+  public override config: BaseGestureConfig & HoverGestureConfig = {};
 
   constructor() {
     super();
@@ -61,7 +61,7 @@ export class HoverGesture extends ContinousBaseGesture<
     return this;
   }
 
-  onChange(
+  override onChange(
     callback: (
       event: GestureUpdateEvent<
         HoverGestureHandlerEventPayload & HoverGestureChangeEventPayload

--- a/packages/react-native-gesture-handler/src/handlers/gestures/longPressGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/longPressGesture.ts
@@ -3,7 +3,7 @@ import { LongPressGestureConfig } from '../LongPressGestureHandler';
 import type { LongPressGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
 
 export class LongPressGesture extends BaseGesture<LongPressGestureHandlerEventPayload> {
-  public config: BaseGestureConfig & LongPressGestureConfig = {};
+  public override config: BaseGestureConfig & LongPressGestureConfig = {};
 
   constructor() {
     super();

--- a/packages/react-native-gesture-handler/src/handlers/gestures/manualGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/manualGesture.ts
@@ -19,7 +19,7 @@ export class ManualGesture extends ContinousBaseGesture<
     this.handlerName = 'ManualGestureHandler';
   }
 
-  onChange(
+  override onChange(
     callback: (event: GestureUpdateEvent<Record<string, never>>) => void
   ) {
     // @ts-ignore TS being overprotective, Record<string, never> is Record

--- a/packages/react-native-gesture-handler/src/handlers/gestures/nativeGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/nativeGesture.ts
@@ -3,7 +3,7 @@ import { NativeViewGestureConfig } from '../NativeViewGestureHandler';
 import type { NativeViewGestureHandlerPayload } from '../GestureHandlerEventPayload';
 
 export class NativeGesture extends BaseGesture<NativeViewGestureHandlerPayload> {
-  public config: BaseGestureConfig & NativeViewGestureConfig = {};
+  public override config: BaseGestureConfig & NativeViewGestureConfig = {};
 
   constructor() {
     super();

--- a/packages/react-native-gesture-handler/src/handlers/gestures/panGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/panGesture.ts
@@ -33,7 +33,7 @@ export class PanGesture extends ContinousBaseGesture<
   PanGestureHandlerEventPayload,
   PanGestureChangeEventPayload
 > {
-  public config: BaseGestureConfig & PanGestureConfig = {};
+  public override config: BaseGestureConfig & PanGestureConfig = {};
 
   constructor() {
     super();
@@ -205,7 +205,7 @@ export class PanGesture extends ContinousBaseGesture<
     return this;
   }
 
-  onChange(
+  override onChange(
     callback: (
       event: GestureUpdateEvent<
         PanGestureHandlerEventPayload & PanGestureChangeEventPayload

--- a/packages/react-native-gesture-handler/src/handlers/gestures/pinchGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/pinchGesture.ts
@@ -35,7 +35,7 @@ export class PinchGesture extends ContinousBaseGesture<
     this.handlerName = 'PinchGestureHandler';
   }
 
-  onChange(
+  override onChange(
     callback: (
       event: GestureUpdateEvent<
         PinchGestureHandlerEventPayload & PinchGestureChangeEventPayload

--- a/packages/react-native-gesture-handler/src/handlers/gestures/rotationGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/rotationGesture.ts
@@ -35,7 +35,7 @@ export class RotationGesture extends ContinousBaseGesture<
     this.handlerName = 'RotationGestureHandler';
   }
 
-  onChange(
+  override onChange(
     callback: (
       event: GestureUpdateEvent<
         RotationGestureHandlerEventPayload & RotationGestureChangeEventPayload

--- a/packages/react-native-gesture-handler/src/handlers/gestures/tapGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/tapGesture.ts
@@ -3,7 +3,7 @@ import { TapGestureConfig } from '../TapGestureHandler';
 import type { TapGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
 
 export class TapGesture extends BaseGesture<TapGestureHandlerEventPayload> {
-  public config: BaseGestureConfig & TapGestureConfig = {};
+  public override config: BaseGestureConfig & TapGestureConfig = {};
 
   constructor() {
     super();

--- a/packages/react-native-gesture-handler/src/web/handlers/FlingGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/FlingGestureHandler.ts
@@ -26,7 +26,10 @@ export default class FlingGestureHandler extends GestureHandler {
   private maxNumberOfPointersSimultaneously = 0;
   private keyPointer = NaN;
 
-  public updateGestureConfig({ enabled = true, ...props }: Config): void {
+  public override updateGestureConfig({
+    enabled = true,
+    ...props
+  }: Config): void {
     super.updateGestureConfig({ enabled: enabled, ...props });
 
     if (this.config.direction) {
@@ -104,7 +107,7 @@ export default class FlingGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerDown(event: AdaptedEvent): void {
+  protected override onPointerDown(event: AdaptedEvent): void {
     if (!this.isButtonInConfig(event.button)) {
       return;
     }
@@ -118,7 +121,7 @@ export default class FlingGestureHandler extends GestureHandler {
     this.tryToSendTouchEvent(event);
   }
 
-  protected onPointerAdd(event: AdaptedEvent): void {
+  protected override onPointerAdd(event: AdaptedEvent): void {
     this.tracker.addToTracker(event);
     super.onPointerAdd(event);
     this.newPointerAction();
@@ -153,24 +156,24 @@ export default class FlingGestureHandler extends GestureHandler {
     this.tryEndFling();
   }
 
-  protected onPointerMove(event: AdaptedEvent): void {
+  protected override onPointerMove(event: AdaptedEvent): void {
     this.pointerMoveAction(event);
     super.onPointerMove(event);
   }
 
-  protected onPointerOutOfBounds(event: AdaptedEvent): void {
+  protected override onPointerOutOfBounds(event: AdaptedEvent): void {
     this.pointerMoveAction(event);
     super.onPointerOutOfBounds(event);
   }
 
-  protected onPointerUp(event: AdaptedEvent): void {
+  protected override onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
     this.onUp(event);
 
     this.keyPointer = NaN;
   }
 
-  protected onPointerRemove(event: AdaptedEvent): void {
+  protected override onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
     this.onUp(event);
   }
@@ -183,12 +186,12 @@ export default class FlingGestureHandler extends GestureHandler {
     this.tracker.removeFromTracker(event.pointerId);
   }
 
-  public activate(force?: boolean): void {
+  public override activate(force?: boolean): void {
     super.activate(force);
     this.end();
   }
 
-  protected resetConfig(): void {
+  protected override resetConfig(): void {
     super.resetConfig();
     this.numberOfPointersRequired = DEFAULT_NUMBER_OF_TOUCHES_REQUIRED;
     this.direction = DEFAULT_DIRECTION;

--- a/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/HoverGestureHandler.ts
@@ -6,14 +6,14 @@ import GestureHandler from './GestureHandler';
 export default class HoverGestureHandler extends GestureHandler {
   private stylusData: StylusData | undefined;
 
-  protected transformNativeEvent(): Record<string, unknown> {
+  protected override transformNativeEvent(): Record<string, unknown> {
     return {
       ...super.transformNativeEvent(),
       stylusData: this.stylusData,
     };
   }
 
-  protected onPointerMoveOver(event: AdaptedEvent): void {
+  protected override onPointerMoveOver(event: AdaptedEvent): void {
     GestureHandlerOrchestrator.instance.recordHandlerIfNotPresent(this);
 
     this.tracker.addToTracker(event);
@@ -26,7 +26,7 @@ export default class HoverGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerMoveOut(event: AdaptedEvent): void {
+  protected override onPointerMoveOut(event: AdaptedEvent): void {
     this.tracker.removeFromTracker(event.pointerId);
     this.stylusData = event.stylusData;
 
@@ -35,14 +35,14 @@ export default class HoverGestureHandler extends GestureHandler {
     this.end();
   }
 
-  protected onPointerMove(event: AdaptedEvent): void {
+  protected override onPointerMove(event: AdaptedEvent): void {
     this.tracker.track(event);
     this.stylusData = event.stylusData;
 
     super.onPointerMove(event);
   }
 
-  protected onPointerCancel(event: AdaptedEvent): void {
+  protected override onPointerCancel(event: AdaptedEvent): void {
     super.onPointerCancel(event);
     this.reset();
   }

--- a/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
@@ -22,7 +22,7 @@ export default class LongPressGestureHandler extends GestureHandler {
 
   private activationTimeout: number | undefined;
 
-  public init(
+  public override init(
     ref: number,
     propsRef: React.RefObject<PropsRef>,
     actionType: ActionType
@@ -34,14 +34,17 @@ export default class LongPressGestureHandler extends GestureHandler {
     super.init(ref, propsRef, actionType);
   }
 
-  protected transformNativeEvent() {
+  protected override transformNativeEvent() {
     return {
       ...super.transformNativeEvent(),
       duration: Date.now() - this.startTime,
     };
   }
 
-  public updateGestureConfig({ enabled = true, ...props }: Config): void {
+  public override updateGestureConfig({
+    enabled = true,
+    ...props
+  }: Config): void {
     super.updateGestureConfig({ enabled: enabled, ...props });
 
     if (this.config.minDurationMs !== undefined) {
@@ -57,17 +60,17 @@ export default class LongPressGestureHandler extends GestureHandler {
     }
   }
 
-  protected resetConfig(): void {
+  protected override resetConfig(): void {
     super.resetConfig();
     this.minDurationMs = DEFAULT_MIN_DURATION_MS;
     this.maxDistSq = this.defaultMaxDistSq;
   }
 
-  protected onStateChange(_newState: State, _oldState: State): void {
+  protected override onStateChange(_newState: State, _oldState: State): void {
     clearTimeout(this.activationTimeout);
   }
 
-  protected onPointerDown(event: AdaptedEvent): void {
+  protected override onPointerDown(event: AdaptedEvent): void {
     if (!this.isButtonInConfig(event.button)) {
       return;
     }
@@ -83,7 +86,7 @@ export default class LongPressGestureHandler extends GestureHandler {
 
     this.tryToSendTouchEvent(event);
   }
-  protected onPointerAdd(event: AdaptedEvent): void {
+  protected override onPointerAdd(event: AdaptedEvent): void {
     super.onPointerAdd(event);
     this.tracker.addToTracker(event);
 
@@ -100,19 +103,19 @@ export default class LongPressGestureHandler extends GestureHandler {
     this.tryActivate();
   }
 
-  protected onPointerMove(event: AdaptedEvent): void {
+  protected override onPointerMove(event: AdaptedEvent): void {
     super.onPointerMove(event);
     this.tracker.track(event);
     this.checkDistanceFail();
   }
 
-  protected onPointerOutOfBounds(event: AdaptedEvent): void {
+  protected override onPointerOutOfBounds(event: AdaptedEvent): void {
     super.onPointerOutOfBounds(event);
     this.tracker.track(event);
     this.checkDistanceFail();
   }
 
-  protected onPointerUp(event: AdaptedEvent): void {
+  protected override onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
     this.tracker.removeFromTracker(event.pointerId);
 
@@ -123,7 +126,7 @@ export default class LongPressGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerRemove(event: AdaptedEvent): void {
+  protected override onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
     this.tracker.removeFromTracker(event.pointerId);
 

--- a/packages/react-native-gesture-handler/src/web/handlers/ManualGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/ManualGestureHandler.ts
@@ -2,7 +2,7 @@ import { AdaptedEvent } from '../interfaces';
 import GestureHandler from './GestureHandler';
 
 export default class ManualGestureHandler extends GestureHandler {
-  protected onPointerDown(event: AdaptedEvent): void {
+  protected override onPointerDown(event: AdaptedEvent): void {
     this.tracker.addToTracker(event);
     super.onPointerDown(event);
     this.begin();
@@ -10,27 +10,27 @@ export default class ManualGestureHandler extends GestureHandler {
     this.tryToSendTouchEvent(event);
   }
 
-  protected onPointerAdd(event: AdaptedEvent): void {
+  protected override onPointerAdd(event: AdaptedEvent): void {
     this.tracker.addToTracker(event);
     super.onPointerAdd(event);
   }
 
-  protected onPointerMove(event: AdaptedEvent): void {
+  protected override onPointerMove(event: AdaptedEvent): void {
     this.tracker.track(event);
     super.onPointerMove(event);
   }
 
-  protected onPointerOutOfBounds(event: AdaptedEvent): void {
+  protected override onPointerOutOfBounds(event: AdaptedEvent): void {
     this.tracker.track(event);
     super.onPointerOutOfBounds(event);
   }
 
-  protected onPointerUp(event: AdaptedEvent): void {
+  protected override onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
     this.tracker.removeFromTracker(event.pointerId);
   }
 
-  protected onPointerRemove(event: AdaptedEvent): void {
+  protected override onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
     this.tracker.removeFromTracker(event.pointerId);
   }

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -17,7 +17,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
   private startY = 0;
   private minDistSq = DEFAULT_TOUCH_SLOP * DEFAULT_TOUCH_SLOP;
 
-  public init(
+  public override init(
     ref: number,
     propsRef: React.RefObject<PropsRef>,
     actionType: ActionType
@@ -36,7 +36,10 @@ export default class NativeViewGestureHandler extends GestureHandler {
     this.buttonRole = view.getAttribute('role') === 'button';
   }
 
-  public updateGestureConfig({ enabled = true, ...props }: Config): void {
+  public override updateGestureConfig({
+    enabled = true,
+    ...props
+  }: Config): void {
     super.updateGestureConfig({ enabled: enabled, ...props });
 
     if (this.config.shouldActivateOnStart !== undefined) {
@@ -60,7 +63,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
     view.style['WebkitTouchCallout'] = 'auto';
   }
 
-  protected onPointerDown(event: AdaptedEvent): void {
+  protected override onPointerDown(event: AdaptedEvent): void {
     this.tracker.addToTracker(event);
     super.onPointerDown(event);
     this.newPointerAction();
@@ -68,7 +71,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
     this.tryToSendTouchEvent(event);
   }
 
-  protected onPointerAdd(event: AdaptedEvent): void {
+  protected override onPointerAdd(event: AdaptedEvent): void {
     this.tracker.addToTracker(event);
     super.onPointerAdd(event);
     this.newPointerAction();
@@ -93,7 +96,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerMove(event: AdaptedEvent): void {
+  protected override onPointerMove(event: AdaptedEvent): void {
     this.tracker.track(event);
 
     const lastCoords = this.tracker.getAbsoluteCoordsAverage();
@@ -110,18 +113,18 @@ export default class NativeViewGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerLeave(): void {
+  protected override onPointerLeave(): void {
     if (this.state === State.BEGAN || this.state === State.ACTIVE) {
       this.cancel();
     }
   }
 
-  protected onPointerUp(event: AdaptedEvent): void {
+  protected override onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
     this.onUp(event);
   }
 
-  protected onPointerRemove(event: AdaptedEvent): void {
+  protected override onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
     this.onUp(event);
   }
@@ -138,7 +141,9 @@ export default class NativeViewGestureHandler extends GestureHandler {
     }
   }
 
-  public shouldRecognizeSimultaneously(handler: GestureHandler): boolean {
+  public override shouldRecognizeSimultaneously(
+    handler: GestureHandler
+  ): boolean {
     if (super.shouldRecognizeSimultaneously(handler)) {
       return true;
     }
@@ -166,7 +171,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
     );
   }
 
-  public shouldBeCancelledByOther(_handler: GestureHandler): boolean {
+  public override shouldBeCancelledByOther(_handler: GestureHandler): boolean {
     return !this.disallowInterruption;
   }
 

--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -61,7 +61,10 @@ export default class PanGestureHandler extends GestureHandler {
   private endWheelTimeout = 0;
   private wheelDevice = WheelDevice.UNDETERMINED;
 
-  public updateGestureConfig({ enabled = true, ...props }: Config): void {
+  public override updateGestureConfig({
+    enabled = true,
+    ...props
+  }: Config): void {
     this.resetConfig();
 
     super.updateGestureConfig({ enabled: enabled, ...props });
@@ -168,7 +171,7 @@ export default class PanGestureHandler extends GestureHandler {
     }
   }
 
-  protected resetConfig(): void {
+  protected override resetConfig(): void {
     super.resetConfig();
 
     this.activeOffsetXStart = -Number.MAX_SAFE_INTEGER;
@@ -193,7 +196,7 @@ export default class PanGestureHandler extends GestureHandler {
     this.activateAfterLongPress = 0;
   }
 
-  protected transformNativeEvent() {
+  protected override transformNativeEvent() {
     const translationX: number = this.getTranslationX();
     const translationY: number = this.getTranslationY();
 
@@ -233,7 +236,7 @@ export default class PanGestureHandler extends GestureHandler {
   }
 
   // Events Handling
-  protected onPointerDown(event: AdaptedEvent): void {
+  protected override onPointerDown(event: AdaptedEvent): void {
     if (!this.isButtonInConfig(event.button)) {
       return;
     }
@@ -254,7 +257,7 @@ export default class PanGestureHandler extends GestureHandler {
     this.tryToSendTouchEvent(event);
   }
 
-  protected onPointerAdd(event: AdaptedEvent): void {
+  protected override onPointerAdd(event: AdaptedEvent): void {
     this.tracker.addToTracker(event);
     super.onPointerAdd(event);
     this.tryBegin(event);
@@ -278,7 +281,7 @@ export default class PanGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerUp(event: AdaptedEvent): void {
+  protected override onPointerUp(event: AdaptedEvent): void {
     this.stylusData = event.stylusData;
 
     super.onPointerUp(event);
@@ -302,7 +305,7 @@ export default class PanGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerRemove(event: AdaptedEvent): void {
+  protected override onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
     this.tracker.removeFromTracker(event.pointerId);
 
@@ -324,7 +327,7 @@ export default class PanGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerMove(event: AdaptedEvent): void {
+  protected override onPointerMove(event: AdaptedEvent): void {
     this.tracker.track(event);
     this.stylusData = event.stylusData;
 
@@ -336,7 +339,7 @@ export default class PanGestureHandler extends GestureHandler {
     super.onPointerMove(event);
   }
 
-  protected onPointerOutOfBounds(event: AdaptedEvent): void {
+  protected override onPointerOutOfBounds(event: AdaptedEvent): void {
     if (this.shouldCancelWhenOutside) {
       return;
     }
@@ -368,7 +371,7 @@ export default class PanGestureHandler extends GestureHandler {
     }, 30);
   }
 
-  protected onWheel(event: AdaptedEvent): void {
+  protected override onWheel(event: AdaptedEvent): void {
     if (
       this.wheelDevice === WheelDevice.MOUSE ||
       !this.enableTrackpadTwoFingerGesture
@@ -545,7 +548,7 @@ export default class PanGestureHandler extends GestureHandler {
     }
   }
 
-  public activate(force = false): void {
+  public override activate(force = false): void {
     if (this.state !== State.ACTIVE) {
       this.resetProgress();
     }
@@ -553,15 +556,15 @@ export default class PanGestureHandler extends GestureHandler {
     super.activate(force);
   }
 
-  protected onCancel(): void {
+  protected override onCancel(): void {
     this.clearActivationTimeout();
   }
 
-  protected onReset(): void {
+  protected override onReset(): void {
     this.clearActivationTimeout();
   }
 
-  protected resetProgress(): void {
+  protected override resetProgress(): void {
     if (this.state === State.ACTIVE) {
       return;
     }

--- a/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PinchGestureHandler.ts
@@ -49,7 +49,7 @@ export default class PinchGestureHandler extends GestureHandler {
     this.scaleDetectorListener
   );
 
-  public init(
+  public override init(
     ref: number,
     propsRef: React.RefObject<PropsRef>,
     actionType: ActionType
@@ -59,7 +59,7 @@ export default class PinchGestureHandler extends GestureHandler {
     this.shouldCancelWhenOutside = false;
   }
 
-  protected transformNativeEvent() {
+  protected override transformNativeEvent() {
     return {
       focalX: this.scaleGestureDetector.focusX,
       focalY: this.scaleGestureDetector.focusY,
@@ -68,21 +68,21 @@ export default class PinchGestureHandler extends GestureHandler {
     };
   }
 
-  protected onPointerDown(event: AdaptedEvent): void {
+  protected override onPointerDown(event: AdaptedEvent): void {
     this.tracker.addToTracker(event);
     super.onPointerDown(event);
 
     this.tryToSendTouchEvent(event);
   }
 
-  protected onPointerAdd(event: AdaptedEvent): void {
+  protected override onPointerAdd(event: AdaptedEvent): void {
     this.tracker.addToTracker(event);
     super.onPointerAdd(event);
     this.tryBegin();
     this.scaleGestureDetector.onTouchEvent(event, this.tracker);
   }
 
-  protected onPointerUp(event: AdaptedEvent): void {
+  protected override onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
     this.tracker.removeFromTracker(event.pointerId);
     if (this.state !== State.ACTIVE) {
@@ -97,7 +97,7 @@ export default class PinchGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerRemove(event: AdaptedEvent): void {
+  protected override onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
     this.scaleGestureDetector.onTouchEvent(event, this.tracker);
     this.tracker.removeFromTracker(event.pointerId);
@@ -107,7 +107,7 @@ export default class PinchGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerMove(event: AdaptedEvent): void {
+  protected override onPointerMove(event: AdaptedEvent): void {
     if (this.tracker.trackedPointersCount < 2) {
       return;
     }
@@ -116,7 +116,7 @@ export default class PinchGestureHandler extends GestureHandler {
     this.scaleGestureDetector.onTouchEvent(event, this.tracker);
     super.onPointerMove(event);
   }
-  protected onPointerOutOfBounds(event: AdaptedEvent): void {
+  protected override onPointerOutOfBounds(event: AdaptedEvent): void {
     if (this.tracker.trackedPointersCount < 2) {
       return;
     }
@@ -135,7 +135,7 @@ export default class PinchGestureHandler extends GestureHandler {
     this.begin();
   }
 
-  public activate(force?: boolean): void {
+  public override activate(force?: boolean): void {
     if (this.state !== State.ACTIVE) {
       this.resetProgress();
     }
@@ -143,11 +143,11 @@ export default class PinchGestureHandler extends GestureHandler {
     super.activate(force);
   }
 
-  protected onReset(): void {
+  protected override onReset(): void {
     this.resetProgress();
   }
 
-  protected resetProgress(): void {
+  protected override resetProgress(): void {
     if (this.state === State.ACTIVE) {
       return;
     }

--- a/packages/react-native-gesture-handler/src/web/handlers/RotationGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/RotationGestureHandler.ts
@@ -45,7 +45,7 @@ export default class RotationGestureHandler extends GestureHandler {
   private rotationGestureDetector: RotationGestureDetector =
     new RotationGestureDetector(this.rotationGestureListener);
 
-  public init(
+  public override init(
     ref: number,
     propsRef: React.RefObject<PropsRef>,
     actionType: ActionType
@@ -55,7 +55,7 @@ export default class RotationGestureHandler extends GestureHandler {
     this.shouldCancelWhenOutside = false;
   }
 
-  protected transformNativeEvent() {
+  protected override transformNativeEvent() {
     return {
       rotation: this.rotation ? this.rotation : 0,
       anchorX: this.getAnchorX(),
@@ -76,14 +76,14 @@ export default class RotationGestureHandler extends GestureHandler {
     return anchorY ? anchorY : this.cachedAnchorY;
   }
 
-  protected onPointerDown(event: AdaptedEvent): void {
+  protected override onPointerDown(event: AdaptedEvent): void {
     this.tracker.addToTracker(event);
     super.onPointerDown(event);
 
     this.tryToSendTouchEvent(event);
   }
 
-  protected onPointerAdd(event: AdaptedEvent): void {
+  protected override onPointerAdd(event: AdaptedEvent): void {
     this.tracker.addToTracker(event);
     super.onPointerAdd(event);
 
@@ -91,7 +91,7 @@ export default class RotationGestureHandler extends GestureHandler {
     this.rotationGestureDetector.onTouchEvent(event, this.tracker);
   }
 
-  protected onPointerMove(event: AdaptedEvent): void {
+  protected override onPointerMove(event: AdaptedEvent): void {
     if (this.tracker.trackedPointersCount < 2) {
       return;
     }
@@ -110,7 +110,7 @@ export default class RotationGestureHandler extends GestureHandler {
     super.onPointerMove(event);
   }
 
-  protected onPointerOutOfBounds(event: AdaptedEvent): void {
+  protected override onPointerOutOfBounds(event: AdaptedEvent): void {
     if (this.tracker.trackedPointersCount < 2) {
       return;
     }
@@ -129,7 +129,7 @@ export default class RotationGestureHandler extends GestureHandler {
     super.onPointerOutOfBounds(event);
   }
 
-  protected onPointerUp(event: AdaptedEvent): void {
+  protected override onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
     this.tracker.removeFromTracker(event.pointerId);
     this.rotationGestureDetector.onTouchEvent(event, this.tracker);
@@ -145,7 +145,7 @@ export default class RotationGestureHandler extends GestureHandler {
     }
   }
 
-  protected onPointerRemove(event: AdaptedEvent): void {
+  protected override onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
     this.rotationGestureDetector.onTouchEvent(event, this.tracker);
     this.tracker.removeFromTracker(event.pointerId);
@@ -159,7 +159,7 @@ export default class RotationGestureHandler extends GestureHandler {
     this.begin();
   }
 
-  protected onReset(): void {
+  protected override onReset(): void {
     if (this.state === State.ACTIVE) {
       return;
     }

--- a/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
@@ -31,7 +31,10 @@ export default class TapGestureHandler extends GestureHandler {
 
   private tapsSoFar = 0;
 
-  public updateGestureConfig({ enabled = true, ...props }: Config): void {
+  public override updateGestureConfig({
+    enabled = true,
+    ...props
+  }: Config): void {
     super.updateGestureConfig({ enabled: enabled, ...props });
 
     if (this.config.numberOfTaps !== undefined) {
@@ -63,7 +66,7 @@ export default class TapGestureHandler extends GestureHandler {
     }
   }
 
-  protected resetConfig(): void {
+  protected override resetConfig(): void {
     super.resetConfig();
 
     this.maxDeltaX = Number.MIN_SAFE_INTEGER;
@@ -107,7 +110,7 @@ export default class TapGestureHandler extends GestureHandler {
   }
 
   // Handling Events
-  protected onPointerDown(event: AdaptedEvent): void {
+  protected override onPointerDown(event: AdaptedEvent): void {
     if (!this.isButtonInConfig(event.button)) {
       return;
     }
@@ -128,7 +131,7 @@ export default class TapGestureHandler extends GestureHandler {
     this.tryToSendTouchEvent(event);
   }
 
-  protected onPointerAdd(event: AdaptedEvent): void {
+  protected override onPointerAdd(event: AdaptedEvent): void {
     super.onPointerAdd(event);
     this.tracker.addToTracker(event);
     this.trySettingPosition(event);
@@ -144,7 +147,7 @@ export default class TapGestureHandler extends GestureHandler {
     this.updateState(event);
   }
 
-  protected onPointerUp(event: AdaptedEvent): void {
+  protected override onPointerUp(event: AdaptedEvent): void {
     super.onPointerUp(event);
 
     this.updateLastCoords();
@@ -154,7 +157,7 @@ export default class TapGestureHandler extends GestureHandler {
     this.updateState(event);
   }
 
-  protected onPointerRemove(event: AdaptedEvent): void {
+  protected override onPointerRemove(event: AdaptedEvent): void {
     super.onPointerRemove(event);
     this.tracker.removeFromTracker(event.pointerId);
 
@@ -169,7 +172,7 @@ export default class TapGestureHandler extends GestureHandler {
     this.updateState(event);
   }
 
-  protected onPointerMove(event: AdaptedEvent): void {
+  protected override onPointerMove(event: AdaptedEvent): void {
     this.trySettingPosition(event);
     this.tracker.track(event);
 
@@ -179,7 +182,7 @@ export default class TapGestureHandler extends GestureHandler {
     super.onPointerMove(event);
   }
 
-  protected onPointerOutOfBounds(event: AdaptedEvent): void {
+  protected override onPointerOutOfBounds(event: AdaptedEvent): void {
     this.trySettingPosition(event);
     this.tracker.track(event);
 
@@ -255,18 +258,18 @@ export default class TapGestureHandler extends GestureHandler {
     );
   }
 
-  public activate(): void {
+  public override activate(): void {
     super.activate();
 
     this.end();
   }
 
-  protected onCancel(): void {
+  protected override onCancel(): void {
     this.resetProgress();
     this.clearTimeouts();
   }
 
-  protected resetProgress(): void {
+  protected override resetProgress(): void {
     this.clearTimeouts();
     this.tapsSoFar = 0;
     this.currentMaxNumberOfPointers = 0;

--- a/packages/react-native-gesture-handler/src/web/tools/PointerEventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/PointerEventManager.ts
@@ -219,7 +219,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
     };
   }
 
-  public resetManager(): void {
+  public override resetManager(): void {
     super.resetManager();
     this.trackedPointers.clear();
   }

--- a/packages/react-native-gesture-handler/src/web/tools/WheelEventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/WheelEventManager.ts
@@ -42,7 +42,7 @@ export default class WheelEventManager extends EventManager<HTMLElement> {
     };
   }
 
-  public resetManager(): void {
+  public override resetManager(): void {
     super.resetManager();
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
     "noStrictGenericChecks": false,
     "forceConsistentCasingInFileNames": true,
     "noImplicitUseStrict": false,
+    "noImplicitOverride": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true
   }


### PR DESCRIPTION
## Description

This PR adds `override` keyword to part of our codebase that is written in `TypeScript`. I think it will improve readability and some cases will be easier to understand.

It also enables `noImplicitOverride` flag in ts compiler, which means that `override` keyword is mandatory when overriding a method. 

## Test plan

Run example app