### PR TITLE
[iOS] Check if `enableTrackpadTwoFingerGesture` is `nil` before applying

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
@@ -408,9 +408,9 @@
   APPLY_FLOAT_PROP(failOffsetYEnd);
 
 #if !TARGET_OS_OSX && !TARGET_OS_TV
-  bool enableTrackpadTwoFingerGesture = [RCTConvert BOOL:config[@"enableTrackpadTwoFingerGesture"]];
-  if (enableTrackpadTwoFingerGesture) {
-    recognizer.allowedScrollTypesMask = UIScrollTypeMaskAll;
+  id enableTrackpadTwoFingerGesture = config[@"enableTrackpadTwoFingerGesture"];
+  if (enableTrackpadTwoFingerGesture != nil) {
+    recognizer.allowedScrollTypesMask = [RCTConvert BOOL:enableTrackpadTwoFingerGesture] ? UIScrollTypeMaskAll : 0;
   }
 
   APPLY_NAMED_INT_PROP(minimumNumberOfTouches, @"minPointers");


### PR DESCRIPTION
## Description

On `iOS`, `enableTrackpadTwoFingerGesture` was read in `RNPanGestureHandler`'s `updateConfig:` without checking whether the key is present in the config, and `allowedScrollTypesMask` was only ever set when the value was truthy. This PR changes it to match other props behavior.

## Test plan

Checked that basic-example builds correctly 