### PR TITLE
[Native] Snap `Touchable` state on sub-frame animations

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt
@@ -1,10 +1,12 @@
 package com.swmansion.gesturehandler.react
 
 import android.content.Context
+import android.view.Display
 import android.view.MotionEvent
 import android.view.accessibility.AccessibilityManager
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.DeviceEventManagerModule
+import kotlin.compareTo
 
 val ReactContext.deviceEventEmitter: DeviceEventManagerModule.RCTDeviceEventEmitter
   get() = this.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
@@ -15,3 +17,17 @@ fun Context.isScreenReaderOn() =
 fun MotionEvent.isHoverAction(): Boolean = action == MotionEvent.ACTION_HOVER_MOVE ||
   action == MotionEvent.ACTION_HOVER_ENTER ||
   action == MotionEvent.ACTION_HOVER_EXIT
+
+val Display.minimumFrameTime: Float
+  get() {
+    val supportedModes = this.supportedModes
+    var maxRefreshRate = 0f
+
+    supportedModes.forEach { mode ->
+      if (mode.refreshRate > maxRefreshRate) {
+        maxRefreshRate = mode.refreshRate
+      }
+    }
+
+    return 1000.0f / maxRefreshRate
+  }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt
@@ -6,7 +6,6 @@ import android.view.MotionEvent
 import android.view.accessibility.AccessibilityManager
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.modules.core.DeviceEventManagerModule
-import kotlin.compareTo
 
 val ReactContext.deviceEventEmitter: DeviceEventManagerModule.RCTDeviceEventEmitter
   get() = this.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
@@ -29,5 +28,11 @@ val Display.minimumFrameTime: Float
       }
     }
 
-    return 1000.0f / maxRefreshRate
+    val effectiveRefreshRate = when {
+      maxRefreshRate > 0f -> maxRefreshRate
+      refreshRate > 0f -> refreshRate
+      else -> 60f
+    }
+
+    return 1000.0f / effectiveRefreshRate
   }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -23,7 +23,7 @@ import android.view.View
 import android.view.ViewGroup
 import android.view.accessibility.AccessibilityNodeInfo
 import androidx.core.view.children
-import androidx.interpolator.view.animation.LinearOutSlowInInterpolator
+import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import com.facebook.react.R
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.BackgroundStyleApplicator
@@ -546,6 +546,28 @@ class RNGestureHandlerButtonViewManager :
       }
 
       currentAnimator?.cancel()
+      currentAnimator = null
+
+      // Sub-frame durations: snap directly. ObjectAnimator with duration 0
+      // still defers its property write to the next frame callback, so if a
+      // follow-up animateTo() cancels it in the same frame the property never
+      // lands on its target and the next animator captures a stale starting
+      // value (e.g. an instant press-in followed by press-out in the same
+      // frame, leaving the press-out to animate default → default).
+      if (durationMs < (display?.minimumFrameTime ?: 16f)) {
+        if (hasOpacity) {
+          alpha = opacity
+        }
+        if (hasScale) {
+          scaleX = scale
+          scaleY = scale
+        }
+        if (hasUnderlay) {
+          underlayDrawable!!.alpha = (underlayOpacity * 255).toInt()
+        }
+        return
+      }
+
       val animators = ArrayList<Animator>()
       if (hasOpacity) {
         animators.add(ObjectAnimator.ofFloat(this, "alpha", opacity))
@@ -560,7 +582,7 @@ class RNGestureHandlerButtonViewManager :
       currentAnimator = AnimatorSet().apply {
         playTogether(animators)
         duration = durationMs
-        interpolator = LinearOutSlowInInterpolator()
+        interpolator = FastOutSlowInInterpolator()
         start()
       }
     }

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -258,19 +258,60 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 #endif
 }
 
