### PR TITLE
Fix Android Pressable TalkBack activation

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/Pressable.accessibility.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/Pressable.accessibility.test.tsx
@@ -4,7 +4,10 @@ import { Platform, Text } from 'react-native';
 
 import GestureHandlerRootView from '../components/GestureHandlerRootView';
 import LegacyPressable from '../components/Pressable/Pressable';
-import type { PressableProps } from '../components/Pressable/PressableProps';
+import type {
+  PressableEvent,
+  PressableProps,
+} from '../components/Pressable/PressableProps';
 import Pressable from '../v3/components/Pressable';
 
 jest.unmock('../components/Pressable/Pressable');
@@ -26,23 +29,25 @@ const implementations = [
   ],
 ] as const;
 
-beforeEach(() => {
+const setPlatform = (platform: typeof Platform.OS) => {
   Object.defineProperty(Platform, 'OS', {
     configurable: true,
-    value: 'android',
+    value: platform,
   });
+};
+
+beforeEach(() => {
+  setPlatform('android');
 });
 
 afterEach(() => {
-  Object.defineProperty(Platform, 'OS', {
-    configurable: true,
-    value: originalPlatformOS,
-  });
+  setPlatform(originalPlatformOS);
 });
 
 function renderPressable(
   Component: React.ComponentType<TestPressableProps>,
-  props: TestPressableProps
+  props: TestPressableProps,
+  layout = { x: 0, y: 0, width: 100, height: 40 }
 ) {
   const result = render(
     <GestureHandlerRootView>
@@ -54,7 +59,7 @@ function renderPressable(
   const pressable = result.getByTestId('pressable');
 
   fireEvent(pressable, 'layout', {
-    nativeEvent: { layout: { x: 0, y: 0, width: 100, height: 40 } },
+    nativeEvent: { layout },
   });
 
   return { ...result, pressable };
@@ -77,6 +82,40 @@ describe.each(implementations)(
       });
 
       expect(calls).toEqual(['in', 'out', 'press']);
+    });
+
+    test('uses separate layout-local synthetic events for press in and out', () => {
+      const onPressIn = jest.fn<void, [PressableEvent]>();
+      const onPressOut = jest.fn<void, [PressableEvent]>();
+
+      const { pressable } = renderPressable(
+        Component,
+        {
+          onPressIn,
+          onPressOut,
+          onPress: jest.fn(),
+        },
+        { x: 10, y: 20, width: 100, height: 40 }
+      );
+
+      fireEvent(pressable, 'accessibilityAction', {
+        nativeEvent: { actionName: 'activate' },
+      });
+
+      const pressInEvent = onPressIn.mock.calls[0][0];
+      const pressOutEvent = onPressOut.mock.calls[0][0];
+
+      expect(pressInEvent.nativeEvent).toEqual(
+        expect.objectContaining({
+          locationX: 50,
+          locationY: 20,
+          pageX: 60,
+          pageY: 40,
+        })
+      );
+      expect(pressOutEvent.nativeEvent.timestamp).toBeGreaterThan(
+        pressInEvent.nativeEvent.timestamp
+      );
     });
 
     test('routes longpress accessibility action to onLongPress on Android', () => {
@@ -148,6 +187,60 @@ describe.each(implementations)(
 
       expect(onPress).toHaveBeenCalledTimes(1);
       expect(onAccessibilityAction).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not add or handle press accessibility actions when disabled', () => {
+      const onPress = jest.fn();
+
+      const { pressable } = renderPressable(Component, {
+        accessibilityActions: [{ name: 'magic', label: 'Magic' }],
+        disabled: true,
+        onPress,
+      });
+
+      expect(pressable.props.accessibilityActions).toEqual([
+        { name: 'magic', label: 'Magic' },
+      ]);
+      expect(pressable.props.onAccessibilityAction).toBeUndefined();
+
+      fireEvent(pressable, 'accessibilityAction', {
+        nativeEvent: { actionName: 'activate' },
+      });
+
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    test('does not add or handle press accessibility actions outside Android', () => {
+      setPlatform('ios');
+      const onPress = jest.fn();
+
+      const { pressable } = renderPressable(Component, {
+        accessibilityActions: [{ name: 'magic', label: 'Magic' }],
+        onPress,
+      });
+
+      expect(pressable.props.accessibilityActions).toEqual([
+        { name: 'magic', label: 'Magic' },
+      ]);
+      expect(pressable.props.onAccessibilityAction).toBeUndefined();
+
+      fireEvent(pressable, 'accessibilityAction', {
+        nativeEvent: { actionName: 'activate' },
+      });
+
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    test('keeps the user accessibility action handler unchanged outside Android', () => {
+      setPlatform('ios');
+      const onAccessibilityAction = jest.fn();
+
+      const { pressable } = renderPressable(Component, {
+        onAccessibilityAction,
+        onPress: jest.fn(),
+      });
+
+      expect(pressable.props.onAccessibilityAction).toBe(onAccessibilityAction);
     });
   }
 );

--- a/packages/react-native-gesture-handler/src/__tests__/Pressable.accessibility.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/Pressable.accessibility.test.tsx
@@ -1,0 +1,153 @@
+import { fireEvent, render } from '@testing-library/react-native';
+import React from 'react';
+import { Platform, Text } from 'react-native';
+
+import GestureHandlerRootView from '../components/GestureHandlerRootView';
+import LegacyPressable from '../components/Pressable/Pressable';
+import type { PressableProps } from '../components/Pressable/PressableProps';
+import Pressable from '../v3/components/Pressable';
+
+jest.unmock('../components/Pressable/Pressable');
+
+type TestPressableProps = Omit<
+  PressableProps,
+  'block' | 'requireToFail' | 'simultaneousWith'
+>;
+type AccessibilityActionHandler = NonNullable<
+  TestPressableProps['onAccessibilityAction']
+>;
+
+const originalPlatformOS = Platform.OS;
+const implementations = [
+  ['Pressable', Pressable as React.ComponentType<TestPressableProps>],
+  [
+    'LegacyPressable',
+    LegacyPressable as React.ComponentType<TestPressableProps>,
+  ],
+] as const;
+
+beforeEach(() => {
+  Object.defineProperty(Platform, 'OS', {
+    configurable: true,
+    value: 'android',
+  });
+});
+
+afterEach(() => {
+  Object.defineProperty(Platform, 'OS', {
+    configurable: true,
+    value: originalPlatformOS,
+  });
+});
+
+function renderPressable(
+  Component: React.ComponentType<TestPressableProps>,
+  props: TestPressableProps
+) {
+  const result = render(
+    <GestureHandlerRootView>
+      <Component testID="pressable" {...props}>
+        <Text>Press me</Text>
+      </Component>
+    </GestureHandlerRootView>
+  );
+  const pressable = result.getByTestId('pressable');
+
+  fireEvent(pressable, 'layout', {
+    nativeEvent: { layout: { x: 0, y: 0, width: 100, height: 40 } },
+  });
+
+  return { ...result, pressable };
+}
+
+describe.each(implementations)(
+  '%s accessibility actions',
+  (_name, Component) => {
+    test('routes activate through the press lifecycle on Android', () => {
+      const calls: string[] = [];
+
+      const { pressable } = renderPressable(Component, {
+        onPressIn: () => calls.push('in'),
+        onPressOut: () => calls.push('out'),
+        onPress: () => calls.push('press'),
+      });
+
+      fireEvent(pressable, 'accessibilityAction', {
+        nativeEvent: { actionName: 'activate' },
+      });
+
+      expect(calls).toEqual(['in', 'out', 'press']);
+    });
+
+    test('routes longpress accessibility action to onLongPress on Android', () => {
+      const onLongPress = jest.fn();
+      const onPress = jest.fn();
+
+      const { pressable } = renderPressable(Component, {
+        onLongPress,
+        onPress,
+      });
+
+      fireEvent(pressable, 'accessibilityAction', {
+        nativeEvent: { actionName: 'longpress' },
+      });
+
+      expect(onLongPress).toHaveBeenCalledTimes(1);
+      expect(onPress).not.toHaveBeenCalled();
+    });
+
+    test('adds Android press accessibility actions without dropping user actions', () => {
+      const { pressable } = renderPressable(Component, {
+        accessibilityActions: [{ name: 'magic', label: 'Magic' }],
+        onLongPress: jest.fn(),
+        onPress: jest.fn(),
+      });
+
+      expect(pressable.props.accessibilityActions).toEqual([
+        { name: 'magic', label: 'Magic' },
+        { name: 'activate' },
+        { name: 'longpress' },
+      ]);
+    });
+
+    test('calls user accessibility action handler alongside default press handling', () => {
+      const onAccessibilityAction = jest.fn();
+      const onPress = jest.fn();
+
+      const { pressable } = renderPressable(Component, {
+        onAccessibilityAction,
+        onPress,
+      });
+
+      fireEvent(pressable, 'accessibilityAction', {
+        nativeEvent: { actionName: 'activate' },
+      });
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+      expect(onAccessibilityAction).toHaveBeenCalledTimes(1);
+    });
+
+    test('does not duplicate user-handled activate actions', () => {
+      const onPress = jest.fn();
+      const handleAccessibilityAction: AccessibilityActionHandler = (event) => {
+        if (event.nativeEvent.actionName === 'activate') {
+          onPress(event);
+        }
+      };
+      const onAccessibilityAction = jest.fn(handleAccessibilityAction);
+
+      const { pressable } = renderPressable(Component, {
+        accessibilityActions: [{ name: 'activate' }],
+        onAccessibilityAction,
+        onPress,
+      });
+
+      fireEvent(pressable, 'accessibilityAction', {
+        nativeEvent: { actionName: 'activate' },
+      });
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+      expect(onAccessibilityAction).toHaveBeenCalledTimes(1);
+    });
+  }
+);

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -28,14 +28,12 @@ import type {
 } from './PressableProps';
 import { getStatesConfig, StateMachineEvent } from './stateDefinitions';
 import { PressableStateMachine } from './StateMachine';
+import { usePressableAccessibility } from './usePressableAccessibility';
 import {
   addInsets,
   gestureToPressableEvent,
   gestureTouchToPressableEvent,
-  getPressableAccessibilityActions,
   isTouchWithinInset,
-  isUserHandledAccessibilityAction,
-  makeSyntheticPressableEvent,
   numberAsInset,
   viewCenterToPressableEvent,
 } from './utils';
@@ -206,63 +204,17 @@ const LegacyPressable = (props: LegacyPressableProps) => {
     [handleFinalize, innerHandlePressIn, onPress, onPressOut]
   );
 
-  const shouldUsePressableAccessibilityActions =
-    Platform.OS === 'android' &&
-    disabled !== true &&
-    (onPress != null || onLongPress != null);
-  const accessibilityActions = useMemo(
-    () =>
-      shouldUsePressableAccessibilityActions
-        ? getPressableAccessibilityActions(
-            userAccessibilityActions,
-            onPress,
-            onLongPress
-          )
-        : userAccessibilityActions,
-    [
-      onLongPress,
-      onPress,
-      shouldUsePressableAccessibilityActions,
-      userAccessibilityActions,
-    ]
-  );
-  const handleAccessibilityAction = useCallback<
-    NonNullable<LegacyPressableProps['onAccessibilityAction']>
-  >(
-    (event) => {
-      const actionName = event.nativeEvent.actionName;
-      const shouldHandleAction =
-        shouldUsePressableAccessibilityActions &&
-        !isUserHandledAccessibilityAction(
-          actionName,
-          userAccessibilityActions,
-          userOnAccessibilityAction
-        );
-
-      if (shouldHandleAction && actionName === 'activate' && onPress) {
-        const pressableEvent = makeSyntheticPressableEvent(dimensions.current);
-        handlePressIn(pressableEvent);
-        handlePressOut(pressableEvent);
-      } else if (shouldHandleAction && actionName === 'longpress') {
-        onLongPress?.(makeSyntheticPressableEvent(dimensions.current));
-      }
-
-      userOnAccessibilityAction?.(event);
-    },
-    [
+  const { accessibilityActions, onAccessibilityAction } =
+    usePressableAccessibility({
+      accessibilityActions: userAccessibilityActions,
+      dimensions,
+      disabled,
       handlePressIn,
       handlePressOut,
+      onAccessibilityAction: userOnAccessibilityAction,
       onLongPress,
       onPress,
-      shouldUsePressableAccessibilityActions,
-      userAccessibilityActions,
-      userOnAccessibilityAction,
-    ]
-  );
-  const onAccessibilityAction =
-    shouldUsePressableAccessibilityActions || userOnAccessibilityAction
-      ? handleAccessibilityAction
-      : undefined;
+    });
 
   const stateMachine = useMemo(() => new PressableStateMachine(), []);
   const isScreenReaderEnabled = useIsScreenReaderEnabled();

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -32,7 +32,10 @@ import {
   addInsets,
   gestureToPressableEvent,
   gestureTouchToPressableEvent,
+  getPressableAccessibilityActions,
   isTouchWithinInset,
+  isUserHandledAccessibilityAction,
+  makeSyntheticPressableEvent,
   numberAsInset,
   viewCenterToPressableEvent,
 } from './utils';
@@ -65,6 +68,8 @@ const LegacyPressable = (props: LegacyPressableProps) => {
     android_ripple,
     disabled,
     accessible,
+    accessibilityActions: userAccessibilityActions,
+    onAccessibilityAction: userOnAccessibilityAction,
     simultaneousWithExternalGesture,
     requireExternalGestureToFail,
     blocksExternalGesture,
@@ -200,6 +205,64 @@ const LegacyPressable = (props: LegacyPressableProps) => {
     },
     [handleFinalize, innerHandlePressIn, onPress, onPressOut]
   );
+
+  const shouldUsePressableAccessibilityActions =
+    Platform.OS === 'android' &&
+    disabled !== true &&
+    (onPress != null || onLongPress != null);
+  const accessibilityActions = useMemo(
+    () =>
+      shouldUsePressableAccessibilityActions
+        ? getPressableAccessibilityActions(
+            userAccessibilityActions,
+            onPress,
+            onLongPress
+          )
+        : userAccessibilityActions,
+    [
+      onLongPress,
+      onPress,
+      shouldUsePressableAccessibilityActions,
+      userAccessibilityActions,
+    ]
+  );
+  const handleAccessibilityAction = useCallback<
+    NonNullable<LegacyPressableProps['onAccessibilityAction']>
+  >(
+    (event) => {
+      const actionName = event.nativeEvent.actionName;
+      const shouldHandleAction =
+        shouldUsePressableAccessibilityActions &&
+        !isUserHandledAccessibilityAction(
+          actionName,
+          userAccessibilityActions,
+          userOnAccessibilityAction
+        );
+
+      if (shouldHandleAction && actionName === 'activate' && onPress) {
+        const pressableEvent = makeSyntheticPressableEvent(dimensions.current);
+        handlePressIn(pressableEvent);
+        handlePressOut(pressableEvent);
+      } else if (shouldHandleAction && actionName === 'longpress') {
+        onLongPress?.(makeSyntheticPressableEvent(dimensions.current));
+      }
+
+      userOnAccessibilityAction?.(event);
+    },
+    [
+      handlePressIn,
+      handlePressOut,
+      onLongPress,
+      onPress,
+      shouldUsePressableAccessibilityActions,
+      userAccessibilityActions,
+      userOnAccessibilityAction,
+    ]
+  );
+  const onAccessibilityAction =
+    shouldUsePressableAccessibilityActions || userOnAccessibilityAction
+      ? handleAccessibilityAction
+      : undefined;
 
   const stateMachine = useMemo(() => new PressableStateMachine(), []);
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
@@ -385,6 +448,8 @@ const LegacyPressable = (props: LegacyPressableProps) => {
     <GestureDetector gesture={gesture}>
       <NativeButton
         {...remainingProps}
+        accessibilityActions={accessibilityActions}
+        onAccessibilityAction={onAccessibilityAction}
         needsOffscreenAlphaCompositing
         onLayout={setDimensions}
         accessible={accessible !== false}

--- a/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/PressableProps.tsx
@@ -12,7 +12,12 @@ import type {
 import type { AnyGesture } from '../../v3/types';
 import type { RelationPropType } from '../utils';
 
-export type PressableDimensions = { width: number; height: number };
+export type PressableDimensions = {
+  x?: number;
+  y?: number;
+  width: number;
+  height: number;
+};
 
 export type PressableStateCallbackType = RNPressableStateCallbackType;
 export type PressableAndroidRippleConfig = RNPressableAndroidRippleConfig;

--- a/packages/react-native-gesture-handler/src/components/Pressable/usePressableAccessibility.ts
+++ b/packages/react-native-gesture-handler/src/components/Pressable/usePressableAccessibility.ts
@@ -1,0 +1,124 @@
+import type { MutableRefObject } from 'react';
+import { useCallback, useMemo } from 'react';
+import { Platform } from 'react-native';
+
+import findNodeHandle from '../../findNodeHandle';
+import type {
+  PressableDimensions,
+  PressableEvent,
+  PressableProps,
+} from './PressableProps';
+import {
+  getPressableAccessibilityActions,
+  isUserHandledAccessibilityAction,
+  makeSyntheticPressableEvent,
+} from './utils';
+
+type UsePressableAccessibilityParams = {
+  accessibilityActions: PressableProps['accessibilityActions'];
+  dimensions: MutableRefObject<PressableDimensions>;
+  disabled: PressableProps['disabled'];
+  handlePressIn: (event: PressableEvent) => void;
+  handlePressOut: (event: PressableEvent) => void;
+  onAccessibilityAction: PressableProps['onAccessibilityAction'];
+  onLongPress: PressableProps['onLongPress'];
+  onPress: PressableProps['onPress'];
+};
+
+const getAccessibilityActionTargetId = (
+  event: Parameters<NonNullable<PressableProps['onAccessibilityAction']>>[0]
+) => {
+  if (event.target == null) {
+    return 0;
+  }
+
+  return (
+    findNodeHandle(
+      event.target as unknown as Parameters<typeof findNodeHandle>[0]
+    ) ?? 0
+  );
+};
+
+function usePressableAccessibility({
+  accessibilityActions: userAccessibilityActions,
+  dimensions,
+  disabled,
+  handlePressIn,
+  handlePressOut,
+  onAccessibilityAction: userOnAccessibilityAction,
+  onLongPress,
+  onPress,
+}: UsePressableAccessibilityParams) {
+  const shouldUsePressableAccessibilityActions =
+    Platform.OS === 'android' &&
+    disabled !== true &&
+    (onPress != null || onLongPress != null);
+  const accessibilityActions = useMemo(
+    () =>
+      shouldUsePressableAccessibilityActions
+        ? getPressableAccessibilityActions(
+            userAccessibilityActions,
+            onPress,
+            onLongPress
+          )
+        : userAccessibilityActions,
+    [
+      onLongPress,
+      onPress,
+      shouldUsePressableAccessibilityActions,
+      userAccessibilityActions,
+    ]
+  );
+  const handleAccessibilityAction = useCallback<
+    NonNullable<PressableProps['onAccessibilityAction']>
+  >(
+    (event) => {
+      const actionName = event.nativeEvent.actionName;
+      const shouldHandleAction =
+        shouldUsePressableAccessibilityActions &&
+        !isUserHandledAccessibilityAction(
+          actionName,
+          userAccessibilityActions,
+          userOnAccessibilityAction
+        );
+      const targetId = getAccessibilityActionTargetId(event);
+
+      if (shouldHandleAction && actionName === 'activate' && onPress) {
+        const timestamp = Date.now();
+        handlePressIn(
+          makeSyntheticPressableEvent(dimensions.current, timestamp, targetId)
+        );
+        handlePressOut(
+          makeSyntheticPressableEvent(
+            dimensions.current,
+            timestamp + 1,
+            targetId
+          )
+        );
+      } else if (shouldHandleAction && actionName === 'longpress') {
+        onLongPress?.(
+          makeSyntheticPressableEvent(dimensions.current, undefined, targetId)
+        );
+      }
+
+      userOnAccessibilityAction?.(event);
+    },
+    [
+      dimensions,
+      handlePressIn,
+      handlePressOut,
+      onLongPress,
+      onPress,
+      shouldUsePressableAccessibilityActions,
+      userAccessibilityActions,
+      userOnAccessibilityAction,
+    ]
+  );
+  const onAccessibilityAction = shouldUsePressableAccessibilityActions
+    ? handleAccessibilityAction
+    : userOnAccessibilityAction;
+
+  return { accessibilityActions, onAccessibilityAction };
+}
+
+export { usePressableAccessibility };

--- a/packages/react-native-gesture-handler/src/components/Pressable/utils.ts
+++ b/packages/react-native-gesture-handler/src/components/Pressable/utils.ts
@@ -15,6 +15,7 @@ import type {
   InnerPressableEvent,
   PressableDimensions,
   PressableEvent,
+  PressableProps,
 } from './PressableProps';
 
 const numberAsInset = (value: number): Insets => ({
@@ -178,11 +179,86 @@ const viewCenterToPressableEvent = (
   };
 };
 
+const makeSyntheticPressableEvent = (
+  dimensions: PressableDimensions,
+  timestamp: number = Date.now(),
+  targetId: number = 0
+): PressableEvent => {
+  const locationX = dimensions.width / 2;
+  const locationY = dimensions.height / 2;
+  // AccessibilityActionEvent does not expose native touch coordinates. Use the
+  // center of the last layout as a layout-local synthetic point.
+  const pageX = (dimensions.x ?? 0) + locationX;
+  const pageY = (dimensions.y ?? 0) + locationY;
+  const pressEvent: InnerPressableEvent = {
+    identifier: 0,
+    locationX,
+    locationY,
+    pageX,
+    pageY,
+    target: targetId,
+    timestamp,
+    touches: [],
+    changedTouches: [],
+    force: undefined,
+  };
+
+  return {
+    nativeEvent: {
+      touches: [pressEvent],
+      changedTouches: [pressEvent],
+      identifier: pressEvent.identifier,
+      locationX,
+      locationY,
+      pageX,
+      pageY,
+      target: targetId,
+      timestamp,
+      force: undefined,
+    },
+  };
+};
+
+const getPressableAccessibilityActions = (
+  accessibilityActions: PressableProps['accessibilityActions'],
+  onPress: PressableProps['onPress'],
+  onLongPress: PressableProps['onLongPress']
+) => {
+  const defaultActions = [
+    ...(onPress ? [{ name: 'activate' }] : []),
+    ...(onLongPress ? [{ name: 'longpress' }] : []),
+  ];
+
+  if (defaultActions.length === 0) {
+    return accessibilityActions;
+  }
+
+  const actionNames = new Set(
+    (accessibilityActions ?? []).map((action) => action.name)
+  );
+
+  return [
+    ...(accessibilityActions ?? []),
+    ...defaultActions.filter((action) => !actionNames.has(action.name)),
+  ];
+};
+
+const isUserHandledAccessibilityAction = (
+  actionName: string,
+  accessibilityActions: PressableProps['accessibilityActions'],
+  onAccessibilityAction: PressableProps['onAccessibilityAction']
+) =>
+  onAccessibilityAction != null &&
+  (accessibilityActions ?? []).some((action) => action.name === actionName);
+
 export {
   addInsets,
   gestureToPressableEvent,
   gestureTouchToPressableEvent,
+  getPressableAccessibilityActions,
   isTouchWithinInset,
+  isUserHandledAccessibilityAction,
+  makeSyntheticPressableEvent,
   numberAsInset,
   viewCenterToPressableEvent,
 };

--- a/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
@@ -23,14 +23,12 @@ import {
   StateMachineEvent,
 } from '../../components/Pressable/stateDefinitions';
 import { PressableStateMachine } from '../../components/Pressable/StateMachine';
+import { usePressableAccessibility } from '../../components/Pressable/usePressableAccessibility';
 import {
   addInsets,
   gestureToPressableEvent,
   gestureTouchToPressableEvent,
-  getPressableAccessibilityActions,
   isTouchWithinInset,
-  isUserHandledAccessibilityAction,
-  makeSyntheticPressableEvent,
   numberAsInset,
   viewCenterToPressableEvent,
 } from '../../components/Pressable/utils';
@@ -207,63 +205,17 @@ const Pressable = (props: PressableProps) => {
     [handleFinalize, innerHandlePressIn, onPress, onPressOut]
   );
 
-  const shouldUsePressableAccessibilityActions =
-    Platform.OS === 'android' &&
-    disabled !== true &&
-    (onPress != null || onLongPress != null);
-  const accessibilityActions = useMemo(
-    () =>
-      shouldUsePressableAccessibilityActions
-        ? getPressableAccessibilityActions(
-            userAccessibilityActions,
-            onPress,
-            onLongPress
-          )
-        : userAccessibilityActions,
-    [
-      onLongPress,
-      onPress,
-      shouldUsePressableAccessibilityActions,
-      userAccessibilityActions,
-    ]
-  );
-  const handleAccessibilityAction = useCallback<
-    NonNullable<PressableProps['onAccessibilityAction']>
-  >(
-    (event) => {
-      const actionName = event.nativeEvent.actionName;
-      const shouldHandleAction =
-        shouldUsePressableAccessibilityActions &&
-        !isUserHandledAccessibilityAction(
-          actionName,
-          userAccessibilityActions,
-          userOnAccessibilityAction
-        );
-
-      if (shouldHandleAction && actionName === 'activate' && onPress) {
-        const pressableEvent = makeSyntheticPressableEvent(dimensions.current);
-        handlePressIn(pressableEvent);
-        handlePressOut(pressableEvent);
-      } else if (shouldHandleAction && actionName === 'longpress') {
-        onLongPress?.(makeSyntheticPressableEvent(dimensions.current));
-      }
-
-      userOnAccessibilityAction?.(event);
-    },
-    [
+  const { accessibilityActions, onAccessibilityAction } =
+    usePressableAccessibility({
+      accessibilityActions: userAccessibilityActions,
+      dimensions,
+      disabled,
       handlePressIn,
       handlePressOut,
+      onAccessibilityAction: userOnAccessibilityAction,
       onLongPress,
       onPress,
-      shouldUsePressableAccessibilityActions,
-      userAccessibilityActions,
-      userOnAccessibilityAction,
-    ]
-  );
-  const onAccessibilityAction =
-    shouldUsePressableAccessibilityActions || userOnAccessibilityAction
-      ? handleAccessibilityAction
-      : undefined;
+    });
 
   const stateMachine = useMemo(() => new PressableStateMachine(), []);
   const isScreenReaderEnabled = useIsScreenReaderEnabled();

--- a/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
@@ -27,7 +27,10 @@ import {
   addInsets,
   gestureToPressableEvent,
   gestureTouchToPressableEvent,
+  getPressableAccessibilityActions,
   isTouchWithinInset,
+  isUserHandledAccessibilityAction,
+  makeSyntheticPressableEvent,
   numberAsInset,
   viewCenterToPressableEvent,
 } from '../../components/Pressable/utils';
@@ -69,6 +72,8 @@ const Pressable = (props: PressableProps) => {
     android_ripple,
     disabled,
     accessible,
+    accessibilityActions: userAccessibilityActions,
+    onAccessibilityAction: userOnAccessibilityAction,
     simultaneousWith,
     requireToFail,
     block,
@@ -201,6 +206,64 @@ const Pressable = (props: PressableProps) => {
     },
     [handleFinalize, innerHandlePressIn, onPress, onPressOut]
   );
+
+  const shouldUsePressableAccessibilityActions =
+    Platform.OS === 'android' &&
+    disabled !== true &&
+    (onPress != null || onLongPress != null);
+  const accessibilityActions = useMemo(
+    () =>
+      shouldUsePressableAccessibilityActions
+        ? getPressableAccessibilityActions(
+            userAccessibilityActions,
+            onPress,
+            onLongPress
+          )
+        : userAccessibilityActions,
+    [
+      onLongPress,
+      onPress,
+      shouldUsePressableAccessibilityActions,
+      userAccessibilityActions,
+    ]
+  );
+  const handleAccessibilityAction = useCallback<
+    NonNullable<PressableProps['onAccessibilityAction']>
+  >(
+    (event) => {
+      const actionName = event.nativeEvent.actionName;
+      const shouldHandleAction =
+        shouldUsePressableAccessibilityActions &&
+        !isUserHandledAccessibilityAction(
+          actionName,
+          userAccessibilityActions,
+          userOnAccessibilityAction
+        );
+
+      if (shouldHandleAction && actionName === 'activate' && onPress) {
+        const pressableEvent = makeSyntheticPressableEvent(dimensions.current);
+        handlePressIn(pressableEvent);
+        handlePressOut(pressableEvent);
+      } else if (shouldHandleAction && actionName === 'longpress') {
+        onLongPress?.(makeSyntheticPressableEvent(dimensions.current));
+      }
+
+      userOnAccessibilityAction?.(event);
+    },
+    [
+      handlePressIn,
+      handlePressOut,
+      onLongPress,
+      onPress,
+      shouldUsePressableAccessibilityActions,
+      userAccessibilityActions,
+      userOnAccessibilityAction,
+    ]
+  );
+  const onAccessibilityAction =
+    shouldUsePressableAccessibilityActions || userOnAccessibilityAction
+      ? handleAccessibilityAction
+      : undefined;
 
   const stateMachine = useMemo(() => new PressableStateMachine(), []);
   const isScreenReaderEnabled = useIsScreenReaderEnabled();
@@ -399,6 +462,8 @@ const Pressable = (props: PressableProps) => {
       <PureNativeButton
         {...remainingProps}
         {...tvProps}
+        accessibilityActions={accessibilityActions}
+        onAccessibilityAction={onAccessibilityAction}
         onLayout={setDimensions}
         accessible={accessible !== false}
         hitSlop={appliedHitSlop}


### PR DESCRIPTION
## Description

Fixes #3899. Root-cause note: https://github.com/software-mansion/react-native-gesture-handler/issues/3899#issuecomment-4587868950

TalkBack's double-tap activation dispatches an Android accessibility click/action to the native view rather than the touch stream consumed by `Pressable`'s gesture state machine. That means the `FINALIZE -> handlePressOut` path that calls `onPress` is never reached. PR #4017 helped with touch-event ordering, but it does not cover this accessibility-action channel.

This brings `Pressable` and `LegacyPressable` to parity with the existing touchables by:

- adding default Android accessibility actions for `activate` and `longpress` when the corresponding press handlers exist;
- routing `activate` through the existing `onPressIn` -> `onPressOut` -> `onPress` lifecycle using synthetic layout-local press events;
- routing `longpress` to `onLongPress`;
- preserving user-provided accessibility actions and forwarding `onAccessibilityAction`;
- avoiding duplicate `onPress` calls for apps that already supplied their own user-handled `activate` action workaround;
- sharing the Android accessibility-action wiring between the v3 and legacy implementations.

## Test plan

- `yarn test Pressable.accessibility.test.tsx`
- `yarn test`
- `yarn ts-check`
- `yarn lint:js` (passes with existing repo warnings only)
- `git diff --check`
