### PR TITLE
[Web] Remove mouse buttons map

### DIFF
--- a/packages/react-native-gesture-handler/src/web/tools/PointerEventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/PointerEventManager.ts
@@ -1,5 +1,4 @@
 import EventManager from './EventManager';
-import { MouseButton } from '../../handlers/gestureHandlerCommon';
 import { AdaptedEvent, EventTypes, Point } from '../interfaces';
 import {
   PointerTypeMapping,
@@ -13,17 +12,10 @@ const POINTER_CAPTURE_EXCLUDE_LIST = new Set<string>(['SELECT', 'INPUT']);
 
 export default class PointerEventManager extends EventManager<HTMLElement> {
   private trackedPointers = new Set<number>();
-  private readonly mouseButtonsMapper = new Map<number, MouseButton>();
   private lastPosition: Point;
 
   constructor(view: HTMLElement) {
     super(view);
-
-    this.mouseButtonsMapper.set(0, MouseButton.LEFT);
-    this.mouseButtonsMapper.set(1, MouseButton.MIDDLE);
-    this.mouseButtonsMapper.set(2, MouseButton.RIGHT);
-    this.mouseButtonsMapper.set(3, MouseButton.BUTTON_4);
-    this.mouseButtonsMapper.set(4, MouseButton.BUTTON_5);
 
     this.lastPosition = {
       x: -Infinity,
@@ -213,7 +205,7 @@ export default class PointerEventManager extends EventManager<HTMLElement> {
       eventType: eventType,
       pointerType:
         PointerTypeMapping.get(event.pointerType) ?? PointerType.OTHER,
-      button: this.mouseButtonsMapper.get(event.button),
+      button: event.buttons,
       time: event.timeStamp,
       stylusData: tryExtractStylusData(event),
     };


### PR DESCRIPTION
## Description

This PR simplifies logic that handles `mouseButton` property. I've changed `event.button` to `event.buttons`. These values now correctly align with our `MouseButton` enum, so `Map` is no longer necessary. 

| Button | `event.button` | `MouseButton` | `event.buttons` |
|--------|--------------|-------------|---------------|
| Left   | 0            | 1           | 1             |
| Right  | 2            | 2           | 2             |
| Middle | 1            | 4           | 4             |
| Btn_4  | 3            | 8           | 8             |
| Btn_5  | 4            | 16          | 16            |


You can find values in MDN docs for:

- `event.button` [here](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/button#value)
- `event.buttons` [here](https://developer.mozilla.org/en-US/docs/Web/API/MouseEvent/buttons#value)

> [!NOTE]
> `event.buttons` also performs logical `or` operation on buttons, so for example using both **left** and **right** buttons at the same time results in value of `3`. 

> [!IMPORTANT]
> I've tested behavior when trying to activate handler with different buttons. In case where handler has `mouseButton(MouseButton.LEFT)` clicking first with left button, then adding other button results in activation. This is fine and aligns with what we have now. Clicking with other button and then adding left button does not result in activation. This is also fine.
>
> Now, clicking with both buttons at the same time does not result in activation. This is because in that case there's no `pointerdown` event. Turns out that `pointerdown` is called only for the first button, all the other pointers result in `pointermove` event. In case where both are pressed at the same time, there's only `pointermove` event.

## Test plan

Tested on **MouseButtons** example
