### PR TITLE
fix(android): guard null Handler in ButtonViewGroup press animations

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -707,7 +707,7 @@ class RNGestureHandlerButtonViewManager :
 
     private fun animatePressIn() {
       pendingPressOut?.let {
-        handler.removeCallbacks(it)
+        handler?.removeCallbacks(it)
         pendingPressOut = null
       }
       pressInTimestamp = SystemClock.uptimeMillis()
@@ -766,7 +766,7 @@ class RNGestureHandlerButtonViewManager :
       event.x >= 0 && event.y >= 0 && event.x < width && event.y < height
 
     private fun animatePressOut() {
-      pendingPressOut?.let { handler.removeCallbacks(it) }
+      pendingPressOut?.let { handler?.removeCallbacks(it) }
       val tapInMs = tapAnimationInDuration.toLong()
       val tapOutMs = tapAnimationOutDuration.toLong()
       val longPressMs = longPressDuration.toLong()
@@ -794,7 +794,7 @@ class RNGestureHandlerButtonViewManager :
         // The animator scales `remaining` by ANIMATOR_DURATION_SCALE internally,
         // so the press-in actually completes after `remaining * scale` ms. We need
         // to match that.
-        handler.postDelayed(runnable, (remaining * getAnimatorDurationScale()).toLong())
+        handler?.postDelayed(runnable, (remaining * getAnimatorDurationScale()).toLong())
       }
     }
 
@@ -911,7 +911,7 @@ class RNGestureHandlerButtonViewManager :
 
     override fun onDetachedFromWindow() {
       super.onDetachedFromWindow()
-      pendingPressOut?.let { handler.removeCallbacks(it) }
+      pendingPressOut?.let { handler?.removeCallbacks(it) }
       pendingPressOut = null
       cancelPendingHoverOut()
       currentAnimator?.cancel()

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -910,7 +910,6 @@ class RNGestureHandlerButtonViewManager :
     }
 
     override fun onDetachedFromWindow() {
-      super.onDetachedFromWindow()
       pendingPressOut?.let { handler?.removeCallbacks(it) }
       pendingPressOut = null
       cancelPendingHoverOut()
@@ -925,6 +924,8 @@ class RNGestureHandlerButtonViewManager :
       if (soundResponder === this) {
         soundResponder = null
       }
+
+      super.onDetachedFromWindow()
     }
 
     override fun onSizeChanged(w: Int, h: Int, oldw: Int, oldh: Int) {


### PR DESCRIPTION
## Description

On Android, `ButtonViewGroup` uses the view's Handler (via `View.getHandler()`) to schedule and cancel the delayed press-out animation. That getter returns null while the view is detached from the window, so when a cancel event is delivered to a button that has just been detached, `animatePressOut` crashes with a NullPointerException.

The crash path is: the orchestrator cancels the native handler, which dispatches a cancel event back to the button, which runs `setPressed(false)` → `animatePressOut()` and dereferences the now-null handler.

This guards the four handler accesses (in `animatePressIn`, `animatePressOut` and `onDetachedFromWindow`) with a null check. When the view is detached there is nothing meaningful to schedule or cancel and no visible animation to play, so skipping the call is the correct behavior; while attached the getter is non-null and behavior is unchanged.

Additionally, `onDetachedFromWindow` now runs its cleanup (cancelling `pendingPressOut`, resetting press/hover state) before calling `super.onDetachedFromWindow()`, so the pending runnable is removed while the view is still fully attached and the handler is guaranteed to be available (addresses the review note about reading the handler after `super` during detach).

Closes #4293

## Test plan

The crash is a detach/cancel race captured in production via Sentry, so it has no deterministic repro. The change only adds null-safety around `View.getHandler()`, which is null exactly while the view is detached:

- Attached (normal) case: the getter is non-null, so press-in and press-out animation scheduling behaves exactly as before.
- Detached case: the affected `removeCallbacks`/`postDelayed` calls are skipped instead of throwing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

