### PR TITLE
Fix `"build MacOS"` CI taking a long time to complete

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -16,7 +16,7 @@ jobs:
   build:
     if: github.repository == 'software-mansion/react-native-gesture-handler'
 
-    runs-on: macos-15
+    runs-on: macos-15-xlarge
     env:
       WORKING_DIRECTORY: apps/macos-example
     concurrency:


### PR DESCRIPTION
## Description

This PR fixes the MacOS CI taking a long time to build by forcing the usage of a faster runner.

This change reduces the MacOS build times from `40-60` minutes to just under `5` minutes.

Just from casual calculations, this should also reduce per-build cost from around `$4` to `$0.8` (`50 * $0.08` vs `5 * $0.16`)

## Test plan

- wait for the CIs to pass
