### PR TITLE
[General] Change how gestures are attached to the native detector to fix StrictMode

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
@@ -16,61 +16,33 @@ import com.swmansion.gesturehandler.react.RNGestureHandlerRootView
 class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
   private val reactContext: ThemedReactContext
     get() = context as ThemedReactContext
-  private var handlersToAttach: List<Int>? = null
-  private var virtualChildrenToAttach: List<VirtualChildren>? = null
+  private var handlersToAttach: List<Int> = emptyList()
+  private var virtualChildrenToAttach: List<VirtualChildren> = emptyList()
   private var nativeHandlers: MutableSet<Int> = mutableSetOf()
+  private var subscribedHandlers: MutableSet<Int> = mutableSetOf()
   private var attachedHandlers: MutableSet<Int> = mutableSetOf()
-  private var attachedVirtualHandlers: MutableMap<Int, MutableSet<Int>> = mutableMapOf()
+  private var subscribedVirtualHandlers: MutableMap<Int, MutableSet<Int>> = mutableMapOf()
   private var moduleId: Int = -1
 
   data class VirtualChildren(val handlerTags: List<Int>, val viewTag: Int)
 
   fun setHandlerTags(handlerTags: ReadableArray?) {
-    val newHandlers = handlerTags?.toArrayList()?.map { (it as Double).toInt() } ?: emptyList()
-    if (moduleId == -1) {
-      // It's possible that handlerTags will be set before module id. In that case, store
-      // the handler ids and attach them after setting module id.
-      handlersToAttach = newHandlers
-      return
+    handlersToAttach = handlerTags?.toArrayList()?.map { (it as Double).toInt() } ?: emptyList()
+    if (moduleId != -1) {
+      attachHandlers(handlersToAttach)
     }
-
-    attachHandlers(newHandlers)
   }
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
-
     if (moduleId != -1) {
-      handlersToAttach?.let {
-        attachHandlers(it)
-      }
-
-      virtualChildrenToAttach?.let {
-        attachVirtualChildren(it)
-      }
-
-      handlersToAttach = null
-      virtualChildrenToAttach = null
+      attachHandlers(handlersToAttach)
+      attachVirtualChildren(virtualChildrenToAttach)
     }
   }
 
   override fun onDetachedFromWindow() {
-    if (attachedHandlers.isNotEmpty()) {
-      handlersToAttach = attachedHandlers.toMutableList().also {
-        it.addAll(handlersToAttach ?: emptyList())
-      }
-    }
-
-    if (attachedVirtualHandlers.isNotEmpty()) {
-      virtualChildrenToAttach = attachedVirtualHandlers.map {
-        VirtualChildren(it.value.toList(), it.key)
-      }.toMutableList().also {
-        it.addAll(virtualChildrenToAttach ?: emptyList())
-      }
-    }
-
     detachAllHandlers()
-
     super.onDetachedFromWindow()
   }
 
@@ -78,30 +50,15 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
     assert(this.moduleId == -1) { "Tried to change moduleId of a native detector" }
 
     this.moduleId = id
