### PR TITLE
Expose animatable refs for v3 touchables

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -1,12 +1,17 @@
 import { render, renderHook } from '@testing-library/react-native';
-import { act } from 'react';
+import { act, createRef } from 'react';
+import type { View } from 'react-native';
 
 import GestureHandlerRootView from '../components/GestureHandlerRootView';
 import { fireGestureHandler, getByGestureTestId } from '../jestUtils';
 import { State } from '../State';
-import { RectButton, Touchable } from '../v3/components';
+import { Pressable, RectButton, Touchable } from '../v3/components';
 import { usePanGesture } from '../v3/hooks/gestures';
 import type { SingleGesture } from '../v3/types';
+
+type AnimatableViewRef = View & {
+  getAnimatableRef?: () => View | null;
+};
 
 describe('[API v3] Hooks', () => {
   test('Pan gesture', () => {
@@ -34,6 +39,51 @@ describe('[API v3] Hooks', () => {
 });
 
 describe('[API v3] Components', () => {
+  test('Pressable exposes the native button as an animatable ref', () => {
+    const ref = createRef<AnimatableViewRef>();
+
+    render(
+      <GestureHandlerRootView>
+        <Pressable ref={ref} />
+      </GestureHandlerRootView>
+    );
+
+    expect(ref.current?.getAnimatableRef?.()).toBe(ref.current);
+  });
+
+  test('Pressable forwards function refs on mount and unmount', () => {
+    const ref = jest.fn();
+
+    const { unmount } = render(
+      <GestureHandlerRootView>
+        <Pressable ref={ref} />
+      </GestureHandlerRootView>
+    );
+
+    expect(ref).toHaveBeenCalledWith(expect.anything());
+
+    unmount();
+
+    expect(ref).toHaveBeenLastCalledWith(null);
+  });
+
+  test('Pressable animatable refs stay bound to their host instance', () => {
+    const ref = createRef<AnimatableViewRef>();
+    const renderPressable = (key: string) => (
+      <GestureHandlerRootView>
+        <Pressable key={key} ref={ref} />
+      </GestureHandlerRootView>
+    );
+    const { rerender } = render(renderPressable('first'));
+    const firstRef = ref.current;
+
+    rerender(renderPressable('second'));
+    const secondRef = ref.current;
+
+    expect(firstRef?.getAnimatableRef?.()).toBe(firstRef);
+    expect(secondRef?.getAnimatableRef?.()).toBe(secondRef);
+  });
+
   test('Rect Button', () => {
     const pressFn = jest.fn();
 
@@ -61,6 +111,18 @@ describe('[API v3] Components', () => {
   });
 
   describe('Touchable', () => {
+    test('exposes the native button as an animatable ref', () => {
+      const ref = createRef<AnimatableViewRef>();
+
+      render(
+        <GestureHandlerRootView>
+          <Touchable ref={ref} />
+        </GestureHandlerRootView>
+      );
+
+      expect(ref.current?.getAnimatableRef?.()).toBe(ref.current);
+    });
+
     test('calls onPress on successful press', () => {
       const pressFn = jest.fn();
 

--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -6,6 +6,7 @@ import GestureHandlerRootView from '../components/GestureHandlerRootView';
 import { fireGestureHandler, getByGestureTestId } from '../jestUtils';
 import { State } from '../State';
 import { Pressable, RectButton, Touchable } from '../v3/components';
+import { setAndForwardAnimatableRef } from '../v3/components/animatableRef';
 import { usePanGesture } from '../v3/hooks/gestures';
 import type { SingleGesture } from '../v3/types';
 
@@ -84,6 +85,21 @@ describe('[API v3] Components', () => {
     expect(secondRef?.getAnimatableRef?.()).toBe(secondRef);
   });
 
+  test('setAndForwardAnimatableRef preserves an existing animatable ref', () => {
+    const localRef = createRef<AnimatableViewRef>();
+    const forwardedRef = createRef<AnimatableViewRef>();
+    const existingAnimatableRef = jest.fn();
+    const hostRef = {
+      getAnimatableRef: existingAnimatableRef,
+    } as unknown as AnimatableViewRef;
+
+    setAndForwardAnimatableRef(localRef, forwardedRef, hostRef);
+
+    expect(localRef.current).toBe(hostRef);
+    expect(forwardedRef.current).toBe(hostRef);
+    expect(hostRef.getAnimatableRef).toBe(existingAnimatableRef);
+  });
+
   test('Rect Button', () => {
     const pressFn = jest.fn();
 
@@ -121,6 +137,39 @@ describe('[API v3] Components', () => {
       );
 
       expect(ref.current?.getAnimatableRef?.()).toBe(ref.current);
+    });
+
+    test('forwards function refs on mount and unmount', () => {
+      const ref = jest.fn();
+
+      const { unmount } = render(
+        <GestureHandlerRootView>
+          <Touchable ref={ref} />
+        </GestureHandlerRootView>
+      );
+
+      expect(ref).toHaveBeenCalledWith(expect.anything());
+
+      unmount();
+
+      expect(ref).toHaveBeenLastCalledWith(null);
+    });
+
+    test('animatable refs stay bound to their host instance', () => {
+      const ref = createRef<AnimatableViewRef>();
+      const renderTouchable = (key: string) => (
+        <GestureHandlerRootView>
+          <Touchable key={key} ref={ref} />
+        </GestureHandlerRootView>
+      );
+      const { rerender } = render(renderTouchable('first'));
+      const firstRef = ref.current;
+
+      rerender(renderTouchable('second'));
+      const secondRef = ref.current;
+
+      expect(firstRef?.getAnimatableRef?.()).toBe(firstRef);
+      expect(secondRef?.getAnimatableRef?.()).toBe(secondRef);
     });
 
     test('calls onPress on successful press', () => {

--- a/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
@@ -42,6 +42,7 @@ import {
   useNativeGesture,
   useSimultaneousGestures,
 } from '../hooks';
+import { setAndForwardAnimatableRef } from './animatableRef';
 import { PureNativeButton } from './GestureButtons';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;
@@ -72,6 +73,7 @@ const Pressable = (props: PressableProps) => {
     simultaneousWith,
     requireToFail,
     block,
+    ref,
     ...remainingProps
   } = props;
 
@@ -81,10 +83,19 @@ const Pressable = (props: PressableProps) => {
   const pressDelayTimeoutRef = useRef<number | null>(null);
   const isOnPressAllowed = useRef<boolean>(true);
   const isCurrentlyPressed = useRef<boolean>(false);
+  const buttonRef = useRef<React.ComponentRef<typeof PureNativeButton> | null>(
+    null
+  );
   const dimensions = useRef<PressableDimensions>({
     width: 0,
     height: 0,
   });
+  const setButtonRef = useCallback(
+    (button: React.ComponentRef<typeof PureNativeButton> | null) => {
+      setAndForwardAnimatableRef(buttonRef, ref, button);
+    },
+    [ref]
+  );
 
   const normalizedHitSlop: Insets = useMemo(
     () =>
@@ -399,6 +410,7 @@ const Pressable = (props: PressableProps) => {
       <PureNativeButton
         {...remainingProps}
         {...tvProps}
+        ref={setButtonRef}
         onLayout={setDimensions}
         accessible={accessible !== false}
         hitSlop={appliedHitSlop}

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -5,6 +5,7 @@ import GestureHandlerButton from '../../../components/GestureHandlerButton';
 import { getTVProps } from '../../../components/utils';
 import { NativeDetector } from '../../detectors/NativeDetector';
 import { useNativeGesture } from '../../hooks';
+import { setAndForwardAnimatableRef } from '../animatableRef';
 import type {
   AnimationDuration,
   CallbackEventType,
@@ -99,6 +100,15 @@ export const Touchable = (props: TouchableProps) => {
   const longPressDetected = useRef(false);
   const longPressTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(
     undefined
+  );
+  const buttonRef = useRef<React.ComponentRef<
+    typeof GestureHandlerButton
+  > | null>(null);
+  const setButtonRef = useCallback(
+    (button: React.ComponentRef<typeof GestureHandlerButton> | null) => {
+      setAndForwardAnimatableRef(buttonRef, ref, button);
+    },
+    [ref]
   );
 
   const wrappedLongPress = useCallback(() => {
@@ -218,7 +228,7 @@ export const Touchable = (props: TouchableProps) => {
         {...tvProps}
         {...rippleProps}
         {...resolvedDurations}
-        ref={ref ?? null}
+        ref={setButtonRef}
         enabled={!disabled}
         defaultOpacity={defaultOpacity}
         defaultUnderlayOpacity={defaultUnderlayOpacity}

--- a/packages/react-native-gesture-handler/src/v3/components/animatableRef.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/animatableRef.ts
@@ -1,0 +1,24 @@
+import type React from 'react';
+
+type AnimatableRef<T> = T & {
+  getAnimatableRef?: () => T | null;
+};
+
+export function setAndForwardAnimatableRef<T extends object>(
+  localRef: React.MutableRefObject<T | null>,
+  forwardedRef: React.Ref<T> | undefined,
+  ref: T | null
+) {
+  localRef.current = ref;
+
+  const animatableRef = ref as AnimatableRef<T> | null;
+  if (animatableRef && !animatableRef.getAnimatableRef) {
+    animatableRef.getAnimatableRef = () => ref;
+  }
+
+  if (typeof forwardedRef === 'function') {
+    forwardedRef(ref);
+  } else if (forwardedRef) {
+    (forwardedRef as React.MutableRefObject<T | null>).current = ref;
+  }
+}


### PR DESCRIPTION
## Description

Fixes #4225.

When v3 `Pressable`/`Touchable` are wrapped with Reanimated's `createAnimatedComponent`, Reanimated can resolve the composite to the outer gesture detector instead of the inner native button. That means style writes like `width` and `opacity` can land on the detector wrapper while only subtree-affecting transforms visibly survive.

This change forwards refs through v3 `Pressable` and `Touchable` to their inner native button and attaches `getAnimatableRef` to that native ref. Reanimated already understands that method and will use it as the host target for animated styles.

## Test plan

```sh
yarn workspace react-native-gesture-handler test api_v3.test.tsx --runInBand
yarn workspace react-native-gesture-handler eslint --ext '.ts,.tsx' src/__tests__/api_v3.test.tsx src/v3/components/Pressable.tsx src/v3/components/Touchable/Touchable.tsx src/v3/components/animatableRef.ts
yarn workspace react-native-gesture-handler prettier --check src/__tests__/api_v3.test.tsx src/v3/components/Pressable.tsx src/v3/components/Touchable/Touchable.tsx src/v3/components/animatableRef.ts
yarn workspace react-native-gesture-handler ts-check
yarn workspace react-native-gesture-handler lint-js
git diff --check
```

Notes:
- `lint-js` passes with the repository's existing warnings.
- The pre-commit hook's staged-file lint/prettier step passed, then the hook failed in unrelated `apps/common-app` type-checking because `react-native-pager-view` types are missing.
