### PR TITLE
Delay dropping native gesture handler on StrictMode

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -1,12 +1,27 @@
 import { render, renderHook } from '@testing-library/react-native';
-import { act } from 'react';
+import React, { act } from 'react';
 
 import GestureHandlerRootView from '../components/GestureHandlerRootView';
 import { fireGestureHandler, getByGestureTestId } from '../jestUtils';
+import RNGestureHandlerModule from '../RNGestureHandlerModule';
 import { State } from '../State';
 import { RectButton, Touchable } from '../v3/components';
 import { usePanGesture } from '../v3/hooks/gestures';
 import type { SingleGesture } from '../v3/types';
+
+async function flushQueuedOperations() {
+  await act(async () => {
+    await new Promise<void>((resolve) => {
+      setImmediate(() => resolve());
+    });
+  });
+}
+
+afterEach(async () => {
+  await flushQueuedOperations();
+  await flushQueuedOperations();
+  jest.restoreAllMocks();
+});
 
 describe('[API v3] Hooks', () => {
   test('Pan gesture', () => {
@@ -30,6 +45,32 @@ describe('[API v3] Hooks', () => {
 
     expect(onBegin).toHaveBeenCalledTimes(1);
     expect(onStart).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not drop native handler during StrictMode effect replay', async () => {
+    const dropGestureHandlerSpy = jest.spyOn(
+      RNGestureHandlerModule,
+      'dropGestureHandler'
+    );
+
+    const StrictModeWrapper = ({ children }: React.PropsWithChildren) => (
+      <React.StrictMode>{children}</React.StrictMode>
+    );
+
+    const { unmount } = renderHook(
+      () => usePanGesture({ disableReanimated: true }),
+      { wrapper: StrictModeWrapper }
+    );
+
+    await flushQueuedOperations();
+
+    expect(dropGestureHandlerSpy).not.toHaveBeenCalled();
+
+    unmount();
+    await flushQueuedOperations();
+    await flushQueuedOperations();
+
+    expect(dropGestureHandlerSpy).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -105,7 +105,12 @@ export function useGesture<
       const dropGestureHandlerToken = ++dropGestureHandlerTokenRef.current;
 
       ghQueueMicrotask(() => {
-        if (dropGestureHandlerTokenRef.current !== dropGestureHandlerToken) {
+        const wasSameHandlerRecreated =
+          dropGestureHandlerTokenRef.current !== dropGestureHandlerToken &&
+          currentGestureRef.current.handlerTag === handlerTag &&
+          currentGestureRef.current.type === type;
+
+        if (wasSameHandlerRecreated) {
           return;
         }
 

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef } from 'react';
 
+import { ghQueueMicrotask } from '../../ghQueueMicrotask';
 import { getNextHandlerTag } from '../../handlers/getNextHandlerTag';
 import {
   registerGesture,
@@ -62,6 +63,7 @@ export function useGesture<
   );
 
   const currentGestureRef = useRef({ type: '', handlerTag: -1 });
+  const dropGestureHandlerTokenRef = useRef(0);
   if (
     currentGestureRef.current.handlerTag !== handlerTag ||
     currentGestureRef.current.type !== (type as string)
@@ -94,13 +96,26 @@ export function useGesture<
   );
 
   useEffect(() => {
-    return () => {
-      if (currentGestureRef.current.handlerTag === handlerTag) {
-        currentGestureRef.current = { type: '', handlerTag: -1 };
-      }
+    // React StrictMode replays effects without re-rendering, while the native
+    // detector can keep the same handler tag attached during that replay.
+    // Delay dropping the native handler so the replayed mount can cancel it.
+    dropGestureHandlerTokenRef.current += 1;
 
-      NativeProxy.dropGestureHandler(handlerTag);
-      scheduleFlushOperations();
+    return () => {
+      const dropGestureHandlerToken = ++dropGestureHandlerTokenRef.current;
+
+      ghQueueMicrotask(() => {
+        if (dropGestureHandlerTokenRef.current !== dropGestureHandlerToken) {
+          return;
+        }
+
+        if (currentGestureRef.current.handlerTag === handlerTag) {
+          currentGestureRef.current = { type: '', handlerTag: -1 };
+        }
+
+        NativeProxy.dropGestureHandler(handlerTag);
+        scheduleFlushOperations();
+      });
     };
   }, [type, handlerTag]);
 

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -96,8 +96,7 @@ export function useGesture<
   );
 
   useEffect(() => {
-    // React StrictMode replays effects without re-rendering, while the native
-    // detector can keep the same handler tag attached during that replay.
+    // React StrictMode replays effects without recreating the hook instance.
     // Delay dropping the native handler so the replayed mount can cancel it.
     dropGestureHandlerTokenRef.current += 1;
 


### PR DESCRIPTION
## Description

In the strict mode React does a simulated unmount/remount of effects (without fully unmounting/remounting the component instance). This causes [dropping](https://github.com/software-mansion/react-native-gesture-handler/blob/main/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts#L102) the native gesture handler and rerunning the [useEffect](https://github.com/software-mansion/react-native-gesture-handler/blob/main/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts#L107-L113) with the same `handlerTag` that was already dropped. 

The solution is to delay dropping the gesture handler with `ghQueueMicrotask` and increment a helper token on each effect setup and cleanup. During StrictMode’s simulated unmount/remount, the replayed setup increments the token before the delayed drop runs. The delayed callback then sees that its captured token no longer matches the current token and skips the drop.

On a real unmount, no setup runs afterward for that hook instance, so the token remains unchanged and the delayed drop proceeds. 

Fixes #4172 

## Test plan

I've used the repro from the #4172 

<!--
Describe how did you test this change here.
-->
