### PR TITLE
Remove obsolete version checks

### DIFF
--- a/packages/react-native-gesture-handler/RNGestureHandler.podspec
+++ b/packages/react-native-gesture-handler/RNGestureHandler.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   s.source       = { :git => "https://github.com/software-mansion/react-native-gesture-handler", :tag => "#{s.version}" }
   s.source_files = "apple/**/*.{h,m,mm}", "shared/**/*.{h,cpp}"
   s.requires_arc = true
-  s.platforms       = { ios: '11.0', tvos: '11.0', osx: '10.15', visionos: '1.0' }
+  s.platforms       = { ios: '15.1', tvos: '15.1', osx: '14.0', visionos: '1.0' }
   s.xcconfig = {
     "OTHER_CFLAGS" => "$(inherited) #{compilation_metadata_generation_flag} #{version_flag}"
   }

--- a/packages/react-native-gesture-handler/apple/Handlers/RNForceTouchHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNForceTouchHandler.m
@@ -89,9 +89,7 @@ static const BOOL defaultFeedbackOnActivation = NO;
 {
 #if !TARGET_OS_TV && !TARGET_OS_VISION
   if (_feedbackOnActivation) {
-    if (@available(iOS 10.0, *)) {
-      [[[UIImpactFeedbackGenerator alloc] initWithStyle:(UIImpactFeedbackStyleMedium)] impactOccurred];
-    }
+    [[[UIImpactFeedbackGenerator alloc] initWithStyle:(UIImpactFeedbackStyleMedium)] impactOccurred];
   }
 #endif
 }

--- a/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.h
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.h
@@ -7,6 +7,5 @@
 
 #import "RNGestureHandler.h"
 
-API_AVAILABLE(ios(13.4))
 @interface RNHoverGestureHandler : RNGestureHandler
 @end

--- a/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
@@ -13,19 +13,14 @@
 #import <React/RCTConvert.h>
 #import <UIKit/UIGestureRecognizerSubclass.h>
 
