### PR TITLE
Adds recognizer-backed Jest gesture simulation for v3 gestures and relations.

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/gestureController.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/gestureController.test.tsx
@@ -1,0 +1,170 @@
+import { renderHook } from '@testing-library/react-native';
+
+import { createGestureController } from '../jestUtils';
+import { State } from '../State';
+import { usePanGesture, useTapGesture } from '../v3/hooks/gestures';
+
+function mockedContinuousCallbacks() {
+  const order: string[] = [];
+
+  return {
+    order,
+    callbacks: {
+      onBegin: jest.fn(() => order.push('onBegin')),
+      onActivate: jest.fn(() => order.push('onActivate')),
+      onUpdate: jest.fn(() => order.push('onUpdate')),
+      onDeactivate: jest.fn(() => order.push('onDeactivate')),
+      onFinalize: jest.fn(() => order.push('onFinalize')),
+    },
+  };
+}
+
+function mockedDiscreteCallbacks() {
+  const order: string[] = [];
+
+  return {
+    order,
+    callbacks: {
+      onBegin: jest.fn(() => order.push('onBegin')),
+      onActivate: jest.fn(() => order.push('onActivate')),
+      onDeactivate: jest.fn(() => order.push('onDeactivate')),
+      onFinalize: jest.fn(() => order.push('onFinalize')),
+    },
+  };
+}
+
+describe('createGestureController', () => {
+  test('allows assertions after each gesture lifecycle step', () => {
+    const { order, callbacks } = mockedContinuousCallbacks();
+    const pan = renderHook(() =>
+      usePanGesture({ disableReanimated: true, ...callbacks })
+    ).result.current;
+    const gesture = createGestureController(pan);
+
+    gesture.begin({ translationX: 0 });
+
+    expect(gesture.getState()).toBe(State.BEGAN);
+    expect(order).toEqual(['onBegin']);
+    expect(callbacks.onBegin).toHaveBeenCalledWith(
+      expect.objectContaining({ translationX: 0 })
+    );
+
+    gesture.activate({ translationX: 10 });
+
+    expect(gesture.getState()).toBe(State.ACTIVE);
+    expect(order).toEqual(['onBegin', 'onActivate']);
+    expect(callbacks.onActivate).toHaveBeenCalledWith(
+      expect.objectContaining({ translationX: 10 })
+    );
+
+    gesture.update({ translationX: 50 });
+
+    expect(gesture.getState()).toBe(State.ACTIVE);
+    expect(order).toEqual(['onBegin', 'onActivate', 'onUpdate']);
+    expect(callbacks.onUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ translationX: 50 })
+    );
+
+    gesture.end({ translationX: 50 });
+
+    expect(gesture.getState()).toBe(State.END);
+    expect(order).toEqual([
+      'onBegin',
+      'onActivate',
+      'onUpdate',
+      'onDeactivate',
+      'onFinalize',
+    ]);
+    expect(callbacks.onFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({ canceled: false, translationX: 50 })
+    );
+  });
+
+  test('can fail a gesture before activation', () => {
+    const { order, callbacks } = mockedDiscreteCallbacks();
+    const tap = renderHook(() =>
+      useTapGesture({ disableReanimated: true, ...callbacks })
+    ).result.current;
+    const gesture = createGestureController(tap);
+
+    gesture.begin({ x: 10 });
+    gesture.fail({ x: 10 });
+
+    expect(gesture.getState()).toBe(State.FAILED);
+    expect(order).toEqual(['onBegin', 'onFinalize']);
+    expect(callbacks.onActivate).not.toHaveBeenCalled();
+    expect(callbacks.onDeactivate).not.toHaveBeenCalled();
+    expect(callbacks.onFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({ canceled: true, x: 10 })
+    );
+  });
+
+  test('resolves gesture test ID strings internally', () => {
+    const { order, callbacks } = mockedDiscreteCallbacks();
+    renderHook(() =>
+      useTapGesture({
+        testID: 'controlled-tap',
+        disableReanimated: true,
+        ...callbacks,
+      })
+    );
+    const gesture = createGestureController('controlled-tap');
+
+    gesture.begin();
+    gesture.activate();
+    gesture.end();
+
+    expect(order).toEqual([
+      'onBegin',
+      'onActivate',
+      'onDeactivate',
+      'onFinalize',
+    ]);
+  });
+
+  test('guards against invalid lifecycle order', () => {
+    const tap = renderHook(() => useTapGesture({ disableReanimated: true }))
+      .result.current;
+    const gesture = createGestureController(tap);
+
+    expect(() => gesture.update()).toThrow(
+      'Cannot update gesture from UNDETERMINED state.'
+    );
+
+    gesture.begin();
+
+    expect(() => gesture.begin()).toThrow(
+      'Cannot begin gesture from BEGAN state.'
+    );
+  });
+
+  test('rejects raw state-machine fields in event payloads', () => {
+    const tap = renderHook(() => useTapGesture({ disableReanimated: true }))
+      .result.current;
+    const gesture = createGestureController(tap);
+
+    expect(() => gesture.begin({ state: State.BEGAN } as never)).toThrow(
+      "createGestureController manages 'state' internally."
+    );
+  });
+
+  test('disabled gestures are no-ops', () => {
+    const { order, callbacks } = mockedContinuousCallbacks();
+    const pan = renderHook(() =>
+      usePanGesture({
+        disableReanimated: true,
+        enabled: false,
+        ...callbacks,
+      })
+    ).result.current;
+    const gesture = createGestureController(pan);
+
+    gesture.begin();
+    gesture.activate();
+    gesture.update({ translationX: 50 });
+    gesture.end();
+
+    expect(gesture.getState()).toBe(State.UNDETERMINED);
+    expect(order).toEqual([]);
+  });
+});

--- a/packages/react-native-gesture-handler/src/__tests__/gestureController.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/gestureController.test.tsx
@@ -1,9 +1,28 @@
 import { renderHook } from '@testing-library/react-native';
 
-import { createGestureController } from '../jestUtils';
+import {
+  createGestureController,
+  doubleTap,
+  fireGesture,
+  longPress,
+  pinch,
+  rotate,
+  swipe,
+  tap,
+} from '../jestUtils';
 import { State } from '../State';
+import {
+  useCompetingGestures,
+  useSimultaneousGestures,
+} from '../v3/hooks/composition';
 import type { PanGesture, TapGesture } from '../v3/hooks/gestures';
