### PR TITLE
[iOS] `TextInput` callbacks

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -17,6 +17,14 @@
 #import <React/RCTTextInputComponentView.h>
 #import <React/UIView+React.h>
 
+#if !TARGET_OS_OSX
+@interface RNNativeViewGestureHandler ()
+- (void)handleTextViewTouchDown:(UIEvent *)event;
+- (void)handleTextViewTouchUp:(UIEvent *)event;
+- (void)handleTextViewTouchCancel:(UIEvent *)event;
+@end
+#endif
+
 #pragma mark RNDummyGestureRecognizer
 
 @implementation RNDummyGestureRecognizer {
@@ -146,6 +154,8 @@
 
 - (void)bindToView:(UIView *)view
 {
+  UIView *textInputChild = nil;
+
   // For UIControl based views (UIButton, UISwitch) we provide special handling that would allow
   // for properties like `disallowInterruption` to work.
   if ([view isKindOfClass:[UIControl class]]) {

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -48,11 +48,6 @@
 - (void)touchesBegan:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler setCurrentPointerTypeForEvent:event];
-
-  if ([self isAttachedToTextView]) {
-    [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchDown:event];
-  }
-
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 }
 
@@ -66,10 +61,6 @@
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
 
-  if ([self isAttachedToTextView]) {
-    [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchUp:event];
-  }
-
   self.state = UIGestureRecognizerStateFailed;
 
   // For now, we are handling only the scroll view case.
@@ -82,10 +73,6 @@
 - (void)touchesCancelled:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-
-  if ([self isAttachedToTextView]) {
-    [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchCancel:event];
-  }
 
   self.state = UIGestureRecognizerStateCancelled;
   [self reset];
@@ -181,9 +168,6 @@
       if ([subview isKindOfClass:[UITextField class]]) {
         _control = (UIControl *)subview;
         break;
-      } else if ([subview isKindOfClass:[UITextView class]]) {
-        textInputChild = subview;
-        break;
       }
     }
   }
@@ -218,14 +202,7 @@
           forControlEvents:UIControlEventTouchCancel];
     }
   } else {
-    // For multiline TextInput (UITextView), bind to the child view so the recognizer receives
-    // touch events directly, then restore viewTag to the parent's react tag.
-    if (textInputChild != nil) {
-      [super bindToView:textInputChild];
-      self.viewTag = view.reactTag;
-    } else {
-      [super bindToView:view];
-    }
+    [super bindToView:view];
   }
 
   // We can restore default scrollview behaviour to delay touches to scrollview's children
@@ -280,47 +257,6 @@
                                                            withPointerType:_pointerType]];
 
   [self reset];
-}
-
-- (void)handleTextViewTouchDown:(UIEvent *)event
-{
-  [self reset];
-
-  RNGestureHandlerEventExtraData *extraData = [RNGestureHandlerEventExtraData forPointerInside:YES
-                                                                           withNumberOfTouches:event.allTouches.count
-                                                                               withPointerType:_pointerType];
-
-  [self sendEventsInState:RNGestureHandlerStateBegan forViewWithTag:self.viewTag withExtraData:extraData];
-  [self sendEventsInState:RNGestureHandlerStateActive forViewWithTag:self.viewTag withExtraData:extraData];
-  _lastActiveExtraData = extraData;
-}
-
-- (void)handleTextViewTouchUp:(UIEvent *)event
-{
-  BOOL isInside = [self containsPointInView];
-
-  if (!isInside && self.shouldCancelWhenOutside) {
-    [self sendEventsInState:RNGestureHandlerStateFailed
-             forViewWithTag:self.viewTag
-              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
-                                                         withNumberOfTouches:event.allTouches.count
-                                                             withPointerType:_pointerType]];
-  } else {
-    [self sendEventsInState:RNGestureHandlerStateEnd
-             forViewWithTag:self.viewTag
-              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:isInside
-                                                         withNumberOfTouches:event.allTouches.count
-                                                             withPointerType:_pointerType]];
-  }
-}
-
-- (void)handleTextViewTouchCancel:(UIEvent *)event
-{
-  [self sendEventsInState:RNGestureHandlerStateCancelled
-           forViewWithTag:self.viewTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
-                                                       withNumberOfTouches:event.allTouches.count
-                                                           withPointerType:_pointerType]];
 }
 
 - (void)handleTouchDown:(UIView *)sender forEvent:(UIEvent *)event

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -297,11 +297,21 @@
 
 - (void)handleTextViewTouchUp:(UIEvent *)event
 {
-  [self sendEventsInState:RNGestureHandlerStateEnd
-           forViewWithTag:self.viewTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES
-                                                       withNumberOfTouches:event.allTouches.count
-                                                           withPointerType:_pointerType]];
+  BOOL isInside = [self containsPointInView];
+
+  if (!isInside && self.shouldCancelWhenOutside) {
+    [self sendEventsInState:RNGestureHandlerStateFailed
+             forViewWithTag:self.viewTag
+              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
+                                                         withNumberOfTouches:event.allTouches.count
+                                                             withPointerType:_pointerType]];
+  } else {
+    [self sendEventsInState:RNGestureHandlerStateEnd
+             forViewWithTag:self.viewTag
+              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:isInside
+                                                         withNumberOfTouches:event.allTouches.count
+                                                             withPointerType:_pointerType]];
+  }
 }
 
 - (void)handleTextViewTouchCancel:(UIEvent *)event

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -115,7 +115,7 @@
   BOOL _shouldActivateOnStart;
   BOOL _disallowInterruption;
   RNGestureHandlerEventExtraData *_lastActiveExtraData;
