### PR TITLE
Do not call `onPress` on buttons while dismissing keyboard

### DIFF
--- a/apps/common-app/src/new_api/tests/keyboardShouldPersistTaps/index.tsx
+++ b/apps/common-app/src/new_api/tests/keyboardShouldPersistTaps/index.tsx
@@ -13,6 +13,7 @@ import {
   Pressable as RNGHPressable,
   ScrollView as RNGHScrollView,
   TextInput as RNGHTextInput,
+  Touchable as RNGHTouchable,
   useTapGesture,
 } from 'react-native-gesture-handler';
 
@@ -20,13 +21,14 @@ import type { FeedbackHandle } from '../../../common';
 import { COLORS, Feedback, InfoSection } from '../../../common';
 
 type Mode = 'never' | 'handled' | 'always';
-type Example = 'pressable' | 'tap';
+type Example = 'pressable' | 'touchable' | 'tap';
 
 const MODES: Mode[] = ['never', 'handled', 'always'];
-const EXAMPLES: Example[] = ['pressable', 'tap'];
+const EXAMPLES: Example[] = ['pressable', 'touchable', 'tap'];
 
 const EXAMPLE_LABELS: Record<Example, string> = {
   pressable: 'GH Pressable',
+  touchable: 'GH Touchable',
   tap: 'useTapGesture',
 };
 