-import { usePanGesture, useTapGesture } from '../v3/hooks/gestures';
+import {
+  useLongPressGesture,
+  usePanGesture,
+  usePinchGesture,
+  useRotationGesture,
+  useTapGesture,
+} from '../v3/hooks/gestures';
 
 function mockedContinuousCallbacks() {
   const order: string[] = [];
@@ -191,5 +210,176 @@ describe('createGestureController', () => {
 
     expect(gesture.getState()).toBe(State.UNDETERMINED);
     expect(order).toEqual([]);
+  });
+});
+
+describe('fireGesture', () => {
+  test('provides a tap convenience helper', () => {
+    const onActivate = jest.fn();
+    const gesture = renderHook(() =>
+      useTapGesture({ disableReanimated: true, onActivate })
+    ).result.current;
+
+    fireGesture(gesture, tap({ at: { x: 20, y: 40 } }));
+
+    expect(onActivate).toHaveBeenCalledWith(
+      expect.objectContaining({ x: 20, y: 40 })
+    );
+  });
+
+  test('advances timer-dependent long presses explicitly', () => {
+    jest.useFakeTimers();
+
+    try {
+      const onActivate = jest.fn();
+      const gesture = renderHook(() =>
+        useLongPressGesture({
+          disableReanimated: true,
+          minDuration: 50,
+          onActivate,
+        })
+      ).result.current;
+
+      fireGesture(gesture, longPress({ at: { x: 20, y: 40 }, duration: 50 }), {
+        advanceTimers: jest.advanceTimersByTime,
+      });
+
+      expect(onActivate).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('supports multi-tap timing through doubleTap', () => {
+    jest.useFakeTimers();
+
+    try {
+      const onActivate = jest.fn();
+      const gesture = renderHook(() =>
+        useTapGesture({
+          disableReanimated: true,
+          numberOfTaps: 2,
+          onActivate,
+        })
+      ).result.current;
+
+      fireGesture(gesture, doubleTap({ at: { x: 20, y: 40 } }), {
+        advanceTimers: jest.advanceTimersByTime,
+      });
+
+      expect(onActivate).toHaveBeenCalledTimes(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  test('provides pinch and rotate helpers over multi-pointer input', () => {
+    const onPinchActivate = jest.fn();
+    const onRotationActivate = jest.fn();
+    const gestures = renderHook(() => ({
+      pinch: usePinchGesture({
+        disableReanimated: true,
+        onActivate: onPinchActivate,
+      }),
+      rotation: useRotationGesture({
+        disableReanimated: true,
+        onActivate: onRotationActivate,
+      }),
+    })).result.current;
+
+    fireGesture(
+      gestures.pinch,
+      pinch({
+        from: [
+          { x: 0, y: 0 },
+          { x: 0, y: 40 },
+        ],
+        to: [
+          { x: 0, y: 0 },
+          { x: 0, y: 100 },
+        ],
+        steps: 3,
+      })
+    );
+    fireGesture(
+      gestures.rotation,
+      rotate({
+        center: { x: 50, y: 50 },
+        radius: 30,
+        fromAngle: 0,
+        toAngle: Math.PI / 2,
+        steps: 3,
+      })
+    );
+
+    expect(onPinchActivate).toHaveBeenCalledTimes(1);
+    expect(onRotationActivate).toHaveBeenCalledTimes(1);
+  });
+
+  test('uses web recognizers and the arbitrator for competing gestures', () => {
+    const onPanActivate = jest.fn();
+    const onTapActivate = jest.fn();
+    const onTapFinalize = jest.fn();
+
+    const competingGestures = renderHook(() => {
+      const tap = useTapGesture({
+        disableReanimated: true,
+        maxDistance: 10,
+        onActivate: onTapActivate,
+        onFinalize: onTapFinalize,
+      });
+      const pan = usePanGesture({
+        disableReanimated: true,
+        minDistance: 10,
+        onActivate: onPanActivate,
+      });
+
+      return useCompetingGestures(tap, pan);
+    }).result.current;
+
+    fireGesture(
+      competingGestures,
+      swipe({
+        from: { x: 0, y: 0 },
+        to: { x: 100, y: 0 },
+        steps: 4,
+      })
+    );
+
+    expect(onPanActivate).toHaveBeenCalledTimes(1);
+    expect(onTapActivate).not.toHaveBeenCalled();
+    expect(onTapFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({ canceled: true })
+    );
+  });
+
+  test('lets simultaneous gestures observe the same pointer stream', () => {
+    const onPanActivate = jest.fn();
+    const onTapActivate = jest.fn();
+
+    const simultaneousGestures = renderHook(() => {
+      const tap = useTapGesture({
+        disableReanimated: true,
+        onActivate: onTapActivate,
+      });
+      const pan = usePanGesture({
+        disableReanimated: true,
+        minDistance: 10,
+        onActivate: onPanActivate,
+      });
+
+      return useSimultaneousGestures(tap, pan);
+    }).result.current;
+
+    fireGesture(
+      simultaneousGestures,
+      swipe({
+        from: { x: 0, y: 0 },
+        to: { x: 100, y: 0 },
+      })
+    );
+
+    expect(onPanActivate).toHaveBeenCalledTimes(1);
+    expect(onTapActivate).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/react-native-gesture-handler/src/__tests__/gestureController.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/gestureController.test.tsx
@@ -2,6 +2,7 @@ import { renderHook } from '@testing-library/react-native';
 
 import { createGestureController } from '../jestUtils';
 import { State } from '../State';
+import type { PanGesture, TapGesture } from '../v3/hooks/gestures';
 import { usePanGesture, useTapGesture } from '../v3/hooks/gestures';
 
 function mockedContinuousCallbacks() {
@@ -32,6 +33,30 @@ function mockedDiscreteCallbacks() {
     },
   };
 }
+
+function assertGestureControllerTypes(pan: PanGesture, tap: TapGesture) {
+  const panController = createGestureController(pan);
+  panController.begin({ x: 1 });
+  panController.update({ translationX: 1, velocityX: 2 });
+  // @ts-expect-error unknown pan payload field
+  panController.update({ translationXX: 1 });
+  // @ts-expect-error raw state-machine fields are managed internally
+  panController.begin({ state: State.BEGAN });
+
+  const tapController = createGestureController(tap);
+  tapController.begin({ x: 1 });
+  // @ts-expect-error tap payloads do not include pan translation fields
+  tapController.update({ translationX: 1 });
+
+  const stringController = createGestureController<{ translationX: number }>(
+    'pan-id'
+  );
+  stringController.update({ translationX: 1 });
+  // @ts-expect-error explicit payload type is respected for string targets
+  stringController.update({ translationXX: 1 });
+}
+
+void assertGestureControllerTypes;
 
 describe('createGestureController', () => {
   test('allows assertions after each gesture lifecycle step', () => {

--- a/packages/react-native-gesture-handler/src/jestUtils/index.ts
+++ b/packages/react-native-gesture-handler/src/jestUtils/index.ts
@@ -1,6 +1,30 @@
-export type { GestureController, GestureControllerEvent } from './jestUtils';
+export type {
+  DoubleTapOptions,
+  FireGestureOptions,
+  GestureController,
+  GestureControllerEvent,
+  LongPressOptions,
+  MultiPointerSequenceOptions,
+  PinchOptions,
+  PointerGesture,
+  PointerPath,
+  PointerPoint,
+  PointerSequenceOptions,
+  RotationOptions,
+  SwipeOptions,
+  TapOptions,
+} from './jestUtils';
 export {
   createGestureController,
+  doubleTap,
+  fireGesture,
   fireGestureHandler,
   getByGestureTestId,
+  longPress,
+  multiPointerSequence,
+  pinch,
+  pointerSequence,
+  rotate,
+  swipe,
+  tap,
 } from './jestUtils';

--- a/packages/react-native-gesture-handler/src/jestUtils/index.ts
+++ b/packages/react-native-gesture-handler/src/jestUtils/index.ts
@@ -1,1 +1,6 @@
-export { fireGestureHandler, getByGestureTestId } from './jestUtils';
+export type { GestureController, GestureControllerEvent } from './jestUtils';
+export {
+  createGestureController,
+  fireGestureHandler,
+  getByGestureTestId,
+} from './jestUtils';

--- a/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
+++ b/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
@@ -491,6 +491,193 @@ type ExtractConfig<T> =
       ? ExtractPayloadFromProps<THandlerProps>
       : Record<string, unknown>;
 
+export type GestureControllerEvent<
+  TEventPayload extends Record<string, unknown> = Record<string, unknown>,
+> = Partial<TEventPayload> & {
+  handlerTag?: never;
+  nativeEvent?: never;
+  oldState?: never;
+  state?: never;
+};
+
+type GestureControllerTarget =
+  | ReactTestInstance
+  | GestureType
+  | SingleGesture<any, any, any>
+  | string;
+
+export interface GestureController<
+  TEventPayload extends Record<string, unknown> = Record<string, unknown>,
+> {
+  begin: (event?: GestureControllerEvent<TEventPayload>) => void;
+  activate: (event?: GestureControllerEvent<TEventPayload>) => void;
+  update: (event?: GestureControllerEvent<TEventPayload>) => void;
+  end: (event?: GestureControllerEvent<TEventPayload>) => void;
+  fail: (event?: GestureControllerEvent<TEventPayload>) => void;
+  cancel: (event?: GestureControllerEvent<TEventPayload>) => void;
+  getState: () => State;
+}
+
+const FORBIDDEN_CONTROLLER_EVENT_FIELDS = [
+  'handlerTag',
+  'nativeEvent',
+  'oldState',
+  'state',
+];
+
+function getStateName(state: State): string {
+  return (
+    Object.entries(State).find(([, value]) => value === state)?.[0] ??
+    String(state)
+  );
+}
+
+function validateControllerEvent(event: Record<string, unknown>) {
+  for (const field of FORBIDDEN_CONTROLLER_EVENT_FIELDS) {
+    invariant(
+      !(field in event),
+      `createGestureController manages '${field}' internally. Pass only gesture event payload fields.`
+    );
+  }
+}
+
+function resolveGestureControllerTarget(target: GestureControllerTarget) {
+  return typeof target === 'string' ? getByGestureTestId(target) : target;
+}
+
+class GestureControllerImpl<
+  TEventPayload extends Record<string, unknown> = Record<string, unknown>,
+> implements GestureController<TEventPayload>
+{
+  private state: State = State.UNDETERMINED;
+
+  // eslint-disable-next-line no-useless-constructor
+  constructor(private handlerData: HandlerData) {}
+
+  public getState() {
+    return this.state;
+  }
+
+  public begin(event: GestureControllerEvent<TEventPayload> = {}) {
+    if (!this.isEnabled()) {
+      return;
+    }
+
+    this.transition('begin', State.BEGAN, [State.UNDETERMINED], event);
+  }
+
+  public activate(event: GestureControllerEvent<TEventPayload> = {}) {
+    if (!this.isEnabled()) {
+      return;
+    }
+
+    this.transition('activate', State.ACTIVE, [State.BEGAN], event);
+  }
+
+  public update(event: GestureControllerEvent<TEventPayload> = {}) {
+    if (!this.isEnabled()) {
+      return;
+    }
+
+    this.assertCurrentState('update', [State.ACTIVE]);
+
+    const nativeEvent = this.buildEvent(State.ACTIVE, event);
+    this.handlerData.emitEvent(
+      'onGestureHandlerEvent',
+      wrapWithNativeEvent(nativeEvent as GestureHandlerTestEvent)
+    );
+  }
+
+  public end(event: GestureControllerEvent<TEventPayload> = {}) {
+    if (!this.isEnabled()) {
+      return;
+    }
+
+    this.transition('end', State.END, [State.BEGAN, State.ACTIVE], event);
+  }
+
+  public fail(event: GestureControllerEvent<TEventPayload> = {}) {
+    if (!this.isEnabled()) {
+      return;
+    }
+
+    this.transition('fail', State.FAILED, [State.BEGAN, State.ACTIVE], event);
+  }
+
+  public cancel(event: GestureControllerEvent<TEventPayload> = {}) {
+    if (!this.isEnabled()) {
+      return;
+    }
+
+    this.transition(
+      'cancel',
+      State.CANCELLED,
+      [State.BEGAN, State.ACTIVE],
+      event
+    );
+  }
+
+  private transition(
+    action: string,
+    nextState: State,
+    allowedStates: State[],
+    event: GestureControllerEvent<TEventPayload>
+  ) {
+    this.assertCurrentState(action, allowedStates);
+
+    const oldState = this.state;
+    this.state = nextState;
+
+    const nativeEvent = {
+      oldState,
+      ...this.buildEvent(nextState, event),
+    } as GestureHandlerTestEvent;
+
+    this.handlerData.emitEvent(
+      'onGestureHandlerStateChange',
+      wrapWithNativeEvent(nativeEvent)
+    );
+  }
+
+  private isEnabled() {
+    return this.handlerData.enabled !== false;
+  }
+
+  private assertCurrentState(action: string, allowedStates: State[]) {
+    invariant(
+      allowedStates.includes(this.state),
+      `Cannot ${action} gesture from ${getStateName(this.state)} state.`
+    );
+  }
+
+  private buildEvent(
+    state: State,
+    event: GestureControllerEvent<TEventPayload>
+  ): Omit<GestureHandlerTestEvent, 'oldState'> {
+    validateControllerEvent(event);
+
+    return fillMissingDefaultsFor(this.handlerData)({
+      ...event,
+      state,
+    } as Partial<GestureHandlerTestEvent>) as Omit<
+      GestureHandlerTestEvent,
+      'oldState'
+    >;
+  }
+}
+
+export function createGestureController<
+  TEventPayload extends Record<string, unknown> = Record<string, unknown>,
+>(
+  componentOrGesture: GestureControllerTarget
+): GestureController<TEventPayload> {
+  const handlerData = getHandlerData(
+    resolveGestureControllerTarget(componentOrGesture)
+  );
+
+  return new GestureControllerImpl<TEventPayload>(handlerData);
+}
+
 export function fireGestureHandler<THandler extends AllGestures | AllHandlers>(
   componentOrGesture:
     | ReactTestInstance

--- a/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
+++ b/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
@@ -1,7 +1,9 @@
 import invariant from 'invariant';
+import type { RefObject } from 'react';
 import { DeviceEventEmitter } from 'react-native';
 import type { ReactTestInstance } from 'react-test-renderer';
 
+import { ActionType } from '../ActionType';
 import type { FlingGestureHandler } from '../handlers/FlingGestureHandler';
 import { flingHandlerName } from '../handlers/FlingGestureHandler';
 import type { ForceTouchGestureHandler } from '../handlers/ForceTouchGestureHandler';
@@ -44,10 +46,27 @@ import type { RotationGestureHandler } from '../handlers/RotationGestureHandler'
 import { rotationHandlerName } from '../handlers/RotationGestureHandler';
 import type { TapGestureHandler } from '../handlers/TapGestureHandler';
 import { tapHandlerName } from '../handlers/TapGestureHandler';
+import { PointerType } from '../PointerType';
 import { State } from '../State';
 import { hasProperty, withPrevAndCurrent } from '../utils';
-import { maybeUnpackValue } from '../v3/hooks/utils';
-import type { DetectorCallbacks, SingleGesture } from '../v3/types';
+import { configureRelations } from '../v3/detectors/utils';
+import {
+  maybeUnpackValue,
+  prepareConfigForNativeSide,
+} from '../v3/hooks/utils';
+import type { DetectorCallbacks, Gesture, SingleGesture } from '../v3/types';
+import { Gestures } from '../web/Gestures';
+import type IGestureHandler from '../web/handlers/IGestureHandler';
+import type {
+  AdaptedEvent,
+  Config,
+  PropsRef,
+  ResultEvent,
+} from '../web/interfaces';
+import { EventTypes } from '../web/interfaces';
+import type { GestureHandlerDelegate } from '../web/tools/GestureHandlerDelegate';
+import GestureHandlerOrchestrator from '../web/tools/GestureHandlerOrchestrator';
+import InteractionManager from '../web/tools/InteractionManager';
 
 // Load fireEvent conditionally, so RNGH may be used in setups without testing-library
 let fireEvent = (
@@ -697,6 +716,505 @@ export function createGestureController(
   );
 
   return new GestureControllerImpl(handlerData);
+}
+
+export type PointerPoint = {
+  x: number;
+  y: number;
+};
+
+export type PointerPath = {
+  id?: number | undefined;
+  start: PointerPoint;
+  moves: readonly PointerPoint[];
+};
+
+type PointerEventStep = {
+  type: 'down' | 'add' | 'move' | 'remove' | 'up';
+  pointerId: number;
+  at: PointerPoint;
+};
+
+type PointerWaitStep = {
+  type: 'wait';
+  duration: number;
+};
+
+export type PointerGesture = {
+  steps: readonly (PointerEventStep | PointerWaitStep)[];
+  timeStepMs: number;
+};
+
+export type PointerSequenceOptions = PointerPath & {
+  timeStepMs?: number | undefined;
+  holdForMs?: number | undefined;
+};
+
+export type MultiPointerSequenceOptions = {
+  pointers: readonly [PointerPath, PointerPath, ...PointerPath[]];
+  timeStepMs?: number | undefined;
+};
+
+export type SwipeOptions = {
+  from: PointerPoint;
+  to: PointerPoint;
+  /** Number of MOVE samples between the initial DOWN and final UP. */
+  steps?: number | undefined;
+  timeStepMs?: number | undefined;
+};
+
+export type TapOptions = {
+  at: PointerPoint;
+  timeStepMs?: number | undefined;
+};
+
+export type LongPressOptions = TapOptions & {
+  duration: number;
+};
+
+export type DoubleTapOptions = TapOptions & {
+  delay?: number | undefined;
+};
+
+export type PinchOptions = {
+  from: readonly [PointerPoint, PointerPoint];
+  to: readonly [PointerPoint, PointerPoint];
+  steps?: number | undefined;
+  timeStepMs?: number | undefined;
+};
+
+export type RotationOptions = {
+  center: PointerPoint;
+  radius: number;
+  fromAngle: number;
+  toAngle: number;
+  steps?: number | undefined;
+  timeStepMs?: number | undefined;
+};
+
+export type FireGestureOptions = {
+  /** Required by helpers that include a wait, such as longPress and doubleTap. */
+  advanceTimers?: ((duration: number) => void) | undefined;
+};
+
+function validateTiming(timeStepMs: number): void {
+  invariant(timeStepMs >= 0, 'timeStepMs must not be negative');
+}
+
+function interpolate(
+  from: PointerPoint,
+  to: PointerPoint,
+  steps: number
+): PointerPoint[] {
+  invariant(
+    Number.isInteger(steps) && steps > 0,
+    'steps must be a positive integer'
+  );
+
+  return Array.from({ length: steps }, (_, index) => {
+    const progress = (index + 1) / steps;
+
+    return {
+      x: from.x + (to.x - from.x) * progress,
+      y: from.y + (to.y - from.y) * progress,
+    };
+  });
+}
+
+/** Creates a single-pointer DOWN / MOVE* / UP sequence. */
+export function pointerSequence({
+  id = 1,
+  start,
+  moves,
+  timeStepMs = 16,
+  holdForMs = 0,
+}: PointerSequenceOptions): PointerGesture {
+  validateTiming(timeStepMs);
+  invariant(holdForMs >= 0, 'holdForMs must not be negative');
+
+  return {
+    steps: [
+      { type: 'down', pointerId: id, at: start },
+      ...moves.map((at) => ({ type: 'move' as const, pointerId: id, at })),
+      ...(holdForMs > 0
+        ? [{ type: 'wait' as const, duration: holdForMs }]
+        : []),
+      { type: 'up', pointerId: id, at: moves[moves.length - 1] ?? start },
+    ],
+    timeStepMs,
+  };
+}
+
+/**
+ * Creates one shared pointer stream. Every pointer moves once per frame and
+ * pointers are lifted in reverse order, matching browser touch semantics.
+ */
+export function multiPointerSequence({
+  pointers,
+  timeStepMs = 16,
+}: MultiPointerSequenceOptions): PointerGesture {
+  validateTiming(timeStepMs);
+
+  const movesCount = pointers[0].moves.length;
+  invariant(
+    pointers.every((pointer) => pointer.moves.length === movesCount),
+    'All multiPointerSequence paths must contain the same number of moves.'
+  );
+
+  const paths = pointers.map((pointer, index) => ({
+    ...pointer,
+    id: pointer.id ?? index + 1,
+  }));
+  const steps: (PointerEventStep | PointerWaitStep)[] = [
+    { type: 'down', pointerId: paths[0].id, at: paths[0].start },
+    ...paths.slice(1).map((pointer) => ({
+      type: 'add' as const,
+      pointerId: pointer.id,
+      at: pointer.start,
+    })),
+  ];
+
+  for (let index = 0; index < movesCount; index++) {
+    paths.forEach((pointer) => {
+      steps.push({
+        type: 'move',
+        pointerId: pointer.id,
+        at: pointer.moves[index],
+      });
+    });
+  }
+
+  paths
+    .slice(1)
+    .reverse()
+    .forEach((pointer) => {
+      steps.push({
+        type: 'remove',
+        pointerId: pointer.id,
+        at: pointer.moves[movesCount - 1] ?? pointer.start,
+      });
+    });
+  steps.push({
+    type: 'up',
+    pointerId: paths[0].id,
+    at: paths[0].moves[movesCount - 1] ?? paths[0].start,
+  });
+
+  return { steps, timeStepMs };
+}
+
+/**
+ * Creates deterministic pointer input. Recognition is intentionally left to
+ * the participating gesture handlers.
+ */
+export function swipe({
+  from,
+  to,
+  steps = 1,
+  timeStepMs = 16,
+}: SwipeOptions): PointerGesture {
+  return pointerSequence({
+    start: from,
+    moves: interpolate(from, to, steps),
+    timeStepMs,
+  });
+}
+
+export function tap({ at, timeStepMs }: TapOptions): PointerGesture {
+  return pointerSequence({ start: at, moves: [], timeStepMs });
+}
+
+export function longPress({
+  at,
+  duration,
+  timeStepMs,
+}: LongPressOptions): PointerGesture {
+  return pointerSequence({
+    start: at,
+    moves: [],
+    holdForMs: duration,
+    timeStepMs,
+  });
+}
+
+export function doubleTap({
+  at,
+  delay = 50,
+  timeStepMs = 16,
+}: DoubleTapOptions): PointerGesture {
+  validateTiming(timeStepMs);
+  invariant(delay >= 0, 'doubleTap delay must not be negative');
+
+  return {
+    steps: [
+      { type: 'down', pointerId: 1, at },
+      { type: 'up', pointerId: 1, at },
+      { type: 'wait', duration: delay },
+      { type: 'down', pointerId: 1, at },
+      { type: 'up', pointerId: 1, at },
+    ],
+    timeStepMs,
+  };
+}
+
+export function pinch({
+  from,
+  to,
+  steps = 2,
+  timeStepMs,
+}: PinchOptions): PointerGesture {
+  return multiPointerSequence({
+    pointers: [
+      { start: from[0], moves: interpolate(from[0], to[0], steps) },
+      { start: from[1], moves: interpolate(from[1], to[1], steps) },
+    ],
+    timeStepMs,
+  });
+}
+
+export function rotate({
+  center,
+  radius,
+  fromAngle,
+  toAngle,
+  steps = 2,
+  timeStepMs,
+}: RotationOptions): PointerGesture {
+  invariant(radius > 0, 'rotate radius must be greater than zero');
+
+  const pointAt = (angle: number): PointerPoint => ({
+    x: center.x + radius * Math.cos(angle),
+    y: center.y + radius * Math.sin(angle),
+  });
+  const angles = interpolate(
+    { x: fromAngle, y: 0 },
+    { x: toAngle, y: 0 },
+    steps
+  ).map((point) => point.x);
+
+  return multiPointerSequence({
+    pointers: [
+      { start: pointAt(fromAngle), moves: angles.map(pointAt) },
+      {
+        start: pointAt(fromAngle + Math.PI),
+        moves: angles.map((angle) => pointAt(angle + Math.PI)),
+      },
+    ],
+    timeStepMs,
+  });
+}
+
+type PointerGestureTarget = Gesture<any, any, any> | string;
+
+const NOOP = () => undefined;
+
+class JestGestureHandlerDelegate
+  implements GestureHandlerDelegate<object, IGestureHandler>
+{
+  public view: object | null;
+
+  public constructor(view: object | null) {
+    this.view = view;
+  }
+
+  public init = NOOP;
+  public detach = NOOP;
+  public updateDOM = NOOP;
+  public reset = NOOP;
+  public onBegin = NOOP;
+  public onActivate = NOOP;
+  public onEnd = NOOP;
+  public onCancel = NOOP;
+  public onFail = NOOP;
+  public onEnabledChange = NOOP;
+  public destroy = NOOP;
+
+  public isPointerInBounds(): boolean {
+    return true;
+  }
+
+  public measureView() {
+    return { pageX: 0, pageY: 0, width: 100, height: 100 };
+  }
+
+  public absoluteToLocal(absoluteX: number, absoluteY: number) {
+    return { x: absoluteX, y: absoluteY };
+  }
+}
+
+type PointerEventHandler = IGestureHandler & {
+  onPointerDown: (event: AdaptedEvent) => void;
+  onPointerAdd: (event: AdaptedEvent) => void;
+  onPointerMove: (event: AdaptedEvent) => void;
+  onPointerRemove: (event: AdaptedEvent) => void;
+  onPointerUp: (event: AdaptedEvent) => void;
+};
+
+function flattenGesture(
+  gesture: Gesture<any, any, any>
+): SingleGesture<any, any, any>[] {
+  if ('gestures' in gesture) {
+    return gesture.gestures.flatMap(flattenGesture);
+  }
+
+  return [gesture];
+}
+
+function resolvePointerGestureTarget(
+  target: PointerGestureTarget
+): Gesture<any, any, any> {
+  const gesture =
+    typeof target === 'string' ? getByGestureTestId(target) : target;
+
+  invariant(
+    typeof gesture === 'object' &&
+      gesture !== null &&
+      (hasProperty(gesture, 'detectorCallbacks') ||
+        hasProperty(gesture, 'gestures')),
+    'fireGesture accepts v3 hook gestures, composed gestures, or a v3 gesture test ID.'
+  );
+
+  return gesture as Gesture<any, any, any>;
+}
+
+function createAdaptedEvent(
+  point: PointerPoint,
+  eventType: EventTypes,
+  pointerId: number,
+  time: number
+): AdaptedEvent {
+  return {
+    x: point.x,
+    y: point.y,
+    offsetX: point.x,
+    offsetY: point.y,
+    pointerId,
+    pointerType: PointerType.TOUCH,
+    eventType,
+    time,
+  };
+}
+
+function createPointerHandler(
+  gesture: SingleGesture<any, any, any>,
+  orchestrator: GestureHandlerOrchestrator,
+  interactionManager: InteractionManager,
+  view: object
+): PointerEventHandler {
+  const GestureHandler = Gestures[gesture.type as keyof typeof Gestures];
+  invariant(
+    GestureHandler !== undefined,
+    `fireGesture does not support ${gesture.type} pointer recognition.`
+  );
+
+  const handler = new GestureHandler(
+    new JestGestureHandlerDelegate(view)
+  ) as unknown as PointerEventHandler;
+  const onGestureEvent = (event: ResultEvent) => {
+    gesture.detectorCallbacks.jsEventHandler?.(event.nativeEvent as never);
+  };
+  const propsRef = {
+    current: {
+      onGestureHandlerEvent: onGestureEvent,
+      onGestureHandlerStateChange: onGestureEvent,
+      onGestureHandlerTouchEvent: NOOP,
+    },
+  } as RefObject<PropsRef>;
+
+  handler.handlerTag = gesture.handlerTag;
+  handler.setGestureHandlerOrchestrator(orchestrator);
+  handler.setInteractionManager(interactionManager);
+  handler.setGestureConfig(
+    prepareConfigForNativeSide(
+      gesture.type,
+      gesture.config
+    ) as unknown as Config
+  );
+  handler.init(gesture.handlerTag, propsRef, ActionType.NATIVE_DETECTOR);
+
+  return handler;
+}
+
+/**
+ * Sends one pointer stream to all handlers in a v3 gesture or composition.
+ * The web recognizers request transitions; GestureArbitrator determines which
+ * of those transitions are observable after applying gesture relations.
+ */
+export function fireGesture(
+  target: PointerGestureTarget,
+  pointerGesture: PointerGesture,
+  { advanceTimers }: FireGestureOptions = {}
+): void {
+  const gesture = resolvePointerGestureTarget(target);
+  const gestures = flattenGesture(gesture);
+  const orchestrator = new GestureHandlerOrchestrator();
+  const interactionManager = new InteractionManager();
+  const view = {};
+  const relations = configureRelations(gesture);
+  const handlers = gestures.map((singleGesture) => {
+    const handler = createPointerHandler(
+      singleGesture,
+      orchestrator,
+      interactionManager,
+      view
+    );
+    interactionManager.configureInteractions(
+      handler,
+      relations.get(singleGesture.handlerTag) ?? singleGesture.gestureRelations
+    );
+
+    return handler;
+  });
+
+  invariant(
+    pointerGesture.steps.length > 0,
+    'fireGesture requires pointer input. Use tap(), swipe(), or pointerSequence().'
+  );
+
+  let time = 0;
+  const pointerActions: Record<
+    PointerEventStep['type'],
+    {
+      eventType: EventTypes;
+      method: keyof Pick<
+        PointerEventHandler,
+        | 'onPointerDown'
+        | 'onPointerAdd'
+        | 'onPointerMove'
+        | 'onPointerRemove'
+        | 'onPointerUp'
+      >;
+    }
+  > = {
+    down: { eventType: EventTypes.DOWN, method: 'onPointerDown' },
+    add: {
+      eventType: EventTypes.ADDITIONAL_POINTER_DOWN,
+      method: 'onPointerAdd',
+    },
+    move: { eventType: EventTypes.MOVE, method: 'onPointerMove' },
+    remove: {
+      eventType: EventTypes.ADDITIONAL_POINTER_UP,
+      method: 'onPointerRemove',
+    },
+    up: { eventType: EventTypes.UP, method: 'onPointerUp' },
+  };
+
+  pointerGesture.steps.forEach((step) => {
+    if (step.type === 'wait') {
+      invariant(
+        advanceTimers !== undefined,
+        'fireGesture needs advanceTimers to process waits. Pass jest.advanceTimersByTime as the third argument.'
+      );
+      advanceTimers(step.duration);
+      time += step.duration;
+      return;
+    }
+
+    const { eventType, method } = pointerActions[step.type];
+    const event = createAdaptedEvent(step.at, eventType, step.pointerId, time);
+    handlers.forEach((handler) => handler[method](event));
+    time += pointerGesture.timeStepMs;
+  });
 }
 
 export function fireGestureHandler<THandler extends AllGestures | AllHandlers>(

--- a/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
+++ b/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
@@ -47,7 +47,7 @@ import { tapHandlerName } from '../handlers/TapGestureHandler';
 import { State } from '../State';
 import { hasProperty, withPrevAndCurrent } from '../utils';
 import { maybeUnpackValue } from '../v3/hooks/utils';
-import type { SingleGesture } from '../v3/types';
+import type { DetectorCallbacks, SingleGesture } from '../v3/types';
 
 // Load fireEvent conditionally, so RNGH may be used in setups without testing-library
 let fireEvent = (
@@ -491,6 +491,19 @@ type ExtractConfig<T> =
       ? ExtractPayloadFromProps<THandlerProps>
       : Record<string, unknown>;
 
+type ExtractHookGesturePayload<T> = T extends {
+  detectorCallbacks: DetectorCallbacks<any, infer TExtendedHandlerData>;
+}
+  ? TExtendedHandlerData
+  : never;
+
+type ExtractGestureControllerPayload<T> =
+  T extends SingleGesture<any, any, any>
+    ? ExtractHookGesturePayload<T>
+    : T extends BaseGesture<any>
+      ? ExtractConfig<T>
+      : Record<string, unknown>;
+
 export type GestureControllerEvent<
   TEventPayload extends Record<string, unknown> = Record<string, unknown>,
 > = Partial<TEventPayload> & {
@@ -535,7 +548,7 @@ function getStateName(state: State): string {
 function validateControllerEvent(event: Record<string, unknown>) {
   for (const field of FORBIDDEN_CONTROLLER_EVENT_FIELDS) {
     invariant(
-      !(field in event),
+      !hasProperty(event, field),
       `createGestureController manages '${field}' internally. Pass only gesture event payload fields.`
     );
   }
@@ -667,15 +680,23 @@ class GestureControllerImpl<
 }
 
 export function createGestureController<
+  TTarget extends GestureType | SingleGesture<any, any, any>,
+>(
+  componentOrGesture: TTarget
+): GestureController<ExtractGestureControllerPayload<TTarget>>;
+export function createGestureController<
   TEventPayload extends Record<string, unknown> = Record<string, unknown>,
 >(
+  componentOrGesture: ReactTestInstance | string
+): GestureController<TEventPayload>;
+export function createGestureController(
   componentOrGesture: GestureControllerTarget
-): GestureController<TEventPayload> {
+): GestureController<Record<string, unknown>> {
   const handlerData = getHandlerData(
     resolveGestureControllerTarget(componentOrGesture)
   );
 
-  return new GestureControllerImpl<TEventPayload>(handlerData);
+  return new GestureControllerImpl(handlerData);
 }
 
 export function fireGestureHandler<THandler extends AllGestures | AllHandlers>(

--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -75,6 +75,8 @@ export default abstract class GestureHandler implements IGestureHandler {
   private _shouldResetProgress = false;
   private _pointerType: PointerType = PointerType.MOUSE;
   private _delegate: GestureHandlerDelegate<unknown, IGestureHandler>;
+  private gestureHandlerOrchestrator = GestureHandlerOrchestrator.instance;
+  private interactionManager = InteractionManager.instance;
 
   public constructor(
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>
@@ -147,6 +149,23 @@ export default abstract class GestureHandler implements IGestureHandler {
     manager.registerListeners();
   }
 
+  /**
+   * Allows non-DOM runtimes, such as Jest's pointer simulator, to run a
+   * handler in an isolated arbitration session.
+   */
+  public setGestureHandlerOrchestrator(
+    orchestrator: GestureHandlerOrchestrator
+  ): void {
+    this.gestureHandlerOrchestrator = orchestrator;
+  }
+
+  /**
+   * Keeps relation configuration local to an isolated handler session.
+   */
+  public setInteractionManager(interactionManager: InteractionManager): void {
+    this.interactionManager = interactionManager;
+  }
+
   //
   // Resetting handler
   //
@@ -183,7 +202,7 @@ export default abstract class GestureHandler implements IGestureHandler {
       this.cancelTouches();
     }
 
-    GestureHandlerOrchestrator.instance.onHandlerStateChange(
+    this.gestureHandlerOrchestrator.onHandlerStateChange(
       this,
       newState,
       oldState,
@@ -279,10 +298,7 @@ export default abstract class GestureHandler implements IGestureHandler {
       return false;
     }
 
-    return InteractionManager.instance.shouldWaitForHandlerFailure(
-      this,
-      handler
-    );
+    return this.interactionManager.shouldWaitForHandlerFailure(this, handler);
   }
 
   public shouldRequireToWaitForFailure(handler: IGestureHandler): boolean {
@@ -290,7 +306,7 @@ export default abstract class GestureHandler implements IGestureHandler {
       return false;
     }
 
-    return InteractionManager.instance.shouldRequireHandlerToWaitForFailure(
+    return this.interactionManager.shouldRequireHandlerToWaitForFailure(
       this,
       handler
     );
@@ -301,10 +317,7 @@ export default abstract class GestureHandler implements IGestureHandler {
       return true;
     }
 
-    return InteractionManager.instance.shouldRecognizeSimultaneously(
-      this,
-      handler
-    );
+    return this.interactionManager.shouldRecognizeSimultaneously(this, handler);
   }
 
   public shouldBeCancelledByOther(handler: IGestureHandler): boolean {
@@ -312,10 +325,7 @@ export default abstract class GestureHandler implements IGestureHandler {
       return false;
     }
 
-    return InteractionManager.instance.shouldHandlerBeCancelledBy(
-      this,
-      handler
-    );
+    return this.interactionManager.shouldHandlerBeCancelledBy(this, handler);
   }
 
   public shouldBeginWithRecordedHandlers(
@@ -333,11 +343,11 @@ export default abstract class GestureHandler implements IGestureHandler {
   //
 
   protected onPointerDown(event: AdaptedEvent): void {
-    GestureHandlerOrchestrator.instance.recordHandlerIfNotPresent(this);
+    this.gestureHandlerOrchestrator.recordHandlerIfNotPresent(this);
     this._pointerType = event.pointerType;
 
     if (this.pointerType === PointerType.TOUCH) {
-      GestureHandlerOrchestrator.instance.cancelMouseAndPenGestures(this);
+      this.gestureHandlerOrchestrator.cancelMouseAndPenGestures(this);
     }
 
     this.tryToSendTouchEvent(event);
@@ -377,7 +387,7 @@ export default abstract class GestureHandler implements IGestureHandler {
   protected onPointerCancel(_event: AdaptedEvent): void {
     // No need to send a cancel touch event explicitly here. `cancel` will
     // handle cancelling all tracked touches if the handler expects pointer data.
-    if (GestureHandlerOrchestrator.instance.isHandlerRecorded(this)) {
+    if (this.gestureHandlerOrchestrator.isHandlerRecorded(this)) {
       this.cancel();
     }
   }
@@ -851,7 +861,7 @@ export default abstract class GestureHandler implements IGestureHandler {
         this.fail(true);
         break;
       case State.UNDETERMINED:
-        GestureHandlerOrchestrator.instance.removeHandlerFromOrchestrator(this);
+        this.gestureHandlerOrchestrator.removeHandlerFromOrchestrator(this);
         break;
       default:
         this.cancel(true);
@@ -999,7 +1009,7 @@ export default abstract class GestureHandler implements IGestureHandler {
   }
 
   public onDestroy(): void {
-    GestureHandlerOrchestrator.instance.removeHandlerFromOrchestrator(this);
+    this.gestureHandlerOrchestrator.removeHandlerFromOrchestrator(this);
     this.delegate.destroy();
   }
 

--- a/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/IGestureHandler.ts
@@ -13,6 +13,8 @@ import type { SingleGestureName } from '../../v3/types';
 import type { Config, HostDetector, PropsRef } from '../interfaces';
 import type EventManager from '../tools/EventManager';
 import type { GestureHandlerDelegate } from '../tools/GestureHandlerDelegate';
+import type GestureHandlerOrchestrator from '../tools/GestureHandlerOrchestrator';
+import type InteractionManager from '../tools/InteractionManager';
 import type PointerTracker from '../tools/PointerTracker';
 
 export default interface IGestureHandler {
@@ -40,6 +42,10 @@ export default interface IGestureHandler {
   usesNativeOrVirtualDetector: () => boolean;
 
   attachEventManager: (manager: EventManager<unknown>) => void;
+  setGestureHandlerOrchestrator: (
+    orchestrator: GestureHandlerOrchestrator
+  ) => void;
+  setInteractionManager: (interactionManager: InteractionManager) => void;
 
   isButtonInConfig: (
     mouseButton: MouseButton | undefined

--- a/packages/react-native-gesture-handler/src/web/tools/GestureArbitrator.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureArbitrator.ts
@@ -1,0 +1,323 @@
+import { State } from '../../State';
+import type IGestureHandler from '../handlers/IGestureHandler';
+
+type HandlerConflictResolver = (
+  handler: IGestureHandler,
+  otherHandler: IGestureHandler
+) => boolean;
+
+/**
+ * Platform-independent policy for deciding which handler state changes are
+ * observable when several handlers participate in the same interaction.
+ *
+ * Platform-specific pointer overlap rules are supplied by the caller. This
+ * keeps relation handling reusable by the web orchestrator and Jest runtime.
+ */
+export default class GestureArbitrator {
+  private gestureHandlers: IGestureHandler[] = [];
+  private awaitingHandlers: IGestureHandler[] = [];
+  private awaitingHandlersTags: Set<number> = new Set();
+
+  private handlingChangeSemaphore = 0;
+  private activationIndex = 0;
+
+  private readonly hasHandlerConflict: HandlerConflictResolver;
+
+  public constructor(hasHandlerConflict: HandlerConflictResolver) {
+    this.hasHandlerConflict = hasHandlerConflict;
+  }
+
+  private scheduleFinishedHandlersCleanup(): void {
+    if (this.handlingChangeSemaphore === 0) {
+      queueMicrotask(() => {
+        this.cleanupFinishedHandlers();
+      });
+    }
+  }
+
+  private cleanHandler(handler: IGestureHandler): void {
+    handler.reset();
+    handler.active = false;
+    handler.awaiting = false;
+    handler.activationIndex = Number.MAX_VALUE;
+  }
+
+  public isHandlerRecorded(handler: IGestureHandler): boolean {
+    return this.gestureHandlers.includes(handler);
+  }
+
+  public removeHandler(handler: IGestureHandler): void {
+    const indexInGestureHandlers = this.gestureHandlers.indexOf(handler);
+    const indexInAwaitingHandlers = this.awaitingHandlers.indexOf(handler);
+
+    if (indexInGestureHandlers >= 0) {
+      this.gestureHandlers.splice(indexInGestureHandlers, 1);
+    }
+
+    if (indexInAwaitingHandlers >= 0) {
+      this.awaitingHandlers.splice(indexInAwaitingHandlers, 1);
+      this.awaitingHandlersTags.delete(handler.handlerTag);
+    }
+  }
+
+  public forEachHandler(callback: (handler: IGestureHandler) => void): void {
+    this.gestureHandlers.forEach(callback);
+  }
+
+  private cleanupFinishedHandlers(): void {
+    const handlersToRemove = new Set<IGestureHandler>();
+
+    for (let i = this.gestureHandlers.length - 1; i >= 0; --i) {
+      const handler = this.gestureHandlers[i];
+
+      if (this.isFinished(handler.state) && !handler.awaiting) {
+        this.cleanHandler(handler);
+        handlersToRemove.add(handler);
+      }
+    }
+
+    this.gestureHandlers = this.gestureHandlers.filter(
+      (handler) => !handlersToRemove.has(handler)
+    );
+  }
+
+  private hasOtherHandlerToWaitFor(handler: IGestureHandler): boolean {
+    return this.gestureHandlers.some(
+      (otherHandler) =>
+        !this.isFinished(otherHandler.state) &&
+        this.shouldHandlerWaitForOther(handler, otherHandler)
+    );
+  }
+
+  private shouldBeCancelledByFinishedHandler(
+    handler: IGestureHandler
+  ): boolean {
+    return this.gestureHandlers.some(
+      (otherHandler) =>
+        this.shouldHandlerWaitForOther(handler, otherHandler) &&
+        otherHandler.state === State.END
+    );
+  }
+
+  private tryActivate(handler: IGestureHandler): void {
+    if (this.shouldBeCancelledByFinishedHandler(handler)) {
+      handler.cancel();
+      return;
+    }
+
+    if (this.hasOtherHandlerToWaitFor(handler)) {
+      this.addAwaitingHandler(handler);
+      return;
+    }
+
+    const handlerState = handler.state;
+
+    if (handlerState === State.CANCELLED || handlerState === State.FAILED) {
+      return;
+    }
+
+    if (this.shouldActivate(handler)) {
+      this.makeActive(handler);
+      return;
+    }
+
+    if (handlerState === State.ACTIVE) {
+      handler.fail();
+      return;
+    }
+
+    if (handlerState === State.BEGAN) {
+      handler.cancel();
+    }
+  }
+
+  private shouldActivate(handler: IGestureHandler): boolean {
+    return !this.gestureHandlers.some((otherHandler) =>
+      this.shouldHandlerBeCancelledBy(handler, otherHandler)
+    );
+  }
+
+  private cleanupAwaitingHandlers(handler: IGestureHandler): void {
+    for (const otherHandler of this.awaitingHandlers) {
+      const shouldWait =
+        !otherHandler.awaiting &&
+        this.shouldHandlerWaitForOther(otherHandler, handler);
+
+      if (shouldWait) {
+        this.cleanHandler(otherHandler);
+        this.awaitingHandlersTags.delete(otherHandler.handlerTag);
+      }
+    }
+
+    this.awaitingHandlers = this.awaitingHandlers.filter((otherHandler) =>
+      this.awaitingHandlersTags.has(otherHandler.handlerTag)
+    );
+  }
+
+  public onHandlerStateChange(
+    handler: IGestureHandler,
+    newState: State,
+    oldState: State,
+    sendIfDisabled?: boolean
+  ): void {
+    if (!handler.enabled && !sendIfDisabled) {
+      return;
+    }
+
+    this.handlingChangeSemaphore += 1;
+
+    if (this.isFinished(newState)) {
+      for (const otherHandler of this.awaitingHandlers) {
+        if (
+          !this.shouldHandlerWaitForOther(otherHandler, handler) ||
+          !this.awaitingHandlersTags.has(otherHandler.handlerTag)
+        ) {
+          continue;
+        }
+
+        if (newState !== State.END) {
+          this.tryActivate(otherHandler);
+          continue;
+        }
+
+        otherHandler.cancel();
+
+        if (otherHandler.state === State.END) {
+          otherHandler.sendEvent(State.CANCELLED, State.BEGAN);
+        }
+
+        otherHandler.awaiting = false;
+      }
+    }
+
+    if (newState === State.ACTIVE) {
+      this.tryActivate(handler);
+    } else if (oldState === State.ACTIVE || oldState === State.END) {
+      if (handler.active) {
+        handler.sendEvent(newState, oldState);
+      } else if (
+        oldState === State.ACTIVE &&
+        (newState === State.CANCELLED || newState === State.FAILED)
+      ) {
+        handler.sendEvent(newState, State.BEGAN);
+      }
+    } else if (
+      oldState !== State.UNDETERMINED ||
+      newState !== State.CANCELLED
+    ) {
+      handler.sendEvent(newState, oldState);
+    }
+
+    this.handlingChangeSemaphore -= 1;
+
+    this.scheduleFinishedHandlersCleanup();
+
+    if (!this.awaitingHandlers.includes(handler)) {
+      this.cleanupAwaitingHandlers(handler);
+    }
+  }
+
+  private makeActive(handler: IGestureHandler): void {
+    const currentState = handler.state;
+
+    handler.active = true;
+    handler.shouldResetProgress = true;
+    handler.activationIndex = this.activationIndex++;
+
+    for (let i = this.gestureHandlers.length - 1; i >= 0; --i) {
+      if (this.shouldHandlerBeCancelledBy(this.gestureHandlers[i], handler)) {
+        this.gestureHandlers[i].cancel();
+      }
+    }
+
+    for (const otherHandler of this.awaitingHandlers) {
+      if (this.shouldHandlerBeCancelledBy(otherHandler, handler)) {
+        otherHandler.awaiting = false;
+      }
+    }
+
+    handler.sendEvent(State.ACTIVE, State.BEGAN);
+
+    if (currentState !== State.ACTIVE) {
+      handler.sendEvent(State.END, State.ACTIVE);
+      if (currentState !== State.END) {
+        handler.sendEvent(State.UNDETERMINED, State.END);
+      }
+    }
+
+    if (!handler.awaiting) {
+      return;
+    }
+
+    handler.awaiting = false;
+    this.awaitingHandlers = this.awaitingHandlers.filter(
+      (otherHandler) => otherHandler !== handler
+    );
+  }
+
+  private addAwaitingHandler(handler: IGestureHandler): void {
+    if (this.awaitingHandlers.includes(handler)) {
+      return;
+    }
+
+    this.awaitingHandlers.push(handler);
+    this.awaitingHandlersTags.add(handler.handlerTag);
+
+    handler.awaiting = true;
+    handler.activationIndex = this.activationIndex++;
+  }
+
+  public recordHandlerIfNotPresent(handler: IGestureHandler): void {
+    if (this.isHandlerRecorded(handler)) {
+      return;
+    }
+
+    handler.active = false;
+    handler.awaiting = false;
+    handler.activationIndex = Number.MAX_SAFE_INTEGER;
+
+    if (!handler.shouldBeginWithRecordedHandlers(this.gestureHandlers)) {
+      handler.cancel();
+    }
+
+    this.gestureHandlers.push(handler);
+  }
+
+  private shouldHandlerWaitForOther(
+    handler: IGestureHandler,
+    otherHandler: IGestureHandler
+  ): boolean {
+    return (
+      handler !== otherHandler &&
+      (handler.shouldWaitForHandlerFailure(otherHandler) ||
+        otherHandler.shouldRequireToWaitForFailure(handler))
+    );
+  }
+
+  private canRunSimultaneously(
+    firstHandler: IGestureHandler,
+    secondHandler: IGestureHandler
+  ): boolean {
+    return (
+      firstHandler === secondHandler ||
+      firstHandler.shouldRecognizeSimultaneously(secondHandler) ||
+      secondHandler.shouldRecognizeSimultaneously(firstHandler)
+    );
+  }
+
+  private shouldHandlerBeCancelledBy(
+    handler: IGestureHandler,
+    otherHandler: IGestureHandler
+  ): boolean {
+    return (
+      !this.canRunSimultaneously(handler, otherHandler) &&
+      this.hasHandlerConflict(handler, otherHandler)
+    );
+  }
+
+  private isFinished(state: State): boolean {
+    return (
+      state === State.END || state === State.FAILED || state === State.CANCELLED
+    );
+  }
+}

--- a/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
@@ -1,154 +1,26 @@
 import { PointerType } from '../../PointerType';
 import { State } from '../../State';
 import type IGestureHandler from '../handlers/IGestureHandler';
+import GestureArbitrator from './GestureArbitrator';
 import PointerTracker from './PointerTracker';
 
+/**
+ * Web adapter for GestureArbitrator. It supplies DOM/pointer-specific conflict
+ * detection and keeps the web singleton used by production handlers.
+ */
 export default class GestureHandlerOrchestrator {
   private static _instance: GestureHandlerOrchestrator;
 
-  private gestureHandlers: IGestureHandler[] = [];
-  private awaitingHandlers: IGestureHandler[] = [];
-  private awaitingHandlersTags: Set<number> = new Set();
-
-  private handlingChangeSemaphore = 0;
-  private activationIndex = 0;
-
-  // Private beacuse of Singleton
-  // eslint-disable-next-line no-useless-constructor, @typescript-eslint/no-empty-function
-  private constructor() {}
-
-  private scheduleFinishedHandlersCleanup(): void {
-    if (this.handlingChangeSemaphore === 0) {
-      queueMicrotask(() => {
-        this.cleanupFinishedHandlers();
-      });
-    }
-  }
-
-  private cleanHandler(handler: IGestureHandler): void {
-    handler.reset();
-    handler.active = false;
-    handler.awaiting = false;
-    handler.activationIndex = Number.MAX_VALUE;
-  }
+  private readonly arbitrator = new GestureArbitrator(
+    this.hasHandlerConflict.bind(this)
+  );
 
   public isHandlerRecorded(handler: IGestureHandler): boolean {
-    return this.gestureHandlers.includes(handler);
+    return this.arbitrator.isHandlerRecorded(handler);
   }
 
   public removeHandlerFromOrchestrator(handler: IGestureHandler): void {
-    const indexInGestureHandlers = this.gestureHandlers.indexOf(handler);
-    const indexInAwaitingHandlers = this.awaitingHandlers.indexOf(handler);
-
-    if (indexInGestureHandlers >= 0) {
-      this.gestureHandlers.splice(indexInGestureHandlers, 1);
-    }
-
-    if (indexInAwaitingHandlers >= 0) {
-      this.awaitingHandlers.splice(indexInAwaitingHandlers, 1);
-      this.awaitingHandlersTags.delete(handler.handlerTag);
-    }
-  }
-
-  private cleanupFinishedHandlers(): void {
-    const handlersToRemove = new Set<IGestureHandler>();
-
-    for (let i = this.gestureHandlers.length - 1; i >= 0; --i) {
-      const handler = this.gestureHandlers[i];
-
-      if (this.isFinished(handler.state) && !handler.awaiting) {
-        this.cleanHandler(handler);
-        handlersToRemove.add(handler);
-      }
-    }
-
-    this.gestureHandlers = this.gestureHandlers.filter(
-      (handler) => !handlersToRemove.has(handler)
-    );
-  }
-
-  private hasOtherHandlerToWaitFor(handler: IGestureHandler): boolean {
-    const hasToWaitFor = (otherHandler: IGestureHandler) => {
-      return (
-        !this.isFinished(otherHandler.state) &&
-        this.shouldHandlerWaitForOther(handler, otherHandler)
-      );
-    };
-
-    return this.gestureHandlers.some(hasToWaitFor);
-  }
-
-  private shouldBeCancelledByFinishedHandler(
-    handler: IGestureHandler
-  ): boolean {
-    const shouldBeCancelled = (otherHandler: IGestureHandler) => {
-      return (
-        this.shouldHandlerWaitForOther(handler, otherHandler) &&
-        otherHandler.state === State.END
-      );
-    };
-
-    return this.gestureHandlers.some(shouldBeCancelled);
-  }
-
-  private tryActivate(handler: IGestureHandler): void {
-    if (this.shouldBeCancelledByFinishedHandler(handler)) {
-      handler.cancel();
-      return;
-    }
-
-    if (this.hasOtherHandlerToWaitFor(handler)) {
-      this.addAwaitingHandler(handler);
-      return;
-    }
-
-    const handlerState = handler.state;
-
-    if (handlerState === State.CANCELLED || handlerState === State.FAILED) {
-      return;
-    }
-
-    if (this.shouldActivate(handler)) {
-      this.makeActive(handler);
-      return;
-    }
-
-    if (handlerState === State.ACTIVE) {
-      handler.fail();
-      return;
-    }
-
-    if (handlerState === State.BEGAN) {
-      handler.cancel();
-    }
-  }
-
-  private shouldActivate(handler: IGestureHandler): boolean {
-    const shouldBeCancelledBy = (otherHandler: IGestureHandler) => {
-      return this.shouldHandlerBeCancelledBy(handler, otherHandler);
-    };
-
-    return !this.gestureHandlers.some(shouldBeCancelledBy);
-  }
-
-  private cleanupAwaitingHandlers(handler: IGestureHandler): void {
-    const shouldWait = (otherHandler: IGestureHandler) => {
-      return (
-        !otherHandler.awaiting &&
-        this.shouldHandlerWaitForOther(otherHandler, handler)
-      );
-    };
-
-    for (const otherHandler of this.awaitingHandlers) {
-      if (shouldWait(otherHandler)) {
-        this.cleanHandler(otherHandler);
-        this.awaitingHandlersTags.delete(otherHandler.handlerTag);
-      }
-    }
-
-    this.awaitingHandlers = this.awaitingHandlers.filter((otherHandler) =>
-      this.awaitingHandlersTags.has(otherHandler.handlerTag)
-    );
+    this.arbitrator.removeHandler(handler);
   }
 
   public onHandlerStateChange(
@@ -157,170 +29,28 @@ export default class GestureHandlerOrchestrator {
     oldState: State,
     sendIfDisabled?: boolean
   ): void {
-    if (!handler.enabled && !sendIfDisabled) {
-      return;
-    }
-
-    this.handlingChangeSemaphore += 1;
-
-    if (this.isFinished(newState)) {
-      for (const otherHandler of this.awaitingHandlers) {
-        if (
-          !this.shouldHandlerWaitForOther(otherHandler, handler) ||
-          !this.awaitingHandlersTags.has(otherHandler.handlerTag)
-        ) {
-          continue;
-        }
-
-        if (newState !== State.END) {
-          this.tryActivate(otherHandler);
-          continue;
-        }
-
-        otherHandler.cancel();
-
-        if (otherHandler.state === State.END) {
-          // Handle edge case, where discrete gestures end immediately after activation thus
-          // their state is set to END and when the gesture they are waiting for activates they
-          // should be cancelled, however `cancel` was never sent as gestures were already in the END state.
-          // Send synthetic BEGAN -> CANCELLED to properly handle JS logic
-          otherHandler.sendEvent(State.CANCELLED, State.BEGAN);
-        }
-
-        otherHandler.awaiting = false;
-      }
-    }
-
-    if (newState === State.ACTIVE) {
-      this.tryActivate(handler);
-    } else if (oldState === State.ACTIVE || oldState === State.END) {
-      if (handler.active) {
-        handler.sendEvent(newState, oldState);
-      } else if (
-        oldState === State.ACTIVE &&
-        (newState === State.CANCELLED || newState === State.FAILED)
-      ) {
-        handler.sendEvent(newState, State.BEGAN);
-      }
-    } else if (
-      oldState !== State.UNDETERMINED ||
-      newState !== State.CANCELLED
-    ) {
-      handler.sendEvent(newState, oldState);
-    }
-
-    this.handlingChangeSemaphore -= 1;
-
-    this.scheduleFinishedHandlersCleanup();
-
-    if (!this.awaitingHandlers.includes(handler)) {
-      this.cleanupAwaitingHandlers(handler);
-    }
-  }
-
-  private makeActive(handler: IGestureHandler): void {
-    const currentState = handler.state;
-
-    handler.active = true;
-    handler.shouldResetProgress = true;
-    handler.activationIndex = this.activationIndex++;
-
-    for (let i = this.gestureHandlers.length - 1; i >= 0; --i) {
-      if (this.shouldHandlerBeCancelledBy(this.gestureHandlers[i], handler)) {
-        this.gestureHandlers[i].cancel();
-      }
-    }
-
-    for (const otherHandler of this.awaitingHandlers) {
-      if (this.shouldHandlerBeCancelledBy(otherHandler, handler)) {
-        otherHandler.awaiting = false;
-      }
-    }
-
-    handler.sendEvent(State.ACTIVE, State.BEGAN);
-
-    if (currentState !== State.ACTIVE) {
-      handler.sendEvent(State.END, State.ACTIVE);
-      if (currentState !== State.END) {
-        handler.sendEvent(State.UNDETERMINED, State.END);
-      }
-    }
-
-    if (!handler.awaiting) {
-      return;
-    }
-
-    handler.awaiting = false;
-
-    this.awaitingHandlers = this.awaitingHandlers.filter(
-      (otherHandler) => otherHandler !== handler
+    this.arbitrator.onHandlerStateChange(
+      handler,
+      newState,
+      oldState,
+      sendIfDisabled
     );
-  }
-
-  private addAwaitingHandler(handler: IGestureHandler): void {
-    if (this.awaitingHandlers.includes(handler)) {
-      return;
-    }
-
-    this.awaitingHandlers.push(handler);
-    this.awaitingHandlersTags.add(handler.handlerTag);
-
-    handler.awaiting = true;
-    handler.activationIndex = this.activationIndex++;
   }
 
   public recordHandlerIfNotPresent(handler: IGestureHandler): void {
-    if (this.isHandlerRecorded(handler)) {
-      return;
-    }
-
-    handler.active = false;
-    handler.awaiting = false;
-    handler.activationIndex = Number.MAX_SAFE_INTEGER;
-
-    if (!handler.shouldBeginWithRecordedHandlers(this.gestureHandlers)) {
-      handler.cancel();
-    }
-
-    this.gestureHandlers.push(handler);
+    this.arbitrator.recordHandlerIfNotPresent(handler);
   }
 
-  private shouldHandlerWaitForOther(
+  private hasHandlerConflict(
     handler: IGestureHandler,
     otherHandler: IGestureHandler
   ): boolean {
-    return (
-      handler !== otherHandler &&
-      (handler.shouldWaitForHandlerFailure(otherHandler) ||
-        otherHandler.shouldRequireToWaitForFailure(handler))
-    );
-  }
-
-  private canRunSimultaneously(
-    gh1: IGestureHandler,
-    gh2: IGestureHandler
-  ): boolean {
-    return (
-      gh1 === gh2 ||
-      gh1.shouldRecognizeSimultaneously(gh2) ||
-      gh2.shouldRecognizeSimultaneously(gh1)
-    );
-  }
-
-  private shouldHandlerBeCancelledBy(
-    handler: IGestureHandler,
-    otherHandler: IGestureHandler
-  ): boolean {
-    if (this.canRunSimultaneously(handler, otherHandler)) {
-      return false;
-    }
-
     if (handler.awaiting || handler.state === State.ACTIVE) {
       return handler.shouldBeCancelledByOther(otherHandler);
     }
 
-    const handlerPointers: number[] = handler.getTrackedPointersID();
-    const otherPointers: number[] = otherHandler.getTrackedPointersID();
+    const handlerPointers = handler.getTrackedPointersID();
+    const otherPointers = otherHandler.getTrackedPointersID();
 
     if (
       !PointerTracker.shareCommonPointers(handlerPointers, otherPointers) &&
@@ -336,12 +66,6 @@ export default class GestureHandlerOrchestrator {
     handler: IGestureHandler,
     otherHandler: IGestureHandler
   ): boolean {
-    // If handlers don't have common pointers, default return value is false.
-    // However, if at least on pointer overlaps with both handlers, we return true
-    // This solves issue in overlapping parents example
-
-    // TODO: Find better way to handle that issue, for example by activation order and handler cancelling
-
     const isPointerWithinBothBounds = (pointer: number) => {
       const point = handler.tracker.getLastAbsoluteCoords(pointer);
 
@@ -355,20 +79,8 @@ export default class GestureHandlerOrchestrator {
     return handler.getTrackedPointersID().some(isPointerWithinBothBounds);
   }
 
-  private isFinished(state: State): boolean {
-    return (
-      state === State.END || state === State.FAILED || state === State.CANCELLED
-    );
-  }
-
-  // This function is called when handler receives touchdown event
-  // If handler is using mouse or pen as a pointer and any handler receives touch event,
-  // mouse/pen event dissappears - it doesn't send onPointerCancel nor onPointerUp (and others)
-  // This became a problem because handler was left at active state without any signal to end or fail
-  // To handle this, when new touch event is received, we loop through active handlers and check which type of
-  // pointer they're using. If there are any handler with mouse/pen as a pointer, we cancel them
   public cancelMouseAndPenGestures(currentHandler: IGestureHandler): void {
-    this.gestureHandlers.forEach((handler: IGestureHandler) => {
+    this.arbitrator.forEachHandler((handler) => {
       if (
         handler.pointerType !== PointerType.MOUSE &&
         handler.pointerType !== PointerType.STYLUS
@@ -379,13 +91,6 @@ export default class GestureHandlerOrchestrator {
       if (handler !== currentHandler) {
         handler.cancel();
       } else {
-        // Handler that received touch event should have its pointer tracker reset
-        // This allows handler to smoothly change from mouse/pen to touch
-        // The drawback is, that when we try to use mouse/pen one more time, it doesn't send onPointerDown at the first time
-        // so it is required to click two times to get handler to work
-        //
-        // However, handler will receive manually created onPointerEnter that is triggered in EventManager in onPointerMove method.
-        // There may be possibility to use that fact to make handler respond properly to first mouse click
         handler.tracker.resetTracker();
       }
     });

--- a/packages/react-native-gesture-handler/src/web/tools/InteractionManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/InteractionManager.ts
@@ -9,10 +9,6 @@ export default class InteractionManager {
   private readonly simultaneousRelations: Map<number, number[]> = new Map();
   private readonly blocksHandlersRelations: Map<number, number[]> = new Map();
 
-  // Private becaues of singleton
-  // eslint-disable-next-line no-useless-constructor, @typescript-eslint/no-empty-function
-  private constructor() {}
-
   public configureInteractions(
     handler: IGestureHandler,
     config: GestureRelations | Config


### PR DESCRIPTION
## Description

The `fireGesture` feeds deterministic pointer input into web gesture recognizers, then routes their state requests through `GestureArbitrator`. This lets tests cover real recognition outcomes and composed relations without manually supplying RNGH states.

```ts
fireGesture(
  useCompetingGestures(tap, pan),
  swipe({
    from: { x: 0, y: 0 },
    to: { x: 100, y: 0 },
    steps: 4,
  })
);

expect(onPanActivate).toHaveBeenCalled();
expect(onTapActivate).not.toHaveBeenCalled();
```

or with other helpers:

```ts
fireGesture(tapGesture, tap({ at: { x: 20, y: 40 } }));

fireGesture(
  longPressGesture,
  longPress({ at: { x: 20, y: 40 }, duration: 500 }),
  { advanceTimers: jest.advanceTimersByTime }
);

fireGesture(
  pinchGesture,
  pinch({
    from: [{ x: 0, y: 0 }, { x: 0, y: 40 }],
    to: [{ x: 0, y: 0 }, { x: 0, y: 100 }],
  })
);
```

The API includes low-level composable primitives (`pointerSequence`, `multiPointerSequence`) and convenience helpers (`tap`, `doubleTap`, `longPress`, `swipe`, `pinch`, `rotate`). Also extracts the shared relation/state policy into `GestureArbitrator`, leaving web-specific pointer-overlap behavior in `GestureHandlerOrchestrator`.

## Test plan

Added new tests. 