### PR TITLE
[Android | Web] FIx `leftActions` not clickable in `ReanimatedSwipeable` 

### DIFF
--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -393,6 +393,10 @@ const Swipeable = (props: SwipeableProps) => {
   const leftActionAnimation = useAnimatedStyle(() => {
     return {
       opacity: showLeftProgress.value === 0 ? 0 : 1,
+      // Both action containers use `absoluteFill` and overlap, so the
+      // inactive one must not intercept touches meant for the visible
+      // actions.
+      pointerEvents: showLeftProgress.value === 0 ? 'none' : 'auto',
     };
   });
 
@@ -423,6 +427,10 @@ const Swipeable = (props: SwipeableProps) => {
   const rightActionAnimation = useAnimatedStyle(() => {
     return {
       opacity: showRightProgress.value === 0 ? 0 : 1,
+      // Both action containers use `absoluteFill` and overlap, so the
+      // inactive one must not intercept touches meant for the visible
+      // actions.
+      pointerEvents: showRightProgress.value === 0 ? 'none' : 'auto',
     };
   });
 


### PR DESCRIPTION
## Description

In `ReanimatedSwipeable` both, left and right panel, use `StyleSheet.absoluteFill`. With this style setting, they cover whole `Swipeable` element, which makes right actions panel swallow events meant to be delivered to left panel. This PR adds `pointerEvents: none;` to hidden panels - in that state they shouldn't be a target for touch anyway.

Fixes #3223

## Test plan

<details>
<summary>Tested on the following example:</summary>

```tsx
import React, { useState } from 'react';
import { StyleSheet, Text, TouchableOpacity, View } from 'react-native';
import Swipeable from 'react-native-gesture-handler/ReanimatedSwipeable';

// Repro for https://github.com/software-mansion/react-native-gesture-handler/issues/3223
// Swipe the blue row to either side to reveal the actions, then tap a button.
// Before the fix, taps on the LEFT actions never fire on iOS (the invisible,
// full-width right-actions overlay swallows them) while RIGHT actions work.
export default function SwipeableLeftActionsExample() {
  const [leftPresses, setLeftPresses] = useState(0);
  const [rightPresses, setRightPresses] = useState(0);

  return (
    <View style={styles.screen}>
      <View style={styles.counters}>
        <Text testID="left-counter" style={styles.counterText}>
          Left presses: {leftPresses}
        </Text>
        <Text testID="right-counter" style={styles.counterText}>
          Right presses: {rightPresses}
        </Text>
      </View>

      <Swipeable
        leftThreshold={50}
        rightThreshold={50}
        renderLeftActions={() => (
          <TouchableOpacity
            testID="left-action"
            onPress={() => setLeftPresses((value) => value + 1)}>
            <View style={[styles.action, { backgroundColor: 'gold' }]}>
              <Text>Left</Text>
            </View>
          </TouchableOpacity>
        )}
        renderRightActions={() => (
          <TouchableOpacity
            testID="right-action"
            onPress={() => setRightPresses((value) => value + 1)}>
            <View style={[styles.action, { backgroundColor: 'magenta' }]}>
              <Text>Right</Text>
            </View>
          </TouchableOpacity>
        )}>
        <View style={styles.row}>
          <Text style={styles.rowText}>Swipe me both ways</Text>
        </View>
      </Swipeable>
    </View>
  );
}

const styles = StyleSheet.create({
  screen: {
    flex: 1,
    marginTop: 100,
  },
  counters: {
    padding: 16,
    gap: 8,
  },
  counterText: {
    fontSize: 18,
    fontWeight: '600',
  },
  row: {
    width: '100%',
    height: 80,
    backgroundColor: 'cornflowerblue',
    justifyContent: 'center',
    alignItems: 'center',
  },
  rowText: {
    color: 'white',
    fontWeight: '600',
  },
  action: {
    height: 80,
    width: 100,
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```

</details>