### PR TITLE
[iOS] Fix js responder cancelation in modals

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
@@ -277,21 +277,28 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 #pragma mark Root Views Management
 
 #if !TARGET_OS_OSX
-static BOOL RNGHIsModallyPresentedScreen(RNGHUIView *view)
+static BOOL RNGHIsScreensTouchHandlerHost(RNGHUIView *view)
 {
+  static Class fullWindowOverlayContainerClass;
   static Class screenViewClass;
   static SEL isModalSelector;
   static dispatch_once_t onceToken;
   dispatch_once(&onceToken, ^{
+    fullWindowOverlayContainerClass = NSClassFromString(@"RNSFullWindowOverlayContainer");
     screenViewClass = NSClassFromString(@"RNSScreenView");
     isModalSelector = NSSelectorFromString(@"isModal");
   });
 
-  if (screenViewClass == nil || ![view isKindOfClass:screenViewClass] || ![view respondsToSelector:isModalSelector]) {
-    return NO;
+  if (fullWindowOverlayContainerClass != nil && [view isKindOfClass:fullWindowOverlayContainerClass]) {
+    return YES;
   }
 
-  return [[view valueForKey:@"isModal"] boolValue];
+  if (screenViewClass != nil && [view isKindOfClass:screenViewClass]) {
+    // For now we consider only modals
+    return [view respondsToSelector:isModalSelector] && [[view valueForKey:@"isModal"] boolValue];
+  }
+
+  return NO;
 }
 #endif // !TARGET_OS_OSX
 
@@ -305,15 +312,11 @@ static BOOL RNGHIsModallyPresentedScreen(RNGHUIView *view)
   RNGHUIView *touchHandlerView = childView;
 
 #if !TARGET_OS_OSX
-  Class fullWindowOverlayContainerClass = NSClassFromString(@"RNSFullWindowOverlayContainer");
-
   if ([[childView reactViewController] isKindOfClass:[RCTFabricModalHostViewController class]]) {
     touchHandlerView = [childView reactViewController].view;
   } else {
-    while (
-        touchHandlerView != nil && ![touchHandlerView isKindOfClass:[RCTSurfaceView class]] &&
-        (fullWindowOverlayContainerClass == nil || ![touchHandlerView isKindOfClass:fullWindowOverlayContainerClass]) &&
-        !RNGHIsModallyPresentedScreen(touchHandlerView)) {
+    while (touchHandlerView != nil && ![touchHandlerView isKindOfClass:[RCTSurfaceView class]] &&
+           !RNGHIsScreensTouchHandlerHost(touchHandlerView)) {
       touchHandlerView = touchHandlerView.superview;
     }
   }

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
@@ -279,10 +279,19 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 #if !TARGET_OS_OSX
 static BOOL RNGHIsModallyPresentedScreen(RNGHUIView *view)
 {
-  Class screenViewClass = NSClassFromString(@"RNSScreenView");
+  static Class screenViewClass;
+  static SEL isModalSelector;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    screenViewClass = NSClassFromString(@"RNSScreenView");
+    isModalSelector = NSSelectorFromString(@"isModal");
+  });
 
-  return screenViewClass != nil && [view isKindOfClass:screenViewClass] &&
-      [view respondsToSelector:NSSelectorFromString(@"isModal")] && [[view valueForKey:@"isModal"] boolValue];
+  if (screenViewClass == nil || ![view isKindOfClass:screenViewClass] || ![view respondsToSelector:isModalSelector]) {
+    return NO;
+  }
+
+  return [[view valueForKey:@"isModal"] boolValue];
 }
 #endif // !TARGET_OS_OSX
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
@@ -276,7 +276,22 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 
 #pragma mark Root Views Management
 
+#if !TARGET_OS_OSX
+static BOOL RNGHIsModallyPresentedScreen(RNGHUIView *view)
+{
+  Class screenViewClass = NSClassFromString(@"RNSScreenView");
+
+  return screenViewClass != nil && [view isKindOfClass:screenViewClass] &&
+      [view respondsToSelector:NSSelectorFromString(@"isModal")] && [[view valueForKey:@"isModal"] boolValue];
+}
+#endif // !TARGET_OS_OSX
+
 - (void)registerViewWithGestureRecognizerAttachedIfNeeded:(RNGHUIView *)childView
