### PR TITLE
[Web] `TextInput` callbacks

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -120,6 +120,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
     if (
       (this.controlType === ControlType.Button && this.shouldActivateOnStart) ||
       this.controlType === ControlType.Switch ||
+      this.controlType === ControlType.TextInput ||
       isRNGHText
     ) {
       this.activate();

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -60,7 +60,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
       this.controlType = ControlType.Button;
     } else if (view.querySelector('input[role="switch"]') !== null) {
       this.controlType = ControlType.Switch;
-    } else if (view.matches('input:not([role]), textarea')) {
+    } else if (view.matches('input:not([role]):not([type]), textarea')) {
       this.controlType = ControlType.TextInput;
     } else {
       this.controlType = ControlType.Other;

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -12,9 +12,15 @@ import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
 import GestureHandler from './GestureHandler';
 import type IGestureHandler from './IGestureHandler';
 
+enum ControlType {
+  Button,
+  Switch,
+  TextInput,
+  Other,
+}
+
 export default class NativeViewGestureHandler extends GestureHandler {
-  private buttonRole!: boolean;
-  private switchRole!: boolean;
+  private controlType!: ControlType;
 
   // TODO: Implement logic for activation on start properly
   private shouldActivateOnStart = false;
@@ -49,8 +55,16 @@ export default class NativeViewGestureHandler extends GestureHandler {
     const view = this.delegate.view as HTMLElement;
 
     this.restoreViewStyles(view);
-    this.buttonRole = view.getAttribute('role') === 'button';
-    this.switchRole = view.querySelector('input[role="switch"]') !== null;
+
+    if (view.getAttribute('role') === 'button') {
+      this.controlType = ControlType.Button;
+    } else if (view.querySelector('input[role="switch"]') !== null) {
+      this.controlType = ControlType.Switch;
+    } else if (view.matches('input:not([role]), textarea')) {
+      this.controlType = ControlType.TextInput;
+    } else {
+      this.controlType = ControlType.Other;
+    }
   }
 
   public override updateGestureConfig(config: Config): void {
@@ -104,8 +118,8 @@ export default class NativeViewGestureHandler extends GestureHandler {
     const isRNGHText = view.hasAttribute('rnghtext');
 
     if (
-      (this.buttonRole && this.shouldActivateOnStart) ||
-      this.switchRole ||
+      (this.controlType === ControlType.Button && this.shouldActivateOnStart) ||
+      this.controlType === ControlType.Switch ||
       isRNGHText
     ) {
       this.activate();
@@ -120,7 +134,10 @@ export default class NativeViewGestureHandler extends GestureHandler {
     const dy = this.startY - lastCoords.y;
     const distSq = dx * dx + dy * dy;
 
-    if (this.switchRole || this.buttonRole) {
+    if (
+      this.controlType === ControlType.Switch ||
+      this.controlType === ControlType.Button
+    ) {
       return;
     }
 
@@ -149,7 +166,10 @@ export default class NativeViewGestureHandler extends GestureHandler {
     this.tracker.removeFromTracker(event.pointerId);
 
     if (this.tracker.trackedPointersCount === 0) {
-      if (this.buttonRole && this.state === State.BEGAN) {
+      if (
+        this.controlType === ControlType.Button &&
+        this.state === State.BEGAN
+      ) {
         this.activate();
       }
 
@@ -204,7 +224,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
   }
 
   public isButton(): boolean {
-    return this.buttonRole;
+    return this.controlType === ControlType.Button;
   }
 
   protected override transformNativeEvent(): Record<string, unknown> {


### PR DESCRIPTION
>[!CAUTION]
>Similarly as [`iOS` version](https://github.com/software-mansion/react-native-gesture-handler/pull/4114), this will be blocked for now.

## Description

To match native platforms behavior, `TextInput` should activate immediately on web. This PR also extracts type of underlying view into separate variable.

## Test plan


<details>
<summary>Tested on the following code:</summary>

```tsx
import { useState } from 'react';
import { StyleSheet, TextInput } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  TextInput as RNGHTextInput,
  useNativeGesture,
} from 'react-native-gesture-handler';

export default function App() {
  const [value, setValue] = useState('');

  const g = useNativeGesture({
    onBegin: () => {
      console.log('gesture begin');
    },
    onActivate: () => {
      console.log('gesture activate');
    },
    onUpdate: () => {
      console.log('gesture update');
    },
    onDeactivate: () => {
      console.log('gesture deactivate');
    },
    onFinalize: () => {
      console.log('gesture finalize');
    },
  });

  return (
    <GestureHandlerRootView style={styles.container}>
      <TextInput
        value={value}
        onChangeText={setValue}
        style={[styles.input, { backgroundColor: 'red' }]}
      />
      <GestureDetector gesture={g}>
        <TextInput
          value={value}
          onChangeText={setValue}
          style={[styles.input, { backgroundColor: 'green' }]}
        />
      </GestureDetector>
      <RNGHTextInput
        onBegin={() => {
          console.log('gesture begin');
        }}
        onActivate={() => {
          console.log('gesture activate');
        }}
        onUpdate={() => {
          console.log('gesture update');
        }}
        onDeactivate={() => {
          console.log('gesture deactivate');
        }}
        onFinalize={() => {
          console.log('gesture finalize');
        }}
        style={[styles.input, { backgroundColor: 'blue' }]}
        value={value}
        onChangeText={setValue}
      />
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    justifyContent: 'center',
  },
  input: {
    width: 200,
    height: 50,
  },
});
```

</details>
