### PR TITLE
[Android] Fix discrete gestures not triggering `onFinalize`

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -191,14 +191,16 @@ class GestureHandlerOrchestrator(
     } else if (prevState == GestureHandler.STATE_ACTIVE || prevState == GestureHandler.STATE_END) {
       if (handler.isActive) {
         handler.dispatchStateChange(newState, prevState)
-      } else if (prevState == GestureHandler.STATE_ACTIVE &&
-        (newState == GestureHandler.STATE_CANCELLED || newState == GestureHandler.STATE_FAILED)
+      } else if (newState == GestureHandler.STATE_CANCELLED || newState == GestureHandler.STATE_FAILED
       ) {
         // Handle edge case where handler awaiting for another one tries to activate but finishes
         // before the other would not send state change event upon ending. Note that we only want
         // to do this if the newState is either CANCELLED or FAILED, if it is END we still want to
         // wait for the other handler to finish as in that case synthetic events will be sent by the
         // makeActive method.
+        // This also covers the case where a discrete gesture (e.g. Tap) ends immediately after
+        // activation (STATE_ACTIVE -> STATE_END) while still awaiting another handler, and is later
+        // cancelled when that handler activates.
         handler.dispatchStateChange(newState, GestureHandler.STATE_BEGAN)
       }
     } else if (prevState != GestureHandler.STATE_UNDETERMINED ||


### PR DESCRIPTION
## Description

Discrete gestures on Android transition to `END` state before being cancelled by other, higher priority gestures. Our current approach missed case where gestures like `Tap` end in such transition (`5 -> 3`), therefore `onFinalize` callback was never triggered.

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import React from 'react';
import { StyleSheet, View } from 'react-native';
import {
  GestureDetector,
  useExclusiveGestures,
  useTapGesture,
} from 'react-native-gesture-handler';

export default function EmptyExample() {
  const t1 = useTapGesture({
    onBegin: () => {
      console.log('tap begin');
    },
    onActivate: () => {
      console.log('tap activate');
    },
    onDeactivate: () => {
      console.log('tap deactivate');
    },
    onFinalize: () => {
      console.log('tap finalize');
    },
  });

  const t2 = useTapGesture({
    numberOfTaps: 2,
    onBegin: () => {
      console.log('double tap begin');
    },
    onActivate: () => {
      console.log('double tap activate');
    },
    onDeactivate: () => {
      console.log('double tap deactivate');
    },
    onFinalize: () => {
      console.log('double tap finalize');
    },
  });

  const g = useExclusiveGestures(t2, t1);

  return (
    <View style={styles.container}>
      <GestureDetector gesture={g}>
        <View style={styles.box} />
      </GestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  box: {
    width: 100,
    height: 100,
    backgroundColor: 'blue',
    borderRadius: 10,
  },
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```

</details>