### PR TITLE
[macOS] Add coordinates to `Hover` events

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
@@ -204,10 +204,9 @@ typedef NS_ENUM(NSInteger, RNGestureHandlerHoverEffect) {
 
 - (RNGestureHandlerEventExtraData *)extraDataForEvent:(NSEvent *)event
 {
-  CGFloat windowHeight = _view.window.contentView.frame.size.height;
-  CGPoint yFlippedAbsolutePos = [event locationInWindow];
-  CGPoint absolutePos = CGPointMake(yFlippedAbsolutePos.x, windowHeight - yFlippedAbsolutePos.y);
-  CGPoint relativePos = [_view convertPoint:absolutePos fromView:_view.window.contentView];
+  CGPoint windowLocation = [event locationInWindow];
+  CGPoint relativePos = [_view convertPoint:windowLocation fromView:nil];
+  CGPoint absolutePos = [_view.window.contentView convertPoint:windowLocation fromView:nil];
 
   return [RNGestureHandlerEventExtraData forPosition:relativePos
                                 withAbsolutePosition:absolutePos

--- a/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
@@ -202,10 +202,6 @@ typedef NS_ENUM(NSInteger, RNGestureHandlerHoverEffect) {
   _view = nil;
 }
 
-// Hover events carry position (x/y + absoluteX/absoluteY), matching
-// HoverHandlerData and the iOS hover path. Mirrors the macOS coordinate
-// convention used by RNGestureHandlerPointerTracker (y-flip `locationInWindow`,
-// then convert into the view's coordinate space).
 - (RNGestureHandlerEventExtraData *)extraDataForEvent:(NSEvent *)event
 {
   CGFloat windowHeight = _view.window.contentView.frame.size.height;

--- a/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
@@ -202,33 +202,35 @@ typedef NS_ENUM(NSInteger, RNGestureHandlerHoverEffect) {
   _view = nil;
 }
 
-- (void)mouseEntered:(NSEvent *)event
+// Hover events carry position (x/y + absoluteX/absoluteY), matching
+// HoverHandlerData and the iOS hover path. Mirrors the macOS coordinate
+// convention used by RNGestureHandlerPointerTracker (y-flip `locationInWindow`,
+// then convert into the view's coordinate space).
+- (RNGestureHandlerEventExtraData *)extraDataForEvent:(NSEvent *)event
 {
-  [self sendEventsInState:RNGestureHandlerStateBegan
-           forViewWithTag:_view.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES
-                                                       withNumberOfTouches:1
-                                                           withPointerType:_pointerType]];
-  [self sendEventsInState:RNGestureHandlerStateActive
-           forViewWithTag:_view.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES
-                                                       withNumberOfTouches:1
-                                                           withPointerType:_pointerType]];
+  CGFloat windowHeight = _view.window.contentView.frame.size.height;
+  CGPoint yFlippedAbsolutePos = [event locationInWindow];
+  CGPoint absolutePos = CGPointMake(yFlippedAbsolutePos.x, windowHeight - yFlippedAbsolutePos.y);
+  CGPoint relativePos = [_view convertPoint:absolutePos fromView:_view.window.contentView];
+
+  return [RNGestureHandlerEventExtraData forPosition:relativePos
+                                withAbsolutePosition:absolutePos
+                                 withNumberOfTouches:1
+                                     withPointerType:_pointerType];
 }
 
-- (void)mouseExited:(NSEvent *)theEvent
+- (void)mouseEntered:(NSEvent *)event
 {
-  [self sendEventsInState:RNGestureHandlerStateEnd
-           forViewWithTag:_view.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
-                                                       withNumberOfTouches:1
-                                                           withPointerType:_pointerType]];
+  RNGestureHandlerEventExtraData *extraData = [self extraDataForEvent:event];
+  [self sendEventsInState:RNGestureHandlerStateBegan forViewWithTag:_view.reactTag withExtraData:extraData];
+  [self sendEventsInState:RNGestureHandlerStateActive forViewWithTag:_view.reactTag withExtraData:extraData];
+}
 
-  [self sendEventsInState:RNGestureHandlerStateUndetermined
-           forViewWithTag:_view.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
-                                                       withNumberOfTouches:1
-                                                           withPointerType:_pointerType]];
+- (void)mouseExited:(NSEvent *)event
+{
+  RNGestureHandlerEventExtraData *extraData = [self extraDataForEvent:event];
+  [self sendEventsInState:RNGestureHandlerStateEnd forViewWithTag:_view.reactTag withExtraData:extraData];
+  [self sendEventsInState:RNGestureHandlerStateUndetermined forViewWithTag:_view.reactTag withExtraData:extraData];
 }
 
 @end


### PR DESCRIPTION
## Description

I've noticed that on `macOS` `Hover` gesture does not provide coordinates, while on other platforms it does. This PR fixes this mismatch.

## Test plan

<details>
<summary>Details</summary>

```tsx
import { View } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  useHoverGesture,
} from 'react-native-gesture-handler';

export default function App() {
  const hover = useHoverGesture({
    onBegin: (e) => console.log(e),
  });
  return (
    <GestureHandlerRootView>
      <GestureDetector gesture={hover}>
        <View style={{ width: 100, height: 100, backgroundColor: 'red' }} />
      </GestureDetector>
    </GestureHandlerRootView>
  );
}
```

</details>
