### PR TITLE
[Docs] Add dynamic topbar banner

### DIFF
--- a/packages/docs-gesture-handler/docusaurus.config.js
+++ b/packages/docs-gesture-handler/docusaurus.config.js
@@ -10,8 +10,7 @@ const webpack = require('webpack');
 const redirectsData = require('./redirects.json');
 
 import { topbarBannerReservationScript } from '@swmansion/t-rex-ui/topbar-banner';
-// @ts-expect-error -- .ts extension is intentional; not type-checked by tsc here.
-import { TOP_BAR_BANNER } from './src/components/topBarBannerConfig.ts';
+import { TOP_BAR_BANNER } from './src/components/topBarBannerConfig';
 
 const firstBannerZone = TOP_BAR_BANNER.zones[0];
 const bannerReservationHeadTags = firstBannerZone

--- a/packages/docs-gesture-handler/docusaurus.config.js
+++ b/packages/docs-gesture-handler/docusaurus.config.js
@@ -9,6 +9,25 @@ const webpack = require('webpack');
 
 const redirectsData = require('./redirects.json');
 
+import { topbarBannerReservationScript } from '@swmansion/t-rex-ui/topbar-banner';
+// @ts-expect-error -- .ts extension is intentional; not type-checked by tsc here.
+import { TOP_BAR_BANNER } from './src/components/topBarBannerConfig.ts';
+
+const firstBannerZone = TOP_BAR_BANNER.zones[0];
+const bannerReservationHeadTags = firstBannerZone
+  ? [
+      {
+        tagName: 'script',
+        attributes: { type: 'text/javascript' },
+        innerHTML: topbarBannerReservationScript(
+          firstBannerZone.zoneId,
+          firstBannerZone.contentId,
+          TOP_BAR_BANNER.hiddenPaths
+        ),
+      },
+    ]
+  : [];
+
 /** @type {import('@docusaurus/types').Config} */
 const config = {
   title: 'React Native Gesture Handler',
@@ -33,6 +52,8 @@ const config = {
 
   onBrokenLinks: 'throw',
   onBrokenMarkdownLinks: 'warn',
+
+  headTags: bannerReservationHeadTags,
 
   presets: [
     [

--- a/packages/docs-gesture-handler/package.json
+++ b/packages/docs-gesture-handler/package.json
@@ -32,7 +32,7 @@
     "@emotion/styled": "^11.14.0",
     "@mdx-js/react": "^3.0.0",
     "@mui/material": "^7.1.0",
-    "@swmansion/t-rex-ui": "1.3.1",
+    "@swmansion/t-rex-ui": "1.3.3",
     "@vercel/og": "^0.6.2",
     "babel-polyfill": "^6.26.0",
     "babel-preset-expo": "^9.2.2",

--- a/packages/docs-gesture-handler/src/components/topBarBannerConfig.ts
+++ b/packages/docs-gesture-handler/src/components/topBarBannerConfig.ts
@@ -1,0 +1,26 @@
+import type { BannerZone } from '@swmansion/t-rex-ui';
+
+export const TOP_BAR_BANNER = {
+  rotateIntervalMs: 4000,
+  hiddenPaths: [
+    '/react-native-gesture-handler/docs',
+    '/react-native-gesture-handler/search',
+  ] as string[],
+  zones: [
+    {
+      zoneId: 'react-native-gesture-handler-topbar-1',
+      contentId: 'ea15c4216158c4097b65fe6504a4b3b7',
+      fallbackBgColor: '#782aeb',
+    },
+    {
+      zoneId: 'react-native-gesture-handler-topbar-2',
+      contentId: 'ea15c4216158c4097b65fe6504a4b3b7',
+      fallbackBgColor: '#782aeb',
+    },
+    {
+      zoneId: 'react-native-gesture-handler-topbar-3',
+      contentId: 'ea15c4216158c4097b65fe6504a4b3b7',
+      fallbackBgColor: '#782aeb',
+    },
+  ] satisfies BannerZone[],
+};

--- a/packages/docs-gesture-handler/src/theme/Navbar/index.js
+++ b/packages/docs-gesture-handler/src/theme/Navbar/index.js
@@ -1,8 +1,16 @@
-import React from 'react';
+import { useLocation } from '@docusaurus/router';
 import useBaseUrl from '@docusaurus/useBaseUrl';
-import { Navbar } from '@swmansion/t-rex-ui';
+import { TOP_BAR_BANNER } from '@site/src/components/topBarBannerConfig';
+import { isBannerHidden, Navbar, TopbarBanner } from '@swmansion/t-rex-ui';
+import React from 'react';
 
 export default function NavbarWrapper(props) {
+  const location = useLocation();
+  const bannerHidden = isBannerHidden(
+    location.pathname,
+    TOP_BAR_BANNER.hiddenPaths
+  );
+
   const titleImages = {
     light: useBaseUrl('/img/title.svg'),
     dark: useBaseUrl('/img/title-dark.svg'),
@@ -12,6 +20,14 @@ export default function NavbarWrapper(props) {
     logo: useBaseUrl('/img/logo-hero.svg'),
   };
   return (
-    <Navbar heroImages={heroImages} titleImages={titleImages} {...props} />
+    <div style={{ display: 'flex', flexDirection: 'column', flexShrink: 0 }}>
+      {!bannerHidden && (
+        <TopbarBanner
+          zones={TOP_BAR_BANNER.zones}
+          rotateIntervalMs={TOP_BAR_BANNER.rotateIntervalMs}
+        />
+      )}
+      <Navbar heroImages={heroImages} titleImages={titleImages} {...props} />
+    </div>
   );
 }

--- a/packages/docs-gesture-handler/yarn.lock
+++ b/packages/docs-gesture-handler/yarn.lock
@@ -3369,10 +3369,10 @@
     "@svgr/plugin-jsx" "8.1.0"
     "@svgr/plugin-svgo" "8.1.0"
 
-"@swmansion/t-rex-ui@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@swmansion/t-rex-ui/-/t-rex-ui-1.3.1.tgz#b16e29f15f863f1e340217592138317829583949"
-  integrity sha512-F4MoFk5Mc9vaAtl4zUFPAwMjOlYTBmxsIk+imeZHcx9m1gx3uCzFYR+svOXMxWcp9ghh1Rj/D8Zf6rFu/Ocg7A==
+"@swmansion/t-rex-ui@1.3.3":
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/@swmansion/t-rex-ui/-/t-rex-ui-1.3.3.tgz#3369a3f45f383d70cd7f3b9bcabaa8bfea379e40"
+  integrity sha512-vk2LGZifWlAw1gij4sxHA4gE31XBLBoKPSk0TMqrEv631YOwAZ8qcwsbjeNlW9Gm/T/7+mq7aT+jcT6/cKWLJw==
   dependencies:
     "@docusaurus/core" "3.9.2"
     "@docusaurus/module-type-aliases" "3.9.2"


### PR DESCRIPTION
## Description

Adds a topbar banner to the landing page. Content is served server-side via external service, so banners can be swapped, rotated, or pulled without any repo change or redeploy.
It won’t be displayed on the docs or search pages. The banners are currently hidden across the site.