### PR TITLE
Update hook usage in the NativeDetector

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/NativeDetector/HostGestureDetector.web.tsx
+++ b/packages/react-native-gesture-handler/src/v3/NativeDetector/HostGestureDetector.web.tsx
@@ -62,8 +62,8 @@ const HostGestureDetector = (props: GestureHandlerDetectorProps) => {
   };
 
   useEffect(() => {
-    detachHandlers(attachedNativeHandlerTags.current);
-  }, [children]);
+    propsRef.current = props;
+  }, [props]);
 
   useEffect(() => {
     if (React.Children.count(children) !== 1) {
@@ -73,13 +73,11 @@ const HostGestureDetector = (props: GestureHandlerDetectorProps) => {
     }
 
     attachHandlers(new Set(handlerTags));
-  }, [handlerTags, children]);
 
-  useEffect(() => {
     return () => {
-      detachHandlers(attachedHandlerTags.current);
+      detachHandlers(attachedNativeHandlerTags.current);
     };
-  }, []);
+  }, [handlerTags, children]);
 
   return (
     <View style={{ display: 'contents' }} ref={viewRef as Ref<View>}>

--- a/packages/react-native-gesture-handler/src/v3/NativeDetector/HostGestureDetector.web.tsx
+++ b/packages/react-native-gesture-handler/src/v3/NativeDetector/HostGestureDetector.web.tsx
@@ -72,10 +72,11 @@ const HostGestureDetector = (props: GestureHandlerDetectorProps) => {
       );
     }
 
-    attachHandlers(new Set(handlerTags));
+    const newHandlerTags = new Set(handlerTags);
+    attachHandlers(newHandlerTags);
 
     return () => {
-      detachHandlers(attachedNativeHandlerTags.current);
+      detachHandlers(newHandlerTags);
     };
   }, [handlerTags, children]);
 

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -94,20 +94,16 @@ export function useGesture<THandlerData, TConfig>(
   }, [type, tag]);
 
   useEffect(() => {
+    const preparedConfig = prepareConfig(config);
+    RNGestureHandlerModule.setGestureHandlerConfig(tag, preparedConfig);
+    RNGestureHandlerModule.flushOperations();
+
     bindSharedValues(config, tag);
 
     return () => {
       unbindSharedValues(config, tag);
     };
   }, [tag, config]);
-
-  useEffect(() => {
-    const preparedConfig = prepareConfig(config);
-
-    RNGestureHandlerModule.setGestureHandlerConfig(tag, preparedConfig);
-
-    RNGestureHandlerModule.flushOperations();
-  }, [config, tag]);
 
   return {
     tag,


### PR DESCRIPTION
## Description

1. Merges two `useEffects` with the same dependency array into one in `useGesture`
2. Adds `useEffect` responsible for updating the `propsRef` in `HostGestureDetector.web.tsx`
3. Removes `useEffects` which were only calling `detachHandlers` and replaces them with a cleanup function in `HostGestureDetector.web.tsx`
