### PR TITLE
fix: crash when mount listener fires after GestureDetector unmount

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useMountReactions.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useMountReactions.ts
@@ -28,6 +28,12 @@ export function useMountReactions(
 ) {
   useEffect(() => {
     return MountRegistry.addMountListener((gesture) => {
+      // The detector may already be unmounted when this fires; bail out to avoid
+      // updating a detached detector.
+      if (!state.isMounted) {
+        return;
+      }
+
       // At this point the ref in the gesture config should be updated, so we can check if one of the gestures
       // set in a relation with the gesture got mounted. If so, we need to update the detector to propagate
       // the changes to the native side.


### PR DESCRIPTION
## Description

`useMountReactions` registers a `MountRegistry` listener in `useEffect`. That listener can fire after the owning `GestureDetector` has already unmounted (e.g. a related gesture mounts while this detector is gone). Calling `updateDetector` in that case updates a detached detector and can crash (occasionally in `findNodeHandle`).

Guard with the existing `state.isMounted` flag — the same pattern `attachHandlers` already uses for the microtask after unmount.

Credit to @hannojg for the original investigation/fix direction.

## Changes

- In `useMountReactions`, return early from the mount listener when `!state.isMounted`.

## Why not `useLayoutEffect`?

An earlier version of this PR also moved the subscription to `useIsomorphicLayoutEffect` (same phase as GestureDetector attach/drop). We A/B tested `useLayoutEffect` vs stock `useEffect`, both with this early return. Crash rates were equivalent; the `isMounted` check alone is sufficient, so this PR keeps `useEffect`.