### PR TITLE
[iOS] Move `Tap` cancelation to `dispatch_after`

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNTapHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNTapHandler.m
@@ -166,6 +166,8 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
 
+  [self cancelPendingCancellations];
+
   if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
     self.state = UIGestureRecognizerStateEnded;
   } else {

--- a/packages/react-native-gesture-handler/apple/Handlers/RNTapHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNTapHandler.m
@@ -38,6 +38,12 @@
   NSUInteger _tapsSoFar;
   CGPoint _initPosition;
   NSInteger _maxNumberOfTouches;
+  // Pending `cancel` invocations scheduled via dispatch_after. We use dispatch blocks instead of
+  // performSelector:afterDelay: because the latter schedules its timer in NSDefaultRunLoopMode only,
+  // which means it is starved while a sibling UIScrollView keeps the run loop in UITrackingRunLoopMode
+  // (during a drag or momentum deceleration). dispatch_after fires regardless of run loop mode, so the
+  // tap can still fail/finalize on time while a list is scrolling. See issue #3471.
+  NSMutableArray<dispatch_block_t> *_pendingCancellations;
 }
 
 static const NSUInteger defaultNumberOfTaps = 1;
@@ -57,8 +63,31 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
     _maxDeltaX = NAN;
     _maxDeltaY = NAN;
     _maxDistSq = NAN;
+    _pendingCancellations = [NSMutableArray array];
   }
   return self;
+}
+
+- (void)scheduleCancelAfterDelay:(NSTimeInterval)delay
+{
+  __weak typeof(self) weakSelf = self;
+
+  dispatch_block_t block = dispatch_block_create(0, ^{
+    [weakSelf cancel];
+  });
+
+  [_pendingCancellations addObject:block];
+
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), block);
+}
+
+- (void)cancelPendingCancellations
+{
+  for (dispatch_block_t block in _pendingCancellations) {
+    dispatch_block_cancel(block);
+  }
+
+  [_pendingCancellations removeAllObjects];
 }
 
 - (void)triggerAction
@@ -98,14 +127,14 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
   }
   _tapsSoFar++;
   if (_tapsSoFar) {
-    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
+    [self cancelPendingCancellations];
   }
   NSInteger numberOfTouches = [touches count];
   if (numberOfTouches > _maxNumberOfTouches) {
     _maxNumberOfTouches = numberOfTouches;
   }
   if (!isnan(_maxDuration)) {
-    [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDuration];
+    [self scheduleCancelAfterDelay:_maxDuration];
   }
   self.state = UIGestureRecognizerStatePossible;
   [self triggerAction];
@@ -140,7 +169,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
   if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
     self.state = UIGestureRecognizerStateEnded;
   } else {
-    [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDelay];
+    [self scheduleCancelAfterDelay:_maxDelay];
   }
 }
 
@@ -255,7 +284,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 
   [_gestureHandler.pointerTracker reset];
 
-  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
+  [self cancelPendingCancellations];
   _tapsSoFar = 0;
   _maxNumberOfTouches = 0;
   self.enabled = _gestureHandler.enabled;


### PR DESCRIPTION
## Description

Fixes #3471

On iOS, in a multi-gesture setup (e.g. an `Exclusive` single-tap / double-tap combination), a `tap`'s `onDeactivate`/`onFinalize` was delayed until a `ScrollView`/`FlatList` finished its drag or momentum scroll. `onBegin` fired immediately, but the single tap never run `onActivate`/`onEnd` — it stayed in the began state and finalized as failed only once scrolling settled.

`RNBetterTapGestureRecognizer` armed its `maxDuration` and `maxDelay` failure timers with `performSelector:withObject:afterDelay:`, which schedules an `NSTimer` in `NSDefaultRunLoopMode` only. While a `UIScrollView` is dragging or decelerating, the main run loop runs in `UITrackingRunLoopMode`, so those timers are starved until the scroll stops.

To fix this, I replaced the two `performSelector:…afterDelay:` calls with cancellable `dispatch_after` blocks which fire regardless of run-loop mode (it is also consistent with current `LongPress` / `Fling` logic). 

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import * as React from 'react';
import { FlatList, Pressable, StyleSheet, Text, View } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  useExclusiveGestures,
  useTapGesture,
} from 'react-native-gesture-handler';

