### PR TITLE
Remove `dispatchesReanimatedEvent` from initial config

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
@@ -21,8 +21,6 @@ export function resolveInternalConfigProps<
   THandlerData,
   TExtendedHandlerData extends THandlerData,
 >(config: BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>) {
-  const runOnJS = maybeUnpackValue(config.runOnJS);
-
   if (
     __DEV__ &&
     isNativeAnimatedEvent(config.onUpdate) &&
@@ -63,8 +61,6 @@ export function resolveInternalConfigProps<
     hasWorkletEventHandlers(config) &&
     !config.dispatchesAnimatedEvents;
   config.needsPointerData = shouldHandleTouchEvents(config);
-  config.dispatchesReanimatedEvents =
-    config.shouldUseReanimatedDetector && !runOnJS;
 }
 
 export function prepareConfigForNativeSide<
@@ -80,7 +76,10 @@ export function prepareConfigForNativeSide<
     TConfig,
     THandlerData,
     TExtendedHandlerData
-  > = {};
+  > = {
+    dispatchesReanimatedEvents:
+      config.shouldUseReanimatedDetector && !maybeUnpackValue(config.runOnJS),
+  };
   const handlerPropsWhiteList =
     PropsWhiteLists.get(handlerType) ?? EMPTY_WHITE_LIST;
 

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
@@ -42,7 +42,6 @@ export const allowedNativeProps = new Set<
   'userSelect',
   'enableContextMenu',
   'touchAction',
-  'dispatchesReanimatedEvents',
   'dispatchesAnimatedEvents',
   'needsPointerData',
 ]);

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts
@@ -38,6 +38,7 @@ export function bindSharedValues<
   }
 
   const baseListenerId = handlerTag + SHARED_VALUE_OFFSET;
+  const { shouldUseReanimatedDetector } = config;
 
   const attachListener = (sharedValue: SharedValue, configKey: string) => {
     'worklet';
@@ -45,16 +46,14 @@ export function bindSharedValues<
     const listenerId = baseListenerId + keyHash;
 
     sharedValue.addListener(listenerId, (value) => {
-      if (configKey === 'runOnJS') {
-        config.dispatchesReanimatedEvents =
-          config.shouldUseReanimatedDetector && !value;
-
-        updateGestureHandlerConfig(handlerTag, {
-          dispatchesReanimatedEvents: config.dispatchesReanimatedEvents,
-        });
-      } else {
-        updateGestureHandlerConfig(handlerTag, { [configKey]: value });
-      }
+      updateGestureHandlerConfig(
+        handlerTag,
+        configKey === 'runOnJS'
+          ? {
+              dispatchesReanimatedEvents: shouldUseReanimatedDetector && !value,
+            }
+          : { [configKey]: value }
+      );
     });
   };
 


### PR DESCRIPTION
## Description

The crash in #4216 was caused by worklets, which [freezes objects](https://github.com/software-mansion/react-native-reanimated/blob/071dc775506184bf03e43ce8c7665d7325a406c3/packages/react-native-worklets/src/memory/serializable.native.ts#L703) when they are passed to the UI side. In our `Swipeable` implementation [`enabled` is a SharedValue](https://github.com/software-mansion/react-native-gesture-handler/blob/4f4f63e1ab8aff376e61b5c77cda9c9555c126c6/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx#L112) for `tap` gesture. Because of that, whole config is sent to the UI when [bindSharedValues](https://github.com/software-mansion/react-native-gesture-handler/blob/4f4f63e1ab8aff376e61b5c77cda9c9555c126c6/packages/react-native-gesture-handler/src/v3/hooks/utils/reanimatedUtils.ts#L49) is called. Trying to modify this config, in that case adding another simultaneous handler, results in a crash.

To fix that, I've removed `dispatchesReanimatedEvents` from initial config and moved its assignment to right before passing the config to the UI. This way it is not a field in config object, so we don't have to update it. Now we don't have to pass config to `SharedValues`' listeners, therefore we do not freeze config anymore.  

Fixes #4216

## Test plan

Tested on example from #4216
