### PR TITLE
Fix Native gesture outside cancellation default

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -43,10 +43,6 @@ class NativeViewGestureHandler : GestureHandler() {
 
   private var lastActiveUpdate: ActiveUpdateSnapshot? = null
 
-  init {
-    shouldCancelWhenOutside = true
-  }
-
   override fun resetConfig() {
     super.resetConfig()
     shouldActivateOnStart = DEFAULT_SHOULD_ACTIVATE_ON_START
@@ -226,7 +222,7 @@ class NativeViewGestureHandler : GestureHandler() {
   }
 
   companion object {
-    private const val DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE = true
+    private const val DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE = false
     private const val DEFAULT_SHOULD_ACTIVATE_ON_START = false
     private const val DEFAULT_DISALLOW_INTERRUPTION = false
     private const val DEFAULT_YIELDS_TO_CONTINUOUS_GESTURES = false


### PR DESCRIPTION
## Summary

Fixes #4236.

`NativeViewGestureHandler` on Android currently overrides the base handler default and sets `shouldCancelWhenOutside` to `true`. That causes `Gesture.Native()` wrappers around scrollable native views to fail once a swipe leaves the view bounds, even though the gesture is already active.

This PR restores the default to `false`, matching the documented base behavior for handlers other than Tap and LongPress, while preserving the explicit `shouldCancelWhenOutside` config path for callers that opt in.

## Changes

- Remove the redundant initializer that set `shouldCancelWhenOutside = true`.
- Change `NativeViewGestureHandler`'s Android default `shouldCancelWhenOutside` value to `false`.

## Validation

- `yarn workspace react-native-gesture-handler format:android`
- `yarn workspace react-native-gesture-handler lint:android`
- `yarn workspace react-native-gesture-handler ts-check`
- `yarn workspace react-native-gesture-handler test --runInBand`
- `git diff --check`

The local pre-commit hook also ran formatting, but then failed in `apps/common-app` on unrelated TypeScript setup issues (`react-native-pager-view` missing in a legacy sample). The targeted package checks above passed.

I did not run the Android Snack/device reproduction locally in this pass.