@@ -105,6 +107,12 @@ export default function KeyboardShouldPersistTapsExample() {
               onPress={() => report('GH Pressable onPress')}>
               <Text style={styles.buttonText}>Press me</Text>
             </RNGHPressable>
+          ) : example === 'touchable' ? (
+            <RNGHTouchable
+              style={[styles.button, { backgroundColor: COLORS.GREEN }]}
+              onPress={() => report('GH Touchable onPress')}>
+              <Text style={styles.buttonText}>Press me</Text>
+            </RNGHTouchable>
           ) : (
             <GestureTapButton
               onTap={() => report('useTapGesture onActivate')}

--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -337,23 +337,42 @@ describe('[API v3] Components', () => {
       addListenerSpy.mockRestore();
     });
 
-    test('Touchable does NOT fire onPress on the keyboard-dismissing tap (never)', async () => {
+    test('Touchable does NOT fire any press callback on the keyboard-dismissing tap (never)', async () => {
       const addListenerSpy = jest.spyOn(Keyboard, 'addListener');
       const onPress = jest.fn();
+      const onPressIn = jest.fn();
+      const onPressOut = jest.fn();
 
       render(
         <GestureHandlerRootView>
           <ScrollView keyboardShouldPersistTaps="never">
-            <Touchable testID="touchable" onPress={onPress} />
+            <Touchable
+              testID="touchable"
+              onPress={onPress}
+              onPressIn={onPressIn}
+              onPressOut={onPressOut}
+            />
           </ScrollView>
         </GestureHandlerRootView>
       );
       await act(flushImmediate);
       showSoftKeyboard(addListenerSpy);
 
-      fireTap('touchable');
+      // Includes a move (second ACTIVE) so the onUpdate path is exercised too.
+      act(() => {
+        fireGestureHandler(getByGestureTestId('touchable'), [
+          { state: State.BEGAN },
+          { state: State.ACTIVE },
+          { state: State.ACTIVE },
+          { state: State.END },
+        ]);
+      });
 
+      // The whole interaction is swallowed - not just onPress, but the press-in/
+      // out side effects too (incl. via onUpdate as the finger moves).
       expect(onPress).not.toHaveBeenCalled();
+      expect(onPressIn).not.toHaveBeenCalled();
+      expect(onPressOut).not.toHaveBeenCalled();
       addListenerSpy.mockRestore();
     });
 

--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -285,13 +285,13 @@ describe('[API v3] Components', () => {
   describe('keyboardShouldPersistTaps="never" drop', () => {
     // The keyboard-visibility tracker subscribes via Keyboard.addListener when a
     // ScrollView mounts. We spy on it to grab the captured `keyboardDidShow`
-    // handler and invoke it, simulating the soft keyboard being open.
-    const showSoftKeyboard = (addListenerSpy: jest.SpyInstance) => {
+    // handler and invoke it, simulating the keyboard being open.
+    const showKeyboard = (addListenerSpy: jest.SpyInstance, height = 300) => {
       const showCall = addListenerSpy.mock.calls.find(
         (call) => call[0] === 'keyboardDidShow'
       );
       act(() => {
-        showCall?.[1]?.({ endCoordinates: { height: 300 } });
+        showCall?.[1]?.({ endCoordinates: { height } });
       });
     };
 
@@ -311,7 +311,7 @@ describe('[API v3] Components', () => {
         ]);
       });
 
-    test('isKeyboardDismissingTap is true only in never mode while the soft keyboard is visible', async () => {
+    test('isKeyboardDismissingTap is true only in never mode while the keyboard is visible', async () => {
       const addListenerSpy = jest.spyOn(Keyboard, 'addListener');
 
       render(
@@ -324,7 +324,7 @@ describe('[API v3] Components', () => {
       // Keyboard not shown yet -> nothing to dismiss.
       expect(isKeyboardDismissingTap(makeContext('never'))).toBe(false);
 
-      showSoftKeyboard(addListenerSpy);
+      showKeyboard(addListenerSpy);
 
       // `never` (and its default, undefined) drops the tap; the others never do.
       expect(isKeyboardDismissingTap(makeContext('never'))).toBe(true);
@@ -333,6 +333,24 @@ describe('[API v3] Components', () => {
       expect(isKeyboardDismissingTap(makeContext('always'))).toBe(false);
       // Outside an RNGH ScrollView there is no context, so nothing is dropped.
       expect(isKeyboardDismissingTap(null)).toBe(false);
+
+      addListenerSpy.mockRestore();
+    });
+
+    test('isKeyboardDismissingTap is false for a detached (height 0) keyboard', async () => {
+      const addListenerSpy = jest.spyOn(Keyboard, 'addListener');
+
+      render(
+        <GestureHandlerRootView>
+          <ScrollView keyboardShouldPersistTaps="never" />
+        </GestureHandlerRootView>
+      );
+      await act(flushImmediate);
+
+      // A detached/floating keyboard reports height 0 - nothing to dismiss.
+      showKeyboard(addListenerSpy, 0);
+
+      expect(isKeyboardDismissingTap(makeContext('never'))).toBe(false);
 
       addListenerSpy.mockRestore();
     });
@@ -356,7 +374,7 @@ describe('[API v3] Components', () => {
         </GestureHandlerRootView>
       );
       await act(flushImmediate);
-      showSoftKeyboard(addListenerSpy);
+      showKeyboard(addListenerSpy);
 
       // Includes a move (second ACTIVE) so the onUpdate path is exercised too.
       act(() => {
@@ -407,7 +425,7 @@ describe('[API v3] Components', () => {
           </GestureHandlerRootView>
         );
         await act(flushImmediate);
-        showSoftKeyboard(addListenerSpy);
+        showKeyboard(addListenerSpy);
 
         fireTap('touchable');
 

--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -1,11 +1,15 @@
 import { render, renderHook } from '@testing-library/react-native';
 import { act } from 'react';
-import { View } from 'react-native';
+import { Keyboard, View } from 'react-native';
 
 import GestureHandlerRootView from '../components/GestureHandlerRootView';
 import { fireGestureHandler, getByGestureTestId } from '../jestUtils';
 import { State } from '../State';
 import { Pressable, RectButton, ScrollView, Touchable } from '../v3/components';
+import {
+  isKeyboardDismissingTap,
+  type JSResponderContextValue,
+} from '../v3/components/ScrollViewResponderInterceptor';
 import { GestureDetector } from '../v3/detectors';
 import { useSimultaneousGestures } from '../v3/hooks';
 import { usePanGesture, useTapGesture } from '../v3/hooks/gestures';
@@ -276,6 +280,122 @@ describe('[API v3] Components', () => {
         false
       );
     });
+  });
+
+  describe('keyboardShouldPersistTaps="never" drop', () => {
+    // The keyboard-visibility tracker subscribes via Keyboard.addListener when a
+    // ScrollView mounts. We spy on it to grab the captured `keyboardDidShow`
+    // handler and invoke it, simulating the soft keyboard being open.
+    const showSoftKeyboard = (addListenerSpy: jest.SpyInstance) => {
+      const showCall = addListenerSpy.mock.calls.find(
+        (call) => call[0] === 'keyboardDidShow'
+      );
+      act(() => {
+        showCall?.[1]?.({ endCoordinates: { height: 300 } });
+      });
+    };
+
+    const makeContext = (
+      keyboardShouldPersistTaps: JSResponderContextValue['keyboardShouldPersistTaps']
+    ): JSResponderContextValue => ({
+      isRNGHResponderEvent: { current: false },
+      keyboardShouldPersistTaps,
+    });
+
+    const fireTap = (testID: string) =>
+      act(() => {
+        fireGestureHandler(getByGestureTestId(testID), [
+          { state: State.BEGAN },
+          { state: State.ACTIVE },
+          { state: State.END },
+        ]);
+      });
+
+    test('isKeyboardDismissingTap is true only in never mode while the soft keyboard is visible', async () => {
+      const addListenerSpy = jest.spyOn(Keyboard, 'addListener');
+
+      render(
+        <GestureHandlerRootView>
+          <ScrollView keyboardShouldPersistTaps="never" />
+        </GestureHandlerRootView>
+      );
+      await act(flushImmediate);
+
+      // Keyboard not shown yet -> nothing to dismiss.
+      expect(isKeyboardDismissingTap(makeContext('never'))).toBe(false);
+
+      showSoftKeyboard(addListenerSpy);
+
+      // `never` (and its default, undefined) drops the tap; the others never do.
+      expect(isKeyboardDismissingTap(makeContext('never'))).toBe(true);
+      expect(isKeyboardDismissingTap(makeContext(undefined))).toBe(true);
+      expect(isKeyboardDismissingTap(makeContext('handled'))).toBe(false);
+      expect(isKeyboardDismissingTap(makeContext('always'))).toBe(false);
+      // Outside an RNGH ScrollView there is no context, so nothing is dropped.
+      expect(isKeyboardDismissingTap(null)).toBe(false);
+
+      addListenerSpy.mockRestore();
+    });
+
+    test('Touchable does NOT fire onPress on the keyboard-dismissing tap (never)', async () => {
+      const addListenerSpy = jest.spyOn(Keyboard, 'addListener');
+      const onPress = jest.fn();
+
+      render(
+        <GestureHandlerRootView>
+          <ScrollView keyboardShouldPersistTaps="never">
+            <Touchable testID="touchable" onPress={onPress} />
+          </ScrollView>
+        </GestureHandlerRootView>
+      );
+      await act(flushImmediate);
+      showSoftKeyboard(addListenerSpy);
+
+      fireTap('touchable');
+
+      expect(onPress).not.toHaveBeenCalled();
+      addListenerSpy.mockRestore();
+    });
+
+    test('Touchable fires onPress in never mode when the keyboard is not visible', async () => {
+      const onPress = jest.fn();
+
+      render(
+        <GestureHandlerRootView>
+          <ScrollView keyboardShouldPersistTaps="never">
+            <Touchable testID="touchable" onPress={onPress} />
+          </ScrollView>
+        </GestureHandlerRootView>
+      );
+      await act(flushImmediate);
+
+      fireTap('touchable');
+
+      expect(onPress).toHaveBeenCalledTimes(1);
+    });
+
+    test.each(['handled', 'always'] as const)(
+      'Touchable fires onPress in %s mode even while the keyboard is visible',
+      async (mode) => {
+        const addListenerSpy = jest.spyOn(Keyboard, 'addListener');
+        const onPress = jest.fn();
+
+        render(
+          <GestureHandlerRootView>
+            <ScrollView keyboardShouldPersistTaps={mode}>
+              <Touchable testID="touchable" onPress={onPress} />
+            </ScrollView>
+          </GestureHandlerRootView>
+        );
+        await act(flushImmediate);
+        showSoftKeyboard(addListenerSpy);
+
+        fireTap('touchable');
+
+        expect(onPress).toHaveBeenCalledTimes(1);
+        addListenerSpy.mockRestore();
+      }
+    );
   });
 
   describe('Touchable', () => {

--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -133,7 +133,7 @@ describe('[API v3] Components', () => {
 
   describe('ScrollView', () => {
     test('handles responder event passed through Pressable for keyboardShouldPersistTaps handled', async () => {
-      const { getByTestId, UNSAFE_getAllByType } = render(
+      const { UNSAFE_getAllByType } = render(
         <GestureHandlerRootView>
           <ScrollView keyboardShouldPersistTaps="handled">
             <Pressable testID="pressable" />
@@ -143,14 +143,14 @@ describe('[API v3] Components', () => {
 
       await act(flushImmediate);
 
-      const pressable = getByTestId('pressable');
+      const nativeDetector = getNativeDetector(UNSAFE_getAllByType);
       const scrollViewResponder = getScrollViewResponder(UNSAFE_getAllByType);
 
       expect(scrollViewResponder).toBeDefined();
       expect(
         scrollViewResponder?.props.onStartShouldSetResponderCapture()
       ).toBe(false);
-      expect(pressable.props.onStartShouldSetResponder()).toBe(false);
+      expect(nativeDetector?.props.onStartShouldSetResponder()).toBe(false);
       expect(scrollViewResponder?.props.onStartShouldSetResponder()).toBe(true);
       expect(scrollViewResponder?.props.onStartShouldSetResponder()).toBe(
         false
@@ -158,7 +158,7 @@ describe('[API v3] Components', () => {
     });
 
     test('does not handle responder event passed through Pressable without keyboardShouldPersistTaps handled', async () => {
-      const { getByTestId, UNSAFE_getAllByType } = render(
+      const { UNSAFE_getAllByType } = render(
         <GestureHandlerRootView>
           <ScrollView>
             <Pressable testID="pressable" />
@@ -168,14 +168,14 @@ describe('[API v3] Components', () => {
 
       await act(flushImmediate);
 
-      const pressable = getByTestId('pressable');
+      const nativeDetector = getNativeDetector(UNSAFE_getAllByType);
       const scrollViewResponder = getScrollViewResponder(UNSAFE_getAllByType);
 
       expect(scrollViewResponder).toBeDefined();
       expect(
         scrollViewResponder?.props.onStartShouldSetResponderCapture()
       ).toBe(false);
-      expect(pressable.props.onStartShouldSetResponder()).toBe(false);
+      expect(nativeDetector?.props.onStartShouldSetResponder()).toBe(false);
       expect(scrollViewResponder?.props.onStartShouldSetResponder()).toBe(
         false
       );

--- a/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
@@ -45,8 +45,8 @@ import {
 } from '../hooks';
 import { PureNativeButton } from './GestureButtons';
 import {
+  isKeyboardDismissingTap,
   JSResponderContext,
-  updateResponderEventValue,
 } from './ScrollViewResponderInterceptor';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;
@@ -91,6 +91,11 @@ const Pressable = (props: PressableProps) => {
     width: 0,
     height: 0,
   });
+
+  // When the touch that begins a press is the one dismissing the keyboard
+  // (keyboardShouldPersistTaps="never"), the press is swallowed to match RN's
+  // touchables.
+  const dropKeyboardTapRef = useRef<boolean | null>(null);
 
   const normalizedHitSlop: Insets = useMemo(
     () =>
@@ -153,10 +158,15 @@ const Pressable = (props: PressableProps) => {
 
   const handleFinalize = useCallback(() => {
     isCurrentlyPressed.current = false;
+    dropKeyboardTapRef.current = null;
     cancelLongPress();
     cancelDelayedPress();
     setPressedState(false);
   }, [cancelDelayedPress, cancelLongPress]);
+
+  const captureKeyboardDismiss = useCallback(() => {
+    dropKeyboardTapRef.current ??= isKeyboardDismissingTap(jsResponderContext);
+  }, [jsResponderContext]);
 
   const handlePressIn = useCallback(
     (event: PressableEvent, skipBoundsCheck = false) => {
@@ -265,6 +275,12 @@ const Pressable = (props: PressableProps) => {
     maxDistance: INT32_MAX, // Stops long press from cancelling on touch move
     cancelsTouchesInView: false,
     onTouchesDown: (event) => {
+      captureKeyboardDismiss();
+
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
       const pressableEvent = gestureTouchToPressableEvent(event);
       stateMachine.handleEvent(
         StateMachineEvent.LONG_PRESS_TOUCHES_DOWN,
@@ -314,6 +330,12 @@ const Pressable = (props: PressableProps) => {
       }
     },
     onBegin: () => {
+      captureKeyboardDismiss();
+
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
       if (Platform.isTV) {
         // tvOS drives this native gesture from the focus-engine Select press.
         // The press state machine is touch-based and never
@@ -398,23 +420,11 @@ const Pressable = (props: PressableProps) => {
     [onLayout]
   );
 
-  // Let RN components higher in the tree handle JS responder negotiation.
-  // RNGH ScrollView uses this marker to preserve keyboardShouldPersistTaps='handled'
-  // when there are no RN responder components between it and this Pressable.
-  const handleStartShouldSetResponder = useCallback(() => {
-    if (!disabled) {
-      updateResponderEventValue(jsResponderContext, true);
-    }
-
-    return false;
-  }, [disabled, jsResponderContext]);
-
   const tvProps = getTVProps(remainingProps);
 
   return (
     <GestureDetector gesture={gesture}>
       <PureNativeButton
-        onStartShouldSetResponder={handleStartShouldSetResponder}
         {...remainingProps}
         {...tvProps}
         onLayout={setDimensions}

--- a/packages/react-native-gesture-handler/src/v3/components/ScrollViewResponderInterceptor.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/ScrollViewResponderInterceptor.tsx
@@ -1,10 +1,58 @@
 import type { PropsWithChildren } from 'react';
-import React, { useCallback, useMemo, useRef } from 'react';
-import type { ScrollViewProps as RNScrollViewProps } from 'react-native';
-import { StyleSheet, View } from 'react-native';
+import React, { useCallback, useEffect, useMemo, useRef } from 'react';
+import type {
+  EmitterSubscription,
+  ScrollViewProps as RNScrollViewProps,
+} from 'react-native';
+import { Keyboard, StyleSheet, View } from 'react-native';
+
+type KeyboardShouldPersistTaps = RNScrollViewProps['keyboardShouldPersistTaps'];
+
+// The listeners are shared by every mounted ScrollView, so attach/detach is
+// reference-counted: we subscribe on the first interceptor and tear down only
+// once the last one unmounts.
+let keyboardTrackerRefCount = 0;
+let keyboardTrackerSubscriptions: EmitterSubscription[] = [];
+let isSoftKeyboardVisible = false;
+
+function subscribeToKeyboardVisibility() {
+  keyboardTrackerRefCount++;
+
+  if (keyboardTrackerRefCount > 1 || Keyboard?.addListener == null) {
+    return;
+  }
+
+  const setVisible = () => {
+    isSoftKeyboardVisible = true;
+  };
+  const setHidden = () => {
+    isSoftKeyboardVisible = false;
+  };
+
+  keyboardTrackerSubscriptions = [
+    Keyboard.addListener('keyboardDidShow', setVisible),
+    Keyboard.addListener('keyboardWillShow', setVisible),
+    Keyboard.addListener('keyboardDidHide', setHidden),
+  ];
+}
+
+function unsubscribeFromKeyboardVisibility() {
+  keyboardTrackerRefCount--;
+
+  if (keyboardTrackerRefCount > 0) {
+    return;
+  }
+
+  for (const subscription of keyboardTrackerSubscriptions) {
+    subscription.remove();
+  }
+  keyboardTrackerSubscriptions = [];
+  isSoftKeyboardVisible = false;
+}
 
 export type JSResponderContextValue = {
   isRNGHResponderEvent: React.MutableRefObject<boolean>;
+  keyboardShouldPersistTaps: KeyboardShouldPersistTaps;
 };
 
 export const JSResponderContext =
@@ -21,6 +69,19 @@ export function updateResponderEventValue(
   }
 }
 
+export function isKeyboardDismissingTap(
+  jsResponderContext: JSResponderContextValue | null | undefined
+): boolean {
+  if (jsResponderContext == null) {
+    return false;
+  }
+
+  const mode = jsResponderContext.keyboardShouldPersistTaps;
+  const keyboardNeverPersistTaps = !mode || mode === 'never';
+
+  return keyboardNeverPersistTaps && isSoftKeyboardVisible;
+}
+
 type ScrollViewResponderInterceptorProps = PropsWithChildren<{
   keyboardShouldPersistTaps?: RNScrollViewProps['keyboardShouldPersistTaps'];
 }>;
@@ -31,9 +92,14 @@ const ScrollViewResponderInterceptor = ({
 }: ScrollViewResponderInterceptorProps) => {
   const isRNGHResponderEvent = useRef(false);
   const contextValue = useMemo(
-    () => ({ isRNGHResponderEvent }),
-    [isRNGHResponderEvent]
+    () => ({ isRNGHResponderEvent, keyboardShouldPersistTaps }),
+    [isRNGHResponderEvent, keyboardShouldPersistTaps]
   );
+
+  useEffect(() => {
+    subscribeToKeyboardVisibility();
+    return () => unsubscribeFromKeyboardVisibility();
+  }, []);
 
   const resetRNGHResponderEvent = useCallback(() => {
     isRNGHResponderEvent.current = false;

--- a/packages/react-native-gesture-handler/src/v3/components/ScrollViewResponderInterceptor.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/ScrollViewResponderInterceptor.tsx
@@ -2,6 +2,7 @@ import type { PropsWithChildren } from 'react';
 import React, { useCallback, useEffect, useMemo, useRef } from 'react';
 import type {
   EmitterSubscription,
+  KeyboardEvent,
   ScrollViewProps as RNScrollViewProps,
 } from 'react-native';
 import { Keyboard, StyleSheet, View } from 'react-native';
@@ -13,7 +14,11 @@ type KeyboardShouldPersistTaps = RNScrollViewProps['keyboardShouldPersistTaps'];
 // once the last one unmounts.
 let keyboardTrackerRefCount = 0;
 let keyboardTrackerSubscriptions: EmitterSubscription[] = [];
-let isSoftKeyboardVisible = false;
+let isKeyboardVisible = false;
+
+function keyboardIsOpen(height: number | undefined): boolean {
+  return height != null && height > 0;
+}
 
 function subscribeToKeyboardVisibility() {
   keyboardTrackerRefCount++;
@@ -22,12 +27,16 @@ function subscribeToKeyboardVisibility() {
     return;
   }
 
-  const setVisible = () => {
-    isSoftKeyboardVisible = true;
+  const setVisible = (event: KeyboardEvent) => {
+    isKeyboardVisible = keyboardIsOpen(event.endCoordinates?.height);
   };
   const setHidden = () => {
-    isSoftKeyboardVisible = false;
+    isKeyboardVisible = false;
   };
+
+  // Seed from the current keyboard metrics in case it is already open when the
+  // first ScrollView mounts (mirrors ScrollView seeding from Keyboard.metrics()).
+  isKeyboardVisible = keyboardIsOpen(Keyboard.metrics?.()?.height);
 
   keyboardTrackerSubscriptions = [
     Keyboard.addListener('keyboardDidShow', setVisible),
@@ -47,7 +56,7 @@ function unsubscribeFromKeyboardVisibility() {
     subscription.remove();
   }
   keyboardTrackerSubscriptions = [];
-  isSoftKeyboardVisible = false;
+  isKeyboardVisible = false;
 }
 
 export type JSResponderContextValue = {
@@ -79,7 +88,7 @@ export function isKeyboardDismissingTap(
   const mode = jsResponderContext.keyboardShouldPersistTaps;
   const keyboardNeverPersistTaps = !mode || mode === 'never';
 
-  return keyboardNeverPersistTaps && isSoftKeyboardVisible;
+  return keyboardNeverPersistTaps && isKeyboardVisible;
 }
 
 type ScrollViewResponderInterceptorProps = PropsWithChildren<{

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -1,10 +1,14 @@
-import React, { useCallback, useRef } from 'react';
+import React, { use, useCallback, useRef } from 'react';
 import { Platform } from 'react-native';
 
 import GestureHandlerButton from '../../../components/GestureHandlerButton';
 import { getTVProps } from '../../../components/utils';
 import { NativeDetector } from '../../detectors/NativeDetector';
 import { useNativeGesture } from '../../hooks';
+import {
+  isKeyboardDismissingTap,
+  JSResponderContext,
+} from '../ScrollViewResponderInterceptor';
 import type {
   AnimationDuration,
   CallbackEventType,
@@ -101,6 +105,19 @@ export const Touchable = (props: TouchableProps) => {
     undefined
   );
 
+  // Swallow the tap that dismisses the keyboard in
+  // keyboardShouldPersistTaps="never", matching RN's touchables.
+  const jsResponderContext = use(JSResponderContext);
+  const dropKeyboardTapRef = useRef<boolean | null>(null);
+
+  const captureKeyboardDismiss = useCallback(() => {
+    dropKeyboardTapRef.current ??= isKeyboardDismissingTap(jsResponderContext);
+  }, [jsResponderContext]);
+
+  const resetKeyboardDismiss = useCallback(() => {
+    dropKeyboardTapRef.current = null;
+  }, []);
+
   const wrappedLongPress = useCallback(() => {
     longPressDetected.current = true;
     onLongPress?.();
@@ -119,7 +136,9 @@ export const Touchable = (props: TouchableProps) => {
 
   const onBegin = useCallback(
     (e: CallbackEventType) => {
-      if (!e.pointerInside) {
+      captureKeyboardDismiss();
+
+      if (!e.pointerInside || dropKeyboardTapRef.current) {
         pointerState.current = PointerState.OUTSIDE;
         return;
       }
@@ -129,7 +148,7 @@ export const Touchable = (props: TouchableProps) => {
 
       pointerState.current = PointerState.INSIDE;
     },
-    [startLongPressTimer, onPressIn]
+    [captureKeyboardDismiss, startLongPressTimer, onPressIn]
   );
 
   const onActivate = useCallback((e: CallbackEventType) => {
@@ -141,11 +160,19 @@ export const Touchable = (props: TouchableProps) => {
 
   const onFinalize = useCallback(
     (e: EndCallbackEventType) => {
-      if (pointerState.current === PointerState.INSIDE) {
+      if (
+        !dropKeyboardTapRef.current &&
+        pointerState.current === PointerState.INSIDE
+      ) {
         onPressOut?.(e);
       }
 
-      if (!e.canceled && !longPressDetected.current && e.pointerInside) {
+      if (
+        !dropKeyboardTapRef.current &&
+        !e.canceled &&
+        !longPressDetected.current &&
+        e.pointerInside
+      ) {
         onPress?.(e);
       }
 
@@ -155,8 +182,10 @@ export const Touchable = (props: TouchableProps) => {
         clearTimeout(longPressTimeout.current);
         longPressTimeout.current = undefined;
       }
+
+      resetKeyboardDismiss();
     },
-    [onPressOut, onPress]
+    [resetKeyboardDismiss, onPressOut, onPress]
   );
 
   const onUpdate = useCallback(

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -190,6 +190,10 @@ export const Touchable = (props: TouchableProps) => {
 
   const onUpdate = useCallback(
     (e: CallbackEventType) => {
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
       if (pointerState.current === PointerState.UNKNOWN) {
         return;
       }


### PR DESCRIPTION
## Description

Currently, when buttons are inside `ScrolView` with `keyboardShouldPersistTaps={never}` they still call `onPress` even though press was meant to dismiss keyboard.

This PR fixes that behavior. It attaches listeners for keyboard state and based on that it blocks `onPress*` callbacks on JS side.

Fixes #992

## Test plan

Tested on Keyboard Should Persist Taps example