### PR TITLE
[iOS] Remove unused detector method

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.h
@@ -33,8 +33,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)detachNativeGestureHandlers;
 
-- (BOOL)shouldAttachGestureToSubview:(nonnull NSNumber *)handlerTag;
-
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Description

Removes unused `shouldAttachGestureToSubview` declaration

## Test plan

Build any of the apps