-  __weak UIControl *_targetControl;
+  __weak UIControl *_control;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag
@@ -137,51 +137,48 @@
 
 - (void)bindToView:(UIView *)view
 {
-  UIControl *control = nil;
-
   // For UIControl based views (UIButton, UISwitch) we provide special handling that would allow
   // for properties like `disallowInterruption` to work.
   if ([view isKindOfClass:[UIControl class]]) {
-    control = (UIControl *)view;
+    _control = (UIControl *)view;
   } else if ([view isKindOfClass:[RCTTextInputComponentView class]]) {
     // TextInput (RCTTextInputComponentView) contains a UITextField or UITextView as a subview.
-    // We need to attach to that subview to receive touch events.
     for (UIView *subview in view.subviews) {
       if ([subview isKindOfClass:[UITextField class]] || [subview isKindOfClass:[UITextView class]]) {
-        control = (UIControl *)subview;
+        _control = (UIControl *)subview;
         break;
       }
     }
   }
 
-  if (control) {
-    _targetControl = control;
-
+  if (_control) {
     // Pressing UISwitch triggers only touchUp and valueChanged callbacks. In order to align its behavior
     // with other UIControls, we have to dispatch full Gesture Handler events flow in one callback, as
     // touchesDown is not executed.
-    if ([control isKindOfClass:[UISwitch class]]) {
+    if ([_control isKindOfClass:[UISwitch class]]) {
       _pointerType = RNGestureHandlerTouch;
-      [control addTarget:self action:@selector(handleSwitch:) forControlEvents:UIControlEventValueChanged];
+      [_control addTarget:self action:@selector(handleSwitch:) forControlEvents:UIControlEventValueChanged];
     } else {
-      [control addTarget:self action:@selector(handleTouchDown:forEvent:) forControlEvents:UIControlEventTouchDown];
-      [control addTarget:self
+      [_control addTarget:self action:@selector(handleTouchDown:forEvent:) forControlEvents:UIControlEventTouchDown];
+      [_control addTarget:self
                     action:@selector(handleTouchUpOutside:forEvent:)
           forControlEvents:UIControlEventTouchUpOutside];
-      [control addTarget:self
+      [_control addTarget:self
                     action:@selector(handleTouchUpInside:forEvent:)
           forControlEvents:UIControlEventTouchUpInside];
-      [control addTarget:self action:@selector(handleDragExit:forEvent:) forControlEvents:UIControlEventTouchDragExit];
-      [control addTarget:self
+      [_control addTarget:self action:@selector(handleDragExit:forEvent:) forControlEvents:UIControlEventTouchDragExit];
+      [_control addTarget:self
                     action:@selector(handleDragInside:forEvent:)
           forControlEvents:UIControlEventTouchDragInside];
-      [control addTarget:self
+      [_control addTarget:self
                     action:@selector(handleDragOutside:forEvent:)
           forControlEvents:UIControlEventTouchDragOutside];
-      [control addTarget:self
+      [_control addTarget:self
                     action:@selector(handleDragEnter:forEvent:)
           forControlEvents:UIControlEventTouchDragEnter];
-      [control addTarget:self action:@selector(handleTouchCancel:forEvent:) forControlEvents:UIControlEventTouchCancel];
+      [_control addTarget:self
+                    action:@selector(handleTouchCancel:forEvent:)
+          forControlEvents:UIControlEventTouchCancel];
     }
   } else {
     [super bindToView:view];
@@ -198,9 +195,9 @@
 {
   UIView *view = self.recognizer.view;
 
-  if (_targetControl) {
-    [_targetControl removeTarget:self action:NULL forControlEvents:UIControlEventAllEvents];
-    _targetControl = nil;
+  if (_control) {
+    [_control removeTarget:self action:NULL forControlEvents:UIControlEventAllEvents];
+    _control = nil;
   }
 
   // Restore the React Native's overriden behavor for not delaying content touches

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -21,6 +21,7 @@
 @interface RNNativeViewGestureHandler ()
 - (void)handleTextViewTouchDown:(UIEvent *)event;
 - (void)handleTextViewTouchUp:(UIEvent *)event;
+- (void)handleTextViewTouchCancel:(UIEvent *)event;
 @end
 #endif
 
@@ -81,6 +82,11 @@
 - (void)touchesCancelled:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+
+  if ([self isAttachedToTextView]) {
+    [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchCancel:event];
+  }
+
   self.state = UIGestureRecognizerStateCancelled;
   [self reset];
 }
@@ -294,6 +300,15 @@
   [self sendEventsInState:RNGestureHandlerStateEnd
            forViewWithTag:self.viewTag
             withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES
+                                                       withNumberOfTouches:event.allTouches.count
+                                                           withPointerType:_pointerType]];
+}
+
+- (void)handleTextViewTouchCancel:(UIEvent *)event
+{
+  [self sendEventsInState:RNGestureHandlerStateCancelled
+           forViewWithTag:self.viewTag
+            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
                                                        withNumberOfTouches:event.allTouches.count
                                                            withPointerType:_pointerType]];
 }

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -17,14 +17,6 @@
 #import <React/RCTTextInputComponentView.h>
 #import <React/UIView+React.h>
 
-#if !TARGET_OS_OSX
-@interface RNNativeViewGestureHandler ()
-- (void)handleTextViewTouchDown:(UIEvent *)event;
-- (void)handleTextViewTouchUp:(UIEvent *)event;
-- (void)handleTextViewTouchCancel:(UIEvent *)event;
-@end
-#endif
-
 #pragma mark RNDummyGestureRecognizer
 
 @implementation RNDummyGestureRecognizer {
@@ -154,8 +146,6 @@
 
 - (void)bindToView:(UIView *)view
 {
-  UIView *textInputChild = nil;
-
   // For UIControl based views (UIButton, UISwitch) we provide special handling that would allow
   // for properties like `disallowInterruption` to work.
   if ([view isKindOfClass:[UIControl class]]) {

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -211,16 +211,13 @@
           forControlEvents:UIControlEventTouchCancel];
     }
   } else {
-    [super bindToView:view];
-
-    // For multiline TextInput (UITextView), we need to move the gesture recognizer from the parent
-    // to the actual text view so it can receive touch events
+    // For multiline TextInput (UITextView), bind to the child view so the recognizer receives
+    // touch events directly, then restore viewTag to the parent's react tag.
     if (textInputChild != nil) {
-      UIView *currentRecognizerView = self.recognizer.view;
-      if (currentRecognizerView != nil) {
-        [currentRecognizerView removeGestureRecognizer:self.recognizer];
-      }
-      [textInputChild addGestureRecognizer:self.recognizer];
+      [super bindToView:textInputChild];
+      self.viewTag = view.reactTag;
+    } else {
+      [super bindToView:view];
     }
   }
 

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -131,7 +131,9 @@
   BOOL _shouldActivateOnStart;
   BOOL _disallowInterruption;
   RNGestureHandlerEventExtraData *_lastActiveExtraData;
+#if !TARGET_OS_OSX
   __weak UIControl *_control;
+#endif
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -39,12 +39,17 @@
 }
 
 #if !TARGET_OS_OSX
+- (BOOL)isAttachedToTextView
+{
+  return [self.view isKindOfClass:[UITextView class]];
+}
+
 - (void)touchesBegan:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler setCurrentPointerTypeForEvent:event];
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 
-  if ([self.view isKindOfClass:[UITextView class]]) {
+  if ([self isAttachedToTextView]) {
     [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchDown:event];
   }
 }
@@ -59,7 +64,7 @@
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
 
-  if ([self.view isKindOfClass:[UITextView class]]) {
+  if ([self isAttachedToTextView]) {
     [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchUp:event];
   }
 

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -115,6 +115,7 @@
   BOOL _shouldActivateOnStart;
   BOOL _disallowInterruption;
   RNGestureHandlerEventExtraData *_lastActiveExtraData;
+  __weak UIControl *_targetControl;
 }
 
 - (instancetype)initWithTag:(NSNumber *)tag
@@ -154,6 +155,8 @@
   }
 
   if (control) {
+    _targetControl = control;
+
     // Pressing UISwitch triggers only touchUp and valueChanged callbacks. In order to align its behavior
     // with other UIControls, we have to dispatch full Gesture Handler events flow in one callback, as
     // touchesDown is not executed.
@@ -195,16 +198,9 @@
 {
   UIView *view = self.recognizer.view;
 
-  if ([view isKindOfClass:[UIControl class]]) {
-    [(UIControl *)view removeTarget:self action:NULL forControlEvents:UIControlEventAllEvents];
-  } else if ([view isKindOfClass:[RCTTextInputComponentView class]]) {
-    // Remove targets from the internal UITextField/UITextView
-    for (UIView *subview in view.subviews) {
-      if ([subview isKindOfClass:[UITextField class]] || [subview isKindOfClass:[UITextView class]]) {
-        [(UIControl *)subview removeTarget:self action:NULL forControlEvents:UIControlEventAllEvents];
-        break;
-      }
-    }
+  if (_targetControl) {
+    [_targetControl removeTarget:self action:NULL forControlEvents:UIControlEventAllEvents];
+    _targetControl = nil;
   }
 
   // Restore the React Native's overriden behavor for not delaying content touches

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -48,6 +48,11 @@
 - (void)touchesBegan:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler setCurrentPointerTypeForEvent:event];
+
+  if ([self isAttachedToTextView]) {
+    [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchDown:event];
+  }
+
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 }
 
@@ -61,6 +66,10 @@
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
 
+  if ([self isAttachedToTextView]) {
+    [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchUp:event];
+  }
+
   self.state = UIGestureRecognizerStateFailed;
 
   // For now, we are handling only the scroll view case.
@@ -73,6 +82,10 @@
 - (void)touchesCancelled:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+
+  if ([self isAttachedToTextView]) {
+    [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchCancel:event];
+  }
 
   self.state = UIGestureRecognizerStateCancelled;
   [self reset];
@@ -168,6 +181,9 @@
       if ([subview isKindOfClass:[UITextField class]]) {
         _control = (UIControl *)subview;
         break;
+      } else if ([subview isKindOfClass:[UITextView class]]) {
+        textInputChild = subview;
+        break;
       }
     }
   }
@@ -202,7 +218,14 @@
           forControlEvents:UIControlEventTouchCancel];
     }
   } else {
-    [super bindToView:view];
+    // For multiline TextInput (UITextView), bind to the child view so the recognizer receives
+    // touch events directly, then restore viewTag to the parent's react tag.
+    if (textInputChild != nil) {
+      [super bindToView:textInputChild];
+      self.viewTag = view.reactTag;
+    } else {
+      [super bindToView:view];
+    }
   }
 
   // We can restore default scrollview behaviour to delay touches to scrollview's children
