### PR TITLE
Preserve literal SingleGestureName in v3 gesture types

### DIFF
--- a/packages/react-native-gesture-handler/src/handlers/handlersRegistry.ts
+++ b/packages/react-native-gesture-handler/src/handlers/handlersRegistry.ts
@@ -1,4 +1,5 @@
 import { isTestEnv } from '../utils';
+import type { AnySingleGesture } from '../v3/hooks/gestures/singleGestureUnion';
 import type { SingleGesture } from '../v3/types';
 import type {
   GestureEvent,
@@ -8,10 +9,9 @@ import type { GestureType } from './gestures/gesture';
 
 export const handlerIDToTag: Record<string, number> = {};
 
-// There were attempts to create types that merge possible HandlerData and Config,
-// but ts was not able to infer them properly in many cases, so we use any here.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-const hookGestures = new Map<number, SingleGesture<any, any, any>>();
+// Stored as the discriminated union of concrete v3 gestures so lookups by
+// test ID can narrow on the `type` field.
+const hookGestures = new Map<number, AnySingleGesture>();
 const gestures = new Map<number, GestureType>();
 const oldHandlers = new Map<number, GestureHandlerCallbacks>();
 const testIDs = new Map<string, number>();
@@ -25,7 +25,9 @@ export function registerGesture<
   gesture: SingleGesture<TConfig, THandlerData, TExtendedHandlerData>
 ) {
   if (isTestEnv() && gesture.config.testID) {
-    hookGestures.set(handlerTag, gesture);
+    // The generic parameters cannot be correlated with the union members
+    // here, but every gesture created by the v3 hooks is a union member.
+    hookGestures.set(handlerTag, gesture as unknown as AnySingleGesture);
     testIDs.set(gesture.config.testID, handlerTag);
   }
 }

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/FlingTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/fling/FlingTypes.ts
@@ -3,6 +3,7 @@ import type {
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
+  SingleGestureName,
   WithSharedValue,
 } from '../../../types';
 
@@ -56,5 +57,7 @@ export type FlingGestureActiveEvent = FlingGestureEvent;
 
 export type FlingGesture = SingleGesture<
   FlingGestureProperties,
-  FlingHandlerData
+  FlingHandlerData,
+  FlingHandlerData,
+  SingleGestureName.Fling
 >;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/hover/HoverTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/hover/HoverTypes.ts
@@ -5,6 +5,7 @@ import type {
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
+  SingleGestureName,
   WithSharedValue,
 } from '../../../types';
 
@@ -72,5 +73,6 @@ export type HoverGestureActiveEvent = GestureEvent<HoverExtendedHandlerData>;
 export type HoverGesture = SingleGesture<
   HoverGestureInternalProperties,
   HoverHandlerData,
-  HoverExtendedHandlerData
+  HoverExtendedHandlerData,
+  SingleGestureName.Hover
 >;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/index.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/index.ts
@@ -124,17 +124,8 @@ export type {
   PanGestureEvent,
 };
 export { usePanGesture } from './pan/usePanGesture';
-
-export type SingleGesture =
-  | TapGesture
-  | FlingGesture
-  | LongPressGesture
-  | PinchGesture
-  | RotationGesture
-  | HoverGesture
-  | ManualGesture
-  | NativeGesture
-  | PanGesture;
+export type { AnySingleGesture } from './singleGestureUnion';
+export type { AnySingleGesture as SingleGesture } from './singleGestureUnion';
 
 /* eslint-disable @typescript-eslint/no-duplicate-type-constituents */
 export type SingleGestureEvent =

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/longPress/LongPressTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/longPress/LongPressTypes.ts
@@ -3,6 +3,7 @@ import type {
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
+  SingleGestureName,
   WithSharedValue,
 } from '../../../types';
 
@@ -68,5 +69,7 @@ export type LongPressGestureActiveEvent = LongPressGestureEvent;
 
 export type LongPressGesture = SingleGesture<
   LongPressGestureProperties,
-  LongPressHandlerData
+  LongPressHandlerData,
+  LongPressHandlerData,
+  SingleGestureName.LongPress
 >;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/longPress/useLongPressGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/longPress/useLongPressGesture.ts
