### PR TITLE
Bump Reanimated in `expo-example`

### DIFF
--- a/apps/expo-example/package.json
+++ b/apps/expo-example/package.json
@@ -27,11 +27,12 @@
     "react-dom": "19.1.0",
     "react-native": "0.81.0",
     "react-native-gesture-handler": "workspace:*",
-    "react-native-reanimated": "^3.19.1",
+    "react-native-reanimated": "^4.0.2",
     "react-native-safe-area-context": "~5.6.0",
     "react-native-screens": "~4.14.0",
     "react-native-svg": "15.12.1",
-    "react-native-web": "^0.21.0"
+    "react-native-web": "^0.21.0",
+    "react-native-worklets": "^0.4.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8392,11 +8392,12 @@ __metadata:
     react-dom: "npm:19.1.0"
     react-native: "npm:0.81.0"
     react-native-gesture-handler: "workspace:*"
-    react-native-reanimated: "npm:^3.19.1"
+    react-native-reanimated: "npm:^4.0.2"
     react-native-safe-area-context: "npm:~5.6.0"
     react-native-screens: "npm:~4.14.0"
     react-native-svg: "npm:15.12.1"
     react-native-web: "npm:^0.21.0"
+    react-native-worklets: "npm:^0.4.0"
     typescript: "npm:~5.9.2"
   languageName: unknown
   linkType: soft
@@ -14297,7 +14298,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-native-reanimated@npm:^3.18.0, react-native-reanimated@npm:^3.19.1":
+"react-native-reanimated@npm:^3.18.0":
   version: 3.19.1
   resolution: "react-native-reanimated@npm:3.19.1"
   dependencies:


### PR DESCRIPTION
## Description

Currently expo-example uses Reanimated 3.19 which seems to break. Given that `next` targets only new architecture, we can bump version of Reanimated, which seems to resolve the problem.

>[!IMPORTANT]
> We should also check if example works on `main`.

## Test plan

Tested that `expo-example` builds on both platforms.
