### PR TITLE
[Android] Fix `Touchable` children clipping

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -407,6 +407,11 @@ class RNGestureHandlerButtonViewManager :
     // When null the ripple lives on the foreground drawable instead.
     private var selectableDrawable: Drawable? = null
 
+    // When true, dispatchDraw clips children to the resolved border-radius shape
+    // (overflow: hidden). ViewGroup's clipChildren is only a rectangular clip and
+    // wouldn't respect rounded corners.
+    private var clipChildrenToShape = false
+
     var isTouched = false
 
     init {
@@ -424,16 +429,7 @@ class RNGestureHandlerButtonViewManager :
     }
 
     fun setOverflow(overflow: String?) {
-      when (overflow) {
-        "hidden" -> {
-          clipChildren = true
-          clipToPadding = true
-        }
-        else -> {
-          clipChildren = false
-          clipToPadding = false
-        }
-      }
+      clipChildrenToShape = overflow == "hidden"
       invalidate()
     }
 
@@ -694,7 +690,14 @@ class RNGestureHandlerButtonViewManager :
           canvas.restore()
         }
       }
-      super.dispatchDraw(canvas)
+      if (clipChildrenToShape) {
+        canvas.save()
+        BackgroundStyleApplicator.clipToPaddingBox(this, canvas)
+        super.dispatchDraw(canvas)
+        canvas.restore()
+      } else {
+        super.dispatchDraw(canvas)
+      }
     }
 
     override fun verifyDrawable(who: Drawable): Boolean =


### PR DESCRIPTION
## Description

Native Android button implementation wasn't clipping its children to its actual shape but to the rectangular bounding box. This PR fixes that, aligning behavior with iOS.

## Test plan

```jsx
import React from 'react';
import { View } from 'react-native';
import { Touchable } from 'react-native-gesture-handler';

export default function EmptyExample() {
  return (
    <View style={{ flex: 1, justifyContent: 'center', alignItems: 'center' }}>
      <Touchable
        activeOpacity={1}
        animationDuration={{ in: 200, out: 200 }}
        underlayColor={'black'}
        style={{
          width: 100,
          height: 100,
          borderRadius: 50,
          backgroundColor: 'red',
          overflow: 'hidden',
        }}>
        <View style={{ flex: 1, backgroundColor: 'green', opacity: 0.5 }} />
      </Touchable>
    </View>
  );
}
```

|Android before|Android after|iOS|
|-|-|-|
|<img width="368" height="783" alt="Screenshot 2026-05-22 at 13 53 47" src="https://github.com/user-attachments/assets/8c38870c-a5cd-446d-b94c-dce92cad2197" />|<img width="368" height="783" alt="Screenshot 2026-05-22 at 13 53 15" src="https://github.com/user-attachments/assets/a08ecd12-9f07-4f14-89c8-3ddb3ce15ec4" />|<img width="1206" height="2622" alt="Simulator Screenshot - iPhone 17 Pro - 2026-05-22 at 13 52 57" src="https://github.com/user-attachments/assets/0cf1c4ab-0389-485e-ad16-068258731367" />|


