### PR TITLE
[iOS] Fix bad access when decorating runtime

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -117,6 +117,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   @ReactMethod
   override fun flushOperations() = Unit
 
+  @ReactMethod
   override fun installUIRuntimeBindings(): Boolean {
     if (!uiRuntimeDecorated) {
       uiRuntimeDecorated = decorateUIRuntime()

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -28,7 +28,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   @DoNotStrip
   @Suppress("unused")
   private var mHybridData: HybridData = initHybrid()
-  private var isReanimatedAvailable = false
   private var uiRuntimeDecorated = false
   private val registry: RNGestureHandlerRegistry
     get() = registries[moduleId]!!
@@ -62,10 +61,6 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
   @ReactMethod
   override fun createGestureHandler(handlerName: String, handlerTagDouble: Double, config: ReadableMap) {
-    if (isReanimatedAvailable && !uiRuntimeDecorated) {
-      uiRuntimeDecorated = decorateUIRuntime()
-    }
-
     val handlerTag = handlerTagDouble.toInt()
 
     createGestureHandlerHelper<GestureHandler>(handlerName, handlerTag, config)
@@ -122,9 +117,12 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
   @ReactMethod
   override fun flushOperations() = Unit
 
-  @ReactMethod
-  override fun setReanimatedAvailable(isAvailable: Boolean) {
-    isReanimatedAvailable = isAvailable
+  override fun installUIRuntimeBindings(): Boolean {
+    if (!uiRuntimeDecorated) {
+      uiRuntimeDecorated = decorateUIRuntime()
+    }
+
+    return uiRuntimeDecorated
   }
 
   @DoNotStrip

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.mm
@@ -41,8 +41,6 @@ typedef void (^GestureHandlerOperation)(RNGestureHandlerManager *manager);
 
   jsi::Runtime *_rnRuntime;
   int _moduleId;
-
-  bool _isReanimatedAvailable;
   bool _uiRuntimeDecorated;
 }
 
@@ -106,7 +104,7 @@ RCT_EXPORT_MODULE()
   _operations = [NSMutableArray new];
 }
 
-- (bool)installUIRuntimeBindings
+- (bool)decorateUIRuntime
 {
   __weak RNGestureHandlerModule *weakSelf = self;
 
@@ -120,10 +118,6 @@ RCT_EXPORT_MODULE()
 
 - (void)createGestureHandler:(NSString *)handlerName handlerTag:(double)handlerTag config:(NSDictionary *)config
 {
-  if (_isReanimatedAvailable && !_uiRuntimeDecorated) {
-    _uiRuntimeDecorated = [self installUIRuntimeBindings];
-  }
-
   [self addOperationBlock:^(RNGestureHandlerManager *manager) {
     [manager createGestureHandler:handlerName tag:[NSNumber numberWithDouble:handlerTag] config:config];
   }];
@@ -188,9 +182,13 @@ RCT_EXPORT_MODULE()
   }];
 }
 
-- (void)setReanimatedAvailable:(BOOL)isAvailable
+- (nonnull NSNumber *)installUIRuntimeBindings
 {
-  _isReanimatedAvailable = isAvailable;
+  if (!_uiRuntimeDecorated) {
+    _uiRuntimeDecorated = [self decorateUIRuntime];
+  }
+
+  return _uiRuntimeDecorated ? @1 : @0;
 }
 
 - (void)setGestureState:(int)state forHandler:(int)handlerTag

--- a/packages/react-native-gesture-handler/src/RNGestureHandlerModule.web.ts
+++ b/packages/react-native-gesture-handler/src/RNGestureHandlerModule.web.ts
@@ -92,7 +92,7 @@ export default {
   },
   // eslint-disable-next-line @typescript-eslint/no-empty-function
   flushOperations() {},
-  setReanimatedAvailable(_isAvailable: boolean) {
+  installUIRuntimeBindings() {
     // No-op on web
   },
 };

--- a/packages/react-native-gesture-handler/src/RNGestureHandlerModule.web.ts
+++ b/packages/react-native-gesture-handler/src/RNGestureHandlerModule.web.ts
@@ -94,5 +94,6 @@ export default {
   flushOperations() {},
   installUIRuntimeBindings() {
     // No-op on web
+    return true;
   },
 };

--- a/packages/react-native-gesture-handler/src/handlers/gestures/reanimatedWrapper.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/reanimatedWrapper.ts
@@ -1,5 +1,6 @@
 import type { ComponentClass } from 'react';
 
+import { ghQueueMicrotask } from '../../ghQueueMicrotask';
 import { tagMessage } from '../../utils';
 import { NativeProxy } from '../../v3/NativeProxy';
 import type {
@@ -82,7 +83,17 @@ let Reanimated:
 
 try {
   Reanimated = require('react-native-reanimated');
-  NativeProxy.setReanimatedAvailable(true);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
+  const Worklets = require('react-native-worklets');
+
+  // Make sure worklets are initialized before attemting to install UI runtime bindings
+  Worklets?.scheduleOnUI(() => {
+    'worklet';
+  });
+
+  ghQueueMicrotask(() => {
+    NativeProxy.installUIRuntimeBindings();
+  });
 } catch (e) {
   // When 'react-native-reanimated' is not available we want to quietly continue
   // @ts-ignore TS demands the variable to be initialized
@@ -93,7 +104,6 @@ if (!Reanimated?.useSharedValue) {
   // @ts-ignore Make sure the loaded module is actually Reanimated, if it's not
   // reset the module to undefined so we can fallback to the default implementation
   Reanimated = undefined;
-  NativeProxy.setReanimatedAvailable(false);
 }
 
 if (Reanimated !== undefined && !Reanimated.setGestureState) {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/reanimatedWrapper.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/reanimatedWrapper.ts
@@ -92,7 +92,15 @@ try {
   });
 
   ghQueueMicrotask(() => {
-    NativeProxy.installUIRuntimeBindings();
+    const decorated = NativeProxy.installUIRuntimeBindings();
+
+    if (!decorated) {
+      console.warn(
+        tagMessage(
+          'Failed to install UI runtime bindings. Please report this at https://github.com/software-mansion/react-native-gesture-handler/issues.'
+        )
+      );
+    }
   });
 } catch (e) {
   // When 'react-native-reanimated' is not available we want to quietly continue

--- a/packages/react-native-gesture-handler/src/handlers/gestures/reanimatedWrapper.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/reanimatedWrapper.ts
@@ -86,7 +86,7 @@ try {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-var-requires
   const Worklets = require('react-native-worklets');
 
-  // Make sure worklets are initialized before attemting to install UI runtime bindings
+  // Make sure worklets are initialized before attempting to install UI runtime bindings
   Worklets?.scheduleOnUI(() => {
     'worklet';
   });

--- a/packages/react-native-gesture-handler/src/mocks/module.tsx
+++ b/packages/react-native-gesture-handler/src/mocks/module.tsx
@@ -2,6 +2,8 @@ const NOOP = () => {
   // Do nothing
 };
 
+const NOOPTrue = () => true;
+
 const attachGestureHandler = NOOP;
 const createGestureHandler = NOOP;
 const dropGestureHandler = NOOP;
@@ -9,7 +11,7 @@ const setGestureHandlerConfig = NOOP;
 const updateGestureHandlerConfig = NOOP;
 const flushOperations = NOOP;
 const configureRelations = NOOP;
-const setReanimatedAvailable = NOOP;
+const installUIRuntimeBindings = NOOPTrue;
 const install = NOOP;
 
 export default {
@@ -19,7 +21,7 @@ export default {
   setGestureHandlerConfig,
   updateGestureHandlerConfig,
   configureRelations,
-  setReanimatedAvailable,
+  installUIRuntimeBindings,
   flushOperations,
   install,
 } as const;

--- a/packages/react-native-gesture-handler/src/specs/NativeRNGestureHandlerModule.ts
+++ b/packages/react-native-gesture-handler/src/specs/NativeRNGestureHandlerModule.ts
@@ -23,7 +23,7 @@ export interface Spec extends TurboModule {
   configureRelations: (handlerTag: Double, relations: Object) => void;
   dropGestureHandler: (handlerTag: Double) => void;
   flushOperations: () => void;
-  setReanimatedAvailable: (isAvailable: boolean) => void;
+  installUIRuntimeBindings: () => boolean;
 }
 
 export default TurboModuleRegistry.getEnforcing<Spec>('RNGestureHandlerModule');

--- a/packages/react-native-gesture-handler/src/v3/NativeProxy.ts
+++ b/packages/react-native-gesture-handler/src/v3/NativeProxy.ts
@@ -61,7 +61,7 @@ export const NativeProxy = {
       RNGestureHandlerModule.configureRelations(handlerTag, relations);
     });
   },
-  setReanimatedAvailable: (isAvailable: boolean) => {
-    RNGestureHandlerModule.setReanimatedAvailable(isAvailable);
+  installUIRuntimeBindings: () => {
+    return RNGestureHandlerModule.installUIRuntimeBindings();
   },
 } as const;

--- a/packages/react-native-gesture-handler/src/v3/NativeProxy.web.ts
+++ b/packages/react-native-gesture-handler/src/v3/NativeProxy.web.ts
@@ -43,7 +43,7 @@ export const NativeProxy = {
   configureRelations: (handlerTag: number, relations: GestureRelations) => {
     RNGestureHandlerModule.configureRelations(handlerTag, relations);
   },
-  setReanimatedAvailable: (isAvailable: boolean) => {
-    RNGestureHandlerModule.setReanimatedAvailable(isAvailable);
+  installUIRuntimeBindings: () => {
+    return RNGestureHandlerModule.installUIRuntimeBindings();
   },
 } as const;


### PR DESCRIPTION
## Description

After https://github.com/software-mansion/react-native-gesture-handler/pull/4179 `createGestureHandler` is no longer synchronous - it's batched and scheduled asynchronously. This behavior change caused the runtime decoration to fail with bad access errors. This PR restores the previous synchronous flow of UI runtime decoration. The main difference is doing it eagerly on startup instead of lazily.

## Test plan

Run the iOS app; it should not crash.
