### PR TITLE
Move ruby utils to module

### DIFF
--- a/packages/react-native-gesture-handler/RNGestureHandler.podspec
+++ b/packages/react-native-gesture-handler/RNGestureHandler.podspec
@@ -5,7 +5,7 @@ is_gh_example_app = ENV["GH_EXAMPLE_APP_NAME"] != nil
 
 compilation_metadata_dir = "CompilationDatabase"
 compilation_metadata_generation_flag = is_gh_example_app ? '-gen-cdb-fragment-path ' + compilation_metadata_dir : ''
-version_flag = "-DREACT_NATIVE_MINOR_VERSION=#{rngh_get_react_native_minor_version()}"
+version_flag = "-DREACT_NATIVE_MINOR_VERSION=#{GestureHandlerUtils.get_react_native_minor_version()}"
 
 Pod::Spec.new do |s|
   # NPM package specification

--- a/packages/react-native-gesture-handler/scripts/gesture_handler_utils.rb
+++ b/packages/react-native-gesture-handler/scripts/gesture_handler_utils.rb
@@ -17,7 +17,9 @@ module GestureHandlerUtils
 
         if react_native_json == nil
             node_modules_dir = ENV["REACT_NATIVE_NODE_MODULES_DIR"]
-            react_native_json = try_to_parse_react_native_package_json(File.join(node_modules_dir, 'react-native'))
+            if node_modules_dir != nil
+                react_native_json = try_to_parse_react_native_package_json(File.join(node_modules_dir, 'react-native'))
+            end
         end
 
         if react_native_json == nil

--- a/packages/react-native-gesture-handler/scripts/gesture_handler_utils.rb
+++ b/packages/react-native-gesture-handler/scripts/gesture_handler_utils.rb
@@ -1,25 +1,29 @@
-def rngh_try_to_parse_react_native_package_json(react_native_dir)
-    react_native_package_json_path = File.join(react_native_dir, 'package.json')
+module GestureHandlerUtils
+    module_function
 
-    if !File.exist?(react_native_package_json_path)
-        return nil
+    def try_to_parse_react_native_package_json(react_native_dir)
+        react_native_package_json_path = File.join(react_native_dir, 'package.json')
+
+        if !File.exist?(react_native_package_json_path)
+            return nil
+        end
+
+        return JSON.parse(File.read(react_native_package_json_path))
     end
 
-    return JSON.parse(File.read(react_native_package_json_path))
-end
+    def get_react_native_minor_version()
+        react_native_dir = File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`)
+        react_native_json = try_to_parse_react_native_package_json(react_native_dir)
 
-def rngh_get_react_native_minor_version()
-    react_native_dir = File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`)
-    react_native_json = rngh_try_to_parse_react_native_package_json(react_native_dir)
+        if react_native_json == nil
+            node_modules_dir = ENV["REACT_NATIVE_NODE_MODULES_DIR"]
+            react_native_json = try_to_parse_react_native_package_json(File.join(node_modules_dir, 'react-native'))
+        end
 
-    if react_native_json == nil
-        node_modules_dir = ENV["REACT_NATIVE_NODE_MODULES_DIR"]
-        react_native_json = rngh_try_to_parse_react_native_package_json(File.join(node_modules_dir, 'react-native'))
+        if react_native_json == nil
+            raise '[react-native-gesture-handler] Unable to recognize your `react-native` version. Please set environmental variable with `react-native` location: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install`.'
+        end
+
+        return react_native_json['version'].split('.')[1].to_i
     end
-
-    if react_native_json == nil
-        raise '[react-native-gesture-handler] Unable to recognize your `react-native` version. Please set environmental variable with `react-native` location: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install`.'
-    end
-
-    return react_native_json['version'].split('.')[1].to_i
 end


### PR DESCRIPTION
## Description

In ruby, functions and variables are global by design. In #4232 we dealt with it by changing name of exported function. However, the correct approach would be to keep our utils in separate module. This has also been introduced in [Reanimated](https://github.com/software-mansion/react-native-reanimated/pull/9617).

## Test plan

`pod install`