-#define CHECK_TARGET(__VERSION__)                                                \
-  defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && defined(__IPHONE_##__VERSION__) && \
-      __IPHONE_OS_VERSION_MAX_ALLOWED >= __IPHONE_##__VERSION__ && !TARGET_OS_TV
-
 typedef NS_ENUM(NSInteger, RNGestureHandlerHoverEffect) {
   RNGestureHandlerHoverEffectNone = 0,
   RNGestureHandlerHoverEffectLift,
   RNGestureHandlerHoverEffectHightlight,
 };
 
-#if CHECK_TARGET(13_4)
+#if !TARGET_OS_TV
 
-API_AVAILABLE(ios(13.4))
 @interface RNBetterHoverGestureRecognizer : UIHoverGestureRecognizer <UIPointerInteractionDelegate>
 
 - (id)initWithGestureHandler:(RNGestureHandler *)gestureHandler;
@@ -85,7 +80,7 @@ API_AVAILABLE(ios(13.4))
 #endif
 
 @implementation RNHoverGestureHandler {
-#if CHECK_TARGET(13_4)
+#if !TARGET_OS_TV
   UIPointerInteraction *_pointerInteraction;
 #endif
 }
@@ -97,12 +92,9 @@ API_AVAILABLE(ios(13.4))
 #endif
 
   if ((self = [super initWithTag:tag])) {
-#if CHECK_TARGET(13_4)
-    if (@available(iOS 13.4, *)) {
-      _recognizer = [[RNBetterHoverGestureRecognizer alloc] initWithGestureHandler:self];
-      _pointerInteraction =
-          [[UIPointerInteraction alloc] initWithDelegate:(id<UIPointerInteractionDelegate>)_recognizer];
-    }
+#if !TARGET_OS_TV
+    _recognizer = [[RNBetterHoverGestureRecognizer alloc] initWithGestureHandler:self];
+    _pointerInteraction = [[UIPointerInteraction alloc] initWithDelegate:(id<UIPointerInteractionDelegate>)_recognizer];
 #endif
   }
   return self;
@@ -110,21 +102,17 @@ API_AVAILABLE(ios(13.4))
 
 - (void)bindToView:(UIView *)view
 {
-#if CHECK_TARGET(13_4)
-  if (@available(iOS 13.4, *)) {
-    [super bindToView:view];
-    [view addInteraction:_pointerInteraction];
-  }
+#if !TARGET_OS_TV
+  [super bindToView:view];
+  [view addInteraction:_pointerInteraction];
 #endif
 }
 
 - (void)unbindFromView
 {
-#if CHECK_TARGET(13_4)
-  if (@available(iOS 13.4, *)) {
-    [super unbindFromView];
-    [self.recognizer.view removeInteraction:_pointerInteraction];
-  }
+#if !TARGET_OS_TV
+  [super unbindFromView];
+  [self.recognizer.view removeInteraction:_pointerInteraction];
 #endif
 }
 
@@ -132,11 +120,9 @@ API_AVAILABLE(ios(13.4))
 {
   [super resetConfig];
 
-#if CHECK_TARGET(13_4)
-  if (@available(iOS 13.4, *)) {
-    RNBetterHoverGestureRecognizer *recognizer = (RNBetterHoverGestureRecognizer *)_recognizer;
-    recognizer.hoverEffect = RNGestureHandlerHoverEffectNone;
-  }
+#if !TARGET_OS_TV
+  RNBetterHoverGestureRecognizer *recognizer = (RNBetterHoverGestureRecognizer *)_recognizer;
+  recognizer.hoverEffect = RNGestureHandlerHoverEffectNone;
 #endif
 }
 
@@ -144,11 +130,9 @@ API_AVAILABLE(ios(13.4))
 {
   [super updateConfig:config];
 
-#if CHECK_TARGET(13_4)
-  if (@available(iOS 13.4, *)) {
-    RNBetterHoverGestureRecognizer *recognizer = (RNBetterHoverGestureRecognizer *)_recognizer;
-    APPLY_INT_PROP(hoverEffect);
-  }
+#if !TARGET_OS_TV
+  RNBetterHoverGestureRecognizer *recognizer = (RNBetterHoverGestureRecognizer *)_recognizer;
+  APPLY_INT_PROP(hoverEffect);
 #endif
 }
 
@@ -156,7 +140,7 @@ API_AVAILABLE(ios(13.4))
 {
   _pointerType = pointerType;
 
-#if CHECK_TARGET(16_1)
+#if !TARGET_OS_TV
   if (@available(iOS 16.1, *)) {
     if (((UIHoverGestureRecognizer *)self.recognizer).zOffset > 0.0) {
       _pointerType = RNGestureHandlerStylus;

--- a/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
@@ -380,7 +380,6 @@
   recognizer.activeOffsetYStart = NAN;
   recognizer.activeOffsetYEnd = NAN;
   recognizer.failOffsetYStart = NAN;
-  recognizer.failOffsetYStart = NAN;
   recognizer.failOffsetYEnd = NAN;
 #if !TARGET_OS_OSX && !TARGET_OS_TV
   recognizer.allowedScrollTypesMask = 0;

--- a/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
@@ -382,12 +382,8 @@
   recognizer.failOffsetYStart = NAN;
   recognizer.failOffsetYStart = NAN;
   recognizer.failOffsetYEnd = NAN;
-#if !TARGET_OS_OSX && !TARGET_OS_TV && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
-  if (@available(iOS 13.4, *)) {
-    recognizer.allowedScrollTypesMask = 0;
-  }
-#endif
 #if !TARGET_OS_OSX && !TARGET_OS_TV
+  recognizer.allowedScrollTypesMask = 0;
   recognizer.minimumNumberOfTouches = 1;
   recognizer.maximumNumberOfTouches = NSUIntegerMax;
 #endif
@@ -412,12 +408,10 @@
   APPLY_FLOAT_PROP(failOffsetYStart);
   APPLY_FLOAT_PROP(failOffsetYEnd);
 
-#if !TARGET_OS_OSX && !TARGET_OS_TV && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
-  if (@available(iOS 13.4, *)) {
-    bool enableTrackpadTwoFingerGesture = [RCTConvert BOOL:config[@"enableTrackpadTwoFingerGesture"]];
-    if (enableTrackpadTwoFingerGesture) {
-      recognizer.allowedScrollTypesMask = UIScrollTypeMaskAll;
-    }
+#if !TARGET_OS_OSX && !TARGET_OS_TV
+  bool enableTrackpadTwoFingerGesture = [RCTConvert BOOL:config[@"enableTrackpadTwoFingerGesture"]];
+  if (enableTrackpadTwoFingerGesture) {
+    recognizer.allowedScrollTypesMask = UIScrollTypeMaskAll;
   }
 
   APPLY_NAMED_INT_PROP(minimumNumberOfTouches, @"minPointers");

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -107,11 +107,9 @@
       forControlEvents:UIControlEventTouchUpInside | UIControlEventTouchUpOutside | UIControlEventTouchDragExit |
       UIControlEventTouchCancel];
 
-  if (@available(iOS 13.4, *)) {
-    UIHoverGestureRecognizer *hoverRecognizer =
-        [[UIHoverGestureRecognizer alloc] initWithTarget:self action:@selector(handleHover:)];
-    [self addGestureRecognizer:hoverRecognizer];
-  }
+  UIHoverGestureRecognizer *hoverRecognizer = [[UIHoverGestureRecognizer alloc] initWithTarget:self
+                                                                                        action:@selector(handleHover:)];
+  [self addGestureRecognizer:hoverRecognizer];
 #endif
 }
 
@@ -394,10 +392,7 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   NSInteger maxFps = screen.maximumFramesPerSecond;
 #else
   NSScreen *screen = self.window.screen ?: NSScreen.mainScreen;
-  NSInteger maxFps = 60;
-  if (@available(macOS 12.0, *)) {
-    maxFps = screen.maximumFramesPerSecond;
-  }
+  NSInteger maxFps = screen.maximumFramesPerSecond;
 #endif
   return maxFps > 0 ? 1000.0 / (NSTimeInterval)maxFps : 1000.0 / 60.0;
 }
@@ -578,7 +573,7 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 }
 
 #if !TARGET_OS_OSX
-- (void)handleHover:(UIHoverGestureRecognizer *)recognizer API_AVAILABLE(ios(13.4))
+- (void)handleHover:(UIHoverGestureRecognizer *)recognizer
 {
   switch (recognizer.state) {
     case UIGestureRecognizerStateBegan:
@@ -980,12 +975,7 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 // hovers.
 - (BOOL)isHoveringTouch:(UITouch *)touch
 {
-  if (@available(iOS 13.4, *)) {
-    if (touch.type == UITouchTypeIndirectPointer) {
-      return YES;
-    }
-  }
-  return touch.type == UITouchTypePencil;
+  return touch.type == UITouchTypeIndirectPointer ? YES : touch.type == UITouchTypePencil;
 }
 
 // Mirrors `sendActionsForControlEvents:` but preserves the real `UIEvent`

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButtonComponentView.mm
@@ -281,21 +281,17 @@ static RNGestureHandlerPointerEvents RCTPointerEventsToEnum(facebook::react::Poi
 
   if (!oldProps ||
       oldButtonProps.accessibilityShowsLargeContentViewer != newButtonProps.accessibilityShowsLargeContentViewer) {
-    if (@available(iOS 13.0, *)) {
-      if (newButtonProps.accessibilityShowsLargeContentViewer) {
-        _buttonView.showsLargeContentViewer = YES;
-        UILargeContentViewerInteraction *interaction = [[UILargeContentViewerInteraction alloc] init];
-        [_buttonView addInteraction:interaction];
-      } else {
-        _buttonView.showsLargeContentViewer = NO;
-      }
+    if (newButtonProps.accessibilityShowsLargeContentViewer) {
+      _buttonView.showsLargeContentViewer = YES;
+      UILargeContentViewerInteraction *interaction = [[UILargeContentViewerInteraction alloc] init];
+      [_buttonView addInteraction:interaction];
+    } else {
+      _buttonView.showsLargeContentViewer = NO;
     }
   }
 
   if (!oldProps || oldButtonProps.accessibilityLargeContentTitle != newButtonProps.accessibilityLargeContentTitle) {
-    if (@available(iOS 13.0, *)) {
-      _buttonView.largeContentTitle = RCTNSStringFromStringNilIfEmpty(newButtonProps.accessibilityLargeContentTitle);
-    }
+    _buttonView.largeContentTitle = RCTNSStringFromStringNilIfEmpty(newButtonProps.accessibilityLargeContentTitle);
   }
 
   if (!oldProps || oldButtonProps.accessibilityTraits != newButtonProps.accessibilityTraits) {


### PR DESCRIPTION
## Description

This PR removes obsolete version checks from our `iOS` codebase.

Minimal targets for iOS and macOS were chosen based on supported versions. tvOS was changed to match iOS

## Test plan

Checked that example apps (basic and macos) are built correctly,
