### PR TITLE
[Web] Bind `SharedValues` in handler config

### DIFF
--- a/packages/react-native-gesture-handler/src/RNGestureHandlerModule.web.ts
+++ b/packages/react-native-gesture-handler/src/RNGestureHandlerModule.web.ts
@@ -74,15 +74,15 @@ export default {
     NodeManager.detachGestureHandler(handlerTag);
   },
   setGestureHandlerConfig(handlerTag: number, newConfig: Config) {
-    NodeManager.getHandler(handlerTag).updateGestureConfig(newConfig);
+    NodeManager.getHandler(handlerTag).setGestureConfig(newConfig);
 
     InteractionManager.instance.configureInteractions(
       NodeManager.getHandler(handlerTag),
       newConfig
     );
   },
-  updateGestureHandlerConfig(_handlerTag: number, _newConfig: Config) {
-    // TODO: To be implemented
+  updateGestureHandlerConfig(handlerTag: number, newConfig: Config) {
+    NodeManager.getHandler(handlerTag).updateGestureConfig(newConfig);
   },
   getGestureHandlerNode(handlerTag: number) {
     return NodeManager.getHandler(handlerTag);

--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -614,6 +614,11 @@ export default abstract class GestureHandler implements IGestureHandler {
   // Handling config
   //
 
+  public setGestureConfig(config: Config) {
+    this.resetConfig();
+    this.updateGestureConfig(config);
+  }
+
   public updateGestureConfig({
     enabled = true,
     dispatchesAnimatedEvents = false,

--- a/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
@@ -45,6 +45,7 @@ export default interface IGestureHandler {
 
   sendEvent: (newState: State, oldState: State) => void;
 
+  setGestureConfig: (config: Config) => void;
   updateGestureConfig: (config: Config) => void;
 
   isButton?: () => boolean;


### PR DESCRIPTION
## Description

Following #3658, this PR introduces web version of `SharedValue` bindings to config. This will allow users to specify values in config as SharedValues, e.g

```ts
const taps = useSharedValue(2);

const gesture = useGesture('TapGestureHandler', {
  onEnd: () => {
    console.log('Tap detected. Required number of taps:', taps.value);
    taps.set(taps.value + 1);
  },
  numberOfTaps: taps,
});
```
## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import * as React from 'react';
import { Animated, Button } from 'react-native';
import { useSharedValue } from 'react-native-reanimated';
import {
  GestureHandlerRootView,
  NativeDetector,
  useGesture,
} from 'react-native-gesture-handler';

export default function App() {
  const [visible, setVisible] = React.useState(true);
  const taps = useSharedValue(2);

  const gesture = useGesture('TapGestureHandler', {
    onEnd: () => {
      console.log('Tap detected. Required number of taps:', taps.value);
      taps.set(taps.value + 1);
    },
    numberOfTaps: taps,
  });

  return (
    <GestureHandlerRootView
      style={{ flex: 1, backgroundColor: 'white', paddingTop: 8 }}>
      <Button
        title="Toggle visibility"
        onPress={() => {
          setVisible(!visible);
        }}
      />

      {visible && (
        <NativeDetector gesture={gesture}>
          <Animated.View
            style={[
              {
                width: 150,
                height: 150,
                backgroundColor: 'blue',
                opacity: 0.5,
                borderWidth: 10,
                borderColor: 'green',
                marginTop: 20,
                marginLeft: 40,
              },
            ]}
          />
        </NativeDetector>
      )}
    </GestureHandlerRootView>
  );
}
```

</details>