### PR TITLE
[Android] Fix mouse interactions

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
@@ -88,7 +88,7 @@ class FlingGestureHandler : GestureHandler() {
   }
 
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
-    if (!shouldActivateWithMouse(sourceEvent)) {
+    if (shouldSkipEvent(sourceEvent)) {
       return
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.graphics.PointF
-import android.os.Build
 import android.view.MotionEvent
 import android.view.MotionEvent.PointerCoords
 import android.view.MotionEvent.PointerProperties
@@ -823,44 +822,38 @@ open class GestureHandler {
     return clickedButton and mouseButton != 0
   }
 
-  protected fun shouldActivateWithMouse(sourceEvent: MotionEvent): Boolean {
-    // While using mouse, we get both sets of events, for example ACTION_DOWN and ACTION_BUTTON_PRESS. That's why we want to take actions to only one of them.
-    // On API >= 23, we will use events with infix BUTTON, otherwise we use standard action events (like ACTION_DOWN).
+  // Decides whether the gesture should ignore this event. While using a mouse we receive both the
+  // touch-compatible stream (ACTION_DOWN/UP/...) and the BUTTON_* events, so we act on only the
+  // latter, and we drop events coming from a button other than the configured `mouseButton`.
+  // Non-mouse input is never skipped here.
+  protected fun shouldSkipEvent(sourceEvent: MotionEvent): Boolean {
+    if (sourceEvent.getToolType(0) != MotionEvent.TOOL_TYPE_MOUSE) {
+      return false
+    }
 
     with(sourceEvent) {
-      // To use actionButton, we need API >= 23.
-      if (getToolType(0) == MotionEvent.TOOL_TYPE_MOUSE &&
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+      // While using mouse, we want to ignore default events for touch.
+      if (action == MotionEvent.ACTION_DOWN ||
+        action == MotionEvent.ACTION_UP ||
+        action == MotionEvent.ACTION_POINTER_UP ||
+        action == MotionEvent.ACTION_POINTER_DOWN
       ) {
-        // While using mouse, we want to ignore default events for touch.
-        if (action == MotionEvent.ACTION_DOWN ||
-          action == MotionEvent.ACTION_UP ||
-          action == MotionEvent.ACTION_POINTER_UP ||
-          action == MotionEvent.ACTION_POINTER_DOWN
-        ) {
-          return@shouldActivateWithMouse false
-        }
+        return@shouldSkipEvent true
+      }
 
-        // We don't want to do anything if wrong button was clicked. If we received event for BUTTON, we have to use actionButton to get which one was clicked.
-        if (action != MotionEvent.ACTION_MOVE && !isButtonInConfig(actionButton)) {
-          return@shouldActivateWithMouse false
-        }
+      // Skip events from a button other than the configured one. For BUTTON_* events the clicked
+      // button is read from `actionButton`.
+      if (action != MotionEvent.ACTION_MOVE && !isButtonInConfig(actionButton)) {
+        return@shouldSkipEvent true
+      }
 
-        // When we receive ACTION_MOVE, we have to check buttonState field.
-        if (action == MotionEvent.ACTION_MOVE && !isButtonInConfig(buttonState)) {
-          return@shouldActivateWithMouse false
-        }
-      } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-        // We do not fully support mouse below API 23, so we will ignore BUTTON events.
-        if (action == MotionEvent.ACTION_BUTTON_PRESS ||
-          action == MotionEvent.ACTION_BUTTON_RELEASE
-        ) {
-          return@shouldActivateWithMouse false
-        }
+      // For ACTION_MOVE the pressed button is read from `buttonState`.
+      if (action == MotionEvent.ACTION_MOVE && !isButtonInConfig(buttonState)) {
+        return@shouldSkipEvent true
       }
     }
 
-    return true
+    return false
   }
 
   /**

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -833,22 +833,22 @@ open class GestureHandler {
 
     with(sourceEvent) {
       // While using mouse, we want to ignore default events for touch.
-      if (action == MotionEvent.ACTION_DOWN ||
-        action == MotionEvent.ACTION_UP ||
-        action == MotionEvent.ACTION_POINTER_UP ||
-        action == MotionEvent.ACTION_POINTER_DOWN
+      if (actionMasked == MotionEvent.ACTION_DOWN ||
+        actionMasked == MotionEvent.ACTION_UP ||
+        actionMasked == MotionEvent.ACTION_POINTER_UP ||
+        actionMasked == MotionEvent.ACTION_POINTER_DOWN
       ) {
         return@shouldSkipEvent true
       }
 
       // Skip events from a button other than the configured one. For BUTTON_* events the clicked
       // button is read from `actionButton`.
-      if (action != MotionEvent.ACTION_MOVE && !isButtonInConfig(actionButton)) {
+      if (actionMasked != MotionEvent.ACTION_MOVE && !isButtonInConfig(actionButton)) {
         return@shouldSkipEvent true
       }
 
       // For ACTION_MOVE the pressed button is read from `buttonState`.
-      if (action == MotionEvent.ACTION_MOVE && !isButtonInConfig(buttonState)) {
+      if (actionMasked == MotionEvent.ACTION_MOVE && !isButtonInConfig(buttonState)) {
         return@shouldSkipEvent true
       }
     }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -71,7 +71,7 @@ class LongPressGestureHandler(context: Context) : GestureHandler() {
   }
 
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
-    if (!shouldActivateWithMouse(sourceEvent)) {
+    if (shouldSkipEvent(sourceEvent)) {
       return
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -108,7 +108,8 @@ class LongPressGestureHandler(context: Context) : GestureHandler() {
       currentPointers == numberOfPointersRequired &&
       (
         sourceEvent.actionMasked == MotionEvent.ACTION_DOWN ||
-          sourceEvent.actionMasked == MotionEvent.ACTION_POINTER_DOWN
+          sourceEvent.actionMasked == MotionEvent.ACTION_POINTER_DOWN ||
+          sourceEvent.actionMasked == MotionEvent.ACTION_BUTTON_PRESS
         )
     ) {
       handler = Handler(Looper.getMainLooper())

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
@@ -160,7 +160,7 @@ class PanGestureHandler(context: Context?) : GestureHandler() {
   }
 
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
-    if (!shouldActivateWithMouse(sourceEvent)) {
+    if (shouldSkipEvent(sourceEvent)) {
       return
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
@@ -89,7 +89,7 @@ class TapGestureHandler : GestureHandler() {
   }
 
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
-    if (!shouldActivateWithMouse(sourceEvent)) {
+    if (shouldSkipEvent(sourceEvent)) {
       return
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt
@@ -17,6 +17,9 @@ fun MotionEvent.isHoverAction(): Boolean = action == MotionEvent.ACTION_HOVER_MO
   action == MotionEvent.ACTION_HOVER_ENTER ||
   action == MotionEvent.ACTION_HOVER_EXIT
 
+fun MotionEvent.isButtonAction(): Boolean = actionMasked == MotionEvent.ACTION_BUTTON_PRESS ||
+  actionMasked == MotionEvent.ACTION_BUTTON_RELEASE
+
 val Display.minimumFrameTime: Float
   get() {
     val supportedModes = this.supportedModes

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
@@ -62,12 +62,14 @@ class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {
     }
   }
 
-  override fun dispatchGenericMotionEvent(ev: MotionEvent) =
-    if (rootViewEnabled && ev.isHoverAction() && rootHelper!!.dispatchTouchEvent(ev)) {
-      true
-    } else {
-      super.dispatchGenericMotionEvent(ev)
-    }
+  override fun dispatchGenericMotionEvent(ev: MotionEvent) = if (rootViewEnabled &&
+    (ev.isHoverAction() || ev.isButtonAction()) &&
+    rootHelper!!.dispatchTouchEvent(ev)
+  ) {
+    true
+  } else {
+    super.dispatchGenericMotionEvent(ev)
+  }
 
   override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
     if (rootViewEnabled) {


### PR DESCRIPTION
## Description

#3850 restricted dispatching of generic motion events to only hover events. This caused a regression in which mouse events stopped being dispatched to handlers.

This PR allows mouse events to be dispatched to handlers and adds check for mouse button press in Long Press so it can activate timeout.

It also removes check for obsolete SDK version and inverts logic of skipping events - `shouldActivateWithMouse` wasn't very descriptive (especially in `onHandle`), so I renamed it to `shouldSkipEvent` instead.

Fixes #3889 

## Test plan

Tested on mouse buttons and Pressable examples