### PR TITLE
fix: remove UIPointerInteraction from the view when unbinding the hover handler

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
@@ -122,8 +122,9 @@ API_AVAILABLE(ios(13.4))
 {
 #if CHECK_TARGET(13_4)
   if (@available(iOS 13.4, *)) {
-    [super unbindFromView];
+    // Remove the interaction before [super unbindFromView] detaches the recognizer and nils recognizer.view.
     [self.recognizer.view removeInteraction:_pointerInteraction];
+    [super unbindFromView];
   }
 #endif
 }


### PR DESCRIPTION
## Description

Fixes #4290.

`RNHoverGestureHandler` adds a `UIPointerInteraction` to the view in `bindToView:`, but never actually removes it. In `unbindFromView`, `[super unbindFromView]` runs first and detaches the gesture recognizer, which sets `self.recognizer.view` to nil. The following `removeInteraction:` call is then a message to nil and does nothing, so the interaction stays on the `UIView` for the rest of its life.

With Fabric view recycling, that leaked interaction later belongs to an unrelated component. Its delegate (the recognizer) is gone by then, and a `UIPointerInteraction` without a delegate applies the system default pointer effect over the whole view. The visible result is native hover effects (very prominent with the Liquid Glass style on iPadOS 26) appearing on random elements that never had a hover gesture, accumulating as hover handlers unmount and remount.

This PR captures the view reference before calling `[super unbindFromView]` and removes the interaction from the captured reference.

## Test plan

Tested in an app that uses `Gesture.Hover()` on most of its toolbar and menu items, on a real iPad (iPadOS 26) with Apple Pencil hover and a trackpad:

- Before the change: after a few mount/unmount cycles of hover-enabled views, hovering over unrelated elements shows the native hover effect on random views.
- With the change (applied to the app as a package patch): the stray hover effects no longer appear, and hover gestures keep working as before.
- The `RNGestureHandler` pod compiles cleanly with the change.