@@ -257,6 +280,47 @@
                                                            withPointerType:_pointerType]];
 
   [self reset];
+}
+
+- (void)handleTextViewTouchDown:(UIEvent *)event
+{
+  [self reset];
+
+  RNGestureHandlerEventExtraData *extraData = [RNGestureHandlerEventExtraData forPointerInside:YES
+                                                                           withNumberOfTouches:event.allTouches.count
+                                                                               withPointerType:_pointerType];
+
+  [self sendEventsInState:RNGestureHandlerStateBegan forViewWithTag:self.viewTag withExtraData:extraData];
+  [self sendEventsInState:RNGestureHandlerStateActive forViewWithTag:self.viewTag withExtraData:extraData];
+  _lastActiveExtraData = extraData;
+}
+
+- (void)handleTextViewTouchUp:(UIEvent *)event
+{
+  BOOL isInside = [self containsPointInView];
+
+  if (!isInside && self.shouldCancelWhenOutside) {
+    [self sendEventsInState:RNGestureHandlerStateFailed
+             forViewWithTag:self.viewTag
+              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
+                                                         withNumberOfTouches:event.allTouches.count
+                                                             withPointerType:_pointerType]];
+  } else {
+    [self sendEventsInState:RNGestureHandlerStateEnd
+             forViewWithTag:self.viewTag
+              withExtraData:[RNGestureHandlerEventExtraData forPointerInside:isInside
+                                                         withNumberOfTouches:event.allTouches.count
+                                                             withPointerType:_pointerType]];
+  }
+}
+
+- (void)handleTextViewTouchCancel:(UIEvent *)event
+{
+  [self sendEventsInState:RNGestureHandlerStateCancelled
+           forViewWithTag:self.viewTag
+            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
+                                                       withNumberOfTouches:event.allTouches.count
+                                                           withPointerType:_pointerType]];
 }
 
 - (void)handleTouchDown:(UIView *)sender forEvent:(UIEvent *)event

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -17,6 +17,13 @@
 #import <React/RCTTextInputComponentView.h>
 #import <React/UIView+React.h>
 