@@ -39,8 +39,10 @@ export function useLongPressGesture(
     LongPressGestureInternalProperties
   >(config, LongPressPropsMapping, transformLongPressProps);
 
-  return useGesture<LongPressGestureInternalProperties, LongPressHandlerData>(
-    SingleGestureName.LongPress,
-    longPressConfig
-  );
+  return useGesture<
+    LongPressGestureInternalProperties,
+    LongPressHandlerData,
+    LongPressHandlerData,
+    SingleGestureName.LongPress
+  >(SingleGestureName.LongPress, longPressConfig);
 }

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/manual/ManualTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/manual/ManualTypes.ts
@@ -3,6 +3,7 @@ import type {
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
+  SingleGestureName,
 } from '../../../types';
 
 export type ManualGestureNativeProperties = Record<string, never>;
@@ -24,5 +25,7 @@ export type ManualGestureActiveEvent = ManualGestureEvent;
 
 export type ManualGesture = SingleGesture<
   ManualGestureProperties,
-  ManualHandlerData
+  ManualHandlerData,
+  ManualHandlerData,
+  SingleGestureName.Manual
 >;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
@@ -3,6 +3,7 @@ import type {
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
+  SingleGestureName,
   WithSharedValue,
 } from '../../../types';
 
@@ -58,5 +59,7 @@ export type NativeGestureActiveEvent = NativeGestureEvent;
 
 export type NativeGesture = SingleGesture<
   NativeGestureProperties,
-  NativeHandlerData
+  NativeHandlerData,
+  NativeHandlerData,
+  SingleGestureName.Native
 >;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/PanTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/PanTypes.ts
@@ -4,6 +4,7 @@ import type {
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
+  SingleGestureName,
   WithSharedValue,
 } from '../../../types';
 
@@ -170,5 +171,6 @@ export type PanGestureActiveEvent = GestureEvent<PanExtendedHandlerData>;
 export type PanGesture = SingleGesture<
   PanGestureInternalProperties,
   PanHandlerData,
-  PanExtendedHandlerData
+  PanExtendedHandlerData,
+  SingleGestureName.Pan
 >;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/usePanGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pan/usePanGesture.ts
@@ -158,6 +158,7 @@ export function usePanGesture(
   return useGesture<
     PanGestureInternalProperties,
     PanHandlerData,
-    PanExtendedHandlerData
+    PanExtendedHandlerData,
+    SingleGestureName.Pan
   >(SingleGestureName.Pan, panConfig);
 }

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/pinch/PinchTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/pinch/PinchTypes.ts
@@ -3,6 +3,7 @@ import type {
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
+  SingleGestureName,
 } from '../../../types';
 
 export type PinchGestureNativeProperties = Record<string, never>;
@@ -36,5 +37,6 @@ export type PinchGestureActiveEvent = GestureEvent<PinchExtendedHandlerData>;
 export type PinchGesture = SingleGesture<
   PinchGestureProperties,
   PinchHandlerData,
-  PinchExtendedHandlerData
+  PinchExtendedHandlerData,
+  SingleGestureName.Pinch
 >;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/rotation/RotationTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/rotation/RotationTypes.ts
@@ -3,6 +3,7 @@ import type {
   ExcludeInternalConfigProps,
   GestureEvent,
   SingleGesture,
+  SingleGestureName,
 } from '../../../types';
 
 export type RotationGestureNativeProperties = Record<string, never>;
@@ -37,5 +38,6 @@ export type RotationGestureActiveEvent =
 export type RotationGesture = SingleGesture<
   RotationGestureProperties,
   RotationHandlerData,
-  RotationExtendedHandlerData
+  RotationExtendedHandlerData,
+  SingleGestureName.Rotation
 >;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/singleGestureUnion.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/singleGestureUnion.ts
