### PR TITLE
Fix Android pinch pointer lift handling

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PinchGestureHandler.kt
@@ -88,7 +88,12 @@ class PinchGestureHandler : GestureHandler() {
       this.focalPointY = point.y
     }
 
-    if (sourceEvent.actionMasked == MotionEvent.ACTION_UP) {
+    val isLastRequiredPointerLifted = sourceEvent.actionMasked == MotionEvent.ACTION_POINTER_UP &&
+      event.pointerCount - 1 < MIN_POINTERS
+
+    if (sourceEvent.actionMasked == MotionEvent.ACTION_UP ||
+      isLastRequiredPointerLifted
+    ) {
       when (state) {
         STATE_UNDETERMINED -> cancel()
         STATE_ACTIVE -> end()
@@ -124,5 +129,9 @@ class PinchGestureHandler : GestureHandler() {
     override fun create(context: Context?): PinchGestureHandler = PinchGestureHandler()
 
     override fun createEventBuilder(handler: PinchGestureHandler) = PinchGestureHandlerEventDataBuilder(handler)
+  }
+
+  companion object {
+    private const val MIN_POINTERS = 2
   }
 }


### PR DESCRIPTION
## Summary
- end an active Android pinch when a pointer lift leaves fewer than two tracked pointers
- fail a begun-but-not-active pinch in the same case
- avoid emitting an extra active pinch update with stale `numberOfPointers` / focal data after one finger is lifted

Fixes #3435.

## Test plan
- `yarn workspace react-native-gesture-handler lint:android`
- `./gradlew :app:assembleDebug --console=plain -PreactNativeArchitectures=arm64-v8a` from `apps/basic-example/android`
