### PR TITLE
[Android] Fix wrong reported number of pointers

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -411,7 +411,10 @@ open class GestureHandler {
       }
     }
 
-    numberOfPointers = adaptedTransformedEvent.pointerCount
+    numberOfPointers = when (adaptedTransformedEvent.actionMasked) {
+      MotionEvent.ACTION_POINTER_UP -> adaptedTransformedEvent.pointerCount - 1
+      else -> adaptedTransformedEvent.pointerCount
+    }
 
     x = adaptedTransformedEvent.x
     y = adaptedTransformedEvent.y


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/3435

Android includes the pointer being lifted in the `ACTION_POINTER_UP` event, so the event where the pointer is lifted is sent with `numberOfPointers = 2`. This PR changes that so the `numberOfPointers` is reported as `n - 1` for `ACTION_POINTER_UP` events.

Note: The same applies to `ACTION_UP` and `ACTION_CANCEL` but I didn't include them to keep the behavior the same as on iOS.

## Test plan

Reproducer from https://github.com/software-mansion/react-native-gesture-handler/issues/3435