@@ -1,0 +1,20 @@
+import type { FlingGesture } from './fling/FlingTypes';
+import type { HoverGesture } from './hover/HoverTypes';
+import type { LongPressGesture } from './longPress/LongPressTypes';
+import type { ManualGesture } from './manual/ManualTypes';
+import type { NativeGesture } from './native/NativeTypes';
+import type { PanGesture } from './pan/PanTypes';
+import type { PinchGesture } from './pinch/PinchTypes';
+import type { RotationGesture } from './rotation/RotationTypes';
+import type { TapGesture } from './tap/TapTypes';
+
+export type AnySingleGesture =
+  | TapGesture
+  | FlingGesture
+  | LongPressGesture
+  | PinchGesture
+  | RotationGesture
+  | HoverGesture
+  | ManualGesture
+  | NativeGesture
+  | PanGesture;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/TapTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/TapTypes.ts
@@ -3,6 +3,7 @@ import type {
   DiscreteSingleGesture,
   ExcludeInternalConfigProps,
   GestureEvent,
+  SingleGestureName,
   WithSharedValue,
 } from '../../../types';
 
@@ -96,5 +97,7 @@ export type TapGestureActiveEvent = TapGestureEvent;
 
 export type TapGesture = DiscreteSingleGesture<
   TapGestureInternalProperties,
-  TapHandlerData
+  TapHandlerData,
+  TapHandlerData,
+  SingleGestureName.Tap
 >;

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/useTapGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/useTapGesture.ts
@@ -29,8 +29,10 @@ export function useTapGesture(
     TapGestureInternalProperties
   >(config, TapPropsMapping);
 
-  return useGesture<TapGestureInternalProperties, TapHandlerData>(
-    SingleGestureName.Tap,
-    tapConfig
-  );
+  return useGesture<
+    TapGestureInternalProperties,
+    TapHandlerData,
+    TapHandlerData,
+    SingleGestureName.Tap
+  >(SingleGestureName.Tap, tapConfig);
 }

--- a/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useGesture.ts
@@ -25,10 +25,11 @@ export function useGesture<
   TConfig,
   THandlerData,
   TExtendedHandlerData extends THandlerData = THandlerData,
+  TType extends SingleGestureName = SingleGestureName,
 >(
-  type: SingleGestureName,
+  type: TType,
   config: BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>
-): SingleGesture<TConfig, THandlerData, TExtendedHandlerData> {
+): SingleGesture<TConfig, THandlerData, TExtendedHandlerData, TType> {
   const handlerTag = useMemo(() => getNextHandlerTag(), []);
   const disableReanimated = useMemo(() => config.disableReanimated, []);
 

--- a/packages/react-native-gesture-handler/src/v3/types/GestureTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/GestureTypes.ts
@@ -39,9 +39,10 @@ export type SingleGesture<
   TConfig,
   THandlerData,
   TExtendedHandlerData extends THandlerData = THandlerData,
+  TType extends SingleGestureName = SingleGestureName,
 > = {
   handlerTag: number;
-  type: SingleGestureName;
+  type: TType;
   config: BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>;
   detectorCallbacks: DetectorCallbacks<THandlerData, TExtendedHandlerData>;
   gestureRelations: GestureRelations;
@@ -51,17 +52,19 @@ export type DiscreteSingleGesture<
   TConfig,
   THandlerData,
   TExtendedHandlerData extends THandlerData = THandlerData,
+  TType extends SingleGestureName = SingleGestureName,
 > = {
   [K in keyof SingleGesture<
     TConfig,
     THandlerData,
-    TExtendedHandlerData
+    TExtendedHandlerData,
+    TType
   >]: K extends 'config'
     ? Omit<
-        SingleGesture<TConfig, THandlerData, TExtendedHandlerData>[K],
+        SingleGesture<TConfig, THandlerData, TExtendedHandlerData, TType>[K],
         'onUpdate'
       >
-    : SingleGesture<TConfig, THandlerData, TExtendedHandlerData>[K];
+    : SingleGesture<TConfig, THandlerData, TExtendedHandlerData, TType>[K];
 };
 
 export type ComposedGesture = {


### PR DESCRIPTION
## Description

Makes SingleGesture/DiscreteSingleGesture generic over their `SingleGestureName` literal so each concrete gesture is a discriminated-union member. This is a prerequisite for inferring gesture scenarios from a target, and is a standalone typing improvement.

## Test plan

type changes only