### PR TITLE
fix(Android): apply numberOfPointers config to the pointer requirement in LongPressGestureHandler

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -199,7 +199,7 @@ class LongPressGestureHandler(context: Context) : GestureHandler() {
         handler.maxDist = PixelUtil.toPixelFromDIP(config.getDouble(KEY_MAX_DIST))
       }
       if (config.hasKey(KEY_NUMBER_OF_POINTERS)) {
-        handler.numberOfPointers = config.getInt(KEY_NUMBER_OF_POINTERS)
+        handler.numberOfPointersRequired = config.getInt(KEY_NUMBER_OF_POINTERS)
       }
     }
 


### PR DESCRIPTION
## Description

Fixes #4252

On Android, the `numberOfPointers` config of the LongPress gesture has been silently ignored since 2.26.0: a gesture configured with `Gesture.LongPress().numberOfPointers(3)` activates after a **single-pointer** long press, and can never activate with the configured pointer count (the second pointer trips `currentPointers > numberOfPointersRequired` and fails the handler). iOS is unaffected, since the prop maps to `UILongPressGestureRecognizer.numberOfTouchesRequired`.

The cause is a one-line mix-up introduced by the factory refactor in 2.26.0. The factory's `updateConfig` assigns the config value to `handler.numberOfPointers`, which resolves to the inherited `GestureHandler.numberOfPointers` — the live pointer-count used for event payloads, overwritten with `event.pointerCount` on every motion event. The field that actually gates activation, `numberOfPointersRequired`, stays at its default of `1` and is never written from config. Before 2.26.0, the module factory called `handler.setNumberOfPointers(...)`, which set `numberOfPointersRequired` correctly.

This PR routes the config value to `numberOfPointersRequired`, restoring the pre-2.26 behavior. The private-field access from the nested `Factory` matches the existing `maxDist` assignment directly above.

## Test plan

- Applied this same one-liner to 2.28.0 via patch-package in an RN 0.81.5 (Expo 54, new architecture, Hermes) app that uses `Gesture.LongPress().numberOfPointers(3)` as a global gesture, and verified on an Android device:
  - three-pointer long press now activates the gesture (previously never fired)
  - single-pointer long press no longer activates it (previously fired after ~500 ms)
  - gestures with the default single pointer (no `numberOfPointers` set) are unaffected
- Verified iOS behavior is unchanged (the fix doesn't touch the iOS path)
- Repro snippet: https://gist.github.com/prashanFOMO/ad838ce8a3c77c59759b8583fe8d3393
