### PR TITLE
[Native] Fix exiting animation crash

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
@@ -225,6 +225,10 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
     }
 
     for (tag in nativeHandlers) {
+      if (attachedHandlers.contains(tag)) {
+        continue
+      }
+
       registry.attachHandlerToView(tag, id, GestureHandler.ACTION_TYPE_NATIVE_DETECTOR, this)
 
       attachedHandlers.add(tag)

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
@@ -329,6 +329,10 @@
   }
 
   for (NSNumber *handlerTag in _nativeHandlers) {
+    if ([_attachedHandlers containsObject:handlerTag]) {
+      continue;
+    }
+
     [handlerManager.registry attachHandlerWithTag:handlerTag
                                            toView:view
                                    withActionType:RNGestureHandlerActionTypeNativeDetector


### PR DESCRIPTION
## Description

@tomekzaw reported a crash with the `Touchable` component when used with `createAnimatedComponent` and layout animations. The specific prop was the `exiting` animation. It caused the native detector view to outlive the relevant gesture hook, which drops the native recognizer on unmount. Due to this, the exiting detector may have tried to reattach a non-existent recognizer, causing the crash.

This PR adds a check not to try reattaching already attached recognizers, which will effectively "freeze" the detector for the duration of the animation, unless its props change (which shouldn't happen, as its react node is gone at that point).

Android wasn't crashing (`attachHandlerToView` no-ops on non-existent handlers), but reattaching it would cause it to be canceled. For symmetry, I added the same guard there.

## Test plan

Rechecked reproducer from https://github.com/software-mansion/react-native-gesture-handler/pull/3672 to make sure it didn't regress.

Tested on the crashing app.
