### PR TITLE
Don't dispatch orphaned touch events

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -477,10 +477,15 @@ open class GestureHandler {
   }
 
   private fun dispatchTouchUpEvent(event: MotionEvent, sourceEvent: MotionEvent) {
+    val pointerId = event.getPointerId(event.actionIndex)
+
+    if (trackedPointers[pointerId] == null) {
+      return
+    }
+
     extractAllPointersData()
     changedTouchesPayload = null
     touchEventType = RNGestureHandlerTouchEvent.EVENT_TOUCH_UP
-    val pointerId = event.getPointerId(event.actionIndex)
     val offsetX = sourceEvent.rawX - sourceEvent.x
     val offsetY = sourceEvent.rawY - sourceEvent.y
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.mm
@@ -116,18 +116,25 @@
   _eventType = RNGHTouchEventTypePointerDown;
 
   NSDictionary *data[touches.count];
+  int changedCount = 0;
 
   for (int i = 0; i < [touches count]; i++) {
     RNGHUITouch *touch = [[touches allObjects] objectAtIndex:i];
     int index = [self registerTouch:touch];
-    if (index >= 0) {
-      _trackedPointersCount++;
+
+    if (index < 0) {
+      continue;
     }
 
-    data[i] = [self extractPointerData:index forTouch:touch];
+    _trackedPointersCount++;
+    data[changedCount++] = [self extractPointerData:index forTouch:touch];
   }
 
-  _changedPointersData = [[NSArray alloc] initWithObjects:data count:[touches count]];
+  if (changedCount == 0) {
+    return;
+  }
+
+  _changedPointersData = [[NSArray alloc] initWithObjects:data count:changedCount];
   // extract all touches last to include the ones that were just added
   [self extractAllTouches];
   [self sendEvent];
@@ -142,14 +149,24 @@
   _eventType = RNGHTouchEventTypePointerMove;
 
   NSDictionary *data[touches.count];
+  int changedCount = 0;
 
   for (int i = 0; i < [touches count]; i++) {
     RNGHUITouch *touch = [[touches allObjects] objectAtIndex:i];
     int index = [self findTouchIndex:touch];
-    data[i] = [self extractPointerData:index forTouch:touch];
+
+    if (index < 0) {
+      continue;
+    }
+
+    data[changedCount++] = [self extractPointerData:index forTouch:touch];
   }
 
-  _changedPointersData = [[NSArray alloc] initWithObjects:data count:[touches count]];
+  if (changedCount == 0) {
+    return;
+  }
+
+  _changedPointersData = [[NSArray alloc] initWithObjects:data count:changedCount];
   [self extractAllTouches];
   [self sendEvent];
 }
@@ -166,18 +183,25 @@
   _eventType = RNGHTouchEventTypePointerUp;
 
   NSDictionary *data[touches.count];
+  int changedCount = 0;
 
   for (int i = 0; i < [touches count]; i++) {
     RNGHUITouch *touch = [[touches allObjects] objectAtIndex:i];
     int index = [self unregisterTouch:touch];
-    if (index >= 0) {
-      _trackedPointersCount--;
+
+    if (index < 0) {
+      continue;
     }
 
-    data[i] = [self extractPointerData:index forTouch:touch];
+    _trackedPointersCount--;
+    data[changedCount++] = [self extractPointerData:index forTouch:touch];
   }
 
-  _changedPointersData = [[NSArray alloc] initWithObjects:data count:[touches count]];
+  if (changedCount == 0) {
+    return;
+  }
+
+  _changedPointersData = [[NSArray alloc] initWithObjects:data count:changedCount];
   [self sendEvent];
 }
 


### PR DESCRIPTION
## Description

Follow-up to #4316, fixing the root cause of the malformed touch events on the native side.

`GestureHandler` on Android keeps two parallel pointer structures with different lifecycles:

- `trackedPointerIDs` — which pointers belong to the gesture. Always maintained (`startTrackingPointer` runs unconditionally) and consulted by `wantsEvent`.
- `trackedPointers` — per-pointer position data used to build touch events. Only maintained while `needsPointerData` is true, i.e. while touch callbacks are attached.

When touch callbacks are attached **mid-gesture** — e.g. a callback attached conditionally, where the attaching re-render is triggered from `onBegin` — `needsPointerData` flips from `false` to `true` while a pointer is already down. That pointer's DOWN was never recorded into `trackedPointers`, but the UP still passes `wantsEvent`, so `dispatchTouchUpEvent()`:

1. built `allTouches` from an empty map — the `null` payload that used to reach JS without the `allTouches` key and crash the v3 update pipeline (fixed defensively in #4316),
2. reported a pointer in `changedTouches` that the JS side has never seen go down,
3. decremented `trackedPointersCount` that was never incremented for that pointer, serializing `numberOfTouches: -1` and corrupting the counter that `moveToState` uses to decide whether to dispatch `TOUCH_CANCEL` (with multi-touch this can suppress a legitimate cancel event).

iOS had the same asymmetry with a different failure mode: `RNGestureHandlerPointerTracker` guards the counter (`unregisterTouch` returns `-1`, no underflow), but still dispatched the orphaned event with `id: -1` in `changedTouches`. Same for moves of an unregistered touch in `touchesMoved`.

Web is not affected: its `PointerTracker` is populated unconditionally and only *sending* is gated on `needsPointerData`, so mid-gesture flips always produce well-formed events there.


## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import React, { useState } from 'react';
import { StyleSheet, Text, View } from 'react-native';
import { GestureDetector, usePanGesture } from 'react-native-gesture-handler';

// Repro / verification screen for the orphaned-touch-event fix (follow-up to
// #4316).
//
// Purple box ("flip"): touch callbacks are attached conditionally, so
// `needsPointerData` flips false -> true mid-gesture (the onBegin re-render
// attaches onTouchesUp). Press, hold ~300ms, release:
// - without the fix: an orphaned onTouchesUp fires for a pointer that never
//   reported a down (Android: numberOfTouches -1, iOS: changed touch id -1;
//   on pre-#4316 builds this crashed the pan change calculator instead)
// - with the fix: the orphaned up event is skipped - counter stays 0
//
// Green box ("static"): touch callbacks attached from the start - the normal
// path. Each tap must count down+up (counter += 2) with and without the fix.
export default function OrphanedTouchRepro() {
  const [flipTouches, setFlipTouches] = useState(0);
  const [staticTouches, setStaticTouches] = useState(0);
  const [lastOrphan, setLastOrphan] = useState('none');
  const [pressed, setPressed] = useState(false);

  const flipPan = usePanGesture({
    onBegin: () => setPressed(true),
    onFinalize: () => setPressed(false),
    onUpdate: () => {},
    runOnJS: true,
    onTouchesUp: pressed
      ? (e) => {
          setFlipTouches((c) => c + 1);
          setLastOrphan(
            `numberOfTouches: ${e.numberOfTouches}, ` +
              `changed id: ${e.changedTouches[0]?.id ?? 'none'}`
          );
        }
      : undefined,
  });

  const staticPan = usePanGesture({
    onTouchesDown: () => setStaticTouches((c) => c + 1),
    onTouchesUp: () => setStaticTouches((c) => c + 1),
    onUpdate: () => {},
    runOnJS: true,
  });

  return (
    <View style={styles.container}>
      <Text style={styles.counter}>
        flip: {flipTouches} static: {staticTouches}
      </Text>
      <Text style={styles.orphanInfo}>last orphaned up: {lastOrphan}</Text>
      <GestureDetector gesture={flipPan}>
        <View style={[styles.box, styles.flipBox]} testID="flipBox">
          <Text style={styles.boxLabel}>flip: hold ~300ms (expect 0)</Text>
        </View>
      </GestureDetector>
      <GestureDetector gesture={staticPan}>
        <View style={[styles.box, styles.staticBox]} testID="staticBox">
          <Text style={styles.boxLabel}>static (expect +2 per tap)</Text>
        </View>
      </GestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    justifyContent: 'center',
    alignItems: 'center',
  },
  counter: {
    fontSize: 16,
    marginBottom: 8,
  },
  orphanInfo: {
    fontSize: 13,
    opacity: 0.6,
    marginBottom: 24,
  },
  box: {
    width: 260,
    height: 150,
    borderRadius: 16,
    justifyContent: 'center',
    alignItems: 'center',
    marginVertical: 12,
  },
  flipBox: {
    backgroundColor: 'mediumpurple',
  },
  staticBox: {
    backgroundColor: 'mediumseagreen',
  },
  boxLabel: {
    color: 'white',
    fontSize: 16,
  },
});
```

</details>