### PR TITLE
[Android] Fix `TextInput` simultaneous relations

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -345,8 +345,12 @@ class NativeViewGestureHandler : GestureHandler() {
 
     // recognize alongside every handler besides RootViewGestureHandler;
     // also if other handler is NativeViewGestureHandler then don't override the default implementation
-    override fun shouldRecognizeSimultaneously(handler: GestureHandler) =
-      handler !is RNGestureHandlerRootHelper.RootViewGestureHandler && handler !is NativeViewGestureHandler
+    override fun shouldRecognizeSimultaneously(handler: GestureHandler): Boolean? =
+      if (handler is NativeViewGestureHandler) {
+        null
+      } else {
+        handler !is RNGestureHandlerRootHelper.RootViewGestureHandler
+      }
 
     override fun wantsToHandleEventBeforeActivation() = true
 


### PR DESCRIPTION
## Description

`shouldRecognizeSimultaneously` hook method has three possible return values: `true`/`false`/`null`. Override in `EditText` hook states that:

> (...) if other handler is `NativeViewGestureHandler` then don't override the default implementation

However, instead of `null` it returns `... && handler !is NativeViewGestureHandler`, so there's no way of getting `null` value, which is used in `Native` gesture [`shouldRecognizeSimultaneously` method](https://github.com/software-mansion/react-native-gesture-handler/blob/ea5f23f3b04032c537cfcd50c7d07ded6d7e2a20/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt#L62).

Fixes #3520 

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import {
  GestureHandlerRootView,
  ScrollView,
  TextInput,
} from 'react-native-gesture-handler';

function Component() {
  return (
    <ScrollView>
      {Array.from({ length: 50 }).map((_, index) => (
        <TextInput
          key={index}
          placeholder={`${index}`}
          style={{
            height: 40,
            borderColor: 'gray',
            borderWidth: 1,
            marginBottom: 10,
          }}
        />
      ))}
    </ScrollView>
  );
}

export default function App() {
  return (
    <GestureHandlerRootView>
      <Component />
    </GestureHandlerRootView>
  );
}
```

</details>