### PR TITLE
Remove `opacity` from `Swipeable` action panels

### DIFF
--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -392,10 +392,6 @@ const Swipeable = (props: SwipeableProps) => {
 
   const leftActionAnimation = useAnimatedStyle(() => {
     return {
-      opacity: showLeftProgress.value === 0 ? 0 : 1,
-      // Both action containers use `absoluteFill` and overlap, so the
-      // inactive one must not intercept touches meant for the visible
-      // actions.
       pointerEvents: showLeftProgress.value === 0 ? 'none' : 'auto',
     };
   });
@@ -426,10 +422,6 @@ const Swipeable = (props: SwipeableProps) => {
 
   const rightActionAnimation = useAnimatedStyle(() => {
     return {
-      opacity: showRightProgress.value === 0 ? 0 : 1,
-      // Both action containers use `absoluteFill` and overlap, so the
-      // inactive one must not intercept touches meant for the visible
-      // actions.
       pointerEvents: showRightProgress.value === 0 ? 'none' : 'auto',
     };
   });

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -392,6 +392,9 @@ const Swipeable = (props: SwipeableProps) => {
 
   const leftActionAnimation = useAnimatedStyle(() => {
     return {
+      // Both action containers use `absoluteFill` and overlap, so the
+      // inactive one must not intercept touches meant for the visible
+      // actions.
       pointerEvents: showLeftProgress.value === 0 ? 'none' : 'auto',
     };
   });
@@ -422,6 +425,9 @@ const Swipeable = (props: SwipeableProps) => {
 
   const rightActionAnimation = useAnimatedStyle(() => {
     return {
+      // Both action containers use `absoluteFill` and overlap, so the
+      // inactive one must not intercept touches meant for the visible
+      // actions.
       pointerEvents: showRightProgress.value === 0 ? 'none' : 'auto',
     };
   });


### PR DESCRIPTION
## Description

Row position and `opacity` depend on different SharedValue, which may lead to them animating out of sync. Since we already have `overflow: hidden;` setting `opacity` is not required.

Fixes #3897 

## Test plan

Tested on the existing Swipeable examples.
