### PR TITLE
[Native] Add `delaysChildPressedState` to native gesture

### DIFF
--- a/packages/docs-gesture-handler/docs/gestures/use-native-gesture.mdx
+++ b/packages/docs-gesture-handler/docs/gestures/use-native-gesture.mdx
@@ -131,9 +131,9 @@ Composes with [`disallowInterruption`](#disallowinterruption). When both are `tr
 delaysChildPressedState: boolean | SharedValue<boolean>;
 ```
 
-When `false`, the wrapped scrollable container displays the pressed state of its children immediately, instead of delaying it until it's clear that the gesture is not a scroll. Defaults to `true`.
+When `true`, the wrapped scrollable container delays displaying the pressed state of its children until it's clear that the gesture is not a scroll. Set it to `false` to display the pressed state immediately. Defaults to `true`.
 
-On iOS this controls [`delaysContentTouches`](https://developer.apple.com/documentation/uikit/uiscrollview/delayscontenttouches) on the underlying `UIScrollView`. On Android it controls whether the container delays the pressed state of its children (see [`shouldDelayChildPressedState`](https://developer.android.com/reference/android/view/ViewGroup#shouldDelayChildPressedState%28%29)) — this requires React Native 0.87 or newer and is a no-op on older versions.
+On iOS this controls [`delaysContentTouches`](https://developer.apple.com/documentation/uikit/uiscrollview/delayscontenttouches) on the underlying `UIScrollView`. On Android it controls whether the container delays the pressed state of its children (see [`shouldDelayChildPressedState`](https://developer.android.com/reference/android/view/ViewGroup#shouldDelayChildPressedState%28%29)) — on Android, this requires React Native 0.87 or newer and is a no-op on older versions.
 
 <BaseGestureConfig />
 

--- a/packages/docs-gesture-handler/docs/gestures/use-native-gesture.mdx
+++ b/packages/docs-gesture-handler/docs/gestures/use-native-gesture.mdx
@@ -123,6 +123,18 @@ yieldsToContinuousGestures: boolean | SharedValue<boolean>;
 
 Composes with [`disallowInterruption`](#disallowinterruption). When both are `true`, this handler still cancels discrete gestures (`Tap`, `LongPress`, `Fling`) on activation but allows continuous gestures (`Pan`, `Pinch`, `Rotation`, `Native`, `Manual`, `Hover`) to interrupt it. No-op when `disallowInterruption` is `false`. Defaults to `false`.
 
+<Badges platforms={['android', 'ios']}>
+### delaysChildPressedState
+</Badges>
+
+```ts
+delaysChildPressedState: boolean | SharedValue<boolean>;
+```
+
+When `false`, the wrapped scrollable container displays the pressed state of its children immediately, instead of delaying it until it's clear that the gesture is not a scroll. Defaults to `true`.
+
+On iOS this controls [`delaysContentTouches`](https://developer.apple.com/documentation/uikit/uiscrollview/delayscontenttouches) on the underlying `UIScrollView`. On Android it controls whether the container delays the pressed state of its children (see [`shouldDelayChildPressedState`](https://developer.android.com/reference/android/view/ViewGroup#shouldDelayChildPressedState%28%29)) — this requires React Native 0.87 or newer and is a no-op on older versions.
+
 <BaseGestureConfig />
 
 ## Callbacks

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -16,6 +16,7 @@ import com.facebook.react.views.textinput.ReactEditText
 import com.facebook.react.views.view.ReactViewGroup
 import com.swmansion.gesturehandler.react.RNGestureHandlerRootHelper
 import com.swmansion.gesturehandler.react.events.eventbuilders.NativeGestureHandlerEventDataBuilder
+import java.lang.reflect.Method
 
 class NativeViewGestureHandler : GestureHandler() {
   override val isContinuous = true
@@ -37,6 +38,17 @@ class NativeViewGestureHandler : GestureHandler() {
   var yieldsToContinuousGestures = false
     private set
 
+  /**
+   * When set, overrides whether the connected scrollable container delays the pressed state of
+   * its children (see [android.view.ViewGroup.shouldDelayChildPressedState]). Only applies to
+   * views implementing `HasChildPressedStateDelay` (React Native 0.87+), no-op otherwise. The
+   * override is applied for the duration of a gesture.
+   */
+  var delaysChildPressedState: Boolean? = null
+    private set
+
+  private var pressedStateDelayOverriddenView: View? = null
+
   private var hook: NativeViewGestureHandlerHook = defaultHook
 
   private data class ActiveUpdateSnapshot(val pointerInside: Boolean, val numberOfPointers: Int, val pointerType: Int)
@@ -53,6 +65,7 @@ class NativeViewGestureHandler : GestureHandler() {
     disallowInterruption = DEFAULT_DISALLOW_INTERRUPTION
     yieldsToContinuousGestures = DEFAULT_YIELDS_TO_CONTINUOUS_GESTURES
     shouldCancelWhenOutside = DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE
+    delaysChildPressedState = DEFAULT_DELAYS_CHILD_PRESSED_STATE
   }
 
   override fun shouldRecognizeSimultaneously(handler: GestureHandler): Boolean {
@@ -114,6 +127,14 @@ class NativeViewGestureHandler : GestureHandler() {
       is ReactHorizontalScrollView -> this.hook = ScrollViewHook()
       is ReactTextView -> this.hook = TextViewHook()
       is ReactViewGroup -> this.hook = ReactViewGroupHook()
+    }
+
+    delaysChildPressedState?.let { delays ->
+      this.view?.let {
+        if (trySetChildPressedStateDelay(it, delays)) {
+          pressedStateDelayOverriddenView = it
+        }
+      }
     }
   }
 
@@ -179,6 +200,9 @@ class NativeViewGestureHandler : GestureHandler() {
   override fun onReset() {
     this.hook = defaultHook
     lastActiveUpdate = null
+    // `null` restores the view's default pressed state delay behavior.
+    pressedStateDelayOverriddenView?.let { trySetChildPressedStateDelay(it, null) }
+    pressedStateDelayOverriddenView = null
   }
 
   override fun dispatchHandlerUpdate(event: MotionEvent) {
@@ -214,6 +238,9 @@ class NativeViewGestureHandler : GestureHandler() {
       if (config.hasKey(KEY_YIELDS_TO_CONTINUOUS_GESTURES)) {
         handler.yieldsToContinuousGestures = config.getBoolean(KEY_YIELDS_TO_CONTINUOUS_GESTURES)
       }
+      if (config.hasKey(KEY_DELAYS_CHILD_PRESSED_STATE)) {
+        handler.delaysChildPressedState = config.getBoolean(KEY_DELAYS_CHILD_PRESSED_STATE)
+      }
     }
 
     override fun createEventBuilder(handler: NativeViewGestureHandler) = NativeGestureHandlerEventDataBuilder(handler)
@@ -222,6 +249,7 @@ class NativeViewGestureHandler : GestureHandler() {
       private const val KEY_SHOULD_ACTIVATE_ON_START = "shouldActivateOnStart"
       private const val KEY_DISALLOW_INTERRUPTION = "disallowInterruption"
       private const val KEY_YIELDS_TO_CONTINUOUS_GESTURES = "yieldsToContinuousGestures"
+      private const val KEY_DELAYS_CHILD_PRESSED_STATE = "delaysChildPressedState"
     }
   }
 
@@ -230,6 +258,28 @@ class NativeViewGestureHandler : GestureHandler() {
     private const val DEFAULT_SHOULD_ACTIVATE_ON_START = false
     private const val DEFAULT_DISALLOW_INTERRUPTION = false
     private const val DEFAULT_YIELDS_TO_CONTINUOUS_GESTURES = false
+    private val DEFAULT_DELAYS_CHILD_PRESSED_STATE: Boolean? = null
+
+    // `HasChildPressedStateDelay` was introduced in React Native 0.87 — it's accessed via
+    // reflection so that the library compiles and runs on older versions.
+    private val childPressedStateDelaySetter: Method? by lazy {
+      try {
+        Class
+          .forName("com.facebook.react.uimanager.HasChildPressedStateDelay")
+          .getMethod("setHasChildPressedStateDelay", Boolean::class.javaObjectType)
+      } catch (e: ReflectiveOperationException) {
+        null
+      }
+    }
+
+    private fun trySetChildPressedStateDelay(view: View, value: Boolean?): Boolean {
+      val setter = childPressedStateDelaySetter ?: return false
+      if (!setter.declaringClass.isInstance(view)) {
+        return false
+      }
+      setter.invoke(view, value)
+      return true
+    }
 
     private fun tryIntercept(view: View, event: MotionEvent) = view is ViewGroup && view.onInterceptTouchEvent(event)
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -277,8 +277,13 @@ class NativeViewGestureHandler : GestureHandler() {
       if (!setter.declaringClass.isInstance(view)) {
         return false
       }
-      setter.invoke(view, value)
-      return true
+
+      return try {
+        setter.invoke(view, value)
+        true
+      } catch (e: ReflectiveOperationException) {
+        false
+      }
     }
 
     private fun tryIntercept(view: View, event: MotionEvent) = view is ViewGroup && view.onInterceptTouchEvent(event)

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -258,7 +258,7 @@ class NativeViewGestureHandler : GestureHandler() {
     private const val DEFAULT_SHOULD_ACTIVATE_ON_START = false
     private const val DEFAULT_DISALLOW_INTERRUPTION = false
     private const val DEFAULT_YIELDS_TO_CONTINUOUS_GESTURES = false
-    private val DEFAULT_DELAYS_CHILD_PRESSED_STATE: Boolean? = null
+    private val DEFAULT_DELAYS_CHILD_PRESSED_STATE: Boolean = true
 
     // `HasChildPressedStateDelay` was introduced in React Native 0.87 — it's accessed via
     // reflection so that the library compiles and runs on older versions.

--- a/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNNativeViewHandler.mm
@@ -114,6 +114,7 @@
   BOOL _shouldActivateOnStart;
   BOOL _disallowInterruption;
   BOOL _yieldsToContinuousGestures;
+  BOOL _delaysChildPressedState;
   RNGestureHandlerEventExtraData *_lastActiveExtraData;
 }
 
@@ -121,6 +122,7 @@
 {
   if ((self = [super initWithTag:tag])) {
     _recognizer = [[RNDummyGestureRecognizer alloc] initWithGestureHandler:self];
+    _delaysChildPressedState = YES;
   }
   return self;
 }
@@ -131,6 +133,17 @@
   _shouldActivateOnStart = [RCTConvert BOOL:config[@"shouldActivateOnStart"]];
   _disallowInterruption = [RCTConvert BOOL:config[@"disallowInterruption"]];
   _yieldsToContinuousGestures = [RCTConvert BOOL:config[@"yieldsToContinuousGestures"]];
+
+  id delaysChildPressedState = config[@"delaysChildPressedState"];
+  _delaysChildPressedState = delaysChildPressedState == nil ? YES : [RCTConvert BOOL:delaysChildPressedState];
+
+#if !TARGET_OS_OSX
+  // Config may be updated after the handler is bound to a view — re-apply to the connected
+  // scroll view if there is one.
+  if (self.recognizer.view != nil) {
+    [self retrieveScrollView:self.recognizer.view].delaysContentTouches = _delaysChildPressedState;
+  }
+#endif
 }
 
 #if !TARGET_OS_OSX
@@ -177,9 +190,10 @@
 
   // We can restore default scrollview behaviour to delay touches to scrollview's children
   // because gesture handler system can handle cancellation of scroll recognizer when JS responder
-  // is set
+  // is set. Setting `delaysChildPressedState` to `false` opts out of this, keeping touches delivered
+  // to children immediately.
   UIScrollView *scrollView = [self retrieveScrollView:view];
-  scrollView.delaysContentTouches = YES;
+  scrollView.delaysContentTouches = _delaysChildPressedState;
 }
 
 - (void)unbindFromView

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
@@ -28,6 +28,19 @@ export type NativeGestureNativeProperties = {
    * `false`.
    */
   yieldsToContinuousGestures?: boolean;
+
+  /**
+   * When `false`, the wrapped scrollable container doesn't delay the pressed
+   * state of its children, making them display press feedback immediately.
+   *
+   * On iOS this controls `delaysContentTouches` on the underlying
+   * `UIScrollView`. On Android it controls whether the container delays the
+   * pressed state of its children (see
+   * `ViewGroup.shouldDelayChildPressedState`); requires React Native 0.87+.
+   *
+   * Defaults to `true`.
+   */
+  delaysChildPressedState?: boolean;
 };
 
 export const NativeHandlerNativeProperties = new Set<
@@ -36,6 +49,7 @@ export const NativeHandlerNativeProperties = new Set<
   'shouldActivateOnStart',
   'disallowInterruption',
   'yieldsToContinuousGestures',
+  'delaysChildPressedState',
 ]);
 
 export type NativeHandlerData = {

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/native/NativeTypes.ts
@@ -30,13 +30,15 @@ export type NativeGestureNativeProperties = {
   yieldsToContinuousGestures?: boolean;
 
   /**
-   * When `false`, the wrapped scrollable container doesn't delay the pressed
-   * state of its children, making them display press feedback immediately.
+   * When `true`, the wrapped scrollable container delays displaying the
+   * pressed state of its children until it's clear that the gesture is not a
+   * scroll. Set it to `false` to display the pressed state immediately.
    *
    * On iOS this controls `delaysContentTouches` on the underlying
    * `UIScrollView`. On Android it controls whether the container delays the
    * pressed state of its children (see
-   * `ViewGroup.shouldDelayChildPressedState`); requires React Native 0.87+.
+   * `ViewGroup.shouldDelayChildPressedState`) — this requires React Native
+   * 0.87 or newer and is a no-op on older versions.
    *
    * Defaults to `true`.
    */


### PR DESCRIPTION
## Description

Based on https://github.com/react/react-native/pull/57259, adds a new `delaysChildPressedState` config entry to the native gesture handler and exposes it on the `ScrollView`.

The default behavior remains unchanged (visual feedback is delayed in scrollable containers), but can be disabled using the new config entry.

Since `HasChildPressedStateDelay` interface is available starting with React Native 0.87, it's currently accessed using reflection to keep backwards compatibility. On older versions, `delaysChildPressedState` is a no-op. Once 0.87 is the lowest compatible version with RNGH, we can drop the reflection and use it directly.

## Test plan

```jsx
import * as React from 'react';
import { Platform, SafeAreaView } from 'react-native';
import {
  GestureHandlerRootView,
  ScrollView,
  Touchable,
} from 'react-native-gesture-handler';

export default function App() {
  return (
    <GestureHandlerRootView style={{ flex: 1 }}>
      <SafeAreaView
        style={[
          { flex: 1, flexDirection: 'row' },
          Platform.OS === 'android' && { paddingTop: 50 },
        ]}>
        <ScrollView
          delaysChildPressedState={false}
          style={{ width: '50%', height: 200, backgroundColor: 'lightgray' }}>
          <Touchable
            style={{ width: 100, height: 100, backgroundColor: 'red' }}
            activeScale={0.9}
            onPress={() => console.log('Pressed!')}
          />
        </ScrollView>

        <ScrollView
          delaysChildPressedState={true}
          style={{ width: '50%', height: 200, backgroundColor: 'lightgray' }}>
          <Touchable
            style={{ width: 100, height: 100, backgroundColor: 'red' }}
            activeScale={0.9}
            onPress={() => console.log('Pressed!')}
          />
        </ScrollView>
      </SafeAreaView>
    </GestureHandlerRootView>
  );
}
```

