### PR TITLE
[Android] Fix buttons cutting of borders of their child views

### DIFF
--- a/packages/docs-gesture-handler/docs/components/pressable.mdx
+++ b/packages/docs-gesture-handler/docs/components/pressable.mdx
@@ -190,6 +190,16 @@ Enables the Android [ripple](https://developer.android.com/reference/android/gra
 
 Accepts values of type [`RippleConfig`](https://reactnative.dev/docs/pressable#rippleconfig).
 
+<Badges platforms={['android']}>
+### needsOffscreenAlphaCompositing
+</Badges>
+
+```ts
+needsOffscreenAlphaCompositing?: boolean;
+```
+
+Whether the view should render with an offscreen alpha-compositing buffer when its `opacity` is less than `1`. Defaults to `false`.
+
 ### testOnly_pressed
 
 ```ts

--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -467,3 +467,13 @@ cancelOnLeave?: boolean;
 ```
 
 Whether the touch should be canceled when the pointer leaves the component. By default set to `true`. On web this prop doesn't have any effect and behaves as if `true` was set.
+
+<Badges platforms={['android']}>
+### needsOffscreenAlphaCompositing
+</Badges>
+
+```ts
+needsOffscreenAlphaCompositing?: boolean;
+```
+
+Whether the view should render with an offscreen alpha-compositing buffer when its `opacity` is less than `1`. Defaults to `false`.

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -887,6 +887,10 @@ class RNGestureHandlerButtonViewManager :
       // by default Viewgroup would pass hotspot change events
     }
 
+    // Skip the offscreen buffer so children's border anti-aliasing at the view
+    // edge isn't clipped by the layer bounds when alpha != 1
+    override fun hasOverlappingRendering(): Boolean = false
+
     companion object {
       var resolveOutValue = TypedValue()
       var touchResponder: ButtonViewGroup? = null

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -289,6 +289,11 @@ class RNGestureHandlerButtonViewManager :
     view.longPressAnimationOutDuration = value
   }
 
+  @ReactProp(name = "needsOffscreenAlphaCompositing")
+  override fun setNeedsOffscreenAlphaCompositing(view: ButtonViewGroup, value: Boolean) {
+    view.needsOffscreenAlphaCompositing = value
+  }
+
   @ReactProp(name = "defaultOpacity")
   override fun setDefaultOpacity(view: ButtonViewGroup, defaultOpacity: Float) {
     view.defaultOpacity = defaultOpacity
@@ -382,6 +387,7 @@ class RNGestureHandlerButtonViewManager :
       set(value) = withBackgroundUpdate {
         field = value
       }
+    var needsOffscreenAlphaCompositing = false
 
     override var pointerEvents: PointerEvents = PointerEvents.AUTO
 
@@ -887,9 +893,10 @@ class RNGestureHandlerButtonViewManager :
       // by default Viewgroup would pass hotspot change events
     }
 
-    // Skip the offscreen buffer so children's border anti-aliasing at the view
-    // edge isn't clipped by the layer bounds when alpha != 1
-    override fun hasOverlappingRendering(): Boolean = false
+    // Default to skipping the offscreen buffer so children's border anti-aliasing
+    // at the view edge isn't clipped by the layer bounds when alpha != 1.
+    // `needsOffscreenAlphaCompositing` opts back into the standard View behavior.
+    override fun hasOverlappingRendering(): Boolean = needsOffscreenAlphaCompositing
 
     companion object {
       var resolveOutValue = TypedValue()

--- a/packages/react-native-gesture-handler/src/components/GestureButtons.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureButtons.tsx
@@ -18,18 +18,29 @@ import type {
   LegacyRectButtonProps,
   RectButtonWithRefProps,
 } from './GestureButtonsProps';
-import GestureHandlerButton from './GestureHandlerButton';
+import GestureHandlerButton, { type ButtonProps } from './GestureHandlerButton';
 
-/**
- * @deprecated use `RawButton` instead
- */
-export const LegacyRawButton = createNativeWrapper<LegacyRawButtonProps>(
-  GestureHandlerButton as unknown as HostComponent<LegacyRawButtonProps>,
+type LegacyRawButtonInnerProps = LegacyRawButtonProps & {
+  needsOffscreenAlphaCompositing?: boolean;
+};
+
+const LegacyRawButtonInner = createNativeWrapper<LegacyRawButtonInnerProps>(
+  GestureHandlerButton as unknown as HostComponent<LegacyRawButtonInnerProps>,
   {
     shouldCancelWhenOutside: false,
     shouldActivateOnStart: Platform.OS === 'web',
   }
 );
+
+/**
+ * @deprecated use `RawButton` instead
+ */
+export const LegacyRawButton = (
+  props: Omit<
+    React.ComponentProps<typeof LegacyRawButtonInner>,
+    'needsOffscreenAlphaCompositing'
+  >
+) => <LegacyRawButtonInner {...props} needsOffscreenAlphaCompositing />;
 
 class InnerBaseButton extends React.Component<BaseButtonWithRefProps> {
   static defaultProps = {
@@ -280,4 +291,9 @@ export const LegacyBorderlessButton = ({
   ref?: React.Ref<React.ComponentType<any>> | undefined;
 }) => <InnerBorderlessButton innerRef={ref} {...props} />;
 
-export { default as LegacyPureNativeButton } from './GestureHandlerButton';
+/**
+ * @deprecated use `PureNativeButton` instead
+ */
+export const LegacyPureNativeButton = (
+  props: Omit<ButtonProps, 'needsOffscreenAlphaCompositing'>
+) => <GestureHandlerButton {...props} needsOffscreenAlphaCompositing />;

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -160,6 +160,17 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
   underlayColor?: ColorValue | undefined;
 
   /**
+   * Android only.
+   *
+   * Whether the view should render with an offscreen alpha-compositing buffer
+   * when its `opacity` is less than 1. Defaults to `false` — without the
+   * offscreen buffer, children that draw past the view's bounds (e.g. anti-
+   * aliased border edges) are not clipped by the layer when `opacity < 1`.
+   * Set to `true` to opt back into the standard Android behavior.
+   */
+  needsOffscreenAlphaCompositing?: boolean | undefined;
+
+  /**
    * Style object, use it to set additional styles.
    */
   style?: StyleProp<ViewStyle>;

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -377,6 +377,7 @@ const LegacyPressable = (props: LegacyPressableProps) => {
     <GestureDetector gesture={gesture}>
       <NativeButton
         {...remainingProps}
+        needsOffscreenAlphaCompositing
         onLayout={setDimensions}
         accessible={accessible !== false}
         hitSlop={appliedHitSlop}

--- a/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
@@ -32,7 +32,8 @@ export type InnerPressableEvent = {
 
 export type PressableEvent = { nativeEvent: InnerPressableEvent };
 
-export interface LegacyPressableProps extends CommonPressableProps {
+export interface LegacyPressableProps
+  extends Omit<CommonPressableProps, 'needsOffscreenAlphaCompositing'> {
   /**
    * A gesture object or an array of gesture objects containing the configuration and callbacks to be
    * used with the Pressable's gesture handlers.

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -23,6 +23,7 @@ interface NativeProps extends ViewProps {
   tapAnimationOutDuration?: WithDefault<Int32, 100>;
   longPressDuration?: WithDefault<Int32, -1>;
   longPressAnimationOutDuration?: WithDefault<Int32, -1>;
+  needsOffscreenAlphaCompositing?: WithDefault<boolean, false>;
   activeOpacity?: WithDefault<Float, 1>;
   activeScale?: WithDefault<Float, 1>;
   activeUnderlayOpacity?: WithDefault<Float, 0>;

--- a/packages/react-native-gesture-handler/src/v3/components/GestureButtons.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureButtons.tsx
@@ -15,16 +15,24 @@ import type {
 type CallbackEventType = GestureEvent<NativeHandlerData>;
 type EndCallbackEventType = GestureEndEvent<NativeHandlerData>;
 
-/**
- * @deprecated `RawButton` is deprecated, use `Clickable` instead
- */
-export const RawButton = createNativeWrapper<
+type RawButtonInnerProps = RawButtonProps & {
+  needsOffscreenAlphaCompositing?: boolean | undefined;
+};
+
+const RawButtonInner = createNativeWrapper<
   React.ComponentRef<typeof GestureHandlerButton>,
-  RawButtonProps
+  RawButtonInnerProps
 >(GestureHandlerButton, {
   shouldCancelWhenOutside: false,
   shouldActivateOnStart: false,
 });
+
+/**
+ * @deprecated `RawButton` is deprecated, use `Clickable` instead
+ */
+export const RawButton = (props: RawButtonProps) => (
+  <RawButtonInner {...props} needsOffscreenAlphaCompositing />
+);
 
 /**
  * @deprecated `BaseButton` is deprecated, use `Touchable` instead

--- a/packages/react-native-gesture-handler/src/v3/components/GestureButtonsProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureButtonsProps.ts
@@ -16,6 +16,7 @@ export interface RawButtonProps
       | 'activeOpacity'
       | 'activeScale'
       | 'activeUnderlayOpacity'
+      | 'needsOffscreenAlphaCompositing'
     >,
     Omit<
       NativeWrapperProperties<React.ComponentRef<typeof GestureHandlerButton>>,


### PR DESCRIPTION
## Description

Sets [`hasOverlappingRendering`](https://developer.android.com/reference/android/view/View#hasOverlappingRendering()) to false on the button component to prevent it from rendering on an off-screen canvas when opacity is less than 1.

React Native views also [set it to false by default](https://github.com/facebook/react-native/blob/45d9b13d6acdbe627990384446e2418c4e58bf9f/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt#L148).

## Test plan

```jsx
import React from 'react';
import { StyleSheet, Text, View } from 'react-native';
import { Touchable } from 'react-native-gesture-handler';

export default function EmptyExample() {
  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <Touchable activeOpacity={0.99} animationDuration={{ in: 0, out: 200 }}>
        <Text style={styles.box}>Button</Text>
      </Touchable>
    </View>
  );
}

const styles = StyleSheet.create({
  box: {
    fontSize: 16,
    fontWeight: 600,
    letterSpacing: -0.5,
    textAlign: 'center',
    textAlignVertical: 'center',
    color: 'black',
    borderWidth: 1,
    borderColor: 'black',
  },
});
```

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/d316c31e-1ced-47f7-b4d8-866f2a168c22" />|<video src="https://github.com/user-attachments/assets/9fea7dc2-3aba-4d9e-8e7e-559bda233301" />|



