### PR TITLE
feat: Adopt AGP v9

### DIFF
--- a/packages/react-native-gesture-handler/android/build.gradle
+++ b/packages/react-native-gesture-handler/android/build.gradle
@@ -68,7 +68,7 @@ def shouldEnableAgpFallback() {
     }
 
     def propertyVal = providers.gradleProperty("android.builtInKotlin").orNull
-    def isBuiltInKotlinEnabled = (propertyVal == "false") ? false : true
+    def isBuiltInKotlinEnabled = propertyVal != null ? propertyVal.toBoolean() : true
 
     return !isBuiltInKotlinEnabled
 }

--- a/packages/react-native-gesture-handler/android/build.gradle
+++ b/packages/react-native-gesture-handler/android/build.gradle
@@ -60,7 +60,22 @@ if (isNewArchitectureEnabled()) {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def shouldEnableAgpFallback() {
+    def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpMajorVersion <= 8) {
+        return true
+    }
+
+    def propertyVal = providers.gradleProperty("android.builtInKotlin").orNull
+    def isBuiltInKotlinEnabled = (propertyVal == "false") ? false : true
+
+    return !isBuiltInKotlinEnabled
+}
+
+if (shouldEnableAgpFallback()) {
+    apply plugin: 'kotlin-android'
+}
 
 if (project == rootProject) {
     apply from: "spotless.gradle"
@@ -201,17 +216,17 @@ android {
     }
 
     sourceSets.main {
-        java {
+        kotlin {
             if (shouldUseCommonInterfaceFromReanimated()) {
-                srcDirs += 'reanimated/src/main/java'
+                directories.add('reanimated/src/main/java')
             } else {
-                srcDirs += 'noreanimated/src/main/java'
+                directories.add('noreanimated/src/main/java')
             }
 
             if (shouldUseCommonInterfaceFromRNSVG()) {
-                srcDirs += 'svg/src/main/java'
+                directories.add('svg/src/main/java')
             } else {
-                srcDirs += 'nosvg/src/main/java'
+                directories.add('nosvg/src/main/java')
             }
         }
     }

--- a/packages/react-native-gesture-handler/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/react-native-gesture-handler/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/packages/react-native-gesture-handler/android/gradle/wrapper/gradle-wrapper.properties
+++ b/packages/react-native-gesture-handler/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-9.4.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## Description

<!--
Description and motivation for this PR.

Include 'Fixes #<number>' if this is fixing some issue.
-->

This PR is rasied following the second phase of the RFC around AGP v9 adoption:

RFC: https://github.com/react-native-community/discussions-and-proposals/pull/1006

The gist of this PR is to make Gesture Handler AGP v9 compliant with backward compatibility. The main scope of changes is the `react-native-gesture-handler/android/build.gradle`. The rest of the changes can be considered temporary.

The rest changes include:

- Making Basic Example App AGP9 compliant
- Upgrade `Gradle` to `v9.4.1`
- Use `proguard-android-optimize` proguard file
- Enable opt outs in the `gradle.properties`

Ideally, we should not enable the opt outs and leverage the AGP 9 built-in kotlin and newDSL. However, if we do not do it, then other libraries which are not yet AGP v9 compliant starts to fail. Hence, we need to keep the opt outs enabled for a while. For the context, react-native starting from 0.87.x will ship with AGP v9 and opt outs enabled by default for the new apps, which is the first phase of AGP v9 adoption.

With the second phase when the libraries starts adoption AGP v9, we can eventually remove the opt outs from Basic Example.

## Test plan

<!--
Describe how did you test this change here.
-->

To test this PR, we need to do a few steps:

- Set the `agp` version to `9.2.1` and `kotlin` to `2.2.0` in `react-native-gradle-plugin`
```diff
--- a/node_modules/@react-native/gradle-plugin/gradle/libs.versions.toml
+++ b/node_modules/@react-native/gradle-plugin/gradle/libs.versions.toml
@@ -1,10 +1,10 @@
 [versions]
-agp = "8.12.0"
+agp = "9.2.1"
 gson = "2.8.9"

-kotlin = "2.1.20"
+kotlin = "2.2.0"
 assertj = "3.25.1"
```

- Comment out the following functions in `react-native-gradle-plugin`
```diff
--- a/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/ReactPlugin.kt
+++ b/node_modules/@react-native/gradle-plugin/react-native-gradle-plugin/ReactPlugin.kt
@@ -1,10 +1,10 @@
      configureBuildTypesForApp(project)
    }

    // Library Only Configuration
-    configureBuildConfigFieldsForLibraries(project)
-    configureNamespaceForLibraries(project)
+    // configureBuildConfigFieldsForLibraries(project)
+    // configureNamespaceForLibraries(project)
    project.pluginManager.withPlugin("com.android.library") {
```

This step is only required because we have RN version on 0.85.2 and `AGP` + `kotlin` bump will be shipped with 0.87.x. 

<details>
<summary>Verified by locally patching Reanimated and Worklet, making those AGP v9 compliant and removing the opt outs to test the changes in the PR </summary>


https://github.com/user-attachments/assets/7f4f571a-6bef-4694-9b32-330571c0c734



</details>


<details>
<summary>Verified these changes work with AGP 8 </summary>


https://github.com/user-attachments/assets/116a0b2e-23f5-499c-8a64-b99f927165c4




</details>
