### PR TITLE
[General] Ignore `testID` property in production environments

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
@@ -46,11 +46,6 @@ export const allowedNativeProps = new Set<
   'needsPointerData',
 ]);
 
-// Don't pass testID to the native side in production
-if (!__DEV__) {
-  allowedNativeProps.delete('testID');
-}
-
 export const HandlerCallbacks = new Set<
   keyof Required<GestureCallbacks<unknown, unknown>>
 >([
@@ -85,6 +80,12 @@ export const PropsToFilter = new Set<
   'failOffsetY',
   'activeOffsetX',
 ]);
+
+// Don't pass testID to the native side in production
+if (!__DEV__) {
+  allowedNativeProps.delete('testID');
+  PropsToFilter.add('testID');
+}
 
 export const PropsWhiteLists = new Map<
   SingleGestureName,


### PR DESCRIPTION
## Description

When in production environments, `testID` is removed from `allowedNativeProps` to prevent it from being passed to the native side. This mean that it no longer falls into the first branch here https://github.com/software-mansion/react-native-gesture-handler/blob/1473f3906e2cc297b92f693fae09b6e789068cfe/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts#L86-L100

But last, which shows a warning. This PR adds `testID` to `PropsToFilter` so they fall into the second (ignore silently) branch.

## Test plan

~~AI said it's ok~~ Run app in release configuration
