### PR TITLE
Export `PressableEvent` type

### DIFF
--- a/packages/react-native-gesture-handler/src/components/Pressable/index.ts
+++ b/packages/react-native-gesture-handler/src/components/Pressable/index.ts
@@ -1,6 +1,7 @@
 export { default } from './Pressable';
 export type {
   LegacyPressableProps,
+  PressableEvent,
   PressableProps,
   PressableStateCallbackType,
 } from './PressableProps';

--- a/packages/react-native-gesture-handler/src/index.ts
+++ b/packages/react-native-gesture-handler/src/index.ts
@@ -25,6 +25,7 @@ export {
 export { default as GestureHandlerRootView } from './components/GestureHandlerRootView';
 export type {
   LegacyPressableProps,
+  PressableEvent,
   PressableProps,
   PressableStateCallbackType,
 } from './components/Pressable';


### PR DESCRIPTION
## Description

As stated in [this discussion](https://github.com/software-mansion/react-native-gesture-handler/discussions/3512), `PressableEvent` is not exported. This PR adds this export.

## Test plan

<details>
<summary>Tested on the following code:</summary>

import React from 'react';
import { StyleSheet, Text, View } from 'react-native';
import type { PressableEvent } from 'react-native-gesture-handler';
import { Pressable } from 'react-native-gesture-handler';

export default function EmptyExample() {
  const handlePress = (e: PressableEvent) => {
    console.log(e.nativeEvent.changedTouches);
  };

  return (
    <View style={styles.container}>
      <Pressable onPress={handlePress} />
      <Pressable
        onPress={(e) => {
          console.log(e.nativeEvent.changedTouches);
        }}
      />
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
});


</details>