+{
+  [self registerViewWithGestureRecognizerAttachedIfNeeded:childView isRetry:NO];
+}
+
+- (void)registerViewWithGestureRecognizerAttachedIfNeeded:(RNGHUIView *)childView isRetry:(BOOL)isRetry
 {
   RNGHUIView *touchHandlerView = childView;
 
@@ -288,7 +303,8 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
   } else {
     while (
         touchHandlerView != nil && ![touchHandlerView isKindOfClass:[RCTSurfaceView class]] &&
-        (fullWindowOverlayContainerClass == nil || ![touchHandlerView isKindOfClass:fullWindowOverlayContainerClass])) {
+        (fullWindowOverlayContainerClass == nil || ![touchHandlerView isKindOfClass:fullWindowOverlayContainerClass]) &&
+        !RNGHIsModallyPresentedScreen(touchHandlerView)) {
       touchHandlerView = touchHandlerView.superview;
     }
   }
@@ -299,6 +315,17 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 #endif // !TARGET_OS_OSX
 
   if (touchHandlerView == nil) {
+#if !TARGET_OS_OSX
+    // Handlers are attached while the mounting transaction is still in progress — the view's
+    // ancestor chain may not be assembled yet (Fabric connects subtrees children-first), in
+    // which case the walk above dead-ends before reaching any touch-handling root. Retry once
+    // on the next run loop turn, when mounting has finished and the hierarchy is connected.
+    if (!isRetry) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [self registerViewWithGestureRecognizerAttachedIfNeeded:childView isRetry:YES];
+      });
+    }
+#endif
     return;
   }
 
@@ -347,6 +374,19 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
       break;
     }
   }
+
+#if !TARGET_OS_OSX
+  if (touchHandler == nil && [viewWithTouchHandler respondsToSelector:NSSelectorFromString(@"touchHandler")]) {
+    // An RNSScreenView may not have the touch handler attached directly (e.g. touches on it are
+    // still driven by an ancestor's touch handler) — ask react-native-screens for the one
+    // responsible for this screen.
+    id screenTouchHandler = [viewWithTouchHandler valueForKey:@"touchHandler"];
+    if ([screenTouchHandler isKindOfClass:[RCTSurfaceTouchHandler class]]) {
+      touchHandler = screenTouchHandler;
+    }
+  }
+#endif // !TARGET_OS_OSX
+
   [touchHandler setEnabled:NO];
   [touchHandler setEnabled:YES];
 }


### PR DESCRIPTION
## Description

On iOS, when a gesture activates inside a `react-native-screens` route presented as `formSheet` or `modal`, the in-flight touch of a core RN `Pressable`/`Touchable` underneath is not cancelled — the press completes and `onPress` fires on release, alongside the gesture. 

In this PR registration walk-up now also stops at a modally-presented `RNSScreenView`, so the root recognizer is attached to the screen view and travels with it when `UIKit` reparents it. When the walk-up dead-ends at `nil`, registration is retried once on the next run loop turn, when the mounting transaction has finished and the hierarchy is connected.

Fixes #4305

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import { useNavigation } from '@react-navigation/native';
import {
  createNativeStackNavigator,
  type NativeStackNavigationProp,
} from '@react-navigation/native-stack';
import React, { useState } from 'react';
import { Button, Pressable, StyleSheet, Text, View } from 'react-native';
import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';
import Animated, {
  useAnimatedStyle,
  useSharedValue,
  withSpring,
} from 'react-native-reanimated';

// Repro for https://github.com/software-mansion/react-native-gesture-handler/issues/4305
//
// Ported to the v3 API (usePanGesture) with explicit `cancelsJSResponder`.
//
// iOS: when a Pan gesture activates inside a react-native-screens native-stack
// route presented as `formSheet` (or `modal`), the in-flight JS-responder touch
// of a core RN Pressable underneath is NOT cancelled — on release `onPress`
// fires alongside the gesture. On a push route the pan activation cancels the
// press as expected.
//
// How to test (iOS):
// 1. Swipe the row horizontally on the home screen — the press counter must
//    NOT increment (control).
// 2. Open the push route, swipe the row — counter must NOT increment.
// 3. Open the formSheet / modal route, swipe the row — BUG: the counter
//    increments on release.

