### PR TITLE
Ignore the `.rnrepo-cache` directory within the Metro config

### DIFF
--- a/apps/expo-example/metro.config.js
+++ b/apps/expo-example/metro.config.js
@@ -27,7 +27,10 @@ config.resolver.blacklistRE = exclusionList(
     modulesBlacklist.map(
       (m) => new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)
     )
-  )
+  ).concat([
+    // Ignore .rnrepo-cache folder and its contents to avoid watchman Invariant Violation
+    /.*\.rnrepo-cache\/.*/
+  ])
 );
 
 config.transformer.getTransformOptions = async () => ({

--- a/apps/expo-example/metro.config.js
+++ b/apps/expo-example/metro.config.js
@@ -22,14 +22,17 @@ config.resolver.nodeModulesPaths = [
   path.resolve(monorepoRoot, 'node_modules'),
 ];
 
+const monorepoExclusions = [monorepoRoot, commonAppRoot].flatMap((root) =>
+  modulesBlacklist.map(
+    (m) => new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)
+  )
+);
+
+// Concat arrays before passing to exclusionList to prevent runtime crash
 config.resolver.blacklistRE = exclusionList(
-  [monorepoRoot, commonAppRoot].flatMap((root) =>
-    modulesBlacklist.map(
-      (m) => new RegExp(`^${escape(path.join(root, 'node_modules', m))}\\/.*$`)
-    )
-  ).concat([
-    // Ignore .rnrepo-cache folder and its contents to avoid watchman Invariant Violation
-    /.*\.rnrepo-cache\/.*/
+  monorepoExclusions.concat([
+    // Regex [\/\\] ensures cross-platform compatibility (macOS/Linux/Windows)
+    /.*[\/\\]\.rnrepo-cache[\/\\].*/
   ])
 );
 


### PR DESCRIPTION
## Description

This prevents Metro from crashing with an `Invariant Violation` when internal scripts dynamically recreate this directory or replace it with a symlink during the `expo prebuild` process in example apps.

```
<>gesture-handler/apps/expo-example/node_modules/@expo/cli/build/src/utils/errors.js:130
    throw error;
    ^

Invariant Violation: Detected addition or modification of file node_modules/react-native-screens/.rnrepo-cache/Current, but it is tracked as a non-empty directory
    at invariant (<>gesture-handler/apps/expo-example/node_modules/invariant/invariant.js:40:15)
    at TreeFS.addOrModify (<>gesture-handler/apps/expo-example/node_modules/@expo/metro-file-map/build/lib/TreeFS.js:386:41)
    at Timeout.emitChange [as _onTimeout] (<>gesture-handler/apps/expo-example/node_modules/@expo/metro-file-map/build/index.js:580:32)
    at listOnTimeout (node:internal/timers:588:17)
    at process.processTimers (node:internal/timers:523:7) {
  framesToPop: 1
}
```

## Test plan

1. Without commit
```
git clone https://github.com/software-mansion/react-native-gesture-handler
cd react-native-gesture-handler
yarn install
cd apps/expo-example
yarn start

# new terminal (2)
cd react-native-gesture-handler/apps/expo-example
yarn ios

# Metro crashes in the first terminal with the Invariant Violation shown above.
```

2. With commit
```
git clone https://github.com/software-mansion/react-native-gesture-handler
cd react-native-gesture-handler
yarn install
cd apps/expo-example
yarn start

# new terminal (2)
cd react-native-gesture-handler/apps/expo-example
yarn ios

# Metro runs normally and no error is thrown in the first terminal
```