### PR TITLE
[iOS] Fix hooks API not cancelling JS Responder

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
@@ -254,14 +254,14 @@
                    withHostDetector:self];
     } else {
       // Hierarchy was folded into a single UIView.
-      [manager.registry attachHandlerWithTag:handler.tag toView:self withActionType:actionType withHostDetector:self];
+      [manager attachHandlerForDetectorWithTag:handler.tag toView:self withActionType:actionType withHostDetector:self];
       handler.virtualViewTag = @(viewTag);
     }
     [_attachedHandlers addObject:handler.tag];
     return;
   }
 
-  [manager.registry attachHandlerWithTag:handler.tag toView:self withActionType:actionType withHostDetector:self];
+  [manager attachHandlerForDetectorWithTag:handler.tag toView:self withActionType:actionType withHostDetector:self];
   [_attachedHandlers addObject:handler.tag];
 }
 
@@ -351,10 +351,10 @@
     if ([handlerManager.registry handlerWithTag:handlerTag] == nil) {
       continue;
     }
-    [handlerManager.registry attachHandlerWithTag:handlerTag
-                                           toView:view
-                                   withActionType:RNGestureHandlerActionTypeNativeDetector
-                                 withHostDetector:self];
+    [handlerManager attachHandlerForDetectorWithTag:handlerTag
+                                             toView:view
+                                     withActionType:RNGestureHandlerActionTypeNativeDetector
+                                   withHostDetector:self];
     [_attachedHandlers addObject:handlerTag];
   }
 }

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.h
@@ -29,6 +29,11 @@
               withActionType:(RNGestureHandlerActionType)actionType
             withHostDetector:(nullable RNGHUIView *)hostDetector;
 
+- (void)attachHandlerForDetectorWithTag:(nonnull NSNumber *)handlerTag
+                                 toView:(nonnull RNGHUIView *)view
+                         withActionType:(RNGestureHandlerActionType)actionType
+                       withHostDetector:(nullable RNGHUIView *)hostDetector;
+
 - (void)setGestureHandlerConfig:(nonnull NSNumber *)handlerTag config:(nonnull NSDictionary *)config;
 
 - (void)updateGestureHandlerConfig:(nonnull NSNumber *)handlerTag config:(nonnull NSDictionary *)config;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
@@ -209,6 +209,15 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
   [self registerViewWithGestureRecognizerAttachedIfNeeded:view];
 }
 
+- (void)attachHandlerForDetectorWithTag:(nonnull NSNumber *)handlerTag
+                                 toView:(nonnull RNGHUIView *)view
+                         withActionType:(RNGestureHandlerActionType)actionType
+                       withHostDetector:(nullable RNGHUIView *)hostDetector
+{
+  [_registry attachHandlerWithTag:handlerTag toView:view withActionType:actionType withHostDetector:hostDetector];
+  [self registerViewWithGestureRecognizerAttachedIfNeeded:view];
+}
+
 - (void)setGestureHandlerConfig:(NSNumber *)handlerTag config:(NSDictionary *)config
 {
   RNGestureHandler *handler = [_registry handlerWithTag:handlerTag];


### PR DESCRIPTION
## Description

Fixes https://github.com/software-mansion/react-native-gesture-handler/issues/4258

JS-responder cancellation relies on `RNRootViewGestureRecognizer` being installed on the surface view. The legacy path installs it in maybeBindHandler via `registerViewWithGestureRecognizerAttachedIfNeeded`, but the hook-API detector attached handlers straight to the registry and skipped that step, so activation could never cancel the JS responder.

This PR adds `attachHandlerForDetectorWithTag:toView:withActionType:withHostDetector:` on `RNGestureHandlerManager` which handles that.

## Test plan

Tested on the issue reproducer
