### PR TITLE
[Android] Refactor `Touchable` not to rely on `GestureDetector`

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -1064,6 +1064,7 @@ open class GestureHandler {
     const val DIRECTION_LEFT = 2
     const val DIRECTION_UP = 4
     const val DIRECTION_DOWN = 8
+    const val ACTION_TYPE_NONE = 0
     const val ACTION_TYPE_REANIMATED_WORKLET = 1
     const val ACTION_TYPE_NATIVE_ANIMATED_EVENT = 2
     const val ACTION_TYPE_JS_FUNCTION_OLD_API = 3

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -212,11 +212,15 @@ class NativeViewGestureHandler : GestureHandler() {
     }
     lastActiveUpdate = snapshot
     super.dispatchHandlerUpdate(event)
+
+    hook.onHandlerUpdate(this)
   }
 
   override fun dispatchStateChange(newState: Int, prevState: Int) {
     lastActiveUpdate = null
     super.dispatchStateChange(newState, prevState)
+
+    hook.onHandlerStateChange(this, newState, prevState)
   }
 
   override fun wantsToAttachDirectlyToView() = true
@@ -356,6 +360,16 @@ class NativeViewGestureHandler : GestureHandler() {
      * Passes the event down to the underlying view using the correct method.
      */
     fun sendTouchEvent(view: View?, event: MotionEvent) = view?.onTouchEvent(event)
+
+    /*
+     * Called when the handler processes a new update event.
+     */
+    fun onHandlerUpdate(handler: NativeViewGestureHandler) = Unit
+
+    /*
+     * Called when the handler moves to a new state.
+     */
+    fun onHandlerStateChange(handler: NativeViewGestureHandler, newState: Int, prevState: Int) = Unit
   }
 
   private class TextViewHook : NativeViewGestureHandlerHook {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -436,6 +436,7 @@ class RNGestureHandlerButtonViewManager :
     private var underlayDrawable: PaintDrawable? = null
     private var pressInTimestamp = 0L
     private var pendingPressOut: Runnable? = null
+    private var pendingLongPress: Runnable? = null
     private var pendingHoverOut: Choreographer.FrameCallback? = null
     private var isPointerInsideBounds = false
     private var isHovered = false
@@ -517,6 +518,93 @@ class RNGestureHandlerButtonViewManager :
 
       if (testId is String) {
         info.setViewIdResourceName(testId)
+      }
+    }
+
+    private var longPressDetected = false
+
+    // Cannot rely on isPointerInsideBounds because it's set to false during motion event processing
+    // which happens before the final state change is handled (state change is triggered by the motion
+    // event).
+    private var lastEventWasInside = false
+
+    override fun onHandlerUpdate(handler: NativeViewGestureHandler) {
+      if (handler.isWithinBounds == lastEventWasInside) {
+        return
+      }
+
+      if (handler.isWithinBounds) {
+        dispatchJSEvent(EventType.PressIn)
+      } else {
+        dispatchJSEvent(EventType.PressOut)
+
+        pendingLongPress?.let {
+          this.handler?.removeCallbacks(it)
+          pendingLongPress = null
+        }
+      }
+    }
+
+    override fun onHandlerStateChange(handler: NativeViewGestureHandler, newState: Int, prevState: Int) {
+      // Capture local copy, since lastEventWasInside can change during this method
+      // Specifically PressOut -> Press scenario on STATE_END
+      val localLastEventWasInside = lastEventWasInside
+
+      if (newState == GestureHandler.STATE_BEGAN) {
+        dispatchJSEvent(EventType.PressIn)
+
+        val runnable = Runnable {
+          pendingLongPress = null
+          longPressDetected = true
+          dispatchJSEvent(EventType.LongPress)
+        }
+        longPressDetected = false
+        pendingLongPress = runnable
+        this.handler?.postDelayed(runnable, longPressDuration.toLong())
+      }
+
+      if (newState == GestureHandler.STATE_END ||
+        newState == GestureHandler.STATE_FAILED ||
+        newState == GestureHandler.STATE_CANCELLED
+      ) {
+        if (localLastEventWasInside) {
+          dispatchJSEvent(EventType.PressOut)
+        }
+
+        pendingLongPress?.let {
+          this.handler?.removeCallbacks(it)
+          pendingLongPress = null
+        }
+      }
+
+      if (newState == GestureHandler.STATE_END && !longPressDetected && localLastEventWasInside) {
+        dispatchJSEvent(EventType.Press)
+      }
+
+      if (newState == GestureHandler.STATE_END ||
+        newState == GestureHandler.STATE_FAILED ||
+        newState == GestureHandler.STATE_CANCELLED
+      ) {
+        dispatchJSEvent(EventType.InteractionFinished)
+      }
+    }
+
+    private fun dispatchJSEvent(type: EventType) {
+      when (type) {
+        EventType.Press -> {
+          Log.w("RNGH", "onPress")
+        }
+        EventType.PressIn -> {
+          lastEventWasInside = true
+          Log.w("RNGH", "onPressIn")
+        }
+        EventType.PressOut -> {
+          lastEventWasInside = false
+          Log.w("RNGH", "onPressOut")
+        }
+        EventType.LongPress -> {
+          Log.w("RNGH", "longPress")
+        }
       }
     }
 
@@ -912,6 +1000,8 @@ class RNGestureHandlerButtonViewManager :
     override fun onDetachedFromWindow() {
       pendingPressOut?.let { handler?.removeCallbacks(it) }
       pendingPressOut = null
+      pendingLongPress?.let { handler?.removeCallbacks(it) }
+      pendingLongPress = null
       cancelPendingHoverOut()
       currentAnimator?.cancel()
       currentAnimator = null
@@ -1103,6 +1193,13 @@ class RNGestureHandlerButtonViewManager :
           false
         }
       }
+    }
+
+    enum class EventType {
+      Press,
+      PressIn,
+      PressOut,
+      LongPress
     }
   }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -27,6 +27,7 @@ import androidx.core.view.children
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import com.facebook.react.R
 import com.facebook.react.bridge.Dynamic
+import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.BackgroundStyleApplicator
@@ -35,6 +36,7 @@ import com.facebook.react.uimanager.PixelUtil
 import com.facebook.react.uimanager.PointerEvents
 import com.facebook.react.uimanager.ReactPointerEventsView
 import com.facebook.react.uimanager.ThemedReactContext
+import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.ViewGroupManager
 import com.facebook.react.uimanager.ViewManagerDelegate
 import com.facebook.react.uimanager.ViewProps
@@ -48,6 +50,7 @@ import com.swmansion.gesturehandler.core.GestureHandler
 import com.swmansion.gesturehandler.core.HoverGestureHandler
 import com.swmansion.gesturehandler.core.NativeViewGestureHandler
 import com.swmansion.gesturehandler.react.RNGestureHandlerButtonViewManager.ButtonViewGroup
+import com.swmansion.gesturehandler.react.events.RNGestureHandlerButtonEvent
 
 @ReactModule(name = RNGestureHandlerButtonViewManager.REACT_CLASS)
 class RNGestureHandlerButtonViewManager :
@@ -62,6 +65,11 @@ class RNGestureHandlerButtonViewManager :
   override fun getName() = REACT_CLASS
 
   public override fun createViewInstance(context: ThemedReactContext) = ButtonViewGroup(context)
