### PR TITLE
Update skill and docs

### DIFF
--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -29,6 +29,19 @@ To replace `RectButton` with `Touchable`, add `underlayColor="black"` to your `T
   animationDuration={0}/>
 ```
 
+:::note Android ripple
+The legacy `RectButton` shows the native theme ripple on Android by default, while `Touchable` disables the ripple unless [`androidRipple`](#androidripple) is set. To keep the legacy Android feedback, set `androidRipple={{}}` on Android *instead of* `underlayColor`/`animationDuration` — combining the two would render a ripple and an underlay animation simultaneously. Use `Platform.select` to apply the right props per platform:
+
+```tsx
+<Touchable
+  {...Platform.select({
+    android: { androidRipple: {} },
+    default: { underlayColor: 'black', animationDuration: 0 },
+  })}
+/>
+```
+:::
+
 ### BorderlessButton
 
 Replacing `BorderlessButton` with `Touchable` is as easy as replacing `RectButton`. Add `activeOpacity={0.3}` to dim the whole component on press, and `animationDuration={0}` to keep the transition instant — matching the legacy `BorderlessButton`.
@@ -39,6 +52,19 @@ Replacing `BorderlessButton` with `Touchable` is as easy as replacing `RectButto
   activeOpacity={0.3}
   animationDuration={0}/>
 ```
+
+:::note Android ripple
+Same caveat as `RectButton`: the legacy `BorderlessButton` shows the native theme ripple on Android. To preserve that, set `androidRipple={{ borderless: true }}` on Android *instead of* `activeOpacity`/`animationDuration`:
+
+```tsx
+<Touchable
+  {...Platform.select({
+    android: { androidRipple: { borderless: true } },
+    default: { activeOpacity: 0.3, animationDuration: 0 },
+  })}
+/>
+```
+:::
 
 ## Migrating from legacy Touchable variants
 

--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -33,6 +33,8 @@ To replace `RectButton` with `Touchable`, add `underlayColor="black"` to your `T
 The legacy `RectButton` shows the native theme ripple on Android by default, while `Touchable` disables the ripple unless [`androidRipple`](#androidripple) is set. To keep the legacy Android feedback, set `androidRipple={{}}` on Android *instead of* `underlayColor`/`animationDuration` — combining the two would render a ripple and an underlay animation simultaneously. Use `Platform.select` to apply the right props per platform:
 
 ```tsx
+import { Platform } from 'react-native';
+
 <Touchable
   {...Platform.select({
     android: { androidRipple: {} },

--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -102,14 +102,12 @@ To replace `TouchableWithoutFeedback`, use a plain `Touchable`.
 
 ### TouchableNativeFeedback
 
-To replicate `TouchableNativeFeedback` behavior, use the [`androidRipple`](#androidripple) prop. Make sure to set `foreground={true}`.
+To replicate `TouchableNativeFeedback` behavior, use the [`androidRipple`](#androidripple) prop. An empty config is enough to render the default theme ripple — add `color`, `radius`, `borderless`, or `foreground` to customize the animation.
 
 ```tsx
 <Touchable
   ...
-  androidRipple={{
-    foreground: true,
-  }}/>
+  androidRipple={{}}/>
 ```
 
 ## Example 

--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -83,13 +83,14 @@ To replace `TouchableOpacity`, add `activeOpacity={0.2}`. The legacy `TouchableO
 
 ### TouchableHighlight
 
-To replace `TouchableHighlight`, keep your existing `underlayColor` and rename `activeOpacity` to `activeUnderlayOpacity`, while keeping the same value.
+A perfect 1:1 replacement isn't possible — in `TouchableHighlight` the container's own background becomes the underlay (solid `underlayColor`) and `activeOpacity` dims just the children on top, so the underlay shows *through* the dimmed children. `Touchable` instead has a separate underlay layer between the background and children, and its `activeOpacity` dims the whole component (background + underlay + children together). The closest approximation: carry `underlayColor` and `activeOpacity` over unchanged and add `activeUnderlayOpacity={1}` so the underlay layer is rendered solid.
 
 ```tsx
 <Touchable
   ...
   underlayColor="#DDDDDD"
-  activeUnderlayOpacity={0.6}/>
+  activeUnderlayOpacity={1}
+  activeOpacity={0.6}/>
 ```
 
 ### TouchableWithoutFeedback

--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -102,12 +102,12 @@ To replace `TouchableWithoutFeedback`, use a plain `Touchable`.
 
 ### TouchableNativeFeedback
 
-To replicate `TouchableNativeFeedback` behavior, use the [`androidRipple`](#androidripple) prop. An empty config is enough to render the default theme ripple — add `color`, `radius`, `borderless`, or `foreground` to customize the animation.
+To replicate `TouchableNativeFeedback` behavior, use the [`androidRipple`](#androidripple) prop. The legacy component defaults to `useForeground: true`, so set `foreground: true` to match — drop it only if the original code passed `useForeground={false}`. Add `color`, `radius`, or `borderless` if the original code customized the `background` prop.
 
 ```tsx
 <Touchable
   ...
-  androidRipple={{}}/>
+  androidRipple={{ foreground: true }}/>
 ```
 
 ## Example 

--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -20,22 +20,24 @@ If you were using `RectButton` or `BorderlessButton` in your app, you should rep
 
 ### RectButton
 
-To replace `RectButton` with `Touchable`, simply add `underlayColor="black"` to your `Touchable`. This will animate the underlay when the button is pressed.
+To replace `RectButton` with `Touchable`, add `underlayColor="black"` to your `Touchable`. This will tint the underlay when the button is pressed. The legacy `RectButton` switches states instantly with no fade, so also set `animationDuration={0}` to match its behavior.
 
 ```tsx
 <Touchable
   ...
-  underlayColor="black"/>
+  underlayColor="black"
+  animationDuration={0}/>
 ```
 
 ### BorderlessButton
 
-Replacing `BorderlessButton` with `Touchable` is as easy as replacing `RectButton`. Just add `activeOpacity={0.3}` to your `Touchable`. This will animate the whole component when the button is pressed.
+Replacing `BorderlessButton` with `Touchable` is as easy as replacing `RectButton`. Add `activeOpacity={0.3}` to dim the whole component on press, and `animationDuration={0}` to keep the transition instant — matching the legacy `BorderlessButton`.
 
 ```tsx
 <Touchable
   ...
-  activeOpacity={0.3}/>
+  activeOpacity={0.3}
+  animationDuration={0}/>
 ```
 
 ## Migrating from legacy Touchable variants
@@ -44,12 +46,13 @@ If you were using the specialized touchable components (`TouchableOpacity`, `Tou
 
 ### TouchableOpacity
 
-To replace `TouchableOpacity`, add `activeOpacity={0.2}`.
+To replace `TouchableOpacity`, add `activeOpacity={0.2}`. The legacy `TouchableOpacity` dims instantly on press-in and fades back over 150ms on release, so set `animationDuration={{ in: 0, out: 150 }}` to mirror that timing.
 
 ```tsx
 <Touchable
   ...
-  activeOpacity={0.2}/>
+  activeOpacity={0.2}
+  animationDuration={{ in: 0, out: 150 }}/>
 ```
 
 ### TouchableHighlight
@@ -114,7 +117,8 @@ export default function TouchableExample() {
           console.log('RectButton built with Touchable');
         }}
         style={[styles.button, { backgroundColor: '#4f9a84' }]}
-        underlayColor="black">
+        underlayColor="black"
+        animationDuration={0}>
         <Text style={styles.buttonText}>RectButton</Text>
       </Touchable>
 
@@ -123,7 +127,8 @@ export default function TouchableExample() {
           console.log('BorderlessButton built with Touchable');
         }}
         style={[styles.button, { backgroundColor: '#5f97c8' }]}
-        activeOpacity={0.3}>
+        activeOpacity={0.3}
+        animationDuration={0}>
         <Text style={styles.buttonText}>BorderlessButton</Text>
       </Touchable>
     </GestureHandlerRootView>

--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -57,12 +57,13 @@ To replace `TouchableOpacity`, add `activeOpacity={0.2}`. The legacy `TouchableO
 
 ### TouchableHighlight
 
-To replace `TouchableHighlight`, add `activeUnderlayOpacity={1}`.
+To replace `TouchableHighlight`, keep your existing `underlayColor` and rename `activeOpacity` to `activeUnderlayOpacity`, while keeping the same value.
 
 ```tsx
 <Touchable
   ...
-  activeUnderlayOpacity={1}/>
+  underlayColor="#DDDDDD"
+  activeUnderlayOpacity={0.6}/>
 ```
 
 ### TouchableWithoutFeedback

--- a/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
+++ b/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
@@ -279,7 +279,11 @@ To help you migrate, here is the current state of our button components:
 - [`Touchable`](/docs/components/touchable) - The recommended component. Can be used to replicate both `RectButton` and `BorderlessButton` effects by adjusting the `underlayColor`, `activeOpacity`, and `animationDuration` props.
   - To replace `RectButton`, add `underlayColor="black"` and `animationDuration={0}` (the legacy button switches states instantly).
   - To replace `BorderlessButton`, add `activeOpacity={0.3}` and `animationDuration={0}`.
-  - **Android ripple:** legacy `RectButton`/`BorderlessButton` show the native theme ripple on Android by default, while `Touchable` disables the ripple unless `androidRipple` is set. To preserve that behavior, set `androidRipple={{}}` on Android *instead of* the underlay/opacity/animation props above — don't combine them, or you'll get both a ripple and an underlay animation at once. Use `Platform.select` to apply different props per platform.
+  - **Android ripple:** legacy `RectButton`/`BorderlessButton` show the native theme ripple on Android by default, while `Touchable` disables the ripple unless `androidRipple` is set. To preserve that behavior, set `androidRipple` on Android *instead of* the underlay/opacity/animation props above (don't combine them, or you'll get both a ripple and an underlay animation at once):
+    - `RectButton` → `androidRipple={{}}`
+    - `BorderlessButton` → `androidRipple={{ borderless: true }}` (matches the legacy borderless ripple shape)
+
+    See the [`Touchable` docs](/docs/components/touchable#rectbutton) for full `Platform.select` examples.
 
 - Standard Buttons (Deprecated) - `BaseButton`, `RectButton` and `BorderlessButton` are still available but are now deprecated. They have been internally rewritten using the new Hooks API to resolve long-standing issues.
 

--- a/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
+++ b/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
@@ -311,7 +311,7 @@ Although the legacy JS implementation of the buttons is still available, they al
 [`Touchable`](/docs/components/touchable) can also be used as a substitute for old, deprecated `Touchables`.
   - To replace `TouchableOpacity`, add `activeOpacity={0.2}` and `animationDuration={{ in: 0, out: 150 }}`.
   - To replace `TouchableHighlight`, keep your existing `underlayColor` and rename `activeOpacity` to `activeUnderlayOpacity` (same value). Do not set `Touchable`'s `activeOpacity` — only the underlay should animate, not the foreground.
-  - To replace `TouchableNativeFeedback`, add `androidRipple` property with an empty object.
+  - To replace `TouchableNativeFeedback`, add `androidRipple={{}}` — an empty config renders the default theme ripple; add `color`, `radius`, `borderless`, or `foreground` only if the original code customized them.
   - `TouchableWithoutFeedback` can be replaced with a plain `Touchable`.
 
 ### Other components

--- a/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
+++ b/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
@@ -310,7 +310,7 @@ Although the legacy JS implementation of the buttons is still available, they al
 
 [`Touchable`](/docs/components/touchable) can also be used as a substitute for old, deprecated `Touchables`.
   - To replace `TouchableOpacity`, add `activeOpacity={0.2}` and `animationDuration={{ in: 0, out: 150 }}`.
-  - To replace `TouchableHighlight`, keep your existing `underlayColor` and rename `activeOpacity` to `activeUnderlayOpacity` (same value). Do not set `Touchable`'s `activeOpacity` — only the underlay should animate, not the foreground.
+  - To replace `TouchableHighlight`, carry `underlayColor` and `activeOpacity` over unchanged and add `activeUnderlayOpacity={1}` so the underlay is solid. A perfect 1:1 replacement isn't possible: in `TouchableHighlight` the container's own background becomes the underlay and `activeOpacity` dims just the children on top (the underlay shows *through* the dimmed children), while `Touchable` renders the underlay as a separate layer between background and children, and its `activeOpacity` dims the whole component. The visual feedback may differ slightly because of the different layering.
   - To replace `TouchableNativeFeedback`, add `androidRipple={{ foreground: true }}` — the legacy component defaults to `useForeground: true`, so `{ foreground: true }` is the closest match. Drop `foreground` only when the original code set `useForeground={false}`; add `color`, `radius`, or `borderless` if it customized the `background` prop.
   - `TouchableWithoutFeedback` can be replaced with a plain `Touchable`.
 

--- a/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
+++ b/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
@@ -311,7 +311,7 @@ Although the legacy JS implementation of the buttons is still available, they al
 [`Touchable`](/docs/components/touchable) can also be used as a substitute for old, deprecated `Touchables`.
   - To replace `TouchableOpacity`, add `activeOpacity={0.2}` and `animationDuration={{ in: 0, out: 150 }}`.
   - To replace `TouchableHighlight`, keep your existing `underlayColor` and rename `activeOpacity` to `activeUnderlayOpacity` (same value). Do not set `Touchable`'s `activeOpacity` — only the underlay should animate, not the foreground.
-  - To replace `TouchableNativeFeedback`, add `androidRipple={{}}` — an empty config renders the default theme ripple; add `color`, `radius`, `borderless`, or `foreground` only if the original code customized them.
+  - To replace `TouchableNativeFeedback`, add `androidRipple={{ foreground: true }}` — the legacy component defaults to `useForeground: true`, so `{ foreground: true }` is the closest match. Drop `foreground` only when the original code set `useForeground={false}`; add `color`, `radius`, or `borderless` if it customized the `background` prop.
   - `TouchableWithoutFeedback` can be replaced with a plain `Touchable`.
 
 ### Other components

--- a/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
+++ b/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
@@ -276,9 +276,9 @@ RNGH3 introduces the [`Touchable`](/docs/components/touchable) component — a f
 
 To help you migrate, here is the current state of our button components:
 
-- [`Touchable`](/docs/components/touchable) - The recommended component. Can be used to replicate both `RectButton` and `BorderlessButton` effects by adjusting the `activeOpacity` and `activeUnderlayOpacity` props.
-  - To replace `RectButton`, add `activeUnderlayOpacity={0.105}`.
-  - To replace `BorderlessButton`, add `activeOpacity={0.3}`.
+- [`Touchable`](/docs/components/touchable) - The recommended component. Can be used to replicate both `RectButton` and `BorderlessButton` effects by adjusting the `underlayColor`, `activeOpacity`, and `animationDuration` props.
+  - To replace `RectButton`, add `underlayColor="black"` and `animationDuration={0}`.
+  - To replace `BorderlessButton`, add `activeOpacity={0.3}` and `animationDuration={0}`.
 
 - Standard Buttons (Deprecated) - `BaseButton`, `RectButton` and `BorderlessButton` are still available but are now deprecated. They have been internally rewritten using the new Hooks API to resolve long-standing issues.
 
@@ -308,9 +308,9 @@ Although the legacy JS implementation of the buttons is still available, they al
 ### Touchables
 
 [`Touchable`](/docs/components/touchable) can also be used as a substitute for old, deprecated `Touchables`.
-  - To replace `TouchableOpacity`, add `activeOpacity={0.2}`.
-  - To replace `TouchableHighlight`, add `activeUnderlayOpacity={1}`.
-  - To replace `TouchableNativeFeedback`, add `androidRipple` property with `foreground: true`.
+  - To replace `TouchableOpacity`, add `activeOpacity={0.2}` and `animationDuration={{ in: 0, out: 150 }}`.
+  - To replace `TouchableHighlight`, keep your existing `underlayColor` and rename `activeOpacity` to `activeUnderlayOpacity` (same value). Do not set `Touchable`'s `activeOpacity` — only the underlay should animate, not the foreground.
+  - To replace `TouchableNativeFeedback`, add `androidRipple` property with an empty object.
   - `TouchableWithoutFeedback` can be replaced with a plain `Touchable`.
 
 ### Other components

--- a/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
+++ b/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
@@ -277,8 +277,9 @@ RNGH3 introduces the [`Touchable`](/docs/components/touchable) component — a f
 To help you migrate, here is the current state of our button components:
 
 - [`Touchable`](/docs/components/touchable) - The recommended component. Can be used to replicate both `RectButton` and `BorderlessButton` effects by adjusting the `underlayColor`, `activeOpacity`, and `animationDuration` props.
-  - To replace `RectButton`, add `underlayColor="black"` and `animationDuration={0}`.
+  - To replace `RectButton`, add `underlayColor="black"` and `animationDuration={0}` (the legacy button switches states instantly).
   - To replace `BorderlessButton`, add `activeOpacity={0.3}` and `animationDuration={0}`.
+  - **Android ripple:** legacy `RectButton`/`BorderlessButton` show the native theme ripple on Android by default, while `Touchable` disables the ripple unless `androidRipple` is set. To preserve that behavior, set `androidRipple={{}}` on Android *instead of* the underlay/opacity/animation props above — don't combine them, or you'll get both a ripple and an underlay animation at once. Use `Platform.select` to apply different props per platform.
 
 - Standard Buttons (Deprecated) - `BaseButton`, `RectButton` and `BorderlessButton` are still available but are now deprecated. They have been internally rewritten using the new Hooks API to resolve long-standing issues.
 

--- a/skills/gesture-handler-3-migration/SKILL.md
+++ b/skills/gesture-handler-3-migration/SKILL.md
@@ -220,7 +220,7 @@ The props you will use when migrating:
 | Old component | Replace with |
 | --------------------------- | ---------------------------------------------------------------------------- |
 | `TouchableOpacity` | `<Touchable activeOpacity={0.2} animationDuration={{ in: 0, out: 150 }} />` |
-| `TouchableHighlight` | `<Touchable activeUnderlayOpacity={1} />` (also pass `underlayColor`) |
+| `TouchableHighlight` | `<Touchable underlayColor={...} activeUnderlayOpacity={...} />` - keep the original `underlayColor`; the old `activeOpacity` value becomes `activeUnderlayOpacity` (do **not** set `Touchable.activeOpacity` - only the underlay should animate) |
 | `TouchableWithoutFeedback` | `<Touchable />` (plain, no visual feedback props) |
 | `TouchableNativeFeedback` | `<Touchable androidRipple={{}} />` (fill ripple config as needed, empty config results in the default ripple) |
 

--- a/skills/gesture-handler-3-migration/SKILL.md
+++ b/skills/gesture-handler-3-migration/SKILL.md
@@ -231,11 +231,13 @@ The props you will use when migrating:
 | Old component | Replace with |
 | --------------------------- | ---------------------------------------------------------------------------- |
 | `TouchableOpacity` | `<Touchable activeOpacity={0.2} animationDuration={{ in: 0, out: 150 }} />` |
-| `TouchableHighlight` | `<Touchable underlayColor={...} activeUnderlayOpacity={...} />` - keep the original `underlayColor`; the old `activeOpacity` value becomes `activeUnderlayOpacity` (do **not** set `Touchable.activeOpacity` - only the underlay should animate) |
+| `TouchableHighlight` | `<Touchable underlayColor={...} activeUnderlayOpacity={1} activeOpacity={...} />` — closest approximation only (not 1:1, see note below) |
 | `TouchableWithoutFeedback` | `<Touchable />` (plain, no visual feedback props) |
 | `TouchableNativeFeedback` | `<Touchable androidRipple={{ foreground: true }} />` (legacy default draws the ripple in the foreground; drop `foreground` if the original code passed `useForeground={false}`) |
 
 For `TouchableNativeFeedback`, `androidRipple` must be set explicitly — without it no ripple is rendered. The legacy component defaults to `useForeground: true`, so `{ foreground: true }` is the closest default replacement; omit `foreground` only when the original code set `useForeground={false}`. Add `color`, `radius`, or `borderless` if the original code customized the `background` prop.
+
+For `TouchableHighlight`, a perfect 1:1 replacement is **not possible** — in the legacy component the container's own background becomes the underlay (solid `underlayColor`) and `activeOpacity` dims just the children on top, so the underlay shows *through* the dimmed children. `Touchable` instead has a separate underlay layer between the background and children, and its `activeOpacity` dims the whole component (background + underlay + children together). The closest approximation: carry `underlayColor` and `activeOpacity` over unchanged, and add `activeUnderlayOpacity={1}` so the underlay layer is rendered solid. Inform the user that the visual feedback may differ from the legacy component because of the different layering.
 
 Do not swap Gesture Handler buttons/touchables for React Native core components or vice versa during migration — keep them within `react-native-gesture-handler`.
 

--- a/skills/gesture-handler-3-migration/SKILL.md
+++ b/skills/gesture-handler-3-migration/SKILL.md
@@ -235,7 +235,7 @@ The props you will use when migrating:
 | `TouchableWithoutFeedback` | `<Touchable />` (plain, no visual feedback props) |
 | `TouchableNativeFeedback` | `<Touchable androidRipple={{}} />` (fill ripple config as needed, empty config results in the default ripple) |
 
-For `TouchableNativeFeedback`, `androidRipple` must be set explicitly — without it no ripple is rendered. `{ foreground: true }` is the minimum to mimic the original behavior; add `color`, `radius`, or `borderless` to match the original ripple appearance.
+For `TouchableNativeFeedback`, `androidRipple` must be set explicitly — without it no ripple is rendered. An empty `{}` is sufficient to get the default theme ripple; add `color`, `radius`, `borderless`, or `foreground` only if the original code customized them.
 
 Do not swap Gesture Handler buttons/touchables for React Native core components or vice versa during migration — keep them within `react-native-gesture-handler`.
 

--- a/skills/gesture-handler-3-migration/SKILL.md
+++ b/skills/gesture-handler-3-migration/SKILL.md
@@ -209,11 +209,22 @@ The props you will use when migrating:
 
 ##### Replacing Gesture Handler buttons
 
-| Old component | Replace with |
+| Old component | Replace with (iOS / cross-platform default) |
 | ----------------- | --------------------------------------------------------- |
 | `BaseButton` | `<Touchable />` (default props) |
 | `RectButton` | `<Touchable underlayColor="black" animationDuration={0} />` |
 | `BorderlessButton`| `<Touchable activeOpacity={0.3} animationDuration={0} />` |
+
+**Android ripple:** legacy `RectButton`/`BorderlessButton` use the native theme ripple on Android, while `Touchable` disables the ripple unless `androidRipple` is set. To preserve the legacy Android feedback, set `androidRipple={{}}` on Android **instead of** `underlayColor`/`activeOpacity`/`animationDuration` (don't combine them — the ripple is the visual feedback on Android). Use `Platform.select` to split:
+
+```jsx
+<Touchable
+  {...Platform.select({
+    android: { androidRipple: {} },
+    default: { underlayColor: 'black', animationDuration: 0 }, // RectButton
+  })}
+/>
+```
 
 ##### Replacing legacy Touchables
 

--- a/skills/gesture-handler-3-migration/SKILL.md
+++ b/skills/gesture-handler-3-migration/SKILL.md
@@ -233,9 +233,9 @@ The props you will use when migrating:
 | `TouchableOpacity` | `<Touchable activeOpacity={0.2} animationDuration={{ in: 0, out: 150 }} />` |
 | `TouchableHighlight` | `<Touchable underlayColor={...} activeUnderlayOpacity={...} />` - keep the original `underlayColor`; the old `activeOpacity` value becomes `activeUnderlayOpacity` (do **not** set `Touchable.activeOpacity` - only the underlay should animate) |
 | `TouchableWithoutFeedback` | `<Touchable />` (plain, no visual feedback props) |
-| `TouchableNativeFeedback` | `<Touchable androidRipple={{}} />` (fill ripple config as needed, empty config results in the default ripple) |
+| `TouchableNativeFeedback` | `<Touchable androidRipple={{ foreground: true }} />` (legacy default draws the ripple in the foreground; drop `foreground` if the original code passed `useForeground={false}`) |
 
-For `TouchableNativeFeedback`, `androidRipple` must be set explicitly — without it no ripple is rendered. An empty `{}` is sufficient to get the default theme ripple; add `color`, `radius`, `borderless`, or `foreground` only if the original code customized them.
+For `TouchableNativeFeedback`, `androidRipple` must be set explicitly — without it no ripple is rendered. The legacy component defaults to `useForeground: true`, so `{ foreground: true }` is the closest default replacement; omit `foreground` only when the original code set `useForeground={false}`. Add `color`, `radius`, or `borderless` if the original code customized the `background` prop.
 
 Do not swap Gesture Handler buttons/touchables for React Native core components or vice versa during migration — keep them within `react-native-gesture-handler`.
 

--- a/skills/gesture-handler-3-migration/SKILL.md
+++ b/skills/gesture-handler-3-migration/SKILL.md
@@ -218,6 +218,8 @@ The props you will use when migrating:
 **Android ripple:** legacy `RectButton`/`BorderlessButton` use the native theme ripple on Android, while `Touchable` disables the ripple unless `androidRipple` is set. To preserve the legacy Android feedback, set `androidRipple={{}}` on Android **instead of** `underlayColor`/`activeOpacity`/`animationDuration` (don't combine them — the ripple is the visual feedback on Android). Use `Platform.select` to split:
 
 ```jsx
+import { Platform } from 'react-native';
+
 <Touchable
   {...Platform.select({
     android: { androidRipple: {} },

--- a/skills/gesture-handler-3-migration/SKILL.md
+++ b/skills/gesture-handler-3-migration/SKILL.md
@@ -184,15 +184,49 @@ The implementation of buttons has been updated, resolving most button-related is
 
 `PureNativeButton` has been removed. If encountered, inform the user that it has been removed and let them decide how to handle that case. They can achieve similar functionality with other buttons.
 
-When migrating buttons, you should use new `Touchable` component instead. To replace `BaseButton` use `Touchable` with default props, to replace `RectButton` use `Touchable` with `underlayColor="black"` and to replace `BorderlessButton` use `Touchable` with `activeOpacity={0.3}`.
-
 ReanimatedSwipeable prop `dragOffsetFromRight` now accepts negative values. If it was used with positive values, make sure to change the sign.
-
-Legacy Touchables (`TouchableOpacity`, `TouchableHighlight`, `TouchableWithoutFeedback`, `TouchableNativeFeedback`) from Gesture Handler are also deprecated and should be replaced with `Touchable`. To replace `TouchableOpacity` use `Touchable` with `activeOpacity={0.2}` and to replace `TouchableHighlight` use `Touchable` with `activeUnderlayOpacity={1}`. To replace `TouchableWithoutFeedback` use a plain `Touchable`. `TouchableNativeFeedback` can be replaced with `Touchable` by setting `androidRipple` property. At minimum, it should be set to `{foreground: true}`, to mimic `TouchableNativeFeedback` ripple effect.
 
 Other components have also been internally rewritten using the new hook API but are exported under their original names, so no changes are necessary on your part. However, if you need to use the previous implementation for any reason, the legacy components are also available and are prefixed with `Legacy`, e.g., `ScrollView` is now available as `LegacyScrollView`.
 
 Rename all instances of createNativeWrapper to legacy_createNativeWrapper. This includes both the import statements and the function calls.
+
+#### Migrating to `Touchable`
+
+In Gesture Handler 3 the `Touchable` component replaces both the old buttons (`BaseButton`, `RectButton`, `BorderlessButton`) and the legacy core-style touchables (`TouchableOpacity`, `TouchableHighlight`, `TouchableWithoutFeedback`, `TouchableNativeFeedback`). It is a single component whose visual feedback is controlled entirely through props — pick the right combination instead of picking a different component.
+
+The props you will use when migrating:
+
+- `onPress(event)` — fired on a successful tap. Note: the callback signature changed; the old `BaseButton.onPress` received `(pointerInside: boolean)`, `Touchable.onPress` receives a gesture event object instead.
+- `onPressIn(event)` / `onPressOut(event)` — fired when the pointer first touches and when it is released or leaves the component.
+- `onLongPress()` — fired after the press is held for `delayLongPress` milliseconds (default `600`). When a long press fires, the subsequent release does **not** call `onPress`.
+- `disabled` — replaces the old `enabled` prop (note the inverted sense). Defaults to `false`.
+- `cancelOnLeave` — whether the press is cancelled when the pointer leaves the component bounds. Defaults to `true`. Use this to replace `shouldCancelWhenOutside` from raw buttons.
+- `activeOpacity` — opacity applied to the component itself while pressed (mirrors `TouchableOpacity`). Defaults to `1` (no opacity change).
+- `underlayColor` + `activeUnderlayOpacity` — color and opacity of the underlay shown while pressed (mirrors `TouchableHighlight` / `RectButton`). `underlayColor` defaults to `'transparent'` and `activeUnderlayOpacity` to `0.105`.
+- `androidRipple` — Android ripple config (`{ color?, radius?, borderless?, foreground? }`). When omitted, no native ripple is rendered. Use this to replace `TouchableNativeFeedback`.
+- `animationDuration` — press/hover animation timing in milliseconds. Pass a single number to apply it to every phase, or `{ in, out }` (optionally with `tap`/`hover`/`longPress` overrides). Defaults to `50` in / `100` out.
+- `hitSlop`, `testID`, `style`, `children` — same as before.
+
+##### Replacing Gesture Handler buttons
+
+| Old component | Replace with |
+| ----------------- | --------------------------------------------------------- |
+| `BaseButton` | `<Touchable />` (default props) |
+| `RectButton` | `<Touchable underlayColor="black" animationDuration={0} />` |
+| `BorderlessButton`| `<Touchable activeOpacity={0.3} animationDuration={0} />` |
+
+##### Replacing legacy Touchables
+
+| Old component | Replace with |
+| --------------------------- | ---------------------------------------------------------------------------- |
+| `TouchableOpacity` | `<Touchable activeOpacity={0.2} animationDuration={{ in: 0, out: 150 }} />` |
+| `TouchableHighlight` | `<Touchable activeUnderlayOpacity={1} />` (also pass `underlayColor`) |
+| `TouchableWithoutFeedback` | `<Touchable />` (plain, no visual feedback props) |
+| `TouchableNativeFeedback` | `<Touchable androidRipple={{}} />` (fill ripple config as needed, empty config results in the default ripple) |
+
+For `TouchableNativeFeedback`, `androidRipple` must be set explicitly — without it no ripple is rendered. `{ foreground: true }` is the minimum to mimic the original behavior; add `color`, `radius`, or `borderless` to match the original ripple appearance.
+
+Do not swap Gesture Handler buttons/touchables for React Native core components or vice versa during migration — keep them within `react-native-gesture-handler`.
 
 ### Replaced types
 

--- a/skills/gesture-handler-3-migration/SKILL.md
+++ b/skills/gesture-handler-3-migration/SKILL.md
@@ -215,7 +215,12 @@ The props you will use when migrating:
 | `RectButton` | `<Touchable underlayColor="black" animationDuration={0} />` |
 | `BorderlessButton`| `<Touchable activeOpacity={0.3} animationDuration={0} />` |
 
-**Android ripple:** legacy `RectButton`/`BorderlessButton` use the native theme ripple on Android, while `Touchable` disables the ripple unless `androidRipple` is set. To preserve the legacy Android feedback, set `androidRipple={{}}` on Android **instead of** `underlayColor`/`activeOpacity`/`animationDuration` (don't combine them — the ripple is the visual feedback on Android). Use `Platform.select` to split:
+**Android ripple:** legacy `RectButton`/`BorderlessButton` use the native theme ripple on Android, while `Touchable` disables the ripple unless `androidRipple` is set. To preserve the legacy Android feedback, set `androidRipple` on Android **instead of** `underlayColor`/`activeOpacity`/`animationDuration` (don't combine them — the ripple is the visual feedback on Android). The two configs are different:
+
+- `RectButton` → `androidRipple={{}}`
+- `BorderlessButton` → `androidRipple={{ borderless: true }}` (matches the legacy borderless ripple shape)
+
+Use `Platform.select` to apply different props per platform. Example for `RectButton`:
 
 ```jsx
 import { Platform } from 'react-native';
@@ -223,7 +228,7 @@ import { Platform } from 'react-native';
 <Touchable
   {...Platform.select({
     android: { androidRipple: {} },
-    default: { underlayColor: 'black', animationDuration: 0 }, // RectButton
+    default: { underlayColor: 'black', animationDuration: 0 },
   })}
 />
 ```


### PR DESCRIPTION
## Description

- Updates the `Touchable` documentation with `animationDuration` props for the relevant components
- Updates the `Touchable` section in the migration skill with the descriptions of prop behaviors and old component replacement examples

## Test plan

Read the new thing
