### PR TITLE
Fix PlatformConstants fallback for RN 0.81 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "devDependencies": {
     "@types/react": "^19.0.12",
+    "@types/react-native": "^0.73.0",
     "@typescript-eslint/eslint-plugin": "^6.9.0",
     "@typescript-eslint/parser": "^6.9.0",
     "eslint": "^8.57.0",

--- a/packages/react-native-gesture-handler/src/PlatformConstants.ts
+++ b/packages/react-native-gesture-handler/src/PlatformConstants.ts
@@ -1,8 +1,18 @@
 import { NativeModules, Platform } from 'react-native';
 
 type PlatformConstants = {
-  forceTouchAvailable: boolean;
+  forceTouchAvailable?: boolean;
+  interfaceIdiom?: string;
+  osVersion?: string;
+  systemName?: string;
+  [key: string]: any;
 };
 
-export default (NativeModules?.PlatformConstants ??
-  Platform.constants) as PlatformConstants;
+const platformConstants =
+  NativeModules && (NativeModules as any).PlatformConstants
+    ? (NativeModules as any).PlatformConstants
+    : Platform && (Platform as any).constants
+      ? (Platform as any).constants
+      : {};
+
+export default platformConstants as PlatformConstants;

--- a/yarn.lock
+++ b/yarn.lock
@@ -4701,6 +4701,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/react-native@npm:^0.73.0":
+  version: 0.73.0
+  resolution: "@types/react-native@npm:0.73.0"
+  dependencies:
+    react-native: "npm:*"
+  checksum: 10c0/81b8824f3bea30f18f92bb1e7c69777801b6b91a603c712173179b10e8fd6754f3594841dc452d0fc4a4cdc597e366fdf7839d27e0c5c5957f7dadde65882212
+  languageName: node
+  linkType: hard
+
 "@types/react-test-renderer@npm:^19.0.0, @types/react-test-renderer@npm:^19.1.0":
   version: 19.1.0
   resolution: "@types/react-test-renderer@npm:19.1.0"
@@ -14180,6 +14189,7 @@ __metadata:
   resolution: "react-native-gesture-handler-monorepo@workspace:."
   dependencies:
     "@types/react": "npm:^19.0.12"
+    "@types/react-native": "npm:^0.73.0"
     "@typescript-eslint/eslint-plugin": "npm:^6.9.0"
     "@typescript-eslint/parser": "npm:^6.9.0"
     eslint: "npm:^8.57.0"


### PR DESCRIPTION
finally solve this problem
[22:43:38] E | ReactNativeJS ▶︎ [runtime not ready]: Invariant Viola
tion: TurboModuleRegistry.getEnforcing(...): 'PlatformConstants' could not be found. Verify that a module by this name is registered in 
the native binary.

[22:43:38] E | ReactNativeJS ▶︎ [runtime not ready]: Error: Non-js e
xception: AppRegistryBinding::startSurface failed. Global was not installed.

solution: i just make a patch of react-native-gesture-handler