### PR TITLE
[Docs] Fix TopbarBanner not refilling content after navigation

### DIFF
--- a/packages/docs-gesture-handler/package.json
+++ b/packages/docs-gesture-handler/package.json
@@ -32,7 +32,7 @@
     "@emotion/styled": "^11.14.0",
     "@mdx-js/react": "^3.0.0",
     "@mui/material": "^7.1.0",
-    "@swmansion/t-rex-ui": "1.3.3",
+    "@swmansion/t-rex-ui": "1.3.5",
     "@vercel/og": "^0.6.2",
     "babel-polyfill": "^6.26.0",
     "babel-preset-expo": "^9.2.2",

--- a/packages/docs-gesture-handler/yarn.lock
+++ b/packages/docs-gesture-handler/yarn.lock
@@ -3479,10 +3479,10 @@
     "@svgr/plugin-jsx" "8.1.0"
     "@svgr/plugin-svgo" "8.1.0"
 
-"@swmansion/t-rex-ui@1.3.3":
-  version "1.3.3"
-  resolved "https://registry.yarnpkg.com/@swmansion/t-rex-ui/-/t-rex-ui-1.3.3.tgz#3369a3f45f383d70cd7f3b9bcabaa8bfea379e40"
-  integrity sha512-vk2LGZifWlAw1gij4sxHA4gE31XBLBoKPSk0TMqrEv631YOwAZ8qcwsbjeNlW9Gm/T/7+mq7aT+jcT6/cKWLJw==
+"@swmansion/t-rex-ui@1.3.5":
+  version "1.3.5"
+  resolved "https://registry.yarnpkg.com/@swmansion/t-rex-ui/-/t-rex-ui-1.3.5.tgz#322adfdce8d5b12141a20352c2833955b5e31ed0"
+  integrity sha512-cCDQmbhDxbA/FGoFHRBN4guKeEFU2DnsTeNnTrLlVxMFP+2dUKjaGhsT0rXg13E2af8U54oe5A/jkZcSWUeM/w==
   dependencies:
     "@docusaurus/core" "3.9.2"
     "@docusaurus/module-type-aliases" "3.9.2"


### PR DESCRIPTION
## Description

Banner content only filled on first page load. After client-side navigation (Docusaurus page swap), the banner remounted empty and stayed collapsed.

This PR bumps `@swmansion/t-rex-u` to pick up a TopbarBanner fix.


## Test plan

1) Open docs, confirm top bar shows
2) Navigate to another page without full reload
3) Confirm top bar still shows content