### PR TITLE
[iOS] Fix duplicated `testID`

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
@@ -360,6 +360,8 @@ static RNGestureHandlerPointerEvents RCTPointerEventsToEnum(facebook::react::Poi
   }
 
   [super updateProps:props oldProps:oldProps];
+
+#if !TARGET_OS_TV && !TARGET_OS_OSX
   // super's updateProps sets self.accessibilityIdentifier from testID via the
   // standard Fabric mechanism. However, setAccessibilityProps already forwards
   // testID to _buttonView.accessibilityIdentifier (the actual button element).
@@ -369,6 +371,8 @@ static RNGestureHandlerPointerEvents RCTPointerEventsToEnum(facebook::react::Poi
   if (!newProps.testId.empty()) {
     self.accessibilityIdentifier = nil;
   }
+#endif
+
   if (shouldApplyStartAnimationState) {
     [_buttonView applyStartAnimationState];
   }

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
@@ -360,6 +360,15 @@ static RNGestureHandlerPointerEvents RCTPointerEventsToEnum(facebook::react::Poi
   }
 
   [super updateProps:props oldProps:oldProps];
+  // super's updateProps sets self.accessibilityIdentifier from testID via the
+  // standard Fabric mechanism. However, setAccessibilityProps already forwards
+  // testID to _buttonView.accessibilityIdentifier (the actual button element).
+  // Having the identifier on both views causes testing frameworks (e.g. Detox)
+  // to report multiple matches for the same testID. Clear it from the wrapper so
+  // only _buttonView carries the identifier.
+  if (!newProps.testId.empty()) {
+    self.accessibilityIdentifier = nil;
+  }
   if (shouldApplyStartAnimationState) {
     [_buttonView applyStartAnimationState];
   }


### PR DESCRIPTION
## Description

This PR fixes duplicated `testID` prop on iOS. Same `accessibilityLabel` was assigned to both, wrapper and button, therefore frameworks like `Detox` failed due to multiple elements with the same ID.

Fixes #3698 

## Test plan

Tested on branch with e2e tests.