### PR TITLE
[General] Fix relations not being applied in api V1

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/createHandler.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/createHandler.tsx
@@ -25,7 +25,11 @@ import {
   unregisterOldGestureHandler,
 } from './handlersRegistry';
 import { PressabilityDebugView } from './PressabilityDebugView';
-import { filterConfig, scheduleFlushOperations } from './utils';
+import {
+  filterConfig,
+  scheduleFlushOperations,
+  selectProperties,
+} from './utils';
 
 customDirectEventTypes.topGestureHandlerEvent = {
   registrationName: 'onGestureHandlerEvent',
@@ -262,6 +266,15 @@ export default function createHandler<
         this.handlerTag,
         newConfig
       );
+
+      RNGestureHandlerModule.configureRelations(
+        this.handlerTag,
+        selectProperties(newConfig, [
+          'waitFor',
+          'simultaneousHandlers',
+          'blocksHandlers',
+        ])
+      );
     };
 
     private attachGestureHandler = (newViewTag: number) => {
@@ -334,7 +347,7 @@ export default function createHandler<
 
       RNGestureHandlerModule.configureRelations(
         this.handlerTag,
-        filterConfig(this.config, [
+        selectProperties(newConfig, [
           'waitFor',
           'simultaneousHandlers',
           'blocksHandlers',

--- a/packages/react-native-gesture-handler/src/handlers/utils.ts
+++ b/packages/react-native-gesture-handler/src/handlers/utils.ts
@@ -18,6 +18,11 @@ function isConfigParam(param: unknown, name: string) {
   );
 }
 
+export const selectProperties = (
+  obj: Record<string, unknown>,
+  keys: string[]
+) => Object.fromEntries(keys.filter((k) => k in obj).map((k) => [k, obj[k]]));
+
 export function filterConfig(
   props: Record<string, unknown>,
   validProps: string[],


### PR DESCRIPTION
## Description

1. `configureRelations` wasn't called after creating the gesture, only after the update.
2. `filterConfig` isn't idempotent, and calling it a second time resulted in the relations arrays being cleared. Adds a simple `selectProperties` util to use instead.

## Test plan

Test legacy Multitap example