+// Duration of a single frame at the current screen's max refresh rate, in ms.
+- (NSTimeInterval)minFrameDurationMs
+{
+#if !TARGET_OS_OSX
+  UIScreen *screen = self.window.screen ?: UIScreen.mainScreen;
+  NSInteger maxFps = screen.maximumFramesPerSecond;
+#else
+  NSScreen *screen = self.window.screen ?: NSScreen.mainScreen;
+  NSInteger maxFps = 60;
+  if (@available(macOS 12.0, *)) {
+    maxFps = screen.maximumFramesPerSecond;
+  }
+#endif
+  return maxFps > 0 ? 1000.0 / (NSTimeInterval)maxFps : 1000.0 / 60.0;
+}
+
 - (void)animateTarget:(RNGHUIView *)target
             toOpacity:(CGFloat)opacity
                 scale:(CGFloat)scale
              duration:(NSTimeInterval)durationMs
 {
-  target.layer.transform =
-      target.layer.presentationLayer ? target.layer.presentationLayer.transform : target.layer.transform;
-  NSTimeInterval duration = durationMs / 1000.0;
+  CALayer *layer = target.layer;
+  CALayer *presentation = layer.presentationLayer;
+  NSTimeInterval snapThresholdMs = [self minFrameDurationMs];
+
+  // Only snap to the presentation layer when an animation is in flight,
+  // that's the only case where it tells us something the model layer doesn't.
+  BOOL hasInFlightAnimation = presentation != nil && layer.animationKeys.count > 0;
+  if (hasInFlightAnimation) {
+    layer.transform = presentation.transform;
+  }
 
 #if !TARGET_OS_OSX
-  target.alpha = target.layer.presentationLayer ? target.layer.presentationLayer.opacity : target.alpha;
-  [target.layer removeAllAnimations];
+  if (hasInFlightAnimation) {
+    target.alpha = presentation.opacity;
+  }
+  [layer removeAllAnimations];
 
+  // Sub-frame durations: snap with implicit actions disabled instead of
+  // routing through UIView.animate. Same rationale as animateUnderlayToOpacity.
+  if (durationMs < snapThresholdMs) {
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    if (_activeOpacity != 1.0 || _defaultOpacity != 1.0) {
+      target.alpha = opacity;
+    }
+    if (_activeScale != 1.0 || _defaultScale != 1.0) {
+      layer.transform = CATransform3DMakeScale(scale, scale, 1.0);
+    }
+    [CATransaction commit];
+    return;
+  }
+
+  NSTimeInterval duration = durationMs / 1000.0;
   [UIView animateWithDuration:duration
                         delay:0
                       options:UIViewAnimationOptionCurveEaseInOut
@@ -285,9 +326,25 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
                    completion:nil];
 #else
   target.wantsLayer = YES;
-  target.alphaValue = target.layer.presentationLayer ? target.layer.presentationLayer.opacity : target.alphaValue;
-  [target.layer removeAllAnimations];
+  if (hasInFlightAnimation) {
+    target.alphaValue = presentation.opacity;
+  }
+  [layer removeAllAnimations];
 
+  if (durationMs < snapThresholdMs) {
+    [CATransaction begin];
+    [CATransaction setDisableActions:YES];
+    if (_activeOpacity != 1.0 || _defaultOpacity != 1.0) {
+      target.alphaValue = opacity;
+    }
+    if (_activeScale != 1.0 || _defaultScale != 1.0) {
+      layer.transform = RNGHCenterScaleTransform(target.bounds, scale);
+    }
+    [CATransaction commit];
+    return;
+  }
+
+  NSTimeInterval duration = durationMs / 1000.0;
   [NSAnimationContext
       runAnimationGroup:^(NSAnimationContext *context) {
         context.allowsImplicitAnimation = YES;


### PR DESCRIPTION
## Description

Updates how `Touchable` handles animations:
- On Android, when the animation would take less than a single frame, apply the values immediately. `ObjectAnimator` would run the animation on the next frame, and if a new animation was started immediately after (like a quick tap in a scroll view), it would read the "resting" state instead of the one just applied.
- On iOS, do the same thing and read values from the presentation layer only when an animation is running (similarly to Android, the animation would start on the next frame).
- On Android, it also changes `LinearOutSlowInInterpolator` to `FastOutSlowInInterpolator` to better match the animation curve from web and iOS

## Test plan

|-|Before|After|
|-|-|-|
|Android|<video src="https://github.com/user-attachments/assets/be32d3e3-8e6a-4697-8c53-5f727c7cb6d4" />|<video src="https://github.com/user-attachments/assets/4b025d79-3caf-42da-b317-f13f56c83927" />|
|iOS|<video src="https://github.com/user-attachments/assets/dc6199db-a3e8-4c3d-ab41-8ec90d0ed829" />|<video src="https://github.com/user-attachments/assets/9ad97e93-c66f-4146-9f3c-114c9e381130" />|

(Yes, iOS before is being pressed on constantly, it's just animating default -> default)







```jsx
import * as React from 'react';
import { StyleSheet } from 'react-native';
import { ScrollView, Touchable } from 'react-native-gesture-handler';

export default function TapToLikeExample() {
  return (
    <ScrollView
      style={styles.container}
      contentContainerStyle={{ flexGrow: 1 }}>
      <Touchable
        style={{ width: 200, height: 40, backgroundColor: 'red' }}
        activeOpacity={0.2}
        animationDuration={{ in: 0, out: 250 }}></Touchable>
    </ScrollView>
  );
}

const styles = StyleSheet.create({
  container: {
    gap: 24,
    padding: 24,
  },
});
```