-    this.attachHandlers(handlersToAttach ?: return)
-    handlersToAttach = null
-    this.attachVirtualChildren(virtualChildrenToAttach ?: return)
-    virtualChildrenToAttach = null
+    attachHandlers(handlersToAttach)
+    attachVirtualChildren(virtualChildrenToAttach)
   }
 
   fun setVirtualChildren(newVirtualChildren: ReadableArray?) {
-    val mappedChildren = newVirtualChildren?.mapVirtualChildren().orEmpty()
-
-    if (moduleId == -1) {
-      // It's possible that handlerTags will be set before module id. In that case, store
-      // the handler ids and attach them after setting module id.
-      virtualChildrenToAttach = mappedChildren
-      return
+    virtualChildrenToAttach = newVirtualChildren?.mapVirtualChildren().orEmpty()
+    if (moduleId != -1) {
+      attachVirtualChildren(virtualChildrenToAttach)
     }
-
-    attachVirtualChildren(mappedChildren)
-  }
-
-  private fun shouldAttachGestureToChildView(tag: Int): Boolean {
-    val registry = RNGestureHandlerModule.registries[moduleId]
-      ?: throw Exception("Tried to access a non-existent registry")
-
-    return registry.getHandler(tag)?.wantsToAttachDirectlyToView() ?: false
   }
 
   // We override this `addView` because it is called inside `addView(child: View?, index: Int)`
@@ -127,49 +84,61 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
     newHandlers: List<Int>,
     viewTag: Int = this.id,
     actionType: Int = GestureHandler.ACTION_TYPE_NATIVE_DETECTOR,
-    attachedHandlers: MutableSet<Int> = this.attachedHandlers,
+    subscribedHandlers: MutableSet<Int> = this.subscribedHandlers,
   ) {
     val registry = RNGestureHandlerModule.registries[moduleId]
       ?: throw Exception("Tried to access a non-existent registry")
 
-    val handlersToDetach = attachedHandlers.toMutableSet()
+    val handlersToDetach = subscribedHandlers.toMutableSet()
 
     for (tag in newHandlers) {
       handlersToDetach.remove(tag)
-      if (!attachedHandlers.contains(tag)) {
-        if (shouldAttachGestureToChildView(tag) && actionType == GestureHandler.ACTION_TYPE_NATIVE_DETECTOR) {
-          // It might happen that `attachHandlers` will be called before children are added into view hierarchy. In that case we cannot
-          // attach `NativeViewGestureHandlers` here and we have to do it in `addView` method.
-          assert(childCount <= 1) {
-            "Cannot attach native gesture handlers when the detector has multiple children"
-          }
-          nativeHandlers.add(tag)
-        } else {
-          registry.attachHandlerToView(tag, viewTag, actionType, this)
-          if (actionType == GestureHandler.ACTION_TYPE_VIRTUAL_DETECTOR) {
-            registry.getHandler(tag)?.hostDetectorView = this
-          }
-          attachedHandlers.add(tag)
+      if (!subscribedHandlers.contains(tag)) {
+        registry.observeHandler(tag, this) { handler ->
+          attachReadyHandler(handler, actionType, viewTag)
         }
+        subscribedHandlers.add(tag)
       }
     }
 
     for (tag in handlersToDetach) {
-      registry.detachHandlerFromHostDetector(tag, this)
+      registry.cancelObservation(tag, this)
+      if (attachedHandlers.contains(tag)) {
+        registry.detachHandlerFromHostDetector(tag, this)
+        attachedHandlers.remove(tag)
+      }
+      subscribedHandlers.remove(tag)
       nativeHandlers.remove(tag)
-      attachedHandlers.remove(tag)
-    }
-
-    val child = getChildAt(0)
-
-    // This covers the case where `NativeViewGestureHandlers` are attached after child views were created.
-    if (child != null) {
-      tryAttachNativeHandlersToChildView(child)
     }
   }
 
+  // Invoked from the registry's `observeHandler` callback once the handler is known to exist.
+  // Branches on handler kind + actionType to pick the right binding flow. May be called multiple
+  // times for the same tag (handler re-registration), so each branch must be idempotent.
+  private fun attachReadyHandler(handler: GestureHandler, actionType: Int, viewTag: Int) {
+    val registry = RNGestureHandlerModule.registries[moduleId]
+      ?: throw Exception("Tried to access a non-existent registry")
+
+    if (handler.wantsToAttachDirectlyToView() && actionType == GestureHandler.ACTION_TYPE_NATIVE_DETECTOR) {
+      assert(childCount <= 1) {
+        "Cannot attach native gesture handlers when the detector has multiple children"
+      }
+      nativeHandlers.add(handler.tag)
+      if (childCount != 0) {
+        tryAttachNativeHandlersToChildView(getChildAt(0))
+      }
+      return
+    }
+
+    registry.attachHandlerToView(handler.tag, viewTag, actionType, this)
+    if (actionType == GestureHandler.ACTION_TYPE_VIRTUAL_DETECTOR) {
+      handler.hostDetectorView = this
+    }
+    attachedHandlers.add(handler.tag)
+  }
+
   private fun attachVirtualChildren(virtualChildrenToAttach: List<VirtualChildren>) {
-    val virtualChildrenToDetach = attachedVirtualHandlers.keys.toMutableSet()
+    val virtualChildrenToDetach = subscribedVirtualHandlers.keys.toMutableSet()
 
     for (child in virtualChildrenToAttach) {
       virtualChildrenToDetach.remove(child.viewTag)
@@ -179,22 +148,26 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
       ?: throw Exception("Tried to access a non-existent registry")
 
     for (child in virtualChildrenToDetach) {
-      for (tag in attachedVirtualHandlers[child]!!) {
-        registry.detachHandlerFromHostDetector(tag, this)
+      for (tag in subscribedVirtualHandlers[child]!!) {
+        registry.cancelObservation(tag, this)
+        if (attachedHandlers.contains(tag)) {
+          registry.detachHandlerFromHostDetector(tag, this)
+          attachedHandlers.remove(tag)
+        }
       }
-      attachedVirtualHandlers.remove(tag)
+      subscribedVirtualHandlers.remove(child)
     }
 
     for (child in virtualChildrenToAttach) {
-      if (!attachedVirtualHandlers.containsKey(child.viewTag)) {
-        attachedVirtualHandlers[child.viewTag] = mutableSetOf()
+      if (!subscribedVirtualHandlers.containsKey(child.viewTag)) {
+        subscribedVirtualHandlers[child.viewTag] = mutableSetOf()
       }
 
       attachHandlers(
         child.handlerTags,
         child.viewTag,
         GestureHandler.ACTION_TYPE_VIRTUAL_DETECTOR,
-        attachedVirtualHandlers[child.viewTag]!!,
+        subscribedVirtualHandlers[child.viewTag]!!,
       )
     }
   }
@@ -225,12 +198,13 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
     }
 
     for (tag in nativeHandlers) {
-      if (attachedHandlers.contains(tag)) {
+      // Defensive: a tag may be in `nativeHandlers` from an earlier ready callback but the
+      // underlying handler may have been dropped since. Skip; a re-registration will fire the
+      // observation again.
+      if (registry.getHandler(tag) == null) {
         continue
       }
-
       registry.attachHandlerToView(tag, id, GestureHandler.ACTION_TYPE_NATIVE_DETECTOR, this)
-
       attachedHandlers.add(tag)
     }
   }
@@ -240,6 +214,9 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
       ?: throw Exception("Tried to access a non-existent registry")
 
     for (tag in nativeHandlers) {
+      if (!attachedHandlers.contains(tag)) {
+        continue
+      }
       registry.detachHandlerFromHostDetector(tag, this)
       attachedHandlers.remove(tag)
     }
@@ -251,20 +228,16 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
   }
 
   fun detachAllHandlers() {
-    val registry = RNGestureHandlerModule.registries[moduleId]
-      ?: throw Exception("Tried to access a non-existent registry")
-
-    for (tag in attachedHandlers.toMutableSet()) {
-      registry.detachHandlerFromHostDetector(tag, this)
-      attachedHandlers.remove(tag)
-    }
-
-    for (child in attachedVirtualHandlers) {
-      for (tag in child.value) {
+    RNGestureHandlerModule.registries[moduleId]?.let { registry ->
+      registry.cancelAllObservationsForOwner(this)
+      for (tag in attachedHandlers) {
         registry.detachHandlerFromHostDetector(tag, this)
       }
-      child.value.clear()
     }
+    attachedHandlers.clear()
+    subscribedVirtualHandlers.clear()
+    subscribedHandlers.clear()
+    nativeHandlers.clear()
   }
 
   fun recordHandlerIfNotPresent(handler: GestureHandler) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -61,7 +61,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   }
 
   @ReactMethod
-  override fun createGestureHandler(handlerName: String, handlerTagDouble: Double, config: ReadableMap): Boolean {
+  override fun createGestureHandler(handlerName: String, handlerTagDouble: Double, config: ReadableMap) {
     if (isReanimatedAvailable && !uiRuntimeDecorated) {
       uiRuntimeDecorated = decorateUIRuntime()
     }
@@ -69,8 +69,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
     val handlerTag = handlerTagDouble.toInt()
 
     createGestureHandlerHelper<GestureHandler>(handlerName, handlerTag, config)
-
-    return true
   }
 
   @ReactMethod

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
@@ -14,19 +14,24 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
   private val observers = mutableMapOf<Int, MutableMap<Any, (GestureHandler) -> Unit>>()
 
   fun registerHandler(handler: GestureHandler) {
-    val callbacks = synchronized(this) {
+    val hasObservers = synchronized(this) {
       handlers.put(handler.tag, handler)
-      observers[handler.tag]?.values?.toList().orEmpty()
+      observers[handler.tag]?.isNotEmpty() == true
     }
 
-    if (callbacks.isEmpty()) {
+    if (!hasObservers) {
       return
     }
 
     // `createGestureHandler` runs on the JS thread, but observer callbacks read detector
     // view state (childCount, getChildAt) and may attach native handlers, so they must run
-    // on the UI thread.
+    // on the UI thread. Re-resolve the observer list on the UI thread so a cancellation that
+    // happens between this post and `notify` running (e.g. detector detach) actually prevents
+    // the callback.
     val notify = {
+      val callbacks = synchronized(this) {
+        observers[handler.tag]?.values?.toList().orEmpty()
+      }
       for (callback in callbacks) {
         callback(handler)
       }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
@@ -19,8 +19,23 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
       observers[handler.tag]?.values?.toList().orEmpty()
     }
 
-    for (block in blocks) {
-      block(handler)
+    if (blocks.isEmpty()) {
+      return
+    }
+
+    // `createGestureHandler` runs on the JS thread, but observer callbacks read detector
+    // view state (childCount, getChildAt) and may attach native handlers, so they must run
+    // on the UI thread.
+    val notify = {
+      for (block in blocks) {
+        block(handler)
+      }
+    }
+
+    if (UiThreadUtil.isOnUiThread()) {
+      notify()
+    } else {
+      UiThreadUtil.runOnUiThread(notify)
     }
   }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
@@ -14,12 +14,12 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
   private val observers = mutableMapOf<Int, MutableMap<Any, (GestureHandler) -> Unit>>()
 
   fun registerHandler(handler: GestureHandler) {
-    val blocks = synchronized(this) {
+    val callbacks = synchronized(this) {
       handlers.put(handler.tag, handler)
       observers[handler.tag]?.values?.toList().orEmpty()
     }
 
-    if (blocks.isEmpty()) {
+    if (callbacks.isEmpty()) {
       return
     }
 
@@ -27,8 +27,8 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
     // view state (childCount, getChildAt) and may attach native handlers, so they must run
     // on the UI thread.
     val notify = {
-      for (block in blocks) {
-        block(handler)
+      for (callback in callbacks) {
+        callback(handler)
       }
     }
 
@@ -55,9 +55,9 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
 
   @Synchronized
   fun cancelObservation(tag: Int, owner: Any) {
-    val table = observers[tag] ?: return
-    table.remove(owner)
-    if (table.isEmpty()) {
+    val observersForTag = observers[tag] ?: return
+    observersForTag.remove(owner)
+    if (observersForTag.isEmpty()) {
       observers.remove(tag)
     }
   }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRegistry.kt
@@ -11,10 +11,52 @@ class RNGestureHandlerRegistry : GestureHandlerRegistry {
   private val handlers = SparseArray<GestureHandler>()
   private val attachedTo = SparseArray<Int?>()
   private val handlersForView = SparseArray<ArrayList<GestureHandler>>()
+  private val observers = mutableMapOf<Int, MutableMap<Any, (GestureHandler) -> Unit>>()
+
+  fun registerHandler(handler: GestureHandler) {
+    val blocks = synchronized(this) {
+      handlers.put(handler.tag, handler)
+      observers[handler.tag]?.values?.toList().orEmpty()
+    }
+
+    for (block in blocks) {
+      block(handler)
+    }
+  }
+
+  // Invokes `block` every time a handler with `tag` is registered, and synchronously once now if
+  // the handler already exists. The observation persists until explicitly cancelled: the registry
+  // holds both `owner` and `block` strongly, so callers MUST call `cancelObservation` or
+  // `cancelAllObservationsForOwner` when the owner is going away (typically in detach / dispose
+  // paths) to avoid leaking the owner. Observing the same tag twice with the same `owner` replaces
+  // the previous block.
+  fun observeHandler(tag: Int, owner: Any, block: (GestureHandler) -> Unit) {
+    val existing = synchronized(this) {
+      observers.getOrPut(tag) { mutableMapOf() }[owner] = block
+      handlers[tag]
+    }
+    existing?.let { block(it) }
+  }
 
   @Synchronized
-  fun registerHandler(handler: GestureHandler) {
-    handlers.put(handler.tag, handler)
+  fun cancelObservation(tag: Int, owner: Any) {
+    val table = observers[tag] ?: return
+    table.remove(owner)
+    if (table.isEmpty()) {
+      observers.remove(tag)
+    }
+  }
+
+  @Synchronized
+  fun cancelAllObservationsForOwner(owner: Any) {
+    val iterator = observers.entries.iterator()
+    while (iterator.hasNext()) {
+      val entry = iterator.next()
+      entry.value.remove(owner)
+      if (entry.value.isEmpty()) {
+        iterator.remove()
+      }
+    }
   }
 
   @Synchronized

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
@@ -16,8 +16,9 @@
 @interface RNGestureHandlerDetector () <RCTRNGestureHandlerDetectorViewProtocol>
 
 @property (nonatomic, nonnull) NSMutableSet *nativeHandlers;
+@property (nonatomic, nonnull) NSMutableSet *subscribedHandlers;
 @property (nonatomic, nonnull) NSMutableSet *attachedHandlers;
-@property (nonatomic) std::unordered_map<int, NSMutableSet *> attachedVirtualHandlers;
+@property (nonatomic) std::unordered_map<int, NSMutableSet *> subscribedVirtualHandlers;
 
 @end
 
@@ -49,25 +50,23 @@
     RNGestureHandlerManager *handlerManager = [RNGestureHandlerModule handlerManagerForModuleId:_moduleId];
     react_native_assert(handlerManager != nullptr && "Tried to access a non-existent handler manager");
 
-    const auto &props = *std::static_pointer_cast<const RNGestureHandlerDetectorProps>(_props);
+    [handlerManager.registry cancelAllObservationsForOwner:self];
 
-    for (const auto handler : props.handlerTags) {
-      NSNumber *handlerTag = [NSNumber numberWithInt:handler];
+    for (NSNumber *handlerTag in _attachedHandlers) {
       [handlerManager.registry detachHandlerWithTag:handlerTag fromHostDetector:self];
     }
-    for (const auto &child : _attachedVirtualHandlers) {
-      for (id handlerTag : child.second) {
-        [handlerManager.registry detachHandlerWithTag:handlerTag fromHostDetector:self];
-      }
-    }
-    _attachedVirtualHandlers.clear();
-    _attachedHandlers = [NSMutableSet set];
+
+    [_attachedHandlers removeAllObjects];
+    _subscribedVirtualHandlers.clear();
+    [_subscribedHandlers removeAllObjects];
+    [_nativeHandlers removeAllObjects];
   } else {
     const auto &props = *std::static_pointer_cast<const RNGestureHandlerDetectorProps>(_props);
     [self attachHandlers:props.handlerTags
-              actionType:RNGestureHandlerActionTypeNativeDetector
-                 viewTag:-1
-        attachedHandlers:_attachedHandlers];
+                actionType:RNGestureHandlerActionTypeNativeDetector
+                   viewTag:-1
+        subscribedHandlers:_subscribedHandlers];
+    [self updateVirtualChildren:props.virtualChildren];
   }
 }
 
@@ -77,6 +76,7 @@
   _props = defaultProps;
   _moduleId = -1;
   _nativeHandlers = [NSMutableSet set];
+  _subscribedHandlers = [NSMutableSet set];
   _attachedHandlers = [NSMutableSet set];
 }
 
@@ -140,13 +140,6 @@
   }
 }
 
-- (BOOL)shouldAttachGestureToSubview:(NSNumber *)handlerTag
-{
-  RNGestureHandlerManager *handlerManager = [RNGestureHandlerModule handlerManagerForModuleId:_moduleId];
-
-  return [[[handlerManager registry] handlerWithTag:handlerTag] wantsToAttachDirectlyToView];
-}
-
 - (void)prepareForRecycle
 {
   [super prepareForRecycle];
@@ -194,62 +187,82 @@
 - (void)attachHandlers:(const std::vector<int> &)handlerTags
             actionType:(RNGestureHandlerActionType)actionType
                viewTag:(const int)viewTag
-      attachedHandlers:(NSMutableSet *)attachedHandlers
+    subscribedHandlers:(NSMutableSet *)subscribedHandlers
 {
   RNGestureHandlerManager *handlerManager = [RNGestureHandlerModule handlerManagerForModuleId:_moduleId];
   react_native_assert(handlerManager != nullptr && "Tried to access a non-existent handler manager");
 
-  NSMutableSet *handlersToDetach = [attachedHandlers mutableCopy];
+  NSMutableSet *handlersToDetach = [subscribedHandlers mutableCopy];
+
+  __weak __typeof(self) weakSelf = self;
 
   for (const int tag : handlerTags) {
     [handlersToDetach removeObject:@(tag)];
-    if (![attachedHandlers containsObject:@(tag)]) {
-      if ([self shouldAttachGestureToSubview:@(tag)] && actionType == RNGestureHandlerActionTypeNativeDetector) {
-        // It might happen that `attachHandlers` will be called before children are added into view hierarchy. In that
-        // case we cannot attach `NativeViewGestureHandlers` here and we have to do it in `didAddSubview` method.
-        react_native_assert(
-            self.subviews.count <= 1 &&
-            "Cannot attach native gesture handlers when the detector has multiple children");
-        [_nativeHandlers addObject:@(tag)];
-      } else {
-        if (actionType == RNGestureHandlerActionTypeVirtualDetector) {
-          RNGHUIView *targetView = [handlerManager viewForReactTag:@(viewTag)];
-
-          if (targetView != nil) {
-            [handlerManager attachGestureHandler:@(tag)
-                                   toViewWithTag:@(viewTag)
-                                  withActionType:actionType
-                                withHostDetector:self];
-          } else {
-            // Let's assume that if the native view for the virtual detector hasn't been found, the hierarchy was folded
-            // into a single UIView.
-            [handlerManager.registry attachHandlerWithTag:@(tag)
-                                                   toView:self
-                                           withActionType:actionType
-                                         withHostDetector:self];
-            [[handlerManager registry] handlerWithTag:@(tag)].virtualViewTag = @(viewTag);
-          }
-        } else {
-          [handlerManager.registry attachHandlerWithTag:@(tag)
-                                                 toView:self
-                                         withActionType:actionType
-                                       withHostDetector:self];
-        }
-        [attachedHandlers addObject:@(tag)];
-      }
+    if ([subscribedHandlers containsObject:@(tag)]) {
+      continue;
     }
+
+    [handlerManager.registry observeHandlerWithTag:@(tag)
+                                             owner:self
+                                        usingBlock:^(RNGestureHandler *handler) {
+                                          __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                          if (strongSelf == nil) {
+                                            return;
+                                          }
+                                          [strongSelf attachReadyHandler:handler actionType:actionType viewTag:viewTag];
+                                        }];
+    [subscribedHandlers addObject:@(tag)];
   }
 
   for (const id tag : handlersToDetach) {
-    [handlerManager.registry detachHandlerWithTag:tag fromHostDetector:self];
-    [attachedHandlers removeObject:tag];
+    [handlerManager.registry cancelObservationForTag:tag owner:self];
+    if ([_attachedHandlers containsObject:tag]) {
+      [handlerManager.registry detachHandlerWithTag:tag fromHostDetector:self];
+      [_attachedHandlers removeObject:tag];
+    }
+    [subscribedHandlers removeObject:tag];
     [_nativeHandlers removeObject:tag];
   }
+}
 
-  // This covers the case where `NativeViewGestureHandlers` are attached after child views were created.
-  if (self.subviews.count != 0) {
-    [self tryAttachNativeHandlersToChildView];
+// Invoked from the registry's `observeHandlerWithTag:` block once the handler is known to exist.
+// Branches on handler kind + actionType to pick the right binding flow. May be called multiple
+// times for the same tag (handler re-registration), so each branch must be idempotent.
+- (void)attachReadyHandler:(RNGestureHandler *)handler
+                actionType:(RNGestureHandlerActionType)actionType
+                   viewTag:(int)viewTag
+{
+  RNGestureHandlerManager *manager = [RNGestureHandlerModule handlerManagerForModuleId:_moduleId];
+  react_native_assert(manager != nullptr && "Tried to access a non-existent handler manager");
+
+  if ([handler wantsToAttachDirectlyToView] && actionType == RNGestureHandlerActionTypeNativeDetector) {
+    react_native_assert(
+        self.subviews.count <= 1 && "Cannot attach native gesture handlers when the detector has multiple children");
+    [_nativeHandlers addObject:handler.tag];
+    if (self.subviews.count != 0) {
+      [self tryAttachNativeHandlersToChildView];
+    }
+    return;
   }
+
+  if (actionType == RNGestureHandlerActionTypeVirtualDetector) {
+    RNGHUIView *targetView = [manager viewForReactTag:@(viewTag)];
+    if (targetView != nil) {
+      [manager attachGestureHandler:handler.tag
+                      toViewWithTag:@(viewTag)
+                     withActionType:actionType
+                   withHostDetector:self];
+    } else {
+      // Hierarchy was folded into a single UIView.
+      [manager.registry attachHandlerWithTag:handler.tag toView:self withActionType:actionType withHostDetector:self];
+      handler.virtualViewTag = @(viewTag);
+    }
+    [_attachedHandlers addObject:handler.tag];
+    return;
+  }
+
+  [manager.registry attachHandlerWithTag:handler.tag toView:self withActionType:actionType withHostDetector:self];
+  [_attachedHandlers addObject:handler.tag];
 }
 
 - (void)updateProps:(const Props::Shared &)propsBase oldProps:(const Props::Shared &)oldPropsBase
@@ -258,9 +271,9 @@
   _moduleId = newProps.moduleId;
 
   [self attachHandlers:newProps.handlerTags
-            actionType:RNGestureHandlerActionTypeNativeDetector
-               viewTag:-1
-      attachedHandlers:_attachedHandlers];
+              actionType:RNGestureHandlerActionTypeNativeDetector
+                 viewTag:-1
+      subscribedHandlers:_subscribedHandlers];
 
   [super updateProps:propsBase oldProps:oldPropsBase];
   [self updateVirtualChildren:newProps.virtualChildren];
@@ -275,7 +288,7 @@
   react_native_assert(handlerManager != nullptr && "Tried to access a non-existent handler manager");
 
   NSMutableSet *virtualChildrenToDetach = [NSMutableSet set];
-  for (const auto &child : _attachedVirtualHandlers) {
+  for (const auto &child : _subscribedVirtualHandlers) {
     [virtualChildrenToDetach addObject:@(child.first)];
   }
 
@@ -284,20 +297,24 @@
   }
 
   for (const NSNumber *tag : virtualChildrenToDetach) {
-    for (id handlerTag : _attachedVirtualHandlers[tag.intValue]) {
-      [handlerManager.registry detachHandlerWithTag:handlerTag fromHostDetector:self];
+    for (id handlerTag : _subscribedVirtualHandlers[tag.intValue]) {
+      [handlerManager.registry cancelObservationForTag:handlerTag owner:self];
+      if ([_attachedHandlers containsObject:handlerTag]) {
+        [handlerManager.registry detachHandlerWithTag:handlerTag fromHostDetector:self];
+        [_attachedHandlers removeObject:handlerTag];
+      }
     }
-    _attachedVirtualHandlers.erase(tag.intValue);
+    _subscribedVirtualHandlers.erase(tag.intValue);
   }
 
   for (const auto &child : virtualChildren) {
-    if (_attachedVirtualHandlers.find(child.viewTag) == _attachedVirtualHandlers.end()) {
-      _attachedVirtualHandlers[child.viewTag] = [NSMutableSet set];
+    if (_subscribedVirtualHandlers.find(child.viewTag) == _subscribedVirtualHandlers.end()) {
+      _subscribedVirtualHandlers[child.viewTag] = [NSMutableSet set];
     }
     [self attachHandlers:child.handlerTags
-              actionType:RNGestureHandlerActionTypeVirtualDetector
-                 viewTag:child.viewTag
-        attachedHandlers:_attachedVirtualHandlers[child.viewTag]];
+                actionType:RNGestureHandlerActionTypeVirtualDetector
+                   viewTag:child.viewTag
+        subscribedHandlers:_subscribedVirtualHandlers[child.viewTag]];
   }
 }
 
@@ -329,15 +346,15 @@
   }
 
   for (NSNumber *handlerTag in _nativeHandlers) {
-    if ([_attachedHandlers containsObject:handlerTag]) {
+    // A tag may be in `_nativeHandlers` from an earlier block fire but the underlying
+    // handler may have been dropped since. Skip - a re-registration will fire the block again.
+    if ([handlerManager.registry handlerWithTag:handlerTag] == nil) {
       continue;
     }
-
     [handlerManager.registry attachHandlerWithTag:handlerTag
                                            toView:view
                                    withActionType:RNGestureHandlerActionTypeNativeDetector
                                  withHostDetector:self];
-
     [_attachedHandlers addObject:handlerTag];
   }
 }
@@ -347,6 +364,9 @@
   RNGestureHandlerManager *handlerManager = [RNGestureHandlerModule handlerManagerForModuleId:_moduleId];
 
   for (NSNumber *handlerTag in _nativeHandlers) {
+    if (![_attachedHandlers containsObject:handlerTag]) {
+      continue;
+    }
     [[handlerManager registry] detachHandlerWithTag:handlerTag fromHostDetector:self];
     [_attachedHandlers removeObject:handlerTag];
   }

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
@@ -204,13 +204,13 @@
 
     [handlerManager.registry observeHandlerWithTag:@(tag)
                                              owner:self
-                                        usingBlock:^(RNGestureHandler *handler) {
-                                          __strong __typeof(weakSelf) strongSelf = weakSelf;
-                                          if (strongSelf == nil) {
-                                            return;
-                                          }
-                                          [strongSelf attachReadyHandler:handler actionType:actionType viewTag:viewTag];
-                                        }];
+                                      withCallback:^(RNGestureHandler *handler) {
+                                        __strong __typeof(weakSelf) strongSelf = weakSelf;
+                                        if (strongSelf == nil) {
+                                          return;
+                                        }
+                                        [strongSelf attachReadyHandler:handler actionType:actionType viewTag:viewTag];
+                                      }];
     [subscribedHandlers addObject:@(tag)];
   }
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.mm
@@ -118,16 +118,15 @@ RCT_EXPORT_MODULE()
   });
 }
 
-- (NSNumber *)createGestureHandler:(NSString *)handlerName handlerTag:(double)handlerTag config:(NSDictionary *)config
+- (void)createGestureHandler:(NSString *)handlerName handlerTag:(double)handlerTag config:(NSDictionary *)config
 {
   if (_isReanimatedAvailable && !_uiRuntimeDecorated) {
     _uiRuntimeDecorated = [self installUIRuntimeBindings];
   }
 
-  RNGestureHandlerManager *manager = [RNGestureHandlerModule handlerManagerForModuleId:_moduleId];
-  [manager createGestureHandler:handlerName tag:[NSNumber numberWithDouble:handlerTag] config:config];
-
-  return @1;
+  [self addOperationBlock:^(RNGestureHandlerManager *manager) {
+    [manager createGestureHandler:handlerName tag:[NSNumber numberWithDouble:handlerTag] config:config];
+  }];
 }
 
 - (void)attachGestureHandler:(double)handlerTag newView:(double)viewTag actionType:(double)actionType

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.h
@@ -29,7 +29,7 @@ typedef void (^RNGestureHandlerReadyBlock)(RNGestureHandler *_Nonnull handler);
 // key; observing the same tag twice with the same `owner` replaces the previous block.
 - (void)observeHandlerWithTag:(nonnull NSNumber *)handlerTag
                         owner:(nonnull id)owner
-                   usingBlock:(nonnull RNGestureHandlerReadyBlock)block;
+                 withCallback:(nonnull RNGestureHandlerReadyBlock)callback;
 
 - (void)cancelObservationForTag:(nonnull NSNumber *)handlerTag owner:(nonnull id)owner;
 - (void)cancelAllObservationsForOwner:(nonnull id)owner;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.h
@@ -8,6 +8,8 @@
 
 #import "RNGestureHandler.h"
 
+typedef void (^RNGestureHandlerReadyBlock)(RNGestureHandler *_Nonnull handler);
+
 @interface RNGestureHandlerRegistry : NSObject
 
 - (nullable RNGestureHandler *)handlerWithTag:(nonnull NSNumber *)handlerTag;
@@ -19,6 +21,18 @@
 - (void)detachHandlerWithTag:(nonnull NSNumber *)handlerTag fromHostDetector:(nonnull RNGHUIView *)hostDetectorView;
 - (void)dropHandlerWithTag:(nonnull NSNumber *)handlerTag;
 - (void)dropAllHandlers;
+
+// Invokes `block` every time a handler with `handlerTag` is registered. If the handler already
+// exists at the time this method is called, `block` is also invoked synchronously before returning.
+// The observation persists until explicitly cancelled (or until `owner` is deallocated, provided
+// the block does not strongly capture `owner`). `owner` is held weakly and acts as the cancellation
+// key; observing the same tag twice with the same `owner` replaces the previous block.
+- (void)observeHandlerWithTag:(nonnull NSNumber *)handlerTag
+                        owner:(nonnull id)owner
+                   usingBlock:(nonnull RNGestureHandlerReadyBlock)block;
+
+- (void)cancelObservationForTag:(nonnull NSNumber *)handlerTag owner:(nonnull id)owner;
+- (void)cancelAllObservationsForOwner:(nonnull id)owner;
 
 @property (nonatomic, readonly, nonnull) NSDictionary<NSNumber *, RNGestureHandler *> *handlers;
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.m
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.m
@@ -54,7 +54,7 @@
   }
 }
 
-- (void)observeHandlerWithTag:(NSNumber *)handlerTag owner:(id)owner usingBlock:(RNGestureHandlerReadyBlock)block
+- (void)observeHandlerWithTag:(NSNumber *)handlerTag owner:(id)owner withCallback:(RNGestureHandlerReadyBlock)callback
 {
   RNGestureHandler *existing = nil;
 
@@ -66,13 +66,13 @@
                                 valueOptions:NSPointerFunctionsStrongMemory];
       _observers[handlerTag] = table;
     }
-    [table setObject:[block copy] forKey:owner];
 
+    [table setObject:[callback copy] forKey:owner];
     existing = _handlers[handlerTag];
   }
 
   if (existing != nil) {
-    block(existing);
+    callback(existing);
   }
 }
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.m
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.m
@@ -12,12 +12,14 @@
 
 @implementation RNGestureHandlerRegistry {
   NSMutableDictionary<NSNumber *, RNGestureHandler *> *_handlers;
+  NSMutableDictionary<NSNumber *, NSMapTable<id, RNGestureHandlerReadyBlock> *> *_observers;
 }
 
 - (instancetype)init
 {
   if ((self = [super init])) {
     _handlers = [NSMutableDictionary new];
+    _observers = [NSMutableDictionary new];
   }
   return self;
 }
@@ -36,8 +38,66 @@
 
 - (void)registerGestureHandler:(RNGestureHandler *)gestureHandler
 {
+  NSArray<RNGestureHandlerReadyBlock> *observers = nil;
+
   @synchronized(_handlers) {
     _handlers[gestureHandler.tag] = gestureHandler;
+
+    NSMapTable *table = _observers[gestureHandler.tag];
+    if (table != nil) {
+      observers = [[table objectEnumerator] allObjects];
+    }
+  }
+
+  for (RNGestureHandlerReadyBlock block in observers) {
+    block(gestureHandler);
+  }
+}
+
+- (void)observeHandlerWithTag:(NSNumber *)handlerTag owner:(id)owner usingBlock:(RNGestureHandlerReadyBlock)block
+{
+  RNGestureHandler *existing = nil;
+
+  @synchronized(_handlers) {
+    NSMapTable *table = _observers[handlerTag];
+    if (table == nil) {
+      table =
+          [NSMapTable mapTableWithKeyOptions:NSPointerFunctionsWeakMemory | NSPointerFunctionsObjectPointerPersonality
+                                valueOptions:NSPointerFunctionsStrongMemory];
+      _observers[handlerTag] = table;
+    }
+    [table setObject:[block copy] forKey:owner];
+
+    existing = _handlers[handlerTag];
+  }
+
+  if (existing != nil) {
+    block(existing);
+  }
+}
+
+- (void)cancelObservationForTag:(NSNumber *)handlerTag owner:(id)owner
+{
+  @synchronized(_handlers) {
+    NSMapTable *table = _observers[handlerTag];
+    [table removeObjectForKey:owner];
+    if (table.count == 0) {
+      [_observers removeObjectForKey:handlerTag];
+    }
+  }
+}
+
+- (void)cancelAllObservationsForOwner:(id)owner
+{
+  @synchronized(_handlers) {
+    NSArray<NSNumber *> *tags = [_observers allKeys];
+    for (NSNumber *tag in tags) {
+      NSMapTable *table = _observers[tag];
+      [table removeObjectForKey:owner];
+      if (table.count == 0) {
+        [_observers removeObjectForKey:tag];
+      }
+    }
   }
 }
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.m
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.m
@@ -92,11 +92,7 @@
   @synchronized(_handlers) {
     NSArray<NSNumber *> *tags = [_observers allKeys];
     for (NSNumber *tag in tags) {
-      NSMapTable *table = _observers[tag];
-      [table removeObjectForKey:owner];
-      if (table.count == 0) {
-        [_observers removeObjectForKey:tag];
-      }
+      [self cancelObservationForTag:tag owner:owner];
     }
   }
 }

