### PR TITLE
[Android] Don't remap pointer ids on native handlers

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -35,6 +35,11 @@ class NativeViewGestureHandler : GestureHandler() {
     shouldCancelWhenOutside = true
   }
 
+  // Preserve original pointer IDs when adapting events. This ensures consistency with
+  // events that flow through super.dispatchTouchEvent() before the handler activates,
+  // preventing pointer ID mismatches that cause crashes in native views.
+  override fun shouldPreserveOriginalPointerIds(): Boolean = true
+
   override fun resetConfig() {
     super.resetConfig()
     shouldActivateOnStart = DEFAULT_SHOULD_ACTIVATE_ON_START


### PR DESCRIPTION
## Description

I think it's possible for the `NativeViewGestureHandler` to cause the underlying component to track the same pointer under a different id. When the touch event starts, the root view first passes it through the gesture handler pipeline and then through the native Android pipeline. When a gesture activates, the second path starts being ignored, but since RNGH does pointer id remapping, the same pointer might have had multiple different ids. If the view tries to access the pointer it registered in the second (Android) path, during the RNGH path, the pointer id might not exist.

## Test plan

TODO
