### PR TITLE
Fix `Fling` tsdoc

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/gestures/flingGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/flingGesture.ts
@@ -23,7 +23,7 @@ export class FlingGesture extends BaseGesture<FlingGestureHandlerEventPayload> {
   /**
    * Expressed allowed direction of movement.
    * Expected values are exported as constants in the Directions object.
-   * Arguments can be combined using `|` operator. Default value is set to `MouseButton.LEFT`.
+   * Arguments can be combined using `|` operator. Default value is set to `Directions.RIGHT`.
    * @param direction
    * @see https://docs.swmansion.com/react-native-gesture-handler/docs/gestures/fling-gesture/#directionvalue-directions
    */


### PR DESCRIPTION
## Description

Seems like I forgot to change it while copying `MouseButton` tsdoc 😅 

## Test plan

### Before 

<img width="916" height="168" alt="image" src="https://github.com/user-attachments/assets/207a340d-d0c5-4673-9854-7c6e2d5aed4a" />


### After 

<img width="920" height="165" alt="image" src="https://github.com/user-attachments/assets/5ffab693-bfc6-4b34-b27f-9c6fe5fc0d13" />
