### PR TITLE
[General] Support reduced motion/animation scale for button animations

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -3,6 +3,7 @@ package com.swmansion.gesturehandler.react
 import android.animation.Animator
 import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
+import android.animation.ValueAnimator
 import android.annotation.SuppressLint
 import android.annotation.TargetApi
 import android.content.Context
@@ -530,6 +531,19 @@ class RNGestureHandlerButtonViewManager :
       return false
     }
 
+    private fun getAnimatorDurationScale(): Float = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      ValueAnimator.getDurationScale()
+    } else {
+      try {
+        android.provider.Settings.Global.getFloat(
+          context.contentResolver,
+          android.provider.Settings.Global.ANIMATOR_DURATION_SCALE,
+        )
+      } catch (e: android.provider.Settings.SettingNotFoundException) {
+        1.0f
+      }
+    }
+
     private fun applyStartAnimationState() {
       if (activeOpacity != 1.0f || defaultOpacity != 1.0f) {
         alpha = defaultOpacity
@@ -558,7 +572,11 @@ class RNGestureHandlerButtonViewManager :
       // lands on its target and the next animator captures a stale starting
       // value (e.g. an instant press-in followed by press-out in the same
       // frame, leaving the press-out to animate default → default).
-      if (durationMs < (display?.minimumFrameTime ?: 16f)) {
+      // Animator duration scale folds in here too: scale 0 collapses any
+      // duration to the same deferred-write territory.
+      val durationScale = getAnimatorDurationScale()
+      val effectiveDurationMs = (durationMs * durationScale).toLong()
+      if (effectiveDurationMs < (display?.minimumFrameTime ?: 16f)) {
         if (hasOpacity) {
           alpha = opacity
         }
@@ -626,7 +644,10 @@ class RNGestureHandlerButtonViewManager :
           animateTo(defaultOpacity, defaultScale, defaultUnderlayOpacity, tapOutMs)
         }
         pendingPressOut = runnable
-        handler.postDelayed(runnable, remaining)
+        // The animator scales `remaining` by ANIMATOR_DURATION_SCALE internally,
+        // so the press-in actually completes after `remaining * scale` ms. We need
+        // to match that.
+        handler.postDelayed(runnable, (remaining * getAnimatorDurationScale()).toLong())
       }
     }
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -201,8 +201,20 @@
   [self applyUnderlayCornerRadii];
 }
 
+- (BOOL)shouldReduceMotion
+{
+#if TARGET_OS_OSX
+  return [[NSWorkspace sharedWorkspace] accessibilityDisplayShouldReduceMotion];
+#else
+  return UIAccessibilityIsReduceMotionEnabled();
+#endif
+}
+
 - (void)animateUnderlayToOpacity:(float)toOpacity duration:(NSTimeInterval)durationMs
 {
+  if ([self shouldReduceMotion]) {
+    durationMs = 0;
+  }
   // Only sync the model from the presentation layer when an animation is actually
   // in flight.
   CALayer *presentation = _underlayLayer.presentationLayer;
@@ -292,6 +304,9 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
                 scale:(CGFloat)scale
              duration:(NSTimeInterval)durationMs
 {
+  if ([self shouldReduceMotion]) {
+    durationMs = 0;
+  }
   CALayer *layer = target.layer;
   CALayer *presentation = layer.presentationLayer;
   NSTimeInterval snapThresholdMs = [self minFrameDurationMs];
@@ -445,8 +460,9 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
         }
       }
     });
+    NSTimeInterval scheduledDelay = [self shouldReduceMotion] ? 0 : remaining;
     dispatch_after(
-        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(remaining * NSEC_PER_MSEC)),
+        dispatch_time(DISPATCH_TIME_NOW, (int64_t)(scheduledDelay * NSEC_PER_MSEC)),
         dispatch_get_main_queue(),
         _pendingPressOutBlock);
   }

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
@@ -5,6 +5,11 @@ import { View } from 'react-native';
 import { NativeGestureRole } from '../web/interfaces';
 import { GestureLifecycleEvent } from '../web/tools/GestureLifecycleEvents';
 
+const prefersReducedMotion = (): boolean =>
+  typeof window !== 'undefined' &&
+  typeof window.matchMedia === 'function' &&
+  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
 type ButtonProps = ViewProps & {
   ref?: React.Ref<React.ComponentRef<typeof View>>;
   enabled?: boolean;
@@ -165,11 +170,14 @@ export const ButtonComponent = ({
       } else {
         // Let the in-progress CSS press-in transition continue; schedule press-out after remaining time.
         const remaining = tapAnimationInDuration - elapsed;
-        pressOutTimer.current = setTimeout(() => {
-          pressOutTimer.current = null;
-          setCurrentDuration(tapAnimationOutDuration);
-          setPressed(false);
-        }, remaining);
+        pressOutTimer.current = setTimeout(
+          () => {
+            pressOutTimer.current = null;
+            setCurrentDuration(tapAnimationOutDuration);
+            setPressed(false);
+          },
+          prefersReducedMotion() ? 0 : remaining
+        );
       }
     },
     [
@@ -234,12 +242,13 @@ export const ButtonComponent = ({
       : defaultScale;
 
   const easing = 'cubic-bezier(0.5, 1, 0.89, 1)';
+  const effectiveDuration = prefersReducedMotion() ? 0 : currentDuration;
   const transitionProps: string[] = [];
   if (hasOpacity) {
-    transitionProps.push(`opacity ${currentDuration}ms ${easing}`);
+    transitionProps.push(`opacity ${effectiveDuration}ms ${easing}`);
   }
   if (hasScale) {
-    transitionProps.push(`transform ${currentDuration}ms ${easing}`);
+    transitionProps.push(`transform ${effectiveDuration}ms ${easing}`);
   }
   const transition = transitionProps.join(', ');
 
@@ -275,7 +284,7 @@ export const ButtonComponent = ({
             backgroundColor: underlayColor as string,
             opacity: currentUnderlayOpacity,
             // @ts-ignore - web-only CSS properties
-            transition: `opacity ${currentDuration}ms ${easing}`,
+            transition: `opacity ${effectiveDuration}ms ${easing}`,
             pointerEvents: 'none',
           }}
         />

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
@@ -7,8 +7,7 @@ import { GestureLifecycleEvent } from '../web/tools/GestureLifecycleEvents';
 
 const prefersReducedMotion = (): boolean =>
   typeof window !== 'undefined' &&
-  typeof window.matchMedia === 'function' &&
-  window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  !!window.matchMedia?.('(prefers-reduced-motion: reduce)')?.matches;
 
 type ButtonProps = ViewProps & {
   ref?: React.Ref<React.ComponentRef<typeof View>>;


### PR DESCRIPTION
## Description

Updates the native button component to respect
- Reduce motion on iOS
- Animator duration scale on Android
- `prefers-reduced-motion: reduce` on web

for the animation its running

## Test plan

Tested on the existing `Touchable` examples

|Android|iOS|
|-|-|
|<video src="https://github.com/user-attachments/assets/0974e273-7da2-436d-aee3-48dcf848809f" />|<video src="https://github.com/user-attachments/assets/429bcddb-5a75-410e-98e3-5ee58c57a773" />|

Web:

https://github.com/user-attachments/assets/16ceb117-0d91-4542-814b-1e17ebbedf6a





