### PR TITLE
[General] Allow to customize the duration of out animation for long press

### DIFF
--- a/apps/common-app/src/new_api/components/touchable/index.tsx
+++ b/apps/common-app/src/new_api/components/touchable/index.tsx
@@ -225,6 +225,25 @@ export default function TouchableExample() {
               }}
             />
           </View>
+
+          <Text>
+            Long-press override — release timing switches once held past
+            `delayLongPress`.
+          </Text>
+
+          <View style={styles.row}>
+            <TouchableWrapper
+              name="Hold"
+              color={COLORS.DARK_SALMON}
+              activeOpacity={0.3}
+              delayLongPress={400}
+              animationDuration={{
+                in: 50,
+                out: 100,
+                longPress: { out: 800 },
+              }}
+            />
+          </View>
         </View>
 
         <View style={styles.section}>

--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -250,10 +250,12 @@ type AnimationDuration =
   | (InOutDuration & {
       tap?: Partial<InOutDuration>;
       hover?: Partial<InOutDuration>;
+      longPress?: { out: number };
     })
   | {
       tap: InOutDuration;
       hover: InOutDuration;
+      longPress?: { out: number };
     };
 `}/>
 
@@ -262,6 +264,8 @@ Press and hover animation timing, in milliseconds. Defaults to 50ms for the in p
 Each animation has two phases — `in` (running while the pointer engages the component) and `out` (running after the pointer releases) — across two categories:
 - `tap` — applies to presses.
 - `hover` — pointer hover (web only).
+
+`longPress` is an optional override for the press-out timing once the press has been held past [`delayLongPress`](#delaylongpress). It only has an `out` field (the press-in is always the `tap` in duration). If omitted, the long-press release uses the resolved `tap` out duration.
 
 Three input shapes are accepted:
 
@@ -290,6 +294,20 @@ Three input shapes are accepted:
   animationDuration={{
     tap: { in: 0, out: 200 },
     hover: { in: 300, out: 300 },
+  }}
+/>
+```
+
+To give a long press its own release timing, add `longPress.out`. The switch fires when the press is held past [`delayLongPress`](#delaylongpress):
+
+```tsx
+<Touchable
+  delayLongPress={400}
+  onLongPress={() => {}}
+  animationDuration={{
+    in: 50,
+    out: 100,
+    longPress: { out: 500 },
   }}
 />
 ```

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -279,6 +279,16 @@ class RNGestureHandlerButtonViewManager :
     view.tapAnimationOutDuration = if (value > 0) value else 0
   }
 
+  @ReactProp(name = "longPressDuration")
+  override fun setLongPressDuration(view: ButtonViewGroup, value: Int) {
+    view.longPressDuration = value
+  }
+
+  @ReactProp(name = "longPressAnimationOutDuration")
+  override fun setLongPressAnimationOutDuration(view: ButtonViewGroup, value: Int) {
+    view.longPressAnimationOutDuration = value
+  }
+
   @ReactProp(name = "defaultOpacity")
   override fun setDefaultOpacity(view: ButtonViewGroup, defaultOpacity: Float) {
     view.defaultOpacity = defaultOpacity
@@ -356,6 +366,9 @@ class RNGestureHandlerButtonViewManager :
     var exclusive = true
     var tapAnimationInDuration: Int = 50
     var tapAnimationOutDuration: Int = 100
+    var longPressDuration: Int = -1
+    var longPressAnimationOutDuration: Int = -1
+      get() = if (field < 0) tapAnimationOutDuration else field
     var activeOpacity: Float = 1.0f
     var defaultOpacity: Float = 1.0f
     var activeScale: Float = 1.0f
@@ -565,9 +578,14 @@ class RNGestureHandlerButtonViewManager :
       pendingPressOut?.let { handler.removeCallbacks(it) }
       val tapInMs = tapAnimationInDuration.toLong()
       val tapOutMs = tapAnimationOutDuration.toLong()
+      val longPressMs = longPressDuration.toLong()
+      val longPressOutMs = longPressAnimationOutDuration.toLong()
       val elapsed = SystemClock.uptimeMillis() - pressInTimestamp
 
-      if (elapsed >= tapInMs) {
+      if (longPressMs >= 0 && elapsed >= longPressMs) {
+        // Long-press release - use the configured long-press out duration.
+        animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, longPressOutMs)
+      } else if (elapsed >= tapInMs) {
         // Press-in animation fully finished — release with the configured out duration.
         animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, tapOutMs)
         // elapsed * 2 to ensure there is at least half of the tapAnimationOutDuration left for the animation to play

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.h
@@ -29,6 +29,8 @@
 
 @property (nonatomic, assign) NSInteger tapAnimationInDuration;
 @property (nonatomic, assign) NSInteger tapAnimationOutDuration;
+@property (nonatomic, assign) NSInteger longPressDuration;
+@property (nonatomic, assign) NSInteger longPressAnimationOutDuration;
 @property (nonatomic, assign) CGFloat activeOpacity;
 @property (nonatomic, assign) CGFloat defaultOpacity;
 @property (nonatomic, assign) CGFloat activeScale;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -49,6 +49,8 @@
   dispatch_block_t _pendingPressOutBlock;
 }
 
+@synthesize longPressAnimationOutDuration = _longPressAnimationOutDuration;
+
 - (void)commonInit
 {
   _isTouchInsideBounds = NO;
@@ -57,6 +59,8 @@
   _pointerEvents = RNGestureHandlerPointerEventsAuto;
   _tapAnimationInDuration = 50;
   _tapAnimationOutDuration = 100;
+  _longPressDuration = -1;
+  _longPressAnimationOutDuration = -1;
   _activeOpacity = 1.0;
   _defaultOpacity = 1.0;
   _activeScale = 1.0;
@@ -154,6 +158,11 @@
   }
 }
 #endif
+
+- (NSInteger)longPressAnimationOutDuration
+{
+  return _longPressAnimationOutDuration < 0 ? _tapAnimationOutDuration : _longPressAnimationOutDuration;
+}
 
 - (void)setUnderlayColor:(RNGHColor *)underlayColor
 {
@@ -317,7 +326,15 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 
   NSTimeInterval elapsed = (CACurrentMediaTime() - _pressInTimestamp) * 1000.0;
 
-  if (elapsed >= _tapAnimationInDuration) {
+  if (_longPressDuration >= 0 && elapsed >= _longPressDuration) {
+    // Long-press release - use the configured long-press out duration.
+    NSInteger longPressOut = self.longPressAnimationOutDuration;
+    RNGHUIView *target = self.animationTarget ?: self;
+    [self animateTarget:target toOpacity:_defaultOpacity scale:_defaultScale duration:longPressOut];
+    if (_activeUnderlayOpacity != _defaultUnderlayOpacity) {
+      [self animateUnderlayToOpacity:_defaultUnderlayOpacity duration:longPressOut];
+    }
+  } else if (elapsed >= _tapAnimationInDuration) {
     // Press-in animation fully finished - release with the configured out duration.
     RNGHUIView *target = self.animationTarget ?: self;
     [self animateTarget:target toOpacity:_defaultOpacity scale:_defaultScale duration:_tapAnimationOutDuration];

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
@@ -325,6 +325,8 @@ static RNGestureHandlerPointerEvents RCTPointerEventsToEnum(facebook::react::Poi
   _buttonView.userEnabled = newProps.enabled;
   _buttonView.tapAnimationInDuration = newProps.tapAnimationInDuration > 0 ? newProps.tapAnimationInDuration : 0;
   _buttonView.tapAnimationOutDuration = newProps.tapAnimationOutDuration > 0 ? newProps.tapAnimationOutDuration : 0;
+  _buttonView.longPressDuration = newProps.longPressDuration;
+  _buttonView.longPressAnimationOutDuration = newProps.longPressAnimationOutDuration;
   _buttonView.activeOpacity = newProps.activeOpacity;
   _buttonView.defaultOpacity = newProps.defaultOpacity;
   _buttonView.activeScale = newProps.activeScale;

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -72,6 +72,21 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
   tapAnimationOutDuration?: number | undefined;
 
   /**
+   * Threshold (in milliseconds) at which the press-out animation
+   * switches from the tap-out timing to `longPressAnimationOutDuration`.
+   * Set to any negative value to disable the switch.
+   */
+  longPressDuration?: number | undefined;
+
+  /**
+   * Duration of the press-out animation, in milliseconds, when the
+   * button is released after being held past `longPressDuration`.
+   * Defaults to `tapAnimationOutDuration` when not set (or set to any
+   * negative value).
+   */
+  longPressAnimationOutDuration?: number | undefined;
+
+  /**
    * Opacity applied to the button when it is pressed.
    */
   activeOpacity?: number | undefined;

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
@@ -10,6 +10,8 @@ type ButtonProps = ViewProps & {
   enabled?: boolean;
   tapAnimationInDuration?: number;
   tapAnimationOutDuration?: number;
+  longPressDuration?: number;
+  longPressAnimationOutDuration?: number;
   hoverAnimationInDuration?: number;
   hoverAnimationOutDuration?: number;
   activeOpacity?: number;
@@ -29,6 +31,8 @@ export const ButtonComponent = ({
   enabled = true,
   tapAnimationInDuration = 50,
   tapAnimationOutDuration = 100,
+  longPressDuration = -1,
+  longPressAnimationOutDuration = 100,
   hoverAnimationInDuration = 50,
   hoverAnimationOutDuration = 100,
   activeOpacity = 1,
@@ -146,7 +150,11 @@ export const ButtonComponent = ({
       const elapsed = performance.now() - pressInTimestamp.current;
       pressInTimestamp.current = 0;
 
-      if (elapsed >= tapAnimationInDuration) {
+      if (longPressDuration >= 0 && elapsed >= longPressDuration) {
+        // Long-press release — use the configured long-press out duration.
+        setCurrentDuration(longPressAnimationOutDuration);
+        setPressed(false);
+      } else if (elapsed >= tapAnimationInDuration) {
         // Press-in animation fully finished - release with the configured out duration.
         setCurrentDuration(tapAnimationOutDuration);
         setPressed(false);
@@ -164,7 +172,12 @@ export const ButtonComponent = ({
         }, remaining);
       }
     },
-    [tapAnimationInDuration, tapAnimationOutDuration]
+    [
+      longPressDuration,
+      longPressAnimationOutDuration,
+      tapAnimationInDuration,
+      tapAnimationOutDuration,
+    ]
   );
 
   const handlePointerEnter = React.useCallback(

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -21,6 +21,8 @@ interface NativeProps extends ViewProps {
   >;
   tapAnimationInDuration?: WithDefault<Int32, 50>;
   tapAnimationOutDuration?: WithDefault<Int32, 100>;
+  longPressDuration?: WithDefault<Int32, -1>;
+  longPressAnimationOutDuration?: WithDefault<Int32, -1>;
   activeOpacity?: WithDefault<Float, 1>;
   activeScale?: WithDefault<Float, 1>;
   activeUnderlayOpacity?: WithDefault<Float, 0>;

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -90,7 +90,7 @@ export const Touchable = (props: TouchableProps) => {
   } = props;
 
   const resolvedDurations = resolveAnimationDuration(animationDuration);
-  const longPressDuration = sanitizeDuration(delayLongPress);
+  const resolvedDelayLongPress = sanitizeDuration(delayLongPress);
 
   const shouldUseNativeRipple = isAndroid && androidRipple !== undefined;
 
@@ -109,9 +109,12 @@ export const Touchable = (props: TouchableProps) => {
     longPressDetected.current = false;
 
     if (onLongPress && !longPressTimeout.current) {
-      longPressTimeout.current = setTimeout(wrappedLongPress, delayLongPress);
+      longPressTimeout.current = setTimeout(
+        wrappedLongPress,
+        resolvedDelayLongPress
+      );
     }
-  }, [onLongPress, delayLongPress, wrappedLongPress]);
+  }, [onLongPress, resolvedDelayLongPress, wrappedLongPress]);
 
   const onBegin = useCallback(
     (e: CallbackEventType) => {
@@ -217,7 +220,7 @@ export const Touchable = (props: TouchableProps) => {
         defaultUnderlayOpacity={defaultUnderlayOpacity}
         activeUnderlayOpacity={activeUnderlayOpacity}
         underlayColor={underlayColor}
-        longPressDuration={longPressDuration}>
+        longPressDuration={resolvedDelayLongPress}>
         {children}
       </GestureHandlerButton>
     </NativeDetector>

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -34,6 +34,7 @@ function resolveAnimationDuration(value: AnimationDuration | undefined) {
     return {
       tapAnimationInDuration: DEFAULT_IN_DURATION_MS,
       tapAnimationOutDuration: DEFAULT_OUT_DURATION_MS,
+      longPressAnimationOutDuration: DEFAULT_OUT_DURATION_MS,
       hoverAnimationInDuration: DEFAULT_IN_DURATION_MS,
       hoverAnimationOutDuration: DEFAULT_OUT_DURATION_MS,
     };
@@ -44,6 +45,7 @@ function resolveAnimationDuration(value: AnimationDuration | undefined) {
     return {
       tapAnimationInDuration: sanitized,
       tapAnimationOutDuration: sanitized,
+      longPressAnimationOutDuration: sanitized,
       hoverAnimationInDuration: sanitized,
       hoverAnimationOutDuration: sanitized,
     };
@@ -54,10 +56,14 @@ function resolveAnimationDuration(value: AnimationDuration | undefined) {
   // always defined for well-typed input; the 0 fallbacks here are unreachable.
   const baseIn = 'in' in value ? value.in : 0;
   const baseOut = 'out' in value ? value.out : 0;
+  const tapOut = value.tap?.out ?? baseOut;
 
   return {
     tapAnimationInDuration: sanitizeDuration(value.tap?.in ?? baseIn),
-    tapAnimationOutDuration: sanitizeDuration(value.tap?.out ?? baseOut),
+    tapAnimationOutDuration: sanitizeDuration(tapOut),
+    longPressAnimationOutDuration: sanitizeDuration(
+      value.longPress?.out ?? tapOut
+    ),
     hoverAnimationInDuration: sanitizeDuration(value.hover?.in ?? baseIn),
     hoverAnimationOutDuration: sanitizeDuration(value.hover?.out ?? baseOut),
   };
@@ -84,6 +90,7 @@ export const Touchable = (props: TouchableProps) => {
   } = props;
 
   const resolvedDurations = resolveAnimationDuration(animationDuration);
+  const longPressDuration = sanitizeDuration(delayLongPress);
 
   const shouldUseNativeRipple = isAndroid && androidRipple !== undefined;
 
@@ -209,7 +216,8 @@ export const Touchable = (props: TouchableProps) => {
         defaultOpacity={defaultOpacity}
         defaultUnderlayOpacity={defaultUnderlayOpacity}
         activeUnderlayOpacity={activeUnderlayOpacity}
-        underlayColor={underlayColor}>
+        underlayColor={underlayColor}
+        longPressDuration={longPressDuration}>
         {children}
       </GestureHandlerButton>
     </NativeDetector>

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
@@ -20,10 +20,13 @@ type RippleProps = 'rippleColor' | 'rippleRadius' | 'borderless' | 'foreground';
 type DurationProps =
   | 'tapAnimationInDuration'
   | 'tapAnimationOutDuration'
+  | 'longPressDuration'
+  | 'longPressAnimationOutDuration'
   | 'hoverAnimationInDuration'
   | 'hoverAnimationOutDuration';
 
 type InOutDuration = { in: number; out: number };
+type LongPressDuration = { out: number };
 
 /**
  * Configuration for press / hover animation timing.
@@ -34,16 +37,22 @@ type InOutDuration = { in: number; out: number };
  *   inherits the top-level value.
  * - Alternatively, both categories may be specified in full without a
  *   top-level baseline.
+ *
+ * `longPress` optionally customizes the press-out duration once the
+ * press has been held past `delayLongPress`. If omitted, the long-press
+ * release falls back to the resolved tap-out timing.
  */
 export type AnimationDuration =
   | number
   | (InOutDuration & {
       tap?: Partial<InOutDuration>;
       hover?: Partial<InOutDuration>;
+      longPress?: LongPressDuration;
     })
   | {
       tap: InOutDuration;
       hover: InOutDuration;
+      longPress?: LongPressDuration;
     };
 
 export type TouchableProps = Omit<


### PR DESCRIPTION
## Description

Adds a `longPress` property to the `animationDuration` logic. When `delayLongPress` is set, the value is propagated to the native side, so it can recognize longpress and trigger the relevant animation path.

## Test plan

Updated the existing example
