### PR TITLE
[Web] Correctly attach v3 handlers

### DIFF
--- a/packages/react-native-gesture-handler/src/ActionType.ts
+++ b/packages/react-native-gesture-handler/src/ActionType.ts
@@ -9,12 +9,3 @@ export const ActionType = {
 
 // eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value
 export type ActionType = (typeof ActionType)[keyof typeof ActionType];
-
-export function usesNativeOrVirtualDetector(
-  actionType: ActionType | null
-): boolean {
-  return (
-    actionType === ActionType.NATIVE_DETECTOR ||
-    actionType === ActionType.VIRTUAL_DETECTOR
-  );
-}

--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-empty-function */
-import { ActionType, usesNativeOrVirtualDetector } from '../../ActionType';
+import { ActionType } from '../../ActionType';
 import type {
   ActiveCursor,
   GestureTouchEvent,
@@ -96,6 +96,13 @@ export default abstract class GestureHandler implements IGestureHandler {
     this.state = State.UNDETERMINED;
 
     this.delegate.init(viewRef, this);
+  }
+
+  public usesNativeOrVirtualDetector(): boolean {
+    return (
+      this.actionType === ActionType.NATIVE_DETECTOR ||
+      this.actionType === ActionType.VIRTUAL_DETECTOR
+    );
   }
 
   public detach() {
@@ -413,7 +420,7 @@ export default abstract class GestureHandler implements IGestureHandler {
       return;
     }
 
-    if (!usesNativeOrVirtualDetector(this.actionType)) {
+    if (!this.usesNativeOrVirtualDetector()) {
       onGestureHandlerEvent?.(touchEvent);
       return;
     }
@@ -440,9 +447,7 @@ export default abstract class GestureHandler implements IGestureHandler {
 
     const isStateChange = this.lastSentState !== newState;
 
-    const resultEvent: ResultEvent = !usesNativeOrVirtualDetector(
-      this.actionType
-    )
+    const resultEvent: ResultEvent = !this.usesNativeOrVirtualDetector()
       ? this.transformEventData(newState, oldState)
       : isStateChange
         ? this.transformStateChangeEvent(newState, oldState)
@@ -467,7 +472,7 @@ export default abstract class GestureHandler implements IGestureHandler {
     }
 
     // Cover only V3 path due to different event shape
-    if (!isStateChange && usesNativeOrVirtualDetector(this.actionType)) {
+    if (!isStateChange && this.usesNativeOrVirtualDetector()) {
       const handlerData = (
         resultEvent.nativeEvent as GestureUpdateEventWithHandlerData<unknown>
       ).handlerData;

--- a/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
@@ -33,6 +33,8 @@ export default interface IGestureHandler {
   readonly touchAction?: TouchAction | undefined;
   readonly userSelect?: UserSelect | undefined;
 
+  usesNativeOrVirtualDetector: () => boolean;
+
   attachEventManager: (manager: EventManager<unknown>) => void;
 
   isButtonInConfig: (

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -1,6 +1,6 @@
 import { Platform } from 'react-native';
 
-import { type ActionType, usesNativeOrVirtualDetector } from '../../ActionType';
+import { type ActionType } from '../../ActionType';
 import { State } from '../../State';
 import { deepEqual } from '../../utils';
 import type { NativeHandlerData } from '../../v3/hooks/gestures/native/NativeTypes';
@@ -59,7 +59,7 @@ export default class NativeViewGestureHandler extends GestureHandler {
 
     this.restoreViewStyles(view);
 
-    if (usesNativeOrVirtualDetector(this.actionType)) {
+    if (this.usesNativeOrVirtualDetector()) {
       this.role =
         (view.getAttribute(
           NATIVE_GESTURE_ROLE_ATTRIBUTE

--- a/packages/react-native-gesture-handler/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureHandlerWebDelegate.ts
@@ -43,7 +43,10 @@ export class GestureHandlerWebDelegate
     }
 
     this.gestureHandler = handler;
-    this.view = findNodeHandle(viewRef) as unknown as HTMLElement;
+
+    this.view = handler.usesNativeOrVirtualDetector()
+      ? (viewRef as unknown as HTMLElement)
+      : (findNodeHandle(viewRef) as unknown as HTMLElement);
 
     this.defaultViewStyles = {
       userSelect: this.view.style.userSelect,

--- a/packages/react-native-gesture-handler/src/web/tools/GestureHandlerWebDelegate.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureHandlerWebDelegate.ts
@@ -4,7 +4,12 @@ import { State } from '../../State';
 import { tagMessage } from '../../utils';
 import { SingleGestureName } from '../../v3/types';
 import type IGestureHandler from '../handlers/IGestureHandler';
-import { getEffectiveBoundingRect, isPointerInBounds } from '../utils';
+import type { SVGRef } from '../interfaces';
+import {
+  getEffectiveBoundingRect,
+  isPointerInBounds,
+  isRNSVGElement,
+} from '../utils';
 import type EventManager from './EventManager';
 import type {
   GestureHandlerDelegate,
@@ -44,9 +49,11 @@ export class GestureHandlerWebDelegate
 
     this.gestureHandler = handler;
 
-    this.view = handler.usesNativeOrVirtualDetector()
-      ? (viewRef as unknown as HTMLElement)
-      : (findNodeHandle(viewRef) as unknown as HTMLElement);
+    this.view =
+      handler.usesNativeOrVirtualDetector() &&
+      !isRNSVGElement(viewRef as unknown as SVGRef)
+        ? (viewRef as unknown as HTMLElement)
+        : (findNodeHandle(viewRef) as unknown as HTMLElement);
 
     this.defaultViewStyles = {
       userSelect: this.view.style.userSelect,


### PR DESCRIPTION
## Description

V3 gestures on web were attached incorrectly to the child view, not the detector itself. This could be observed in `Pressable` - #4179 changed order of attaching gestures. Because all gestures on `Pressable` were incorrectly attached to the `button`, `StateMachine` stopped working, since it expected `Native` gesture event, but got `LongPress` event instead [see here](https://github.com/software-mansion/react-native-gesture-handler/blob/46a2bde7f2f806879a6211499d739b5ccfc79f99/packages/react-native-gesture-handler/src/components/Pressable/stateDefinitions.ts#L80). 

This PR moves `usesNativeOrVirtualDetector` directly to `GestureHandler` (there's no need to keep it as separate function) and then uses this check in web delegate to correctly handle v3 view assignment.

>[!NOTE]
>This works because in v3 `viewRef` is passed from `HostGestureDetector`, so it is correctly set to either detector view with `display: contents;` or `firstChild`, if `Native` gesture is used.

## Test plan

Tested on example app (Nested Pressables and some other examples)
