### PR TITLE
[Release] Don't pin nightly version

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -73,5 +73,4 @@ jobs:
           package-json-path: 'packages/react-native-gesture-handler/package.json'
           install-dependencies-command: 'yarn install --immutable'
           release-type: 'nightly'
-          version: "3.0.0"
           dry-run: false


### PR DESCRIPTION
## Description

So far, the nightlies have been pinned to version `3.0.0` - the stable release is 2.x, so automatic resolution would pick it up and release 2.x+1.

Once 3.0 is released on the stable channel, pinning stops being necessary.