+#if !TARGET_OS_OSX
+@interface RNNativeViewGestureHandler ()
+- (void)handleTextViewTouchDown:(UIEvent *)event;
+- (void)handleTextViewTouchUp:(UIEvent *)event;
+@end
+#endif
+
 #pragma mark RNDummyGestureRecognizer
 
 @implementation RNDummyGestureRecognizer {
@@ -36,6 +43,10 @@
 {
   [_gestureHandler setCurrentPointerTypeForEvent:event];
   [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
+
+  if ([self.view isKindOfClass:[UITextView class]]) {
+    [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchDown:event];
+  }
 }
 
 - (void)touchesMoved:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
@@ -47,6 +58,11 @@
 - (void)touchesEnded:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+
+  if ([self.view isKindOfClass:[UITextView class]]) {
+    [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchUp:event];
+  }
+
   self.state = UIGestureRecognizerStateFailed;
 
   // For now, we are handling only the scroll view case.
@@ -137,15 +153,22 @@
 
 - (void)bindToView:(UIView *)view
 {
+  UIView *textInputChild = nil;
+
   // For UIControl based views (UIButton, UISwitch) we provide special handling that would allow
   // for properties like `disallowInterruption` to work.
   if ([view isKindOfClass:[UIControl class]]) {
     _control = (UIControl *)view;
   } else if ([view isKindOfClass:[RCTTextInputComponentView class]]) {
-    // TextInput (RCTTextInputComponentView) contains a UITextField or UITextView as a subview.
+    // TextInput (RCTTextInputComponentView) contains a UITextField (single-line) or UITextView (multi-line) as a
+    // subview. UITextField is a UIControl, so we can use UIControl events. UITextView is not a UIControl, so we need to
+    // attach the gesture recognizer to it directly.
     for (UIView *subview in view.subviews) {
-      if ([subview isKindOfClass:[UITextField class]] || [subview isKindOfClass:[UITextView class]]) {
+      if ([subview isKindOfClass:[UITextField class]]) {
         _control = (UIControl *)subview;
+        break;
+      } else if ([subview isKindOfClass:[UITextView class]]) {
+        textInputChild = subview;
         break;
       }
     }
@@ -182,6 +205,16 @@
     }
   } else {
     [super bindToView:view];
+
+    // For multiline TextInput (UITextView), we need to move the gesture recognizer from the parent
+    // to the actual text view so it can receive touch events
+    if (textInputChild != nil) {
+      UIView *currentRecognizerView = self.recognizer.view;
+      if (currentRecognizerView != nil) {
+        [currentRecognizerView removeGestureRecognizer:self.recognizer];
+      }
+      [textInputChild addGestureRecognizer:self.recognizer];
+    }
   }
 
   // We can restore default scrollview behaviour to delay touches to scrollview's children
@@ -236,6 +269,28 @@
                                                            withPointerType:_pointerType]];
 
   [self reset];
+}
+
+- (void)handleTextViewTouchDown:(UIEvent *)event
+{
+  [self reset];
+
+  RNGestureHandlerEventExtraData *extraData = [RNGestureHandlerEventExtraData forPointerInside:YES
+                                                                           withNumberOfTouches:event.allTouches.count
+                                                                               withPointerType:_pointerType];
+
+  [self sendEventsInState:RNGestureHandlerStateBegan forViewWithTag:self.viewTag withExtraData:extraData];
+  [self sendEventsInState:RNGestureHandlerStateActive forViewWithTag:self.viewTag withExtraData:extraData];
+  _lastActiveExtraData = extraData;
+}
+
+- (void)handleTextViewTouchUp:(UIEvent *)event
+{
+  [self sendEventsInState:RNGestureHandlerStateEnd
+           forViewWithTag:self.viewTag
+            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES
+                                                       withNumberOfTouches:event.allTouches.count
+                                                           withPointerType:_pointerType]];
 }
 
 - (void)handleTouchDown:(UIView *)sender forEvent:(UIEvent *)event

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -32,6 +32,11 @@
 }
 
 #if !TARGET_OS_OSX