// Repro for https://github.com/software-mansion/react-native-gesture-handler/issues/3471
//
// A FlatList (a plain RN ScrollView under the hood) lives OUTSIDE the
// GestureDetector. Below it, a tracked box has a single-tap / double-tap
// Exclusive combination (v3 API).
//
// Bug (iOS only): when the list has an active touch or is still in momentum
// scroll, tapping the box fires onBegin immediately, but onDeactivate (v2
// onEnd) / onFinalize of the single tap are delayed until the list's touch is
// released / momentum finishes. The log below timestamps every lifecycle
// callback so the delay is visible.

const DATA = Array.from({ length: 60 }, (_, i) => `List item ${i + 1}`);

const MAX_LOG = 12;

export default function App() {
  const [log, setLog] = React.useState<string[]>([]);

  const seq = React.useRef(0);

  const append = React.useCallback((line: string) => {
    const t = new Date();
    const pad = (n: number, len = 2) => n.toString().padStart(len, '0');
    const stamp = `${pad(t.getHours())}:${pad(t.getMinutes())}:${pad(
      t.getSeconds()
    )}.${pad(t.getMilliseconds(), 3)}`;
    const n = (seq.current += 1);
    setLog((prev) =>
      [`#${pad(n, 3)}  ${stamp}  ${line}`, ...prev].slice(0, MAX_LOG)
    );
  }, []);

  const singleTap = useTapGesture({
    disableReanimated: true,
    onBegin: () => append('single  onBegin'),
    onActivate: () => append('single  onActivate (v2 onStart)'),
    onDeactivate: () => append('single  onDeactivate (v2 onEnd)'),
    onFinalize: () => append('single  onFinalize'),
  });

  const doubleTap = useTapGesture({
    disableReanimated: true,
    numberOfTaps: 2,
    onBegin: () => append('double  onBegin'),
    onActivate: () => append('double  onActivate (v2 onStart)'),
    onDeactivate: () => append('double  onDeactivate (v2 onEnd)'),
    onFinalize: () => append('double  onFinalize'),
  });

  const tap = useExclusiveGestures(doubleTap, singleTap);

  return (
    <GestureHandlerRootView style={styles.root}>
      <FlatList
        style={styles.list}
        data={DATA}
        keyExtractor={(item) => item}
        renderItem={({ item }) => (
          <View style={styles.row}>
            <Text style={styles.rowText}>{item}</Text>
          </View>
        )}
      />

      <GestureDetector gesture={tap}>
        <View style={styles.tapArea}>
          <Text style={styles.tapAreaText}>Tap here (single / double)</Text>
        </View>
      </GestureDetector>

      <View style={styles.logBox}>
        <View style={styles.logHeader}>
          <Text style={styles.logTitle}>Log</Text>
          <Pressable
            style={styles.clearButton}
            onPress={() => {
              seq.current = 0;
              setLog([]);
            }}>
            <Text style={styles.clearButtonText}>Clear</Text>
          </Pressable>
        </View>
        {log.map((line, i) => (
          <Text key={`${line}-${i}`} style={styles.logLine}>
            {line}
          </Text>
        ))}
      </View>
    </GestureHandlerRootView>
  );
}

const styles = StyleSheet.create({
  root: {
    flex: 1,
    backgroundColor: '#ecf0f1',
  },
  list: {
    flex: 1,
  },
  row: {
    paddingVertical: 16,
    paddingHorizontal: 12,
    borderBottomWidth: StyleSheet.hairlineWidth,
    borderBottomColor: '#bdc3c7',
  },
  rowText: {
    fontSize: 16,
  },
  tapArea: {
    height: 100,
    backgroundColor: '#3498db',
    alignItems: 'center',
    justifyContent: 'center',
  },
  tapAreaText: {
    color: 'white',
    fontSize: 18,
    fontWeight: 'bold',
  },
  logBox: {
    height: 220,
    backgroundColor: '#2c3e50',
    padding: 8,
  },
  logHeader: {
    flexDirection: 'row',
    alignItems: 'center',
    justifyContent: 'space-between',
    marginBottom: 6,
  },
  logTitle: {
    color: '#ecf0f1',
    fontSize: 14,
    fontWeight: 'bold',
  },
  clearButton: {
    backgroundColor: '#e74c3c',
    paddingVertical: 4,
    paddingHorizontal: 12,
    borderRadius: 4,
  },
  clearButtonText: {
    color: 'white',
    fontSize: 13,
    fontWeight: 'bold',
  },
  logLine: {
    color: '#ecf0f1',
    fontFamily: 'Courier',
    fontSize: 13,
  },
});
```

</details>
