### PR TITLE
[Android] Remove old versions checks

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -5,7 +5,6 @@ import android.animation.AnimatorSet
 import android.animation.ObjectAnimator
 import android.animation.ValueAnimator
 import android.annotation.SuppressLint
-import android.annotation.TargetApi
 import android.content.Context
 import android.content.res.ColorStateList
 import android.graphics.Canvas
@@ -63,7 +62,6 @@ class RNGestureHandlerButtonViewManager :
 
   public override fun createViewInstance(context: ThemedReactContext) = ButtonViewGroup(context)
 
-  @TargetApi(Build.VERSION_CODES.M)
   @ReactProp(name = "foreground")
   override fun setForeground(view: ButtonViewGroup, useDrawableOnForeground: Boolean) {
     view.useDrawableOnForeground = useDrawableOnForeground
@@ -681,10 +679,7 @@ class RNGestureHandlerButtonViewManager :
         return
       }
       needBackgroundUpdate = false
-
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-        foreground = null
-      }
+      foreground = null
 
       val selectable = createSelectableDrawable()
       val underlay = createUnderlayDrawable()
@@ -692,7 +687,7 @@ class RNGestureHandlerButtonViewManager :
       // Set this view as callback so ObjectAnimator alpha changes trigger redraws.
       underlay.callback = this
 
-      if (useDrawableOnForeground && selectable != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      if (useDrawableOnForeground && selectable != null) {
         // Explicit foreground mode — View natively forwards state/hotspot.
         foreground = selectable
         selectableDrawable = null
@@ -777,7 +772,7 @@ class RNGestureHandlerButtonViewManager :
         if (useBorderlessDrawable) null else ShapeDrawable(RectShape()),
       )
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && rippleRadius != null) {
+      if (rippleRadius != null) {
         drawable.radius = PixelUtil.toPixelFromDIP(rippleRadius.toFloat()).toInt()
       }
 


### PR DESCRIPTION
## Description

This PR removes old version checks in Button. `M` resolves to `23`, while in React Native current minimum is 24 ([see here](https://github.com/react/react-native/blob/ce72288bfc7d306040d7d1c291f78573ae83d7a0/packages/react-native/gradle/libs.versions.toml#L3))

## Test plan

Build expo-example