+- (BOOL)isAttachedToTextView
+{
+  return [self.view isKindOfClass:[UITextView class]];
+}
+
 - (void)touchesBegan:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler setCurrentPointerTypeForEvent:event];
@@ -47,6 +52,7 @@
 - (void)touchesEnded:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
+
   self.state = UIGestureRecognizerStateFailed;
 
   // For now, we are handling only the scroll view case.
@@ -59,6 +65,7 @@
 - (void)touchesCancelled:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
+
   self.state = UIGestureRecognizerStateCancelled;
   [self reset];
 }

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -32,11 +32,6 @@
 }
 
 #if !TARGET_OS_OSX
-- (BOOL)isAttachedToTextView
-{
-  return [self.view isKindOfClass:[UITextView class]];
-}
-
 - (void)touchesBegan:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler setCurrentPointerTypeForEvent:event];
@@ -52,7 +47,6 @@
 - (void)touchesEnded:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
-
   self.state = UIGestureRecognizerStateFailed;
 
   // For now, we are handling only the scroll view case.
@@ -65,7 +59,6 @@
 - (void)touchesCancelled:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler.pointerTracker touchesCancelled:touches withEvent:event];
-
   self.state = UIGestureRecognizerStateCancelled;
   [self reset];
 }

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -47,11 +47,12 @@
 - (void)touchesBegan:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event
 {
   [_gestureHandler setCurrentPointerTypeForEvent:event];
-  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 
   if ([self isAttachedToTextView]) {
     [(RNNativeViewGestureHandler *)_gestureHandler handleTextViewTouchDown:event];
   }
+
+  [_gestureHandler.pointerTracker touchesBegan:touches withEvent:event];
 }
 
 - (void)touchesMoved:(NSSet<RNGHUITouch *> *)touches withEvent:(UIEvent *)event

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -14,6 +14,7 @@
 
 #import <React/RCTConvert.h>
 #import <React/RCTScrollViewComponentView.h>
