### PR TITLE
[iOS] Don't iterate to root while resolving recognizer

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -639,15 +639,19 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
   // We may try to extract "DummyGestureHandler" in case when "otherGestureRecognizer" belongs to
   // a native view being wrapped with "NativeViewGestureHandler"
-  RNGHUIView *reactView = recognizer.view;
-  while (reactView != nil) {
-    for (UIGestureRecognizer *recognizer in reactView.gestureRecognizers) {
-      if ([recognizer isKindOfClass:[RNDummyGestureRecognizer class]]) {
-        return recognizer.gestureHandler;
+  RNGHUIView *view = recognizer.view;
+  while (view != nil) {
+    for (UIGestureRecognizer *candidateRecognizer in view.gestureRecognizers) {
+      if ([candidateRecognizer isKindOfClass:[RNDummyGestureRecognizer class]]) {
+        return candidateRecognizer.gestureHandler;
       }
     }
 
-    reactView = reactView.superview;
+    if ([view isKindOfClass:[RCTViewComponentView class]]) {
+      return nil;
+    }
+
+    view = view.superview;
   }
 
   return nil;


### PR DESCRIPTION
## Description

The updated loop in https://github.com/software-mansion/react-native-gesture-handler/pull/4199 didn't accurately represent the semantics from the old arch. It didn't stop on the views managed by React Native, instead iterating to the root of the hierarchy.

## Test plan

Checked that it doesn't regress https://github.com/software-mansion/react-native-gesture-handler/pull/4199
