### PR TITLE
Fix Android Pressable crash with Reanimated animations

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
@@ -47,6 +47,10 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
   }
 
   fun setModuleId(id: Int) {
+    if (this.moduleId == id) {
+      return
+    }
+
     assert(this.moduleId == -1) { "Tried to change moduleId of a native detector" }
 
     this.moduleId = id


### PR DESCRIPTION
## Summary
- make native detector `moduleId` updates idempotent when Fabric sends the same value again
- keep the existing guard against moving a detector to a different module registry
- avoid the Android crash from issue #4210 when a v3 `Pressable` is animated through Reanimated

Fixes #4210.

## Test plan
- `yarn workspace react-native-gesture-handler lint:android`
- `./gradlew :app:assembleDebug --console=plain -PreactNativeArchitectures=arm64-v8a` from `apps/basic-example/android`