function Row({ label }: { label: string }) {
  const [pressCount, setPressCount] = useState(0);
  const translateX = useSharedValue(0);

  const pan = usePanGesture({
    activeOffsetX: [-12, 12],
    failOffsetY: [-12, 12],
    cancelsJSResponder: true,
    onUpdate: (e) => {
      'worklet';
      translateX.value = Math.min(0, e.translationX);
    },
    onFinalize: () => {
      'worklet';
      translateX.value = withSpring(0);
    },
  });

  const animatedStyle = useAnimatedStyle(() => ({
    transform: [{ translateX: translateX.value }],
  }));

  return (
    <View style={styles.rowContainer}>
      <Text style={styles.caption}>{label}</Text>
      <GestureDetector gesture={pan}>
        <Animated.View style={animatedStyle}>
          <Pressable
            style={({ pressed }) => [styles.row, pressed && styles.rowPressed]}
            onPress={() => {
              console.log(`onPress fired (${label})`);
              setPressCount((c) => c + 1);
            }}>
            <Text style={styles.rowText}>Swipe me left</Text>
            <Text style={styles.counter}>
              onPress fired: {pressCount} {pressCount > 0 ? '❌' : ''}
            </Text>
          </Pressable>
        </Animated.View>
      </GestureDetector>
    </View>
  );
}

type StackParamList = {
  home: undefined;
  push: undefined;
  sheet: undefined;
  modal: undefined;
};

function HomeScreen() {
  const navigation = useNavigation<NativeStackNavigationProp<StackParamList>>();

  return (
    <View style={styles.screen}>
      <Row label="home screen (control — swipe must not press)" />
      <Button
        title="Open push route"
        onPress={() => navigation.navigate('push')}
      />
      <Button
        title="Open formSheet route"
        onPress={() => navigation.navigate('sheet')}
      />
      <Button
        title="Open modal route"
        onPress={() => navigation.navigate('modal')}
      />
    </View>
  );
}

function PushScreen() {
  return (
    <View style={styles.screen}>
      <Row label="push route (expected: swipe must not press)" />
    </View>
  );
}

function SheetScreen() {
  return (
    <View style={styles.sheet}>
      <Row label="formSheet (bug: onPress fires after swipe)" />
      <Text style={styles.hint}>Swipe down to dismiss</Text>
    </View>
  );
}

function ModalScreen() {
  return (
    <View style={styles.sheet}>
      <Row label="modal (bug: onPress fires after swipe)" />
      <Text style={styles.hint}>Swipe down to dismiss</Text>
    </View>
  );
}

const Stack = createNativeStackNavigator<StackParamList>();

export default function EmptyExample() {
  return (
    <Stack.Navigator>
      <Stack.Screen
        name="home"
        component={HomeScreen}
        options={{ headerShown: false }}
      />
      <Stack.Screen
        name="push"
        component={PushScreen}
        options={{ title: 'Push route' }}
      />
      <Stack.Screen
        name="sheet"
        component={SheetScreen}
        options={{
          presentation: 'formSheet',
          sheetAllowedDetents: [0.5],
          headerShown: false,
        }}
      />
      <Stack.Screen
        name="modal"
        component={ModalScreen}
        options={{ presentation: 'modal', headerShown: false }}
      />
    </Stack.Navigator>
  );
}

const styles = StyleSheet.create({
  screen: {
    flex: 1,
    justifyContent: 'center',
    gap: 16,
    padding: 20,
    backgroundColor: '#f5f5f7',
  },
  sheet: {
    flex: 1,
    justifyContent: 'center',
    gap: 16,
    padding: 20,
  },
  rowContainer: {
    gap: 6,
  },
  caption: {
    fontSize: 13,
    color: '#555',
  },
  row: {
    backgroundColor: '#a78bfa',
    borderRadius: 12,
    padding: 20,
    gap: 4,
  },
  rowPressed: {
    backgroundColor: '#7c5cd6',
  },
  rowText: {
    fontSize: 17,
    fontWeight: '600',
    color: '#1a1a2e',
  },
  counter: {
    fontSize: 14,
    color: '#1a1a2e',
  },
  hint: {
    textAlign: 'center',
    color: '#888',
  },
});
```

</details>