### PR TITLE
[iOS] Remove unused old-arch import to fix build with React Native 0.87-nightly

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
@@ -4,7 +4,6 @@
 #import <React/RCTEventDispatcherProtocol.h>
 #import <React/RCTLog.h>
 #import <React/RCTModalHostViewController.h>
-#import <React/RCTRootContentView.h>
 #import <React/RCTRootView.h>
 #import <React/RCTUIManager.h>
 #import <React/RCTViewManager.h>


### PR DESCRIPTION
## Description

React Native 0.87 will be the first version with parts of the old architecture actually removed. The current nightly releases are failing to build with RNGH due to a stale import of an old-arch header.

## Test plan

Create a new RN app using the nightly release and add RNGH.
