### PR TITLE
Fix Easing import in LongPress example

### DIFF
--- a/packages/docs-gesture-handler/static/examples/LongPressGestureBasic.js
+++ b/packages/docs-gesture-handler/static/examples/LongPressGestureBasic.js
@@ -4,8 +4,9 @@ import {
   GestureHandlerRootView,
   useLongPressGesture,
 } from 'react-native-gesture-handler';
-import { Easing, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import Animated, {
+  Easing,
   interpolateColor,
   useAnimatedStyle,
   useSharedValue,


### PR DESCRIPTION
## Description

`Easing` should be imported from `react-native-reanimated` instead of `react-native`. `Easing` from `react-native` is not a worklet like the one from `react-native-reanimated`. 

Using `Easing` from `react-native` here throws an error `[Worklets] Tried to synchronously call a Remote Function. Called "BezierEasing" on the UI Runtime`