+
+  @ReactProp(name = "hasLongPressHandler")
+  override fun setHasLongPressHandler(view: ButtonViewGroup, hasLongPressHandler: Boolean) {
+    view.hasLongPressHandler = hasLongPressHandler
+  }
 
   @ReactProp(name = "foreground")
   override fun setForeground(view: ButtonViewGroup, useDrawableOnForeground: Boolean) {
@@ -398,6 +406,7 @@ class RNGestureHandlerButtonViewManager :
     var useBorderlessDrawable = false
 
     var exclusive = true
+    var hasLongPressHandler = false
     var tapAnimationInDuration: Int = 50
     var tapAnimationOutDuration: Int = 100
     var longPressDuration: Int = -1
@@ -534,9 +543,9 @@ class RNGestureHandlerButtonViewManager :
       }
 
       if (handler.isWithinBounds) {
-        dispatchJSEvent(EventType.PressIn)
+        dispatchJSEvent(EventType.PressIn, handler)
       } else {
-        dispatchJSEvent(EventType.PressOut)
+        dispatchJSEvent(EventType.PressOut, handler)
 
         pendingLongPress?.let {
           this.handler?.removeCallbacks(it)
@@ -551,16 +560,18 @@ class RNGestureHandlerButtonViewManager :
       val localLastEventWasInside = lastEventWasInside
 
       if (newState == GestureHandler.STATE_BEGAN) {
-        dispatchJSEvent(EventType.PressIn)
-
-        val runnable = Runnable {
-          pendingLongPress = null
-          longPressDetected = true
-          dispatchJSEvent(EventType.LongPress)
-        }
+        dispatchJSEvent(EventType.PressIn, handler)
         longPressDetected = false
-        pendingLongPress = runnable
-        this.handler?.postDelayed(runnable, longPressDuration.toLong())
+
+        if (hasLongPressHandler && longPressDuration >= 0) {
+          val runnable = Runnable {
+            pendingLongPress = null
+            longPressDetected = true
+            dispatchJSEvent(EventType.LongPress, handler)
+          }
+          pendingLongPress = runnable
+          this.handler?.postDelayed(runnable, longPressDuration.toLong())
+        }
       }
 
       if (newState == GestureHandler.STATE_END ||
@@ -568,7 +579,7 @@ class RNGestureHandlerButtonViewManager :
         newState == GestureHandler.STATE_CANCELLED
       ) {
         if (localLastEventWasInside) {
-          dispatchJSEvent(EventType.PressOut)
+          dispatchJSEvent(EventType.PressOut, handler)
         }
 
         pendingLongPress?.let {
@@ -578,33 +589,26 @@ class RNGestureHandlerButtonViewManager :
       }
 
       if (newState == GestureHandler.STATE_END && !longPressDetected && localLastEventWasInside) {
-        dispatchJSEvent(EventType.Press)
+        dispatchJSEvent(EventType.Press, handler)
       }
 
       if (newState == GestureHandler.STATE_END ||
         newState == GestureHandler.STATE_FAILED ||
         newState == GestureHandler.STATE_CANCELLED
       ) {
-        dispatchJSEvent(EventType.InteractionFinished)
+        dispatchJSEvent(EventType.InteractionFinished, handler)
       }
     }
 
-    private fun dispatchJSEvent(type: EventType) {
-      when (type) {
-        EventType.Press -> {
-          Log.w("RNGH", "onPress")
-        }
-        EventType.PressIn -> {
-          lastEventWasInside = true
-          Log.w("RNGH", "onPressIn")
-        }
-        EventType.PressOut -> {
-          lastEventWasInside = false
-          Log.w("RNGH", "onPressOut")
-        }
-        EventType.LongPress -> {
-          Log.w("RNGH", "longPress")
-        }
+    private fun dispatchJSEvent(type: EventType, handler: NativeViewGestureHandler) {
+      val reactContext = context as? ReactContext ?: return
+      val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext) ?: return
+      eventDispatcher.dispatchEvent(RNGestureHandlerButtonEvent.obtain(this, handler, type))
+
+      if (type == EventType.PressIn) {
+        lastEventWasInside = true
+      } else if (type == EventType.PressOut) {
+        lastEventWasInside = false
       }
     }
 
@@ -1199,7 +1203,8 @@ class RNGestureHandlerButtonViewManager :
       Press,
       PressIn,
       PressOut,
-      LongPress
+      LongPress,
+      InteractionFinished,
     }
   }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -26,9 +26,11 @@ import android.view.accessibility.AccessibilityNodeInfo
 import androidx.core.view.children
 import androidx.interpolator.view.animation.FastOutSlowInInterpolator
 import com.facebook.react.R
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.Dynamic
 import com.facebook.react.bridge.ReactContext
 import com.facebook.react.bridge.ReadableArray
+import com.facebook.react.bridge.ReadableMap
 import com.facebook.react.module.annotations.ReactModule
 import com.facebook.react.uimanager.BackgroundStyleApplicator
 import com.facebook.react.uimanager.LengthPercentage
@@ -66,6 +68,85 @@ class RNGestureHandlerButtonViewManager :
 
   public override fun createViewInstance(context: ThemedReactContext) = ButtonViewGroup(context)
 
+  override fun onDropViewInstance(view: ButtonViewGroup) {
+    view.managedHandlerTag?.let { tag ->
+      getGestureHandlerModule(view).dropGestureHandler(tag)
+    }
+
+    super.onDropViewInstance(view)
+  }
+
+  private fun getGestureHandlerModule(view: ButtonViewGroup) =
+    (view.context as ReactContext).getNativeModule(RNGestureHandlerModule::class.java)!!
+
+  private fun updateManagedHandlerConfig(view: ButtonViewGroup, config: ReadableMap) {
+    view.managedHandlerTag?.let { getGestureHandlerModule(view).updateGestureHandlerConfig(it, config) }
+  }
+
+  @ReactProp(name = "handlerTag")
+  override fun setHandlerTag(view: ButtonViewGroup, handlerTag: Double) {
+    if (view.managedHandlerTag == handlerTag) {
+      return
+    }
+
+    view.managedHandlerTag?.let { oldTag ->
+      getGestureHandlerModule(view).dropGestureHandler(oldTag)
+    }
+
+    view.managedHandlerTag = handlerTag
+    val module = getGestureHandlerModule(view)
+
+    module.createGestureHandler(
+      "NativeViewGestureHandler",
+      handlerTag,
+      Arguments.createMap().apply {
+        putBoolean("shouldActivateOnStart", false)
+        putBoolean("disallowInterruption", true)
+        putBoolean("yieldsToContinuousGestures", true)
+        putBoolean("enabled", view.isEnabled)
+        view.managedHandlerCancelOnLeave?.let { putBoolean("shouldCancelWhenOutside", it) }
+        view.managedHandlerTestID?.let { putString("testID", it) }
+        view.managedHandlerHitSlop?.let { putMap("hitSlop", it) }
+      },
+    )
+    module.attachGestureHandler(handlerTag, view.id.toDouble(), GestureHandler.ACTION_TYPE_NONE.toDouble())
+  }
+
+  @ReactProp(name = "cancelOnLeave")
+  override fun setCancelOnLeave(view: ButtonViewGroup, cancelOnLeave: Boolean) {
+    view.managedHandlerCancelOnLeave = cancelOnLeave
+    updateManagedHandlerConfig(
+      view,
+      Arguments.createMap().apply {
+        putBoolean("shouldCancelWhenOutside", cancelOnLeave)
+      },
+    )
+  }
+
+  @ReactProp(name = "gestureTestID")
+  override fun setGestureTestID(view: ButtonViewGroup, gestureTestID: String?) {
+    view.managedHandlerTestID = gestureTestID
+    updateManagedHandlerConfig(
+      view,
+      Arguments.createMap().apply {
+        putString("testID", gestureTestID)
+      },
+    )
+  }
+
+  @ReactProp(name = "gestureHitSlop")
+  override fun setGestureHitSlop(view: ButtonViewGroup, gestureHitSlop: ReadableMap?) {
+    view.managedHandlerHitSlop = gestureHitSlop
+    if (gestureHitSlop != null) {
+      updateManagedHandlerConfig(
+        view,
+        Arguments.createMap().apply {
+          putMap("hitSlop", gestureHitSlop)
+        },
+      )
+    }
+  }
+
   @ReactProp(name = "hasLongPressHandler")
   override fun setHasLongPressHandler(view: ButtonViewGroup, hasLongPressHandler: Boolean) {
     view.hasLongPressHandler = hasLongPressHandler
@@ -89,6 +170,13 @@ class RNGestureHandlerButtonViewManager :
   @ReactProp(name = "enabled")
   override fun setEnabled(view: ButtonViewGroup, enabled: Boolean) {
     view.isEnabled = enabled
+
+    updateManagedHandlerConfig(
+      view,
+      Arguments.createMap().apply {
+        putBoolean("enabled", enabled)
+      },
+    )
   }
 
   @ReactProp(name = "borderWidth")
@@ -405,6 +493,16 @@ class RNGestureHandlerButtonViewManager :
       }
     var useBorderlessDrawable = false
 
+    var managedHandlerTag: Double? = null
+
+    // Config props may be applied before `handlerTag` (prop order is not guaranteed) and
+    // `updateManagedHandlerConfig` no-ops until the handler exists, so the values are cached
+    // here and seeded into the config when `setHandlerTag` creates the handler. This also
+    // re-applies them when the handler is recreated for a new tag.
+    var managedHandlerCancelOnLeave: Boolean? = null
+    var managedHandlerTestID: String? = null
+    var managedHandlerHitSlop: ReadableMap? = null
+
     var exclusive = true
     var hasLongPressHandler = false
     var tapAnimationInDuration: Int = 50
@@ -538,7 +636,7 @@ class RNGestureHandlerButtonViewManager :
     private var lastEventWasInside = false
 
     override fun onHandlerUpdate(handler: NativeViewGestureHandler) {
-      if (handler.isWithinBounds == lastEventWasInside) {
+      if (managedHandlerTag == null || handler.isWithinBounds == lastEventWasInside) {
         return
       }
 
@@ -555,6 +653,10 @@ class RNGestureHandlerButtonViewManager :
     }
 
     override fun onHandlerStateChange(handler: NativeViewGestureHandler, newState: Int, prevState: Int) {
+      if (managedHandlerTag == null) {
+        return
+      }
+
       // Capture local copy, since lastEventWasInside can change during this method
       // Specifically PressOut -> Press scenario on STATE_END
       val localLastEventWasInside = lastEventWasInside

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/events/RNGestureHandlerButtonEvent.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/events/RNGestureHandlerButtonEvent.kt
@@ -1,0 +1,93 @@
+package com.swmansion.gesturehandler.react.events
+
+import androidx.core.util.Pools
+import com.facebook.react.bridge.Arguments
+import com.facebook.react.bridge.WritableMap
+import com.facebook.react.uimanager.PixelUtil
+import com.facebook.react.uimanager.UIManagerHelper
+import com.facebook.react.uimanager.events.Event
+import com.swmansion.gesturehandler.core.NativeViewGestureHandler
+import com.swmansion.gesturehandler.react.RNGestureHandlerButtonViewManager
+
+class RNGestureHandlerButtonEvent private constructor() : Event<RNGestureHandlerButtonEvent>() {
+  private lateinit var type: RNGestureHandlerButtonViewManager.ButtonViewGroup.EventType
+  private lateinit var eventData: ButtonEventData
+
+  private fun init(
+    button: RNGestureHandlerButtonViewManager.ButtonViewGroup,
+    handler: NativeViewGestureHandler,
+    type: RNGestureHandlerButtonViewManager.ButtonViewGroup.EventType,
+  ) {
+    super.init(UIManagerHelper.getSurfaceId(button), button.id)
+
+    this.type = type
+    this.eventData = ButtonEventData(
+      x = PixelUtil.toDIPFromPixel(handler.lastRelativePositionX).toDouble(),
+      y = PixelUtil.toDIPFromPixel(handler.lastRelativePositionY).toDouble(),
+      absoluteX = PixelUtil.toDIPFromPixel(handler.lastPositionInWindowX).toDouble(),
+      absoluteY = PixelUtil.toDIPFromPixel(handler.lastPositionInWindowY).toDouble(),
+      numberOfPointers = handler.numberOfPointers,
+      pointerType = handler.pointerType,
+      pointerInside = handler.isWithinBounds,
+    )
+  }
+
+  override fun onDispose() {
+    EVENTS_POOL.release(this)
+  }
+
+  override fun getEventName() = when (type) {
+    RNGestureHandlerButtonViewManager.ButtonViewGroup.EventType.Press -> ON_PRESS_EVENT_NAME
+    RNGestureHandlerButtonViewManager.ButtonViewGroup.EventType.PressIn -> ON_PRESS_IN_EVENT_NAME
+    RNGestureHandlerButtonViewManager.ButtonViewGroup.EventType.PressOut -> ON_PRESS_OUT_EVENT_NAME
+    RNGestureHandlerButtonViewManager.ButtonViewGroup.EventType.LongPress -> ON_LONG_PRESS_EVENT_NAME
+    RNGestureHandlerButtonViewManager.ButtonViewGroup.EventType.InteractionFinished ->
+      ON_INTERACTION_FINISHED_EVENT_NAME
+  }
+
+  // Unfortunately getCoalescingKey is not considered when sending event to C++, therefore we have to disable coalescing in v3
+  override fun canCoalesce() = false
+
+  override fun getCoalescingKey(): Short = 0
+
+  override fun getEventData(): WritableMap = this.eventData.toWritableMap()
+
+  private data class ButtonEventData(
+    val x: Double,
+    val y: Double,
+    val absoluteX: Double,
+    val absoluteY: Double,
+    val numberOfPointers: Int,
+    val pointerType: Int,
+    val pointerInside: Boolean,
+  ) {
+    fun toWritableMap(): WritableMap = Arguments.createMap().apply {
+      putDouble("x", x)
+      putDouble("y", y)
+      putDouble("absoluteX", absoluteX)
+      putDouble("absoluteY", absoluteY)
+      putInt("numberOfPointers", numberOfPointers)
+      putInt("pointerType", pointerType)
+      putBoolean("pointerInside", pointerInside)
+    }
+  }
+
+  companion object {
+    private const val ON_PRESS_EVENT_NAME = "onPress"
+    private const val ON_PRESS_IN_EVENT_NAME = "onPressIn"
+    private const val ON_PRESS_OUT_EVENT_NAME = "onPressOut"
+    private const val ON_LONG_PRESS_EVENT_NAME = "onLongPress"
+    private const val ON_INTERACTION_FINISHED_EVENT_NAME = "onInteractionFinished"
+
+    private const val TOUCH_EVENTS_POOL_SIZE = 7 // magic
+    private val EVENTS_POOL = Pools.SynchronizedPool<RNGestureHandlerButtonEvent>(TOUCH_EVENTS_POOL_SIZE)
+
+    fun obtain(
+      button: RNGestureHandlerButtonViewManager.ButtonViewGroup,
+      handler: NativeViewGestureHandler,
+      type: RNGestureHandlerButtonViewManager.ButtonViewGroup.EventType,
+    ): RNGestureHandlerButtonEvent = (EVENTS_POOL.acquire() ?: RNGestureHandlerButtonEvent()).apply {
+      init(button, handler, type)
+    }
+  }
+}

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -3,6 +3,7 @@ import type {
   ColorValue,
   HostComponent,
   LayoutChangeEvent,
+  NativeSyntheticEvent,
   StyleProp,
   ViewProps,
   ViewStyle,
@@ -27,6 +28,36 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
    * set true.
    */
   exclusive?: boolean | undefined;
+
+  /**
+   * Called when the button gets pressed.
+   */
+  onPress?: ((event: NativeSyntheticEvent<ButtonEvent>) => void) | undefined;
+
+  /**
+   * Called when the pointer touches the button.
+   */
+  onPressIn?: ((event: NativeSyntheticEvent<ButtonEvent>) => void) | undefined;
+
+  /**
+   * Called when the pointer is released or leaves the button.
+   */
+  onPressOut?: ((event: NativeSyntheticEvent<ButtonEvent>) => void) | undefined;
+
+  /**
+   * Called when the button gets pressed and held past `longPressDuration`.
+   */
+  onLongPress?:
+    | ((event: NativeSyntheticEvent<ButtonEvent>) => void)
+    | undefined;
+
+  /**
+   * Called when the interaction with the button ends, after any terminal
+   * `onPressOut`/`onPress` events, regardless of how it ended.
+   */
+  onInteractionFinished?:
+    | ((event: NativeSyntheticEvent<ButtonEvent>) => void)
+    | undefined;
 
   /**
    * Android only.

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -8,7 +8,9 @@ import type {
   ViewStyle,
 } from 'react-native';
 
-import RNGestureHandlerButtonNativeComponent from '../specs/RNGestureHandlerButtonNativeComponent';
+import RNGestureHandlerButtonNativeComponent, {
+  type ButtonEvent,
+} from '../specs/RNGestureHandlerButtonNativeComponent';
 
 export interface ButtonProps extends ViewProps, AccessibilityProps {
   children?: React.ReactNode;
@@ -17,6 +19,8 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
    * Defines if buttons should respond to touches. By default set to true.
    */
   enabled?: boolean | undefined;
+
+  hasLongPressHandler?: boolean | undefined;
 
   /**
    * Defines if more than one button could be pressed simultaneously. By default
@@ -203,3 +207,4 @@ export const ButtonComponent =
   RNGestureHandlerButtonNativeComponent as HostComponent<ButtonProps>;
 
 export default ButtonComponent;
+export type { ButtonEvent };

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -22,6 +22,17 @@ export interface ButtonProps extends ViewProps, AccessibilityProps {
   enabled?: boolean | undefined;
 
   hasLongPressHandler?: boolean | undefined;
+  handlerTag?: number | undefined;
+  cancelOnLeave?: boolean | undefined;
+  gestureTestID?: string | undefined;
+  gestureHitSlop?:
+    | {
+        top?: number | undefined;
+        left?: number | undefined;
+        bottom?: number | undefined;
+        right?: number | undefined;
+      }
+    | undefined;
 
   /**
    * Defines if more than one button could be pressed simultaneously. By default

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -27,6 +27,16 @@ interface NativeProps extends ViewProps {
     | undefined;
 
   hasLongPressHandler?: CodegenTypes.WithDefault<boolean, false>;
+  handlerTag?: CodegenTypes.Double | undefined;
+  cancelOnLeave?: CodegenTypes.WithDefault<boolean, true>;
+  gestureTestID?: string;
+  gestureHitSlop?: Readonly<{
+    top?: CodegenTypes.Double | undefined;
+    left?: CodegenTypes.Double | undefined;
+    bottom?: CodegenTypes.Double | undefined;
+    right?: CodegenTypes.Double | undefined;
+  }>;
+
   exclusive?: CodegenTypes.WithDefault<boolean, true>;
   foreground?: boolean;
   borderless?: boolean;

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerButtonNativeComponent.ts
@@ -6,8 +6,27 @@ import type {
 } from 'react-native';
 import { codegenNativeComponent } from 'react-native';
 
+export type ButtonEvent = Readonly<{
+  pointerInside: boolean;
+  x: CodegenTypes.Double;
+  y: CodegenTypes.Double;
+  absoluteX: CodegenTypes.Double;
+  absoluteY: CodegenTypes.Double;
+  numberOfPointers: CodegenTypes.Int32;
+  pointerType: CodegenTypes.Int32;
+}>;
+
 // @ts-ignore - Redefining pointerEvents with WithDefault for codegen, conflicts with ViewProps type but codegen needs it
 interface NativeProps extends ViewProps {
+  onPress?: CodegenTypes.DirectEventHandler<ButtonEvent> | undefined;
+  onPressIn?: CodegenTypes.DirectEventHandler<ButtonEvent> | undefined;
+  onPressOut?: CodegenTypes.DirectEventHandler<ButtonEvent> | undefined;
+  onLongPress?: CodegenTypes.DirectEventHandler<ButtonEvent> | undefined;
+  onInteractionFinished?:
+    | CodegenTypes.DirectEventHandler<ButtonEvent>
+    | undefined;
+
+  hasLongPressHandler?: CodegenTypes.WithDefault<boolean, false>;
   exclusive?: CodegenTypes.WithDefault<boolean, true>;
   foreground?: boolean;
   borderless?: boolean;

--- a/packages/react-native-gesture-handler/src/v3/components/GestureButtonsProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/GestureButtonsProps.ts
@@ -10,6 +10,14 @@ import type { NativeWrapperProperties } from '../types/NativeWrapperType';
 export interface RawButtonProps
   extends Omit<
       ButtonProps,
+      // The native press events are omitted — the deprecated buttons drive
+      // their press callbacks from the gesture in JS and redeclare them with
+      // their own signatures.
+      | 'onPress'
+      | 'onPressIn'
+      | 'onPressOut'
+      | 'onLongPress'
+      | 'onInteractionFinished'
       | 'defaultOpacity'
       | 'defaultScale'
       | 'defaultUnderlayOpacity'

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.android.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.android.tsx
@@ -1,0 +1,200 @@
+import React, { use, useCallback, useRef, useState } from 'react';
+import type { NativeSyntheticEvent } from 'react-native';
+import { Platform } from 'react-native';
+
+import GestureHandlerButton, {
+  type ButtonEvent,
+} from '../../../components/GestureHandlerButton';
+import { getTVProps } from '../../../components/utils';
+import { getNextHandlerTag } from '../../../handlers/getNextHandlerTag';
+import {
+  isKeyboardDismissingTap,
+  JSResponderContext,
+} from '../ScrollViewResponderInterceptor';
+import type { AnimationDuration, TouchableProps } from './TouchableProps';
+
+const isAndroid = Platform.OS === 'android';
+const TRANSPARENT_RIPPLE = { rippleColor: 'transparent' as const };
+const DEFAULT_IN_DURATION_MS = 50;
+const DEFAULT_OUT_DURATION_MS = 100;
+
+// Clamp user-supplied durations to finite, non-negative milliseconds.
+// Negative, NaN, or Infinity values would produce invalid CSS transitions
+// on web and negative setTimeout delays in branch 3 of the press-out path.
+function sanitizeDuration(value: number): number {
+  return Number.isFinite(value) && value >= 0 ? value : 0;
+}
+
+function resolveAnimationDuration(value: AnimationDuration | undefined) {
+  if (value === undefined) {
+    return {
+      tapAnimationInDuration: DEFAULT_IN_DURATION_MS,
+      tapAnimationOutDuration: DEFAULT_OUT_DURATION_MS,
+      longPressAnimationOutDuration: DEFAULT_OUT_DURATION_MS,
+      hoverAnimationInDuration: DEFAULT_IN_DURATION_MS,
+      hoverAnimationOutDuration: DEFAULT_OUT_DURATION_MS,
+    };
+  }
+
+  if (typeof value === 'number') {
+    const sanitized = sanitizeDuration(value);
+    return {
+      tapAnimationInDuration: sanitized,
+      tapAnimationOutDuration: sanitized,
+      longPressAnimationOutDuration: sanitized,
+      hoverAnimationInDuration: sanitized,
+      hoverAnimationOutDuration: sanitized,
+    };
+  }
+
+  // The union guarantees variant 2 supplies top-level `in`/`out`, variant 3
+  // supplies both category objects — so per-category fallback to base is
+  // always defined for well-typed input; the 0 fallbacks here are unreachable.
+  const baseIn = 'in' in value ? value.in : 0;
+  const baseOut = 'out' in value ? value.out : 0;
+  const tapOut = value.tap?.out ?? baseOut;
+
+  return {
+    tapAnimationInDuration: sanitizeDuration(value.tap?.in ?? baseIn),
+    tapAnimationOutDuration: sanitizeDuration(tapOut),
+    longPressAnimationOutDuration: sanitizeDuration(
+      value.longPress?.out ?? tapOut
+    ),
+    hoverAnimationInDuration: sanitizeDuration(value.hover?.in ?? baseIn),
+    hoverAnimationOutDuration: sanitizeDuration(value.hover?.out ?? baseOut),
+  };
+}
+
+export const Touchable = (props: TouchableProps) => {
+  const {
+    underlayColor = 'transparent',
+    defaultUnderlayOpacity = 0,
+    activeUnderlayOpacity = 0.105,
+    defaultOpacity = 1,
+    animationDuration,
+    androidRipple,
+    delayLongPress = 600,
+    onLongPress,
+    onPress,
+    onPressIn,
+    onPressOut,
+    children,
+    disabled = false,
+    cancelOnLeave = true,
+    ref,
+    ...rest
+  } = props;
+  const [handlerTag] = useState(() => getNextHandlerTag());
+
+  const resolvedDurations = resolveAnimationDuration(animationDuration);
+  const resolvedDelayLongPress = sanitizeDuration(delayLongPress);
+
+  const shouldUseNativeRipple = isAndroid && androidRipple !== undefined;
+
+  const jsResponderContext = use(JSResponderContext);
+  const dropKeyboardTapRef = useRef<boolean | null>(null);
+
+  const internalOnPress = useCallback(
+    (e: NativeSyntheticEvent<ButtonEvent>) => {
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
+      onPress?.(e.nativeEvent);
+    },
+    [onPress]
+  );
+
+  const internalOnPressIn = useCallback(
+    (e: NativeSyntheticEvent<ButtonEvent>) => {
+      // PressIn opens every press sequence; capture the verdict once per
+      // sequence so a re-entry PressIn (with cancelOnLeave={false}) doesn't
+      // overwrite it after the keyboard is already dismissed.
+      dropKeyboardTapRef.current ??=
+        isKeyboardDismissingTap(jsResponderContext);
+
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
+      onPressIn?.(e.nativeEvent);
+    },
+    [jsResponderContext, onPressIn]
+  );
+
+  const internalOnPressOut = useCallback(
+    (e: NativeSyntheticEvent<ButtonEvent>) => {
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
+      onPressOut?.(e.nativeEvent);
+    },
+    [onPressOut]
+  );
+
+  const internalOnLongPress = useCallback(
+    (e: NativeSyntheticEvent<ButtonEvent>) => {
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
+      onLongPress?.(e.nativeEvent);
+    },
+    [onLongPress]
+  );
+
+  // InteractionFinished is dispatched after the terminal PressOut/Press
+  // events, so resetting synchronously here is safe.
+  const internalOnInteractionFinished = useCallback(() => {
+    dropKeyboardTapRef.current = null;
+  }, []);
+
+  const rippleProps = shouldUseNativeRipple
+    ? {
+        rippleColor: androidRipple?.color,
+        rippleRadius: androidRipple?.radius,
+        borderless: androidRipple?.borderless,
+        foreground: androidRipple?.foreground,
+      }
+    : TRANSPARENT_RIPPLE;
+
+  const tvProps = getTVProps(rest);
+
+  const hitSlop =
+    typeof props.hitSlop === 'number' || props.hitSlop == null
+      ? {
+          top: props.hitSlop ?? 0,
+          left: props.hitSlop ?? 0,
+          bottom: props.hitSlop ?? 0,
+          right: props.hitSlop ?? 0,
+        }
+      : props.hitSlop;
+
+  return (
+    <GestureHandlerButton
+      {...rest}
+      {...tvProps}
+      {...rippleProps}
+      {...resolvedDurations}
+      ref={ref ?? null}
+      enabled={!disabled}
+      handlerTag={handlerTag}
+      cancelOnLeave={cancelOnLeave}
+      gestureTestID={props.testID}
+      gestureHitSlop={hitSlop}
+      defaultOpacity={defaultOpacity}
+      defaultUnderlayOpacity={defaultUnderlayOpacity}
+      activeUnderlayOpacity={activeUnderlayOpacity}
+      underlayColor={underlayColor}
+      longPressDuration={resolvedDelayLongPress}
+      hasLongPressHandler={onLongPress !== undefined}
+      onPress={internalOnPress}
+      onPressIn={internalOnPressIn}
+      onPressOut={internalOnPressOut}
+      onLongPress={internalOnLongPress}
+      onInteractionFinished={internalOnInteractionFinished}>
+      {children}
+    </GestureHandlerButton>
+  );
+};

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -1,7 +1,10 @@
 import React, { use, useCallback, useRef } from 'react';
+import type { NativeSyntheticEvent } from 'react-native';
 import { Platform } from 'react-native';
 
-import GestureHandlerButton from '../../../components/GestureHandlerButton';
+import GestureHandlerButton, {
+  type ButtonEvent,
+} from '../../../components/GestureHandlerButton';
 import { getTVProps } from '../../../components/utils';
 import { NativeDetector } from '../../detectors/NativeDetector';
 import { useNativeGesture } from '../../hooks';
@@ -99,130 +102,35 @@ export const Touchable = (props: TouchableProps) => {
 
   const shouldUseNativeRipple = isAndroid && androidRipple !== undefined;
 
-  const pointerState = useRef<PointerState>(PointerState.UNKNOWN);
-  const longPressDetected = useRef(false);
-  const longPressTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(
-    undefined
+  const internalOnPress = useCallback(
+    (e: NativeSyntheticEvent<ButtonEvent>) => {
+      onPress?.(e.nativeEvent);
+    },
+    [onPress]
   );
 
-  // Swallow the tap that dismisses the keyboard in
-  // keyboardShouldPersistTaps="never", matching RN's touchables.
-  const jsResponderContext = use(JSResponderContext);
-  const dropKeyboardTapRef = useRef<boolean | null>(null);
-
-  const captureKeyboardDismiss = useCallback(() => {
-    dropKeyboardTapRef.current ??= isKeyboardDismissingTap(jsResponderContext);
-  }, [jsResponderContext]);
-
-  const resetKeyboardDismiss = useCallback(() => {
-    dropKeyboardTapRef.current = null;
-  }, []);
-
-  const wrappedLongPress = useCallback(() => {
-    longPressDetected.current = true;
-    onLongPress?.();
-  }, [onLongPress]);
-
-  const startLongPressTimer = useCallback(() => {
-    longPressDetected.current = false;
-
-    if (onLongPress && !longPressTimeout.current) {
-      longPressTimeout.current = setTimeout(
-        wrappedLongPress,
-        resolvedDelayLongPress
-      );
-    }
-  }, [onLongPress, resolvedDelayLongPress, wrappedLongPress]);
-
-  const onBegin = useCallback(
-    (e: CallbackEventType) => {
-      captureKeyboardDismiss();
-
-      if (!e.pointerInside || dropKeyboardTapRef.current) {
-        pointerState.current = PointerState.OUTSIDE;
-        return;
-      }
-
-      onPressIn?.(e);
-      startLongPressTimer();
-
-      pointerState.current = PointerState.INSIDE;
+  const internalOnPressIn = useCallback(
+    (e: NativeSyntheticEvent<ButtonEvent>) => {
+      onPressIn?.(e.nativeEvent);
     },
-    [captureKeyboardDismiss, startLongPressTimer, onPressIn]
+    [onPressIn]
   );
 
-  const onActivate = useCallback((e: CallbackEventType) => {
-    if (!e.pointerInside && longPressTimeout.current !== undefined) {
-      clearTimeout(longPressTimeout.current);
-      longPressTimeout.current = undefined;
-    }
-  }, []);
-
-  const onFinalize = useCallback(
-    (e: EndCallbackEventType) => {
-      if (
-        !dropKeyboardTapRef.current &&
-        pointerState.current === PointerState.INSIDE
-      ) {
-        onPressOut?.(e);
-      }
-
-      if (
-        !dropKeyboardTapRef.current &&
-        !e.canceled &&
-        !longPressDetected.current &&
-        e.pointerInside
-      ) {
-        onPress?.(e);
-      }
-
-      pointerState.current = PointerState.UNKNOWN;
-
-      if (longPressTimeout.current !== undefined) {
-        clearTimeout(longPressTimeout.current);
-        longPressTimeout.current = undefined;
-      }
-
-      resetKeyboardDismiss();
+  const internalOnPressOut = useCallback(
+    (e: NativeSyntheticEvent<ButtonEvent>) => {
+      onPressOut?.(e.nativeEvent);
     },
-    [resetKeyboardDismiss, onPressOut, onPress]
+    [onPressOut]
   );
 
-  const onUpdate = useCallback(
-    (e: CallbackEventType) => {
-      if (dropKeyboardTapRef.current) {
-        return;
-      }
-
-      if (pointerState.current === PointerState.UNKNOWN) {
-        return;
-      }
-
-      if (e.pointerInside) {
-        if (pointerState.current === PointerState.OUTSIDE) {
-          onPressIn?.(e);
-        }
-        pointerState.current = PointerState.INSIDE;
-      } else {
-        if (pointerState.current === PointerState.INSIDE) {
-          onPressOut?.(e);
-
-          if (longPressTimeout.current !== undefined) {
-            clearTimeout(longPressTimeout.current);
-            longPressTimeout.current = undefined;
-          }
-        }
-        pointerState.current = PointerState.OUTSIDE;
-      }
+  const internalOnLongPress = useCallback(
+    (e: NativeSyntheticEvent<ButtonEvent>) => {
+      onLongPress?.(e.nativeEvent);
     },
-    [onPressIn, onPressOut]
+    [onLongPress]
   );
 
   const nativeGesture = useNativeGesture({
-    onBegin,
-    onActivate,
-    onFinalize,
-    onUpdate,
     hitSlop: props.hitSlop,
     testID: props.testID,
     enabled: !disabled,
@@ -257,7 +165,12 @@ export const Touchable = (props: TouchableProps) => {
         defaultUnderlayOpacity={defaultUnderlayOpacity}
         activeUnderlayOpacity={activeUnderlayOpacity}
         underlayColor={underlayColor}
-        longPressDuration={resolvedDelayLongPress}>
+        longPressDuration={resolvedDelayLongPress}
+        hasLongPressHandler={onLongPress !== undefined}
+        onPress={internalOnPress}
+        onPressIn={internalOnPressIn}
+        onPressOut={internalOnPressOut}
+        onLongPress={internalOnLongPress}>
         {children}
       </GestureHandlerButton>
     </NativeDetector>

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -1,22 +1,31 @@
-import React, { use, useCallback, useRef, useState } from 'react';
-import type { NativeSyntheticEvent } from 'react-native';
+import React, { use, useCallback, useRef } from 'react';
 import { Platform } from 'react-native';
 
-import GestureHandlerButton, {
-  type ButtonEvent,
-} from '../../../components/GestureHandlerButton';
+import GestureHandlerButton from '../../../components/GestureHandlerButton';
 import { getTVProps } from '../../../components/utils';
-import { getNextHandlerTag } from '../../../handlers/getNextHandlerTag';
+import { NativeDetector } from '../../detectors/NativeDetector';
+import { useNativeGesture } from '../../hooks';
 import {
   isKeyboardDismissingTap,
   JSResponderContext,
 } from '../ScrollViewResponderInterceptor';
-import type { AnimationDuration, TouchableProps } from './TouchableProps';
+import type {
+  AnimationDuration,
+  CallbackEventType,
+  EndCallbackEventType,
+  TouchableProps,
+} from './TouchableProps';
 
 const isAndroid = Platform.OS === 'android';
 const TRANSPARENT_RIPPLE = { rippleColor: 'transparent' as const };
 const DEFAULT_IN_DURATION_MS = 50;
 const DEFAULT_OUT_DURATION_MS = 100;
+
+enum PointerState {
+  UNKNOWN,
+  INSIDE,
+  OUTSIDE,
+}
 
 // Clamp user-supplied durations to finite, non-negative milliseconds.
 // Negative, NaN, or Infinity values would produce invalid CSS transitions
@@ -84,71 +93,146 @@ export const Touchable = (props: TouchableProps) => {
     ref,
     ...rest
   } = props;
-  const [handlerTag] = useState(() => getNextHandlerTag());
 
   const resolvedDurations = resolveAnimationDuration(animationDuration);
   const resolvedDelayLongPress = sanitizeDuration(delayLongPress);
 
   const shouldUseNativeRipple = isAndroid && androidRipple !== undefined;
 
+  const pointerState = useRef<PointerState>(PointerState.UNKNOWN);
+  const longPressDetected = useRef(false);
+  const longPressTimeout = useRef<ReturnType<typeof setTimeout> | undefined>(
+    undefined
+  );
+
+  // Swallow the tap that dismisses the keyboard in
+  // keyboardShouldPersistTaps="never", matching RN's touchables.
   const jsResponderContext = use(JSResponderContext);
   const dropKeyboardTapRef = useRef<boolean | null>(null);
 
-  const internalOnPress = useCallback(
-    (e: NativeSyntheticEvent<ButtonEvent>) => {
-      if (dropKeyboardTapRef.current) {
-        return;
-      }
+  const captureKeyboardDismiss = useCallback(() => {
+    dropKeyboardTapRef.current ??= isKeyboardDismissingTap(jsResponderContext);
+  }, [jsResponderContext]);
 
-      onPress?.(e.nativeEvent);
-    },
-    [onPress]
-  );
-
-  const internalOnPressIn = useCallback(
-    (e: NativeSyntheticEvent<ButtonEvent>) => {
-      // PressIn opens every press sequence; capture the verdict once per
-      // sequence so a re-entry PressIn (with cancelOnLeave={false}) doesn't
-      // overwrite it after the keyboard is already dismissed.
-      dropKeyboardTapRef.current ??=
-        isKeyboardDismissingTap(jsResponderContext);
-
-      if (dropKeyboardTapRef.current) {
-        return;
-      }
-
-      onPressIn?.(e.nativeEvent);
-    },
-    [jsResponderContext, onPressIn]
-  );
-
-  const internalOnPressOut = useCallback(
-    (e: NativeSyntheticEvent<ButtonEvent>) => {
-      if (dropKeyboardTapRef.current) {
-        return;
-      }
-
-      onPressOut?.(e.nativeEvent);
-    },
-    [onPressOut]
-  );
-
-  const internalOnLongPress = useCallback(
-    (e: NativeSyntheticEvent<ButtonEvent>) => {
-      if (dropKeyboardTapRef.current) {
-        return;
-      }
-
-      onLongPress?.(e.nativeEvent);
-    },
-    [onLongPress]
-  );
-
-  // InteractionFinished is dispatched after the terminal PressOut/Press
-  // events, so resetting synchronously here is safe.
-  const internalOnInteractionFinished = useCallback(() => {
+  const resetKeyboardDismiss = useCallback(() => {
     dropKeyboardTapRef.current = null;
   }, []);
+
+  const wrappedLongPress = useCallback(() => {
+    longPressDetected.current = true;
+    // @ts-ignore - the detector-based implementation is missing the event argument
+    onLongPress?.();
+  }, [onLongPress]);
+
+  const startLongPressTimer = useCallback(() => {
+    longPressDetected.current = false;
+
+    if (onLongPress && !longPressTimeout.current) {
+      longPressTimeout.current = setTimeout(
+        wrappedLongPress,
+        resolvedDelayLongPress
+      );
+    }
+  }, [onLongPress, resolvedDelayLongPress, wrappedLongPress]);
+
+  const onBegin = useCallback(
+    (e: CallbackEventType) => {
+      captureKeyboardDismiss();
+
+      if (!e.pointerInside || dropKeyboardTapRef.current) {
+        pointerState.current = PointerState.OUTSIDE;
+        return;
+      }
+
+      onPressIn?.(e);
+      startLongPressTimer();
+
+      pointerState.current = PointerState.INSIDE;
+    },
+    [captureKeyboardDismiss, startLongPressTimer, onPressIn]
+  );
+
+  const onActivate = useCallback((e: CallbackEventType) => {
+    if (!e.pointerInside && longPressTimeout.current !== undefined) {
+      clearTimeout(longPressTimeout.current);
+      longPressTimeout.current = undefined;
+    }
+  }, []);
+
+  const onFinalize = useCallback(
+    (e: EndCallbackEventType) => {
+      if (
+        !dropKeyboardTapRef.current &&
+        pointerState.current === PointerState.INSIDE
+      ) {
+        onPressOut?.(e);
+      }
+
+      if (
+        !dropKeyboardTapRef.current &&
+        !e.canceled &&
+        !longPressDetected.current &&
+        e.pointerInside
+      ) {
+        onPress?.(e);
+      }
+
+      pointerState.current = PointerState.UNKNOWN;
+
+      if (longPressTimeout.current !== undefined) {
+        clearTimeout(longPressTimeout.current);
+        longPressTimeout.current = undefined;
+      }
+
+      resetKeyboardDismiss();
+    },
+    [resetKeyboardDismiss, onPressOut, onPress]
+  );
+
+  const onUpdate = useCallback(
+    (e: CallbackEventType) => {
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
+      if (pointerState.current === PointerState.UNKNOWN) {
+        return;
+      }
+
+      if (e.pointerInside) {
+        if (pointerState.current === PointerState.OUTSIDE) {
+          onPressIn?.(e);
+        }
+        pointerState.current = PointerState.INSIDE;
+      } else {
+        if (pointerState.current === PointerState.INSIDE) {
+          onPressOut?.(e);
+
+          if (longPressTimeout.current !== undefined) {
+            clearTimeout(longPressTimeout.current);
+            longPressTimeout.current = undefined;
+          }
+        }
+        pointerState.current = PointerState.OUTSIDE;
+      }
+    },
+    [onPressIn, onPressOut]
+  );
+
+  const nativeGesture = useNativeGesture({
+    onBegin,
+    onActivate,
+    onFinalize,
+    onUpdate,
+    hitSlop: props.hitSlop,
+    testID: props.testID,
+    enabled: !disabled,
+    shouldCancelWhenOutside: cancelOnLeave,
+    disableReanimated: true,
+    shouldActivateOnStart: false,
+    disallowInterruption: true,
+    yieldsToContinuousGestures: true,
+  });
 
   const rippleProps = shouldUseNativeRipple
     ? {
@@ -161,40 +245,22 @@ export const Touchable = (props: TouchableProps) => {
 
   const tvProps = getTVProps(rest);
 
-  const hitSlop =
-    typeof props.hitSlop === 'number'
-      ? {
-          top: props.hitSlop,
-          left: props.hitSlop,
-          bottom: props.hitSlop,
-          right: props.hitSlop,
-        }
-      : (props.hitSlop ?? undefined);
-
   return (
-    <GestureHandlerButton
-      {...rest}
-      {...tvProps}
-      {...rippleProps}
-      {...resolvedDurations}
-      ref={ref ?? null}
-      enabled={!disabled}
-      handlerTag={handlerTag}
-      cancelOnLeave={cancelOnLeave}
-      gestureTestID={props.testID}
-      gestureHitSlop={hitSlop}
-      defaultOpacity={defaultOpacity}
-      defaultUnderlayOpacity={defaultUnderlayOpacity}
-      activeUnderlayOpacity={activeUnderlayOpacity}
-      underlayColor={underlayColor}
-      longPressDuration={resolvedDelayLongPress}
-      hasLongPressHandler={onLongPress !== undefined}
-      onPress={internalOnPress}
-      onPressIn={internalOnPressIn}
-      onPressOut={internalOnPressOut}
-      onLongPress={internalOnLongPress}
-      onInteractionFinished={internalOnInteractionFinished}>
-      {children}
-    </GestureHandlerButton>
+    <NativeDetector gesture={nativeGesture}>
+      <GestureHandlerButton
+        {...rest}
+        {...tvProps}
+        {...rippleProps}
+        {...resolvedDurations}
+        ref={ref ?? null}
+        enabled={!disabled}
+        defaultOpacity={defaultOpacity}
+        defaultUnderlayOpacity={defaultUnderlayOpacity}
+        activeUnderlayOpacity={activeUnderlayOpacity}
+        underlayColor={underlayColor}
+        longPressDuration={resolvedDelayLongPress}>
+        {children}
+      </GestureHandlerButton>
+    </NativeDetector>
   );
 };

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -12,23 +12,12 @@ import {
   isKeyboardDismissingTap,
   JSResponderContext,
 } from '../ScrollViewResponderInterceptor';
-import type {
-  AnimationDuration,
-  CallbackEventType,
-  EndCallbackEventType,
-  TouchableProps,
-} from './TouchableProps';
+import type { AnimationDuration, TouchableProps } from './TouchableProps';
 
 const isAndroid = Platform.OS === 'android';
 const TRANSPARENT_RIPPLE = { rippleColor: 'transparent' as const };
 const DEFAULT_IN_DURATION_MS = 50;
 const DEFAULT_OUT_DURATION_MS = 100;
-
-enum PointerState {
-  UNKNOWN,
-  INSIDE,
-  OUTSIDE,
-}
 
 // Clamp user-supplied durations to finite, non-negative milliseconds.
 // Negative, NaN, or Infinity values would produce invalid CSS transitions
@@ -102,8 +91,15 @@ export const Touchable = (props: TouchableProps) => {
 
   const shouldUseNativeRipple = isAndroid && androidRipple !== undefined;
 
+  const jsResponderContext = use(JSResponderContext);
+  const dropKeyboardTapRef = useRef<boolean | null>(null);
+
   const internalOnPress = useCallback(
     (e: NativeSyntheticEvent<ButtonEvent>) => {
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
       onPress?.(e.nativeEvent);
     },
     [onPress]
@@ -111,13 +107,27 @@ export const Touchable = (props: TouchableProps) => {
 
   const internalOnPressIn = useCallback(
     (e: NativeSyntheticEvent<ButtonEvent>) => {
+      // PressIn opens every press sequence; capture the verdict once per
+      // sequence so a re-entry PressIn (with cancelOnLeave={false}) doesn't
+      // overwrite it after the keyboard is already dismissed.
+      dropKeyboardTapRef.current ??=
+        isKeyboardDismissingTap(jsResponderContext);
+
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
       onPressIn?.(e.nativeEvent);
     },
-    [onPressIn]
+    [jsResponderContext, onPressIn]
   );
 
   const internalOnPressOut = useCallback(
     (e: NativeSyntheticEvent<ButtonEvent>) => {
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
       onPressOut?.(e.nativeEvent);
     },
     [onPressOut]
@@ -125,10 +135,20 @@ export const Touchable = (props: TouchableProps) => {
 
   const internalOnLongPress = useCallback(
     (e: NativeSyntheticEvent<ButtonEvent>) => {
+      if (dropKeyboardTapRef.current) {
+        return;
+      }
+
       onLongPress?.(e.nativeEvent);
     },
     [onLongPress]
   );
+
+  // InteractionFinished is dispatched after the terminal PressOut/Press
+  // events, so resetting synchronously here is safe.
+  const internalOnInteractionFinished = useCallback(() => {
+    dropKeyboardTapRef.current = null;
+  }, []);
 
   const nativeGesture = useNativeGesture({
     hitSlop: props.hitSlop,
@@ -170,7 +190,8 @@ export const Touchable = (props: TouchableProps) => {
         onPress={internalOnPress}
         onPressIn={internalOnPressIn}
         onPressOut={internalOnPressOut}
-        onLongPress={internalOnLongPress}>
+        onLongPress={internalOnLongPress}
+        onInteractionFinished={internalOnInteractionFinished}>
         {children}
       </GestureHandlerButton>
     </NativeDetector>

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -1,4 +1,4 @@
-import React, { use, useCallback, useRef } from 'react';
+import React, { use, useCallback, useRef, useState } from 'react';
 import type { NativeSyntheticEvent } from 'react-native';
 import { Platform } from 'react-native';
 
@@ -6,8 +6,7 @@ import GestureHandlerButton, {
   type ButtonEvent,
 } from '../../../components/GestureHandlerButton';
 import { getTVProps } from '../../../components/utils';
-import { NativeDetector } from '../../detectors/NativeDetector';
-import { useNativeGesture } from '../../hooks';
+import { getNextHandlerTag } from '../../../handlers/getNextHandlerTag';
 import {
   isKeyboardDismissingTap,
   JSResponderContext,
@@ -85,6 +84,7 @@ export const Touchable = (props: TouchableProps) => {
     ref,
     ...rest
   } = props;
+  const [handlerTag] = useState(() => getNextHandlerTag());
 
   const resolvedDurations = resolveAnimationDuration(animationDuration);
   const resolvedDelayLongPress = sanitizeDuration(delayLongPress);
@@ -150,17 +150,6 @@ export const Touchable = (props: TouchableProps) => {
     dropKeyboardTapRef.current = null;
   }, []);
 
-  const nativeGesture = useNativeGesture({
-    hitSlop: props.hitSlop,
-    testID: props.testID,
-    enabled: !disabled,
-    shouldCancelWhenOutside: cancelOnLeave,
-    disableReanimated: true,
-    shouldActivateOnStart: false,
-    disallowInterruption: true,
-    yieldsToContinuousGestures: true,
-  });
-
   const rippleProps = shouldUseNativeRipple
     ? {
         rippleColor: androidRipple?.color,
@@ -172,28 +161,40 @@ export const Touchable = (props: TouchableProps) => {
 
   const tvProps = getTVProps(rest);
 
+  const hitSlop =
+    typeof props.hitSlop === 'number'
+      ? {
+          top: props.hitSlop,
+          left: props.hitSlop,
+          bottom: props.hitSlop,
+          right: props.hitSlop,
+        }
+      : (props.hitSlop ?? undefined);
+
   return (
-    <NativeDetector gesture={nativeGesture}>
-      <GestureHandlerButton
-        {...rest}
-        {...tvProps}
-        {...rippleProps}
-        {...resolvedDurations}
-        ref={ref ?? null}
-        enabled={!disabled}
-        defaultOpacity={defaultOpacity}
-        defaultUnderlayOpacity={defaultUnderlayOpacity}
-        activeUnderlayOpacity={activeUnderlayOpacity}
-        underlayColor={underlayColor}
-        longPressDuration={resolvedDelayLongPress}
-        hasLongPressHandler={onLongPress !== undefined}
-        onPress={internalOnPress}
-        onPressIn={internalOnPressIn}
-        onPressOut={internalOnPressOut}
-        onLongPress={internalOnLongPress}
-        onInteractionFinished={internalOnInteractionFinished}>
-        {children}
-      </GestureHandlerButton>
-    </NativeDetector>
+    <GestureHandlerButton
+      {...rest}
+      {...tvProps}
+      {...rippleProps}
+      {...resolvedDurations}
+      ref={ref ?? null}
+      enabled={!disabled}
+      handlerTag={handlerTag}
+      cancelOnLeave={cancelOnLeave}
+      gestureTestID={props.testID}
+      gestureHitSlop={hitSlop}
+      defaultOpacity={defaultOpacity}
+      defaultUnderlayOpacity={defaultUnderlayOpacity}
+      activeUnderlayOpacity={activeUnderlayOpacity}
+      underlayColor={underlayColor}
+      longPressDuration={resolvedDelayLongPress}
+      hasLongPressHandler={onLongPress !== undefined}
+      onPress={internalOnPress}
+      onPressIn={internalOnPressIn}
+      onPressOut={internalOnPressOut}
+      onLongPress={internalOnLongPress}
+      onInteractionFinished={internalOnInteractionFinished}>
+      {children}
+    </GestureHandlerButton>
   );
 };

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
@@ -20,6 +20,15 @@ type PressableAndroidRippleConfig = {
 
 type RippleProps = 'rippleColor' | 'rippleRadius' | 'borderless' | 'foreground';
 
+// The press events are redeclared below with the unwrapped `ButtonEvent`
+// signature; `onInteractionFinished` is consumed internally by `Touchable`.
+type PressProps =
+  | 'onPress'
+  | 'onPressIn'
+  | 'onPressOut'
+  | 'onLongPress'
+  | 'onInteractionFinished';
+
 type DurationProps =
   | 'tapAnimationInDuration'
   | 'tapAnimationOutDuration'
@@ -60,7 +69,7 @@ export type AnimationDuration =
 
 export type TouchableProps = Omit<
   ButtonProps,
-  RippleProps | 'enabled' | DurationProps
+  RippleProps | PressProps | 'enabled' | DurationProps
 > &
   Omit<
     BaseButtonProps,

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/TouchableProps.ts
@@ -1,6 +1,9 @@
 import type { PressableAndroidRippleConfig as RNPressableAndroidRippleConfig } from 'react-native';
 
-import type { ButtonProps } from '../../../components/GestureHandlerButton';
+import type {
+  ButtonEvent,
+  ButtonProps,
+} from '../../../components/GestureHandlerButton';
 import type { NativeHandlerData } from '../../hooks/gestures/native/NativeTypes';
 import type { GestureEndEvent, GestureEvent } from '../../types';
 import type { BaseButtonProps, RawButtonProps } from '../GestureButtonsProps';
@@ -61,7 +64,7 @@ export type TouchableProps = Omit<
 > &
   Omit<
     BaseButtonProps,
-    keyof RawButtonProps | 'onActiveStateChange' | 'onPress'
+    keyof RawButtonProps | 'onActiveStateChange' | 'onPress' | 'onLongPress'
   > & {
     /**
      * Press and hover animation durations, in milliseconds. Pass a single
@@ -78,17 +81,22 @@ export type TouchableProps = Omit<
     /**
      * Called when the component gets pressed.
      */
-    onPress?: ((event: CallbackEventType) => void) | undefined;
+    onPress?: ((event: ButtonEvent) => void) | undefined;
+
+    /**
+     * Called when the component gets long pressed.
+     */
+    onLongPress?: ((event: ButtonEvent) => void) | undefined;
 
     /**
      * Called when pointer touches the component.
      */
-    onPressIn?: ((event: CallbackEventType) => void) | undefined;
+    onPressIn?: ((event: ButtonEvent) => void) | undefined;
 
     /**
      * Called when pointer is released from the component.
      */
-    onPressOut?: ((event: CallbackEventType) => void) | undefined;
+    onPressOut?: ((event: ButtonEvent) => void) | undefined;
 
     /**
      * Whether the component should ignore touches. By default set to false.


### PR DESCRIPTION
## Description

Part 1/3 of the `Touchable` refactor (Android; iOS and web follow in stacked PRs). Previously, `Touchable` wrapped the button in a `NativeDetector` and derived `onPress`/`onPressIn`/`onPressOut`/`onLongPress` from gesture callbacks in JS, adding unnecessary overhead.

This PR moves the whole press pipeline into the button on Android:

- `RNGestureHandlerButtonViewManager` now creates, attaches, and drops a `NativeViewGestureHandler` itself, driven by a new `handlerTag` prop. The handler is attached with the new `ACTION_TYPE_NONE`, so it dispatches no gesture events to JS; its config is kept in sync via the `cancelOnLeave`, `gestureTestID`, `gestureHitSlop`, and `enabled` props (cached on the view, since prop application order isn't guaranteed).
- `NativeViewGestureHandlerHook` gains `onHandlerUpdate`/`onHandlerStateChange` hooks, which `ButtonViewGroup` uses to run a press state machine natively — including the long-press timer (`hasLongPressHandler` + `longPressDuration`).
- The resulting `press`/`pressIn`/`pressOut`/`longPress`/`interactionFinished` events are dispatched as direct events (`RNGestureHandlerButtonEvent`) carrying pointer data.
- The new `Touchable.android.tsx` renders `GestureHandlerButton` directly — no `NativeDetector`, no JS state machine — and only forwards the native events, keeping the keyboard-dismissing-tap suppression in JS.

## Test plan

Existing tests in the Example app
