### PR TITLE
Fix relations old api

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -899,8 +899,7 @@ open class GestureHandler {
       if (config.hasKey(KEY_MOUSE_BUTTON)) {
         handler.mouseButton = config.getInt(KEY_MOUSE_BUTTON)
       }
-      if (config.hasKey(WAIT_FOR) && config.hasKey(SIMULTANEOUS_HANDLERS) && config.hasKey(BLOCKS_HANDLERS)) {
-        // Compatibility with old api, it will never happen on new api
+      if (handler.actionType != ACTION_TYPE_NATIVE_DETECTOR) {
         interactionManager.dropRelationsForHandlerWithTag(handler.tag)
         interactionManager.configureInteractions(handler, config)
       }
@@ -925,9 +924,6 @@ open class GestureHandler {
       private const val KEY_HIT_SLOP_HORIZONTAL = "horizontal"
       private const val KEY_HIT_SLOP_WIDTH = "width"
       private const val KEY_HIT_SLOP_HEIGHT = "height"
-      private const val WAIT_FOR = "waitFor"
-      private const val SIMULTANEOUS_HANDLERS = "simultaneousHandlers"
-      private const val BLOCKS_HANDLERS = "blocksHandlers"
 
       private fun handleHitSlopProperty(handler: GestureHandler, config: ReadableMap) {
         if (config.getType(KEY_HIT_SLOP) == ReadableType.Number) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -863,6 +863,7 @@ open class GestureHandler {
   abstract class Factory<T : GestureHandler> {
     abstract val type: Class<T>
     abstract val name: String
+
     protected abstract fun create(context: Context?): T
 
     fun create(context: Context?, handlerTag: Int): T = create(context).also { it.tag = handlerTag }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -19,7 +19,6 @@ import com.facebook.react.uimanager.PixelUtil
 import com.swmansion.gesturehandler.BuildConfig
 import com.swmansion.gesturehandler.RNSVGHitTester
 import com.swmansion.gesturehandler.react.RNGestureHandlerDetectorView
-import com.swmansion.gesturehandler.react.RNGestureHandlerInteractionManager
 import com.swmansion.gesturehandler.react.events.RNGestureHandlerTouchEvent
 import com.swmansion.gesturehandler.react.events.eventbuilders.GestureHandlerEventDataBuilder
 import java.lang.IllegalStateException
@@ -864,7 +863,6 @@ open class GestureHandler {
   abstract class Factory<T : GestureHandler> {
     abstract val type: Class<T>
     abstract val name: String
-    private val interactionManager = RNGestureHandlerInteractionManager()
     protected abstract fun create(context: Context?): T
 
     fun create(context: Context?, handlerTag: Int): T = create(context).also { it.tag = handlerTag }
@@ -898,10 +896,6 @@ open class GestureHandler {
       }
       if (config.hasKey(KEY_MOUSE_BUTTON)) {
         handler.mouseButton = config.getInt(KEY_MOUSE_BUTTON)
-      }
-      if (handler.actionType != ACTION_TYPE_NATIVE_DETECTOR) {
-        interactionManager.dropRelationsForHandlerWithTag(handler.tag)
-        interactionManager.configureInteractions(handler, config)
       }
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -98,6 +98,11 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
     val factory = RNGestureHandlerFactoryUtil.findFactoryForHandler<GestureHandler>(handler) ?: return
 
     factory.setConfig(handler, config)
+
+    if (handler.actionType != GestureHandler.ACTION_TYPE_NATIVE_DETECTOR) {
+      interactionManager.dropRelationsForHandlerWithTag(handlerTag)
+      interactionManager.configureInteractions(handler, config)
+    }
   }
 
   @ReactMethod
@@ -107,11 +112,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
     val factory = RNGestureHandlerFactoryUtil.findFactoryForHandler<GestureHandler>(handler) ?: return
 
     factory.updateConfig(handler, config)
-
-    if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_DETECTOR) {
-      interactionManager.dropRelationsForHandlerWithTag(handlerTag)
-      interactionManager.configureInteractions(handler, config)
-    }
   }
 
   @ReactMethod

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -107,6 +107,11 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
     val factory = RNGestureHandlerFactoryUtil.findFactoryForHandler<GestureHandler>(handler) ?: return
 
     factory.updateConfig(handler, config)
+
+    if (handler.actionType == GestureHandler.ACTION_TYPE_NATIVE_DETECTOR) {
+      interactionManager.dropRelationsForHandlerWithTag(handlerTag)
+      interactionManager.configureInteractions(handler, config)
+    }
   }
 
   @ReactMethod

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -183,8 +183,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     }
   }
 
-  if (config[@"waitFor"] != nil and config[@"simultaneousHandlers"] != nil and config[@"blocksHandlers"] != nil) {
-    // Compatibility with old api, it will never happen on new api
+  if (_actionType != RNGestureHandlerActionTypeNativeDetector) {
     [self updateRelations:config];
   }
 }

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -182,6 +182,11 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
       RCTLogError(@"Cannot have all of top, bottom and height defined");
     }
   }
+
+  if (config[@"waitFor"] != nil and config[@"simultaneousHandlers"] != nil and config[@"blocksHandlers"] != nil) {
+    // Compatibility with old api, it will never happen on new api
+    [self updateRelations:config];
+  }
 }
 
 - (void)updateRelations:(NSDictionary *)relations


### PR DESCRIPTION
## Description

After #3693 old api gesture relations did not work as they were never configured. This PR fixes this issue

## Test plan

Check if relations examples from [v2 docs](https://docs.swmansion.com/react-native-gesture-handler/docs/fundamentals/gesture-composition) work