### PR TITLE
[Native] Fix native GestureDetector `zIndex` handling

### DIFF
--- a/packages/react-native-gesture-handler/shared/shadowNodes/react/renderer/components/rngesturehandler_codegen/RNGestureHandlerDetectorShadowNode.cpp
+++ b/packages/react-native-gesture-handler/shared/shadowNodes/react/renderer/components/rngesturehandler_codegen/RNGestureHandlerDetectorShadowNode.cpp
@@ -29,11 +29,14 @@ void RNGestureHandlerDetectorShadowNode::initialize() {
     // Will clone the child and ensure it's not flattened
     replaceChild(*children[i], children[i], i);
   }
+
+  updateOrderIndexFromChildren();
 }
 
 void RNGestureHandlerDetectorShadowNode::appendChild(
     const std::shared_ptr<const ShadowNode> &child) {
   YogaLayoutableShadowNode::appendChild(unflattenNode(child));
+  updateOrderIndexFromChildren();
 }
 
 void RNGestureHandlerDetectorShadowNode::replaceChild(
@@ -42,6 +45,7 @@ void RNGestureHandlerDetectorShadowNode::replaceChild(
     size_t suggestedIndex) {
   YogaLayoutableShadowNode::replaceChild(
       oldChild, unflattenNode(newChild), suggestedIndex);
+  updateOrderIndexFromChildren();
 }
 
 void RNGestureHandlerDetectorShadowNode::layout(LayoutContext layoutContext) {
@@ -125,6 +129,21 @@ RNGestureHandlerDetectorShadowNode::unflattenNode(
       ShadowNodeTraits::FormsStackingContext);
 
   return clonedNode;
+}
+
+void RNGestureHandlerDetectorShadowNode::updateOrderIndexFromChildren() {
+  const auto &children = getChildren();
+  if (children.size() != 1) {
+    ShadowNode::orderIndex_ = 0;
+    return;
+  }
+
+  // The detector behaves like a transparent wrapper around its child.
+  // With a single child, mirror the child's RN-computed order index so styles
+  // such as zIndex keep affecting sibling ordering despite the extra native
+  // detector node. With multiple children, no single order index can preserve
+  // each child's independent ordering relative to outside siblings.
+  ShadowNode::orderIndex_ = children.front()->getOrderIndex();
 }
 
 } // namespace facebook::react

--- a/packages/react-native-gesture-handler/shared/shadowNodes/react/renderer/components/rngesturehandler_codegen/RNGestureHandlerDetectorShadowNode.h
+++ b/packages/react-native-gesture-handler/shared/shadowNodes/react/renderer/components/rngesturehandler_codegen/RNGestureHandlerDetectorShadowNode.h
@@ -65,6 +65,7 @@ class RNGestureHandlerDetectorShadowNode final
   std::shared_ptr<const ShadowNode> unflattenNode(
       const std::shared_ptr<const ShadowNode> &node);
   void initialize();
+  void updateOrderIndexFromChildren();
 
   std::optional<LayoutMetrics> previousLayoutMetrics_;
 };


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/4254

Fabric computes view ordering from each shadow node’s orderIndex, which React Native derives from zIndex. Since RNGH v3 inserts an RNGestureHandlerDetector shadow node between the parent and the actual child view, the parent was sorting the detector instead of the styled child. The detector kept the default order index, so components like v3 Pressable did not respect zIndex.

This PR makes RNGestureHandlerDetectorShadowNode mirror its single child’s RN-computed order index. For multi-child detectors, it keeps neutral ordering because no single detector order index can accurately represent multiple children with independent zIndex values.

## Test plan

Test reproducer from the issue