+#import <React/RCTTextInputComponentView.h>
 #import <React/UIView+React.h>
 
 #pragma mark RNDummyGestureRecognizer
@@ -135,15 +136,28 @@
 
 - (void)bindToView:(UIView *)view
 {
+  UIControl *control = nil;
+
   // For UIControl based views (UIButton, UISwitch) we provide special handling that would allow
   // for properties like `disallowInterruption` to work.
   if ([view isKindOfClass:[UIControl class]]) {
-    UIControl *control = (UIControl *)view;
+    control = (UIControl *)view;
+  } else if ([view isKindOfClass:[RCTTextInputComponentView class]]) {
+    // TextInput (RCTTextInputComponentView) contains a UITextField or UITextView as a subview.
+    // We need to attach to that subview to receive touch events.
+    for (UIView *subview in view.subviews) {
+      if ([subview isKindOfClass:[UITextField class]] || [subview isKindOfClass:[UITextView class]]) {
+        control = (UIControl *)subview;
+        break;
+      }
+    }
+  }
 
+  if (control) {
     // Pressing UISwitch triggers only touchUp and valueChanged callbacks. In order to align its behavior
     // with other UIControls, we have to dispatch full Gesture Handler events flow in one callback, as
     // touchesDown is not executed.
-    if ([view isKindOfClass:[UISwitch class]]) {
+    if ([control isKindOfClass:[UISwitch class]]) {
       _pointerType = RNGestureHandlerTouch;
       [control addTarget:self action:@selector(handleSwitch:) forControlEvents:UIControlEventValueChanged];
     } else {
@@ -183,6 +197,14 @@
 
   if ([view isKindOfClass:[UIControl class]]) {
     [(UIControl *)view removeTarget:self action:NULL forControlEvents:UIControlEventAllEvents];
+  } else if ([view isKindOfClass:[RCTTextInputComponentView class]]) {
+    // Remove targets from the internal UITextField/UITextView
+    for (UIView *subview in view.subviews) {
+      if ([subview isKindOfClass:[UITextField class]] || [subview isKindOfClass:[UITextView class]]) {
+        [(UIControl *)subview removeTarget:self action:NULL forControlEvents:UIControlEventAllEvents];
+        break;
+      }
+    }
   }
 
   // Restore the React Native's overriden behavor for not delaying content touches

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.mm
@@ -244,11 +244,13 @@
   // it may happen that the gesture recognizer is reset after it's been unbound from the view,
   // it that recognizer tried to send event, the app would crash because the target of the event
   // would be nil.
-  if (_gestureHandler.viewTag == nil && _gestureHandler.actionType != RNGestureHandlerActionTypeNativeDetector) {
+  if (_gestureHandler.recognizer.view.reactTag == nil &&
+      _gestureHandler.actionType != RNGestureHandlerActionTypeNativeDetector) {
     return;
   }
 
-  [_gestureHandler sendTouchEventInState:[_gestureHandler state] forViewWithTag:_gestureHandler.viewTag];
+  [_gestureHandler sendTouchEventInState:[_gestureHandler state]
+                          forViewWithTag:_gestureHandler.recognizer.view.reactTag];
 }
 
 @end

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.mm
@@ -244,13 +244,11 @@
   // it may happen that the gesture recognizer is reset after it's been unbound from the view,
   // it that recognizer tried to send event, the app would crash because the target of the event
   // would be nil.
-  if (_gestureHandler.recognizer.view.reactTag == nil &&
-      _gestureHandler.actionType != RNGestureHandlerActionTypeNativeDetector) {
+  if (_gestureHandler.viewTag == nil && _gestureHandler.actionType != RNGestureHandlerActionTypeNativeDetector) {
     return;
   }
 
-  [_gestureHandler sendTouchEventInState:[_gestureHandler state]
-                          forViewWithTag:_gestureHandler.recognizer.view.reactTag];
+  [_gestureHandler sendTouchEventInState:[_gestureHandler state] forViewWithTag:_gestureHandler.viewTag];
 }
 
 @end


### PR DESCRIPTION
>[!CAUTION]
>I've reverted last commits as they actually broke `multiline` text inputs. Since this PR introduces many changes and is focused on component that is not widely used, we decided to drop the idea of merging it, at least for now. Maybe it will be useful in the future.

## Description

I've noticed that on `iOS` none of the gesture callbacks is triggered when using our `TextInput`. This works fine on `Android` and `web`. 

When we attach handler it is not attached to `UITextField` nor to `UITextView`. Instead it is attached to `RCTTextInputComponentView`. Because of that we do not receive any `up`/`down` events.

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import { useState } from 'react';
import { StyleSheet, TextInput } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  TextInput as RNGHTextInput,
  useNativeGesture,
} from 'react-native-gesture-handler';

export default function App() {
  const [value, setValue] = useState('');

  const g = useNativeGesture({
    onBegin: () => {
      console.log('gesture begin');
    },
    onActivate: () => {
      console.log('gesture activate');
    },
    onUpdate: () => {
      console.log('gesture update');
    },
    onDeactivate: () => {
      console.log('gesture deactivate');
    },
    onFinalize: () => {
      console.log('gesture finalize');
    },
  });

  return (
    <GestureHandlerRootView style={styles.container}>
      <TextInput
        value={value}
        onChangeText={setValue}
        style={[styles.input, { backgroundColor: 'red' }]}
      />
      <GestureDetector gesture={g}>
        <TextInput
          value={value}
          onChangeText={setValue}
          style={[styles.input, { backgroundColor: 'green' }]}
        />
      </GestureDetector>
      <RNGHTextInput
        onBegin={() => {
          console.log('gesture begin');
        }}
        onActivate={() => {
          console.log('gesture activate');
        }}
        onUpdate={() => {
          console.log('gesture update');
        }}
        onDeactivate={() => {
          console.log('gesture deactivate');
        }}
        onFinalize={() => {
          console.log('gesture finalize');
        }}
        style={[styles.input, { backgroundColor: 'blue' }]}
        value={value}
        onChangeText={setValue}
      />
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  input: {
    width: 200,
    height: 50,
  },
});
```

</details>
