### PR TITLE
[Android] Make `BorderlessButton` borderless by default

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/components/GestureButtons.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureButtons.tsx
@@ -186,6 +186,7 @@ export const BorderlessButton = (props: BorderlessButtonProps) => {
 
   return (
     <AnimatedBaseButton
+      borderless
       {...rest}
       ref={ref ?? null}
       onActiveStateChange={onActiveStateChange}


### PR DESCRIPTION
## Description

`LegacyBorderlessButton` sets `borderless` by default, while `BorderlessButton` doesn't. This PR changes that.

## Test plan

Tested the buttons example
