### PR TITLE
[iOS] Fix underlay animation not firing in ScrollView with `in: 0`

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -195,8 +195,13 @@
 
 - (void)animateUnderlayToOpacity:(float)toOpacity duration:(NSTimeInterval)durationMs
 {
-  _underlayLayer.opacity =
-      _underlayLayer.presentationLayer ? [_underlayLayer.presentationLayer opacity] : _underlayLayer.opacity;
+  // Only sync the model from the presentation layer when an animation is actually
+  // in flight.
+  CALayer *presentation = _underlayLayer.presentationLayer;
+  BOOL hasInFlightAnimation = presentation != nil && _underlayLayer.animationKeys.count > 0;
+  if (hasInFlightAnimation) {
+    _underlayLayer.opacity = presentation.opacity;
+  }
   [_underlayLayer removeAllAnimations];
 
   // CABasicAnimation with duration 0 resolves to the current CATransaction's


### PR DESCRIPTION
## Description

Fixes the underlay animation not starting when `Touchable` is inside `ScrollView` and `in` animation duration is set to 0.

## Test plan

```jsx
import React from 'react';
import { StyleSheet } from 'react-native';
import { ScrollView, Touchable } from 'react-native-gesture-handler';

export default function EmptyExample() {
  return (
    <ScrollView style={styles.container}>
      <Touchable
        style={{ width: 300, height: 40, backgroundColor: '#ddd' }}
        underlayColor="black"
        animationDuration={{ in: 0, out: 200 }}
      />
    </ScrollView>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
});

```