--- a/packages/react-native-gesture-handler/src/RNGestureHandlerModule.web.ts
+++ b/packages/react-native-gesture-handler/src/RNGestureHandlerModule.web.ts
@@ -82,6 +82,14 @@ export default {
     NodeManager.dropGestureHandler(handlerTag);
   },
   configureRelations(handlerTag: number, relations: GestureRelations) {
+    // Match Android/iOS behavior: silently no-op when the handler isn't registered yet. There is
+    // an unavoidable race on initial mount where `useGestureRelationsUpdater`'s effect (child)
+    // fires before `useGesture`'s `createGestureHandler` effect (parent). The relations get
+    // re-applied on the next pass once the `gesture` identity changes (which it typically does
+    // when the user's config contains inline callbacks).
+    if (!NodeManager.hasHandler(handlerTag)) {
+      return;
+    }
     InteractionManager.instance.configureInteractions(
       NodeManager.getHandler(handlerTag),
       relations

--- a/packages/react-native-gesture-handler/src/specs/NativeRNGestureHandlerModule.ts
+++ b/packages/react-native-gesture-handler/src/specs/NativeRNGestureHandlerModule.ts
@@ -3,15 +3,13 @@ import { TurboModuleRegistry } from 'react-native';
 import type { Double } from 'react-native/Libraries/Types/CodegenTypes';
 
 export interface Spec extends TurboModule {
-  // This method returns a boolean only to force the codegen to generate
-  // a synchronous method. The returned value doesn't have any meaning.
   createGestureHandler: (
     handlerName: string,
     handlerTag: Double,
     // Record<> is not supported by codegen
     // eslint-disable-next-line @typescript-eslint/ban-types
     config: Object
-  ) => boolean;
+  ) => void;
   attachGestureHandler: (
     handlerTag: Double,
     newView: Double,

--- a/packages/react-native-gesture-handler/src/v3/NativeProxy.ts
+++ b/packages/react-native-gesture-handler/src/v3/NativeProxy.ts
@@ -16,11 +16,13 @@ export const NativeProxy = {
     handlerTag: number,
     config?: T
   ) => {
-    RNGestureHandlerModule.createGestureHandler(
-      handlerName,
-      handlerTag,
-      config || {}
-    );
+    scheduleOperationToBeFlushed(() => {
+      RNGestureHandlerModule.createGestureHandler(
+        handlerName,
+        handlerTag,
+        config || {}
+      );
+    });
   },
   setGestureHandlerConfig: <
     TConfig,

--- a/packages/react-native-gesture-handler/src/v3/detectors/HostGestureDetector.web.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/HostGestureDetector.web.tsx
@@ -10,6 +10,7 @@ import type {
 import RNGestureHandlerModule from '../../RNGestureHandlerModule.web';
 import { tagMessage } from '../../utils';
 import { type PropsRef } from '../../web/interfaces';
+import NodeManager from '../../web/tools/NodeManager';
 import { useNativeGestureRole } from './useNativeGestureRole';
 
 export interface GestureHandlerDetectorProps extends PropsRef {
@@ -31,81 +32,227 @@ export interface VirtualChildrenWeb {
   enableContextMenu?: boolean | undefined;
 }
 
-const EMPTY_HANDLERS = new Set<number>();
+// Bundles all per-instance state passed to the standalone helpers below. Holding everything in
+// one stable object keeps the helpers pure (no closures over component-render-scoped values),
+// which means the useEffects don't need them in their deps lists.
+type DetectorRefs = {
+  owner: object;
+  viewRef: RefObject<Element | null>;
+  propsRef: RefObject<GestureHandlerDetectorProps>;
+  // Tags observed for the detector view (top-level).
+  subscribedHandlers: Set<number>;
+  // Flat set of tags currently bound to *some* element (top-level or virtual). Mirrors iOS
+  // `_attachedHandlers` / Android `attachedHandlers`.
+  attachedHandlers: Set<number>;
+  // Tags whose handler asked to attach to the detector's child element rather than the detector
+  // itself (`shouldAttachGestureToChildView`). Kept here so we can (re)bind them as subviews
+  // appear.
+  nativeHandlers: Set<number>;
+  // For each virtual child's viewTag, the set of currently-observed handler tags.
+  subscribedVirtualHandlers: Map<number, Set<number>>;
+  // Latest snapshot of virtual children keyed by viewTag. The ready callback reads this so
+  // re-fires after a child's per-DOM props change use the up-to-date values.
+  virtualChildren: Map<number, VirtualChildrenWeb>;
+};
+
+// Invoked from `NodeManager.observeHandler` once the handler is known to exist. Branches on
+// handler kind + actionType to pick the right binding flow. May be called multiple times for
+// the same tag (handler re-registration), so each branch must be idempotent.
+function attachReadyHandler(
+  refs: DetectorRefs,
+  tag: number,
+  actionType: ActionType,
+  virtualViewTag?: number
+) {
+  const handler = RNGestureHandlerModule.getGestureHandlerNode(tag);
+
+  if (
+    actionType === ActionType.NATIVE_DETECTOR &&
+    handler.shouldAttachGestureToChildView()
+  ) {
+    refs.nativeHandlers.add(tag);
+    if (
+      refs.viewRef.current != null &&
+      refs.viewRef.current.childElementCount > 0
+    ) {
+      tryAttachNativeHandlersToChildView(refs);
+    }
+    return;
+  }
+
+  if (actionType === ActionType.VIRTUAL_DETECTOR) {
+    const child =
+      virtualViewTag != null
+        ? refs.virtualChildren.get(virtualViewTag)
+        : undefined;
+    if (child == null || child.viewRef.current == null) {
+      return;
+    }
+
+    if (!refs.attachedHandlers.has(tag)) {
+      RNGestureHandlerModule.attachGestureHandler(
+        tag,
+        child.viewRef.current,
+        actionType,
+        refs.propsRef
+      );
+      refs.attachedHandlers.add(tag);
+    }
+
+    RNGestureHandlerModule.updateGestureHandlerConfig(tag, {
+      userSelect: child.userSelect,
+      touchAction: child.touchAction,
+      enableContextMenu: child.enableContextMenu,
+    });
+    return;
+  }
+
+  if (refs.viewRef.current == null) {
+    return;
+  }
+
+  if (!refs.attachedHandlers.has(tag)) {
+    RNGestureHandlerModule.attachGestureHandler(
+      tag,
+      refs.viewRef.current,
+      actionType,
+      refs.propsRef
+    );
+    refs.attachedHandlers.add(tag);
+  }
+
+  RNGestureHandlerModule.updateGestureHandlerConfig(tag, {
+    userSelect: refs.propsRef.current.userSelect,
+    touchAction: refs.propsRef.current.touchAction,
+    enableContextMenu: refs.propsRef.current.enableContextMenu,
+  });
+}
+
+function tryAttachNativeHandlersToChildView(refs: DetectorRefs) {
+  if (refs.nativeHandlers.size === 0) {
+    return;
+  }
+
+  const view = refs.viewRef.current;
+  if (view == null) {
+    return;
+  }
+
+  if (view.childElementCount > 1) {
+    throw new Error(
+      tagMessage(
+        'Cannot have more than one child view when native gesture handlers are attached to the detector'
+      )
+    );
+  }
+
+  const target = view.firstElementChild;
+  if (target == null) {
+    return;
+  }
+
+  for (const tag of refs.nativeHandlers) {
+    // A tag may be in `nativeHandlers` from an earlier ready callback but the underlying
+    // handler may have been dropped since. Skip — a re-registration fires the observation again.
+    if (!NodeManager.hasHandler(tag)) {
+      continue;
+    }
+    if (refs.attachedHandlers.has(tag)) {
+      continue;
+    }
+    RNGestureHandlerModule.attachGestureHandler(
+      tag,
+      target,
+      ActionType.NATIVE_DETECTOR,
+      refs.propsRef
+    );
+    refs.attachedHandlers.add(tag);
+    RNGestureHandlerModule.updateGestureHandlerConfig(tag, {
+      userSelect: refs.propsRef.current.userSelect,
+      touchAction: refs.propsRef.current.touchAction,
+      enableContextMenu: refs.propsRef.current.enableContextMenu,
+    });
+  }
+}
+
+// Reconcile `subscribedSet` against `currentTags`: observe new tags, cancel observation and
+// detach for tags no longer present. The ready callback set up here is responsible for actually
+// binding the handler once it exists.
+function syncSubscriptions(
+  refs: DetectorRefs,
+  currentTags: Iterable<number>,
+  subscribedSet: Set<number>,
+  actionType: ActionType,
+  virtualViewTag?: number
+) {
+  const toUnsubscribe = new Set(subscribedSet);
+  for (const tag of currentTags) {
+    toUnsubscribe.delete(tag);
+    if (subscribedSet.has(tag)) {
+      continue;
+    }
+    NodeManager.observeHandler(tag, refs.owner, () => {
+      attachReadyHandler(refs, tag, actionType, virtualViewTag);
+    });
+    subscribedSet.add(tag);
+  }
+
+  for (const tag of toUnsubscribe) {
+    NodeManager.cancelObservation(tag, refs.owner);
+    if (refs.attachedHandlers.has(tag)) {
+      RNGestureHandlerModule.detachGestureHandler(tag);
+      refs.attachedHandlers.delete(tag);
+    }
+    subscribedSet.delete(tag);
+    refs.nativeHandlers.delete(tag);
+  }
+}
+
+function teardown(refs: DetectorRefs) {
+  NodeManager.cancelAllObservationsForOwner(refs.owner);
+  for (const tag of refs.attachedHandlers) {
+    RNGestureHandlerModule.detachGestureHandler(tag);
+  }
+  refs.attachedHandlers.clear();
+  refs.subscribedHandlers.clear();
+  refs.nativeHandlers.clear();
+  refs.subscribedVirtualHandlers.clear();
+  refs.virtualChildren.clear();
+}
 
 const HostGestureDetector = (props: GestureHandlerDetectorProps) => {
   const { handlerTags, children } = props;
 
-  const handlerTagsSet = useMemo(() => new Set(handlerTags), [...handlerTags]);
+  const handlerTagsSet = useMemo(
+    () => new Set(handlerTags),
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [...handlerTags]
+  );
 
   const viewRef = useRef<Element>(null);
   const propsRef = useRef<GestureHandlerDetectorProps>(props);
-  const attachedHandlers = useRef<Set<number>>(new Set<number>());
-  const attachedNativeHandlers = useRef<Set<number>>(new Set<number>());
-  const attachedVirtualHandlers = useRef<Map<number, Set<number>>>(new Map());
 
-  const detachHandlers = (
-    currentHandlerTags: Set<number>,
-    attachedHandlerTags: Set<number>
-  ) => {
-    const oldHandlerTags = attachedHandlerTags.difference(currentHandlerTags);
-    oldHandlerTags.forEach((tag) => {
-      RNGestureHandlerModule.detachGestureHandler(tag);
-      attachedHandlerTags.delete(tag);
-    });
-  };
-
-  const attachHandlers = (
-    viewRef: RefObject<Element | null>,
-    propsRef: RefObject<GestureHandlerDetectorProps>,
-    currentHandlerTags: Set<number>,
-    attachedHandlerTags: Set<number>,
-    actionType: ActionType
-  ) => {
-    const newHandlerTags = currentHandlerTags.difference(attachedHandlerTags);
-
-    newHandlerTags.forEach((tag) => {
-      if (
-        RNGestureHandlerModule.getGestureHandlerNode(
-          tag
-        ).shouldAttachGestureToChildView() &&
-        actionType === ActionType.NATIVE_DETECTOR
-      ) {
-        if (viewRef.current!.childElementCount > 1) {
-          throw new Error(
-            tagMessage(
-              'Cannot have more than one child view when native gesture handlers are attached to the detector'
-            )
-          );
-        }
-
-        RNGestureHandlerModule.attachGestureHandler(
-          tag,
-          viewRef.current!.firstChild,
-          actionType,
-          propsRef
-        );
-        attachedNativeHandlers.current.add(tag);
-      } else {
-        RNGestureHandlerModule.attachGestureHandler(
-          tag,
-          viewRef.current,
-          actionType,
-          propsRef
-        );
-      }
-      attachedHandlerTags.add(tag);
-
-      RNGestureHandlerModule.updateGestureHandlerConfig(tag, {
-        userSelect: props.userSelect,
-        touchAction: props.touchAction,
-        enableContextMenu: props.enableContextMenu,
-      });
-    });
-  };
+  // Stable per-instance state
+  const refsRef = useRef<DetectorRefs | null>(null);
+  if (refsRef.current === null) {
+    refsRef.current = {
+      owner: {},
+      viewRef,
+      propsRef,
+      subscribedHandlers: new Set<number>(),
+      attachedHandlers: new Set<number>(),
+      nativeHandlers: new Set<number>(),
+      subscribedVirtualHandlers: new Map<number, Set<number>>(),
+      virtualChildren: new Map<number, VirtualChildrenWeb>(),
+    };
+  }
+  const refs = refsRef.current;
 
   useNativeGestureRole(viewRef, children);
 
+  // Keep propsRef in sync and re-apply detector-level DOM props to top-level attached handlers
+  // when they change. Virtual children get their own (potentially different) DOM props applied
+  // in the virtualChildren effect below, so we only touch top-level subscribers here.
   useEffect(() => {
     const shouldUpdateDOMProps =
       propsRef.current.userSelect !== props.userSelect ||
@@ -115,7 +262,20 @@ const HostGestureDetector = (props: GestureHandlerDetectorProps) => {
     propsRef.current = props;
 
     if (shouldUpdateDOMProps) {
-      for (const tag of attachedHandlers.current) {
+      // attachedHandlers ⊆ subscribedHandlers ⋃ subscribedVirtualHandlers, we want to ignore the
+      // handlers attached by the virtual detectors not to overwrite their DOM props.
+      const claimedByVirtual = new Set<number>();
+      for (const virtualHandlers of refs.subscribedVirtualHandlers.values()) {
+        for (const tag of virtualHandlers) {
+          claimedByVirtual.add(tag);
+        }
+      }
+
+      for (const tag of refs.subscribedHandlers) {
+        if (!refs.attachedHandlers.has(tag) || claimedByVirtual.has(tag)) {
+          continue;
+        }
+
         RNGestureHandlerModule.updateGestureHandlerConfig(tag, {
           userSelect: props.userSelect,
           touchAction: props.touchAction,
@@ -123,38 +283,38 @@ const HostGestureDetector = (props: GestureHandlerDetectorProps) => {
         });
       }
     }
-  }, [props]);
+  }, [props, refs]);
 
   useEffect(() => {
-    detachHandlers(handlerTagsSet, attachedHandlers.current);
-
-    attachHandlers(
-      viewRef,
-      propsRef,
+    syncSubscriptions(
+      refs,
       handlerTagsSet,
-      attachedHandlers.current,
+      refs.subscribedHandlers,
       ActionType.NATIVE_DETECTOR
     );
-    return () => {
-      detachHandlers(EMPTY_HANDLERS, attachedHandlers.current);
-      attachedVirtualHandlers?.current.forEach((childHandlerTags) => {
-        detachHandlers(EMPTY_HANDLERS, childHandlerTags);
-      });
-    };
-  }, [handlerTagsSet, viewRef]);
+  }, [handlerTagsSet, refs]);
 
   useEffect(() => {
-    const virtualChildrenToDetach: Set<number> = new Set(
-      attachedVirtualHandlers.current.keys()
-    );
+    // Refresh the snapshot used by the ready callback so re-fires read current child props.
+    refs.virtualChildren.clear();
+    props.virtualChildren?.forEach((child) => {
+      refs.virtualChildren.set(child.viewTag, child);
+    });
 
+    const virtualChildrenToDetach = new Set(
+      refs.subscribedVirtualHandlers.keys()
+    );
     props.virtualChildren?.forEach((child) => {
       virtualChildrenToDetach.delete(child.viewTag);
     });
 
-    virtualChildrenToDetach.forEach((tag) => {
-      detachHandlers(EMPTY_HANDLERS, attachedVirtualHandlers.current.get(tag)!);
-    });
+    for (const viewTag of virtualChildrenToDetach) {
+      const tags = refs.subscribedVirtualHandlers.get(viewTag);
+      if (tags != null) {
+        syncSubscriptions(refs, [], tags, ActionType.VIRTUAL_DETECTOR, viewTag);
+      }
+      refs.subscribedVirtualHandlers.delete(viewTag);
+    }
 
     props.virtualChildren?.forEach((child) => {
       if (child.viewRef.current == null) {
@@ -162,33 +322,37 @@ const HostGestureDetector = (props: GestureHandlerDetectorProps) => {
         // switches its component based on whether animated/reanimated events should run.
         return;
       }
-      if (!attachedVirtualHandlers.current.has(child.viewTag)) {
-        attachedVirtualHandlers.current.set(child.viewTag, new Set());
+
+      let subs = refs.subscribedVirtualHandlers.get(child.viewTag);
+      if (subs == null) {
+        subs = new Set();
+        refs.subscribedVirtualHandlers.set(child.viewTag, subs);
       }
-
-      const currentHandlerTags = new Set(child.handlerTags);
-      detachHandlers(
-        currentHandlerTags,
-        attachedVirtualHandlers.current.get(child.viewTag)!
+      syncSubscriptions(
+        refs,
+        child.handlerTags,
+        subs,
+        ActionType.VIRTUAL_DETECTOR,
+        child.viewTag
       );
-
-      attachHandlers(
-        child.viewRef,
-        propsRef,
-        currentHandlerTags,
-        attachedVirtualHandlers.current.get(child.viewTag)!,
-        ActionType.VIRTUAL_DETECTOR
-      );
-
-      currentHandlerTags.forEach((tag) => {
-        RNGestureHandlerModule.updateGestureHandlerConfig(tag, {
-          userSelect: child.userSelect,
-          touchAction: child.touchAction,
-          enableContextMenu: child.enableContextMenu,
-        });
-      });
+      // Re-apply per-child DOM props on every run. Already-attached tags need this when only
+      // the child's props change; tags attached via a sync-fired observer already had it
+      // applied in `attachReadyHandler`, so this is a no-op for them.
+      for (const tag of subs) {
+        if (refs.attachedHandlers.has(tag)) {
+          RNGestureHandlerModule.updateGestureHandlerConfig(tag, {
+            userSelect: child.userSelect,
+            touchAction: child.touchAction,
+            enableContextMenu: child.enableContextMenu,
+          });
+        }
+      }
     });
-  }, [props.virtualChildren]);
+  }, [props.virtualChildren, refs]);
+
+  useEffect(() => {
+    return () => teardown(refs);
+  }, [refs]);
 
   return (
     <View style={{ display: 'contents' }} ref={viewRef as Ref<View>}>

--- a/packages/react-native-gesture-handler/src/v3/detectors/HostGestureDetector.web.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/HostGestureDetector.web.tsx
@@ -260,18 +260,15 @@ const HostGestureDetector = (props: GestureHandlerDetectorProps) => {
     if (shouldUpdateDOMProps) {
       // attachedHandlers ⊆ subscribedHandlers ⋃ subscribedVirtualHandlers, we want to ignore the
       // handlers attached by the virtual detectors not to overwrite their DOM props.
-      const claimedByVirtual = new Set<number>();
-      for (const virtualHandlers of refs.subscribedVirtualHandlers.values()) {
-        for (const tag of virtualHandlers) {
-          claimedByVirtual.add(tag);
-        }
-      }
+      const claimedByVirtual = Array.from(
+        refs.subscribedVirtualHandlers.values()
+      ).reduce((acc, current) => acc.union(current), new Set<number>());
 
-      for (const tag of refs.subscribedHandlers) {
-        if (!refs.attachedHandlers.has(tag) || claimedByVirtual.has(tag)) {
-          continue;
-        }
+      const handlersToUpdate = refs.subscribedHandlers
+        .intersection(refs.attachedHandlers)
+        .difference(claimedByVirtual);
 
+      for (const tag of handlersToUpdate) {
         RNGestureHandlerModule.updateGestureHandlerConfig(tag, {
           userSelect: props.userSelect,
           touchAction: props.touchAction,

--- a/packages/react-native-gesture-handler/src/v3/detectors/HostGestureDetector.web.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/HostGestureDetector.web.tsx
@@ -223,11 +223,7 @@ function teardown(refs: DetectorRefs) {
 const HostGestureDetector = (props: GestureHandlerDetectorProps) => {
   const { handlerTags, children } = props;
 
-  const handlerTagsSet = useMemo(
-    () => new Set(handlerTags),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    [...handlerTags]
-  );
+  const handlerTagsSet = useMemo(() => new Set(handlerTags), [...handlerTags]);
 
   const viewRef = useRef<Element>(null);
   const propsRef = useRef<GestureHandlerDetectorProps>(props);

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useMemo } from 'react';
 
 import { getNextHandlerTag } from '../../handlers/getNextHandlerTag';
 import {
@@ -61,15 +61,6 @@ export function useGesture<
     [handlerTag, config.simultaneousWith, config.requireToFail, config.block]
   );
 
-  const currentGestureRef = useRef({ type: '', handlerTag: -1 });
-  if (
-    currentGestureRef.current.handlerTag !== handlerTag ||
-    currentGestureRef.current.type !== (type as string)
-  ) {
-    currentGestureRef.current = { type, handlerTag };
-    NativeProxy.createGestureHandler(type, handlerTag, {});
-  }
-
   const gesture = useMemo(
     () => ({
       handlerTag,
@@ -94,11 +85,10 @@ export function useGesture<
   );
 
   useEffect(() => {
-    return () => {
-      if (currentGestureRef.current.handlerTag === handlerTag) {
-        currentGestureRef.current = { type: '', handlerTag: -1 };
-      }
+    NativeProxy.createGestureHandler(type, handlerTag, {});
+    scheduleFlushOperations();
 
+    return () => {
       NativeProxy.dropGestureHandler(handlerTag);
       scheduleFlushOperations();
     };

--- a/packages/react-native-gesture-handler/src/web/tools/NodeManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/NodeManager.ts
@@ -102,11 +102,8 @@ export default abstract class NodeManager {
   }
 
   public static cancelAllObservationsForOwner(owner: object): void {
-    for (const [tag, table] of this.observers) {
-      table.delete(owner);
-      if (table.size === 0) {
-        this.observers.delete(tag);
-      }
+    for (const tag of this.observers.keys()) {
+      this.cancelObservation(tag, owner);
     }
   }
 

--- a/packages/react-native-gesture-handler/src/web/tools/NodeManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/NodeManager.ts
@@ -2,6 +2,8 @@ import type { ValueOf } from '../../typeUtils';
 import type { Gestures } from '../Gestures';
 import type IGestureHandler from '../handlers/IGestureHandler';
 
+type HandlerReadyBlock = (handler: IGestureHandler) => void;
+
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export default abstract class NodeManager {
   private static gestures: Record<
@@ -9,12 +11,19 @@ export default abstract class NodeManager {
     InstanceType<ValueOf<typeof Gestures>>
   > = {};
 
+  private static observers: Map<number, Map<object, HandlerReadyBlock>> =
+    new Map();
+
   public static getHandler(tag: number): IGestureHandler {
     if (tag in this.gestures) {
       return this.gestures[tag] as IGestureHandler;
     }
 
     throw new Error(`No handler for tag ${tag}`);
+  }
+
+  public static hasHandler(tag: number): boolean {
+    return tag in this.gestures;
   }
 
   public static createGestureHandler(
@@ -29,6 +38,15 @@ export default abstract class NodeManager {
 
     this.gestures[handlerTag] = handler;
     this.gestures[handlerTag].handlerTag = handlerTag;
+
+    const pending = this.observers.get(handlerTag);
+    if (pending) {
+      // Snapshot before iterating — blocks may call back into observeHandler / cancelObservation
+      // and mutate the underlying map.
+      for (const block of Array.from(pending.values())) {
+        block(handler as IGestureHandler);
+      }
+    }
   }
 
   public static dropGestureHandler(handlerTag: number): void {
@@ -48,6 +66,48 @@ export default abstract class NodeManager {
     }
 
     this.gestures[handlerTag].detach();
+  }
+
+  // Invokes `block` every time a handler with `tag` is created, and synchronously once now if
+  // the handler already exists. The observation persists until explicitly cancelled: the registry
+  // holds both `owner` and `block` strongly, so callers MUST call `cancelObservation` or
+  // `cancelAllObservationsForOwner` when the owner is going away (typically in effect cleanup) to
+  // avoid leaking. Observing the same tag twice with the same `owner` replaces the previous block.
+  public static observeHandler(
+    tag: number,
+    owner: object,
+    block: HandlerReadyBlock
+  ): void {
+    let table = this.observers.get(tag);
+    if (!table) {
+      table = new Map();
+      this.observers.set(tag, table);
+    }
+    table.set(owner, block);
+
+    if (tag in this.gestures) {
+      block(this.gestures[tag] as IGestureHandler);
+    }
+  }
+
+  public static cancelObservation(tag: number, owner: object): void {
+    const table = this.observers.get(tag);
+    if (!table) {
+      return;
+    }
+    table.delete(owner);
+    if (table.size === 0) {
+      this.observers.delete(tag);
+    }
+  }
+
+  public static cancelAllObservationsForOwner(owner: object): void {
+    for (const [tag, table] of this.observers) {
+      table.delete(owner);
+      if (table.size === 0) {
+        this.observers.delete(tag);
+      }
+    }
   }
 
   public static get nodes() {

--- a/packages/react-native-gesture-handler/src/web/tools/NodeManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/NodeManager.ts
@@ -68,8 +68,8 @@ export default abstract class NodeManager {
     this.gestures[handlerTag].detach();
   }
 
-  // Invokes `block` every time a handler with `tag` is created, and synchronously once now if
-  // the handler already exists. The observation persists until explicitly cancelled: the registry
+  // Invokes `block` every time a handler with `tag` is created and, if the handler already exists,
+  // immediately before returning. The observation persists until explicitly cancelled: the registry
   // holds both `owner` and `block` strongly, so callers MUST call `cancelObservation` or
   // `cancelAllObservationsForOwner` when the owner is going away (typically in effect cleanup) to
   // avoid leaking. Observing the same tag twice with the same `owner` replaces the previous block.

--- a/packages/react-native-gesture-handler/src/web/tools/NodeManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/NodeManager.ts
@@ -2,7 +2,7 @@ import type { ValueOf } from '../../typeUtils';
 import type { Gestures } from '../Gestures';
 import type IGestureHandler from '../handlers/IGestureHandler';
 
-type HandlerReadyBlock = (handler: IGestureHandler) => void;
+type HandlerReadyCallback = (handler: IGestureHandler) => void;
 
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export default abstract class NodeManager {
@@ -11,7 +11,7 @@ export default abstract class NodeManager {
     InstanceType<ValueOf<typeof Gestures>>
   > = {};
 
-  private static observers: Map<number, Map<object, HandlerReadyBlock>> =
+  private static observers: Map<number, Map<object, HandlerReadyCallback>> =
     new Map();
 
   public static getHandler(tag: number): IGestureHandler {
@@ -41,10 +41,10 @@ export default abstract class NodeManager {
 
     const pending = this.observers.get(handlerTag);
     if (pending) {
-      // Snapshot before iterating — blocks may call back into observeHandler / cancelObservation
+      // Snapshot before iterating — callbacks may call back into observeHandler / cancelObservation
       // and mutate the underlying map.
-      for (const block of Array.from(pending.values())) {
-        block(handler as IGestureHandler);
+      for (const callback of Array.from(pending.values())) {
+        callback(handler as IGestureHandler);
       }
     }
   }
@@ -68,25 +68,25 @@ export default abstract class NodeManager {
     this.gestures[handlerTag].detach();
   }
 
-  // Invokes `block` every time a handler with `tag` is created and, if the handler already exists,
+  // Invokes `callback` every time a handler with `tag` is created and, if the handler already exists,
   // immediately before returning. The observation persists until explicitly cancelled: the registry
-  // holds both `owner` and `block` strongly, so callers MUST call `cancelObservation` or
+  // holds both `owner` and `callback` strongly, so callers MUST call `cancelObservation` or
   // `cancelAllObservationsForOwner` when the owner is going away (typically in effect cleanup) to
-  // avoid leaking. Observing the same tag twice with the same `owner` replaces the previous block.
+  // avoid leaking. Observing the same tag twice with the same `owner` replaces the previous callback.
   public static observeHandler(
     tag: number,
     owner: object,
-    block: HandlerReadyBlock
+    callback: HandlerReadyCallback
   ): void {
     let table = this.observers.get(tag);
     if (!table) {
       table = new Map();
       this.observers.set(tag, table);
     }
-    table.set(owner, block);
+    table.set(owner, callback);
 
     if (tag in this.gestures) {
-      block(this.gestures[tag] as IGestureHandler);
+      callback(this.gestures[tag] as IGestureHandler);
     }
   }
 


### PR DESCRIPTION
## Description

1. Changes `Module.createGestureHandler` to be asynchronous
2. Changes `NativeProxy.createGestureHandler` to use the same scheduling as drop to preserve relative ordering
3. Moves the creation of the native handler to the effect from the render phase
4. Updates the native implementations of `GestureDetector` not to rely on synchronous creation of gesture handlers. Instead, introduces the ability to register a callback to be fired once a gesture is created. This way, the detector can attach gestures as they are created on the native side with no dependency on JS (the only required thing is the relative ordering of create and drop operations, so `create -> drop -> create` isn't run as `create -> create -> drop`.

## Test plan

Use the example app.
