### PR TITLE
[iOS] Fix handler retrieval and mismatched coordinate space

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -640,14 +640,14 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   // We may try to extract "DummyGestureHandler" in case when "otherGestureRecognizer" belongs to
   // a native view being wrapped with "NativeViewGestureHandler"
   RNGHUIView *reactView = recognizer.view;
-  while (reactView != nil && ![reactView isKindOfClass:[RCTViewComponentView class]]) {
-    reactView = reactView.superview;
-  }
-
-  for (UIGestureRecognizer *recognizer in reactView.gestureRecognizers) {
-    if ([recognizer isKindOfClass:[RNDummyGestureRecognizer class]]) {
-      return recognizer.gestureHandler;
+  while (reactView != nil) {
+    for (UIGestureRecognizer *recognizer in reactView.gestureRecognizers) {
+      if ([recognizer isKindOfClass:[RNDummyGestureRecognizer class]]) {
+        return recognizer.gestureHandler;
+      }
     }
+
+    reactView = reactView.superview;
   }
 
   return nil;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -640,7 +640,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   // We may try to extract "DummyGestureHandler" in case when "otherGestureRecognizer" belongs to
   // a native view being wrapped with "NativeViewGestureHandler"
   RNGHUIView *reactView = recognizer.view;
-  while (reactView != nil && reactView.reactTag == nil) {
+  while (reactView != nil && ![reactView isKindOfClass:[RCTViewComponentView class]]) {
     reactView = reactView.superview;
   }
 
@@ -816,7 +816,8 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
   RNGHUIView *viewToHitTest = _recognizer.view;
 
-  if ([self usesNativeOrVirtualDetector] && [_recognizer.view.subviews count] > 0) {
+  if ([self usesNativeOrVirtualDetector] && [_recognizer.view.subviews count] > 0 &&
+      _recognizer.view == self.hostDetectorView) {
     viewToHitTest = _recognizer.view.subviews[0];
     point = [_recognizer.view convertPoint:point toView:viewToHitTest];
   }

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -850,7 +850,7 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   for (UIGestureRecognizer *recognizer in enabledGestureRecognizers) {
     RNGestureHandler *handler = [RNGestureHandler findGestureHandlerByRecognizer:recognizer];
     if (handler != nil) {
-      CGPoint pointInView = [self convertPoint:point toView:view];
+      CGPoint pointInView = [self convertPoint:point toView:handler.recognizer.view];
       gestureRecognizerWantsEvent = [handler wantsToHandleEventsAtPoint:pointInView];
     } else {
       gestureRecognizerWantsEvent = YES;


### PR DESCRIPTION
## Description

Fixes three issues:
1. `findGestureHandlerByRecognizer` was relying on `reactTag` to determine whether a view is managed by React Native. This is no longer set on the new architecture (we do it [here](https://github.com/software-mansion/react-native-gesture-handler/blob/e362f3a1ea2c04b78d3923c377dc2c62b23ca2d0/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm#L206), this needs to be investigated). Instead, I changed it to check whether the view is a subclass of `RCTViewComponentView` which is a base for Fabric components.
2. `shouldHandleTouch` in the button component was converting the point to the wrong coordinate space when calling `wantsToHandleEventsAtPoint`.
3. `wantsToHandleEventsAtPoint` for api v3 was always trying to get the child of the view the gesture is attached to. Correct when gesture is attached to the detector, not when directly to view (virtual detector/`wantsToAttachDirectlyToView: YES`).

## Test plan

Enable "Legacy examples" in the expo app and try to scroll, starting on one of the disabled buttons.

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/28cd0b95-85df-46e8-8ca4-28c042d725b0" />|<video src="https://github.com/user-attachments/assets/7116d3aa-557f-4828-9b4e-c0177ed89202" />|

There's no pointer captured, but in the "before" video, I'm trying to scroll starting on `Nested buttons (sound & ripple)`.




