### PR TITLE
[Android] Guard update events to only be dispatched in ACTIVE state

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -328,9 +328,8 @@ class GestureHandlerOrchestrator(
     }
 
     if (!handler.isAwaiting || action != MotionEvent.ACTION_MOVE) {
-      val isFirstEvent = handler.state == 0
       handler.handle(event, sourceEvent)
-      if (handler.isActive) {
+      if (handler.state == GestureHandler.STATE_ACTIVE && handler.isActive) {
         // After handler is done waiting for other one to fail its progress should be
         // reset, otherwise there may be a visible jump in values sent by the handler.
         // When handler is waiting it's already activated but the `isAwaiting` flag


### PR DESCRIPTION
## Description

1. Removes unused `isFirstEvent`
2. Adds a guard to ensure `update` events are only dispatched in `ACTIVE` state. I've noticed that `dispatchHandlerUpdate` was being called in state `END`.

## Test plan

I didn't observe it in the runtime, only in the debugger while working on `Touchable` optimizations.
