### PR TITLE
Fix: exclude libfbjni.so

### DIFF
--- a/packages/react-native-gesture-handler/android/build.gradle
+++ b/packages/react-native-gesture-handler/android/build.gradle
@@ -187,6 +187,7 @@ android {
         exclude "**/libreactnative.so"
         exclude "**/libjsi.so"
         exclude "**/libc++_shared.so"
+        exclude "**/libfbjni.so"
     }
 
     sourceSets.main {


### PR DESCRIPTION
## Description

Fixes #3705
Follow-up on #3283

## Test plan
In android directory run:
`./gradlew assembleRelease assembleAndroidTest -DtestBuildType=release`.
