### PR TITLE
[Android] Apply the button's managed handler config once per prop transaction

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -108,8 +108,8 @@ class RNGestureHandlerButtonViewManager :
     view.hasLongPressHandler = hasLongPressHandler
   }
 
-  // No-op — only iOS needs the module id to resolve the handler manager, Android
-  // gets the module from the view's context.
+  // Cached like the other managed-handler props — prop order isn't guaranteed, so the module is
+  // resolved from the id only once the transaction ends, in `updateManagedHandler`.
   @ReactProp(name = "moduleId")
   override fun setModuleId(view: ButtonViewGroup, moduleId: Int) {
     view.moduleId = moduleId

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -78,6 +78,8 @@ class RNGestureHandlerButtonViewManager :
     view.managedHandlerCancelOnLeave = null
     view.managedHandlerTestID = null
     view.managedHandlerHitSlop = null
+    view.moduleId = null
+    // Has to come last — every setter above flags the view as needing a managed handler update.
     view.managedHandlerNeedsUpdate = false
 
     super.onDropViewInstance(view)
@@ -460,11 +462,12 @@ class RNGestureHandlerButtonViewManager :
   }
 
   private fun dropManagedHandler(view: ButtonViewGroup) {
+    val tag = view.managedHandlerTag ?: return
+    // Cleared even if the drop below doesn't go through — the view must not keep a dangling tag.
+    view.managedHandlerTag = null
+
     val moduleId = view.moduleId ?: return
-    view.managedHandlerTag?.let { tag ->
-      RNGestureHandlerModule.getModule(moduleId)?.dropGestureHandler(tag)
-      view.managedHandlerTag = null
-    }
+    RNGestureHandlerModule.getModule(moduleId)?.dropGestureHandler(tag)
   }
 
   private fun buildManagedHandlerConfig(view: ButtonViewGroup): ReadableMap = Arguments.createMap().apply {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -69,80 +69,38 @@ class RNGestureHandlerButtonViewManager :
   public override fun createViewInstance(context: ThemedReactContext) = ButtonViewGroup(context)
 
   override fun onDropViewInstance(view: ButtonViewGroup) {
-    view.managedHandlerTag?.let { tag ->
-      getGestureHandlerModule(view).dropGestureHandler(tag)
-    }
+    dropManagedHandler(view)
+
+    // The view may end up recycled, and props matching their default aren't re-applied on the next
+    // mount — leaving the cached values behind would configure (or even create) a handler for the
+    // next button from the previous one's props.
+    view.pendingHandlerTag = null
+    view.managedHandlerCancelOnLeave = null
+    view.managedHandlerTestID = null
+    view.managedHandlerHitSlop = null
+    view.managedHandlerNeedsUpdate = false
 
     super.onDropViewInstance(view)
   }
 
-  private fun getGestureHandlerModule(view: ButtonViewGroup) =
-    (view.context as ReactContext).getNativeModule(RNGestureHandlerModule::class.java)!!
-
-  private fun updateManagedHandlerConfig(view: ButtonViewGroup, config: ReadableMap) {
-    view.managedHandlerTag?.let { getGestureHandlerModule(view).updateGestureHandlerConfig(it, config) }
-  }
-
   @ReactProp(name = "handlerTag")
   override fun setHandlerTag(view: ButtonViewGroup, handlerTag: Double) {
-    if (view.managedHandlerTag == handlerTag) {
-      return
-    }
-
-    view.managedHandlerTag?.let { oldTag ->
-      getGestureHandlerModule(view).dropGestureHandler(oldTag)
-    }
-
-    view.managedHandlerTag = handlerTag
-    val module = getGestureHandlerModule(view)
-
-    module.createGestureHandler(
-      "NativeViewGestureHandler",
-      handlerTag,
-      Arguments.createMap().apply {
-        putBoolean("shouldActivateOnStart", false)
-        putBoolean("disallowInterruption", true)
-        putBoolean("yieldsToContinuousGestures", true)
-        putBoolean("enabled", view.isEnabled)
-        view.managedHandlerCancelOnLeave?.let { putBoolean("shouldCancelWhenOutside", it) }
-        view.managedHandlerTestID?.let { putString("testID", it) }
-        view.managedHandlerHitSlop?.let { putMap("hitSlop", it) }
-      },
-    )
-    module.attachGestureHandler(handlerTag, view.id.toDouble(), GestureHandler.ACTION_TYPE_NONE.toDouble())
+    view.pendingHandlerTag = handlerTag
   }
 
   @ReactProp(name = "cancelOnLeave")
   override fun setCancelOnLeave(view: ButtonViewGroup, cancelOnLeave: Boolean) {
     view.managedHandlerCancelOnLeave = cancelOnLeave
-    updateManagedHandlerConfig(
-      view,
-      Arguments.createMap().apply {
-        putBoolean("shouldCancelWhenOutside", cancelOnLeave)
-      },
-    )
   }
 
   @ReactProp(name = "gestureTestID")
   override fun setGestureTestID(view: ButtonViewGroup, gestureTestID: String?) {
     view.managedHandlerTestID = gestureTestID
-    updateManagedHandlerConfig(
-      view,
-      Arguments.createMap().apply {
-        putString("testID", gestureTestID)
-      },
-    )
   }
 
   @ReactProp(name = "gestureHitSlop")
   override fun setGestureHitSlop(view: ButtonViewGroup, gestureHitSlop: ReadableMap?) {
     view.managedHandlerHitSlop = gestureHitSlop
-    updateManagedHandlerConfig(
-      view,
-      Arguments.createMap().apply {
-        putMap("hitSlop", gestureHitSlop)
-      },
-    )
   }
 
   @ReactProp(name = "hasLongPressHandler")
@@ -153,7 +111,9 @@ class RNGestureHandlerButtonViewManager :
   // No-op — only iOS needs the module id to resolve the handler manager, Android
   // gets the module from the view's context.
   @ReactProp(name = "moduleId")
-  override fun setModuleId(view: ButtonViewGroup, moduleId: Int) = Unit
+  override fun setModuleId(view: ButtonViewGroup, moduleId: Int) {
+    view.moduleId = moduleId
+  }
 
   @ReactProp(name = "foreground")
   override fun setForeground(view: ButtonViewGroup, useDrawableOnForeground: Boolean) {
@@ -173,13 +133,6 @@ class RNGestureHandlerButtonViewManager :
   @ReactProp(name = "enabled")
   override fun setEnabled(view: ButtonViewGroup, enabled: Boolean) {
     view.isEnabled = enabled
-
-    updateManagedHandlerConfig(
-      view,
-      Arguments.createMap().apply {
-        putBoolean("enabled", enabled)
-      },
-    )
   }
 
   @ReactProp(name = "borderWidth")
@@ -467,9 +420,69 @@ class RNGestureHandlerButtonViewManager :
     }
   }
 
+  /**
+   * Creates, reconfigures or drops the [NativeViewGestureHandler] the button manages, based on the
+   * props cached on the view. Runs once per prop transaction rather than from the individual prop
+   * setters: each of those would otherwise repeat the module lookup, build a config map and look
+   * the handler up in the registry, and since prop order isn't guaranteed, `handlerTag` may be
+   * applied after the props that configure the handler.
+   */
+  private fun updateManagedHandler(view: ButtonViewGroup) {
+    val moduleId = view.moduleId ?: return
+    if (!view.managedHandlerNeedsUpdate) {
+      return
+    }
+
+    view.managedHandlerNeedsUpdate = false
+
+    // Handler tags start at 1, so anything below that means the prop was either never set or reset
+    // to its default because it got removed.
+    val handlerTag = view.pendingHandlerTag?.takeIf { it > 0 }
+
+    if (handlerTag == null) {
+      dropManagedHandler(view)
+      return
+    }
+
+    val module = RNGestureHandlerModule.getModule(moduleId) ?: return
+
+    if (handlerTag != view.managedHandlerTag) {
+      dropManagedHandler(view)
+
+      module.createGestureHandler("NativeViewGestureHandler", handlerTag, buildManagedHandlerConfig(view))
+      module.attachGestureHandler(handlerTag, view.id.toDouble(), GestureHandler.ACTION_TYPE_NONE.toDouble())
+
+      view.managedHandlerTag = handlerTag
+      return
+    }
+
+    module.updateGestureHandlerConfig(handlerTag, buildManagedHandlerConfig(view))
+  }
+
+  private fun dropManagedHandler(view: ButtonViewGroup) {
+    val moduleId = view.moduleId ?: return
+    view.managedHandlerTag?.let { tag ->
+      RNGestureHandlerModule.getModule(moduleId)?.dropGestureHandler(tag)
+      view.managedHandlerTag = null
+    }
+  }
+
+  private fun buildManagedHandlerConfig(view: ButtonViewGroup): ReadableMap = Arguments.createMap().apply {
+    putBoolean("shouldActivateOnStart", false)
+    putBoolean("disallowInterruption", true)
+    putBoolean("yieldsToContinuousGestures", true)
+    putBoolean("enabled", view.isEnabled)
+    // Written even when null so that a removed prop clears the one on the handler.
+    putString("testID", view.managedHandlerTestID)
+    putMap("hitSlop", view.managedHandlerHitSlop)
+
+    putBoolean("shouldCancelWhenOutside", view.managedHandlerCancelOnLeave ?: true)
+  }
+
   override fun onAfterUpdateTransaction(view: ButtonViewGroup) {
     super.onAfterUpdateTransaction(view)
 
+    updateManagedHandler(view)
     view.updateBackground()
     view.updateLongPressAccessibility()
   }
@@ -498,13 +511,27 @@ class RNGestureHandlerButtonViewManager :
 
     var managedHandlerTag: Double? = null
 
-    // Config props may be applied before `handlerTag` (prop order is not guaranteed) and
-    // `updateManagedHandlerConfig` no-ops until the handler exists, so the values are cached
-    // here and seeded into the config when `setHandlerTag` creates the handler. This also
-    // re-applies them when the handler is recreated for a new tag.
+    var pendingHandlerTag: Double? = null
+      set(tag) = withManagedHandlerUpdate {
+        field = tag
+      }
     var managedHandlerCancelOnLeave: Boolean? = null
+      set(cancelOnLeave) = withManagedHandlerUpdate {
+        field = cancelOnLeave
+      }
     var managedHandlerTestID: String? = null
+      set(testID) = withManagedHandlerUpdate {
+        field = testID
+      }
     var managedHandlerHitSlop: ReadableMap? = null
+      set(hitSlop) = withManagedHandlerUpdate {
+        field = hitSlop
+      }
+    var moduleId: Int? = null
+      set(moduleId) = withManagedHandlerUpdate {
+        field = moduleId
+      }
+    var managedHandlerNeedsUpdate = false
 
     var exclusive = true
     var hasLongPressHandler = false
@@ -589,6 +616,11 @@ class RNGestureHandlerButtonViewManager :
     private inline fun withBackgroundUpdate(block: () -> Unit) {
       block()
       needBackgroundUpdate = true
+    }
+
+    private inline fun withManagedHandlerUpdate(block: () -> Unit) {
+      block()
+      managedHandlerNeedsUpdate = true
     }
 
     fun setOverflow(overflow: String?) {
@@ -1249,7 +1281,14 @@ class RNGestureHandlerButtonViewManager :
       val changed = enabled != isEnabled
       super.setEnabled(enabled)
 
-      if (changed && isHovered) {
+      if (!changed) {
+        return
+      }
+
+      // The managed handler mirrors the button's enabled state.
+      managedHandlerNeedsUpdate = true
+
+      if (isHovered) {
         animateHoverState()
       }
     }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerModule.kt
@@ -14,6 +14,8 @@ import com.facebook.soloader.SoLoader
 import com.swmansion.gesturehandler.NativeRNGestureHandlerModuleSpec
 import com.swmansion.gesturehandler.core.GestureHandler
 import com.swmansion.gesturehandler.react.events.RNGestureHandlerEventDispatcher
+import java.lang.ref.WeakReference
+import java.util.concurrent.ConcurrentHashMap
 
 @ReactModule(name = RNGestureHandlerModule.NAME)
 class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
@@ -34,6 +36,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
   init {
     registries[moduleId] = RNGestureHandlerRegistry()
+    modules[moduleId] = WeakReference(this)
   }
 
   override fun getName() = NAME
@@ -182,6 +185,7 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
       }
     }
     registries.remove(moduleId)
+    modules.remove(moduleId)
     invalidateNative()
     super.invalidate()
   }
@@ -202,6 +206,21 @@ class RNGestureHandlerModule(reactContext: ReactApplicationContext?) :
 
     private var nextModuleId = 0
     val registries: MutableMap<Int, RNGestureHandlerRegistry> = mutableMapOf()
+
+    private val modules: MutableMap<Int, WeakReference<RNGestureHandlerModule>> = ConcurrentHashMap()
+
+    fun getModule(moduleId: Int): RNGestureHandlerModule? {
+      val module = modules[moduleId]?.get()
+
+      if (module == null) {
+        // Either the module was never registered, or it was collected without `invalidate`
+        // running — drop the dangling reference so the maps don't grow across reloads.
+        modules.remove(moduleId)
+        registries.remove(moduleId)
+      }
+
+      return module
+    }
 
     init {
       SoLoader.loadLibrary("gesturehandler")


### PR DESCRIPTION
## Description

Each prop setter on `RNGestureHandlerButtonViewManager` created or reconfigured the button's managed `NativeViewGestureHandler` on its own. That meant, per prop: a module lookup, a fresh config map, and a registry lookup — and since React Native does not guarantee prop order, `handlerTag` could be applied *after* the props meant to configure the handler, so those updates were silently dropped.

Prop setters now only cache their value on the view and flag it dirty; a single `updateManagedHandler` pass runs from `onAfterUpdateTransaction` and creates, reconfigures or drops the handler from the cached state. Other changes this required:

- The module is resolved by `moduleId` through a new `RNGestureHandlerModule.getModule` (a `WeakReference` map cleaned up on `invalidate`, and on a dangling read) rather than from the view's context, so `moduleId` participates in the same batched update.
- A `handlerTag` that resets to its default (removed prop) now drops the handler instead of leaving it attached.
- Cached props are cleared in `onDropViewInstance`: views are recycled and props matching their default are not re-applied on the next mount, so stale values would otherwise configure — or create — a handler for the next button from the previous one's props.
- The config is now written in full every time, including `null`s, so a removed `testID` or `hitSlop` actually clears on the handler.

## Test plan

- Buttons in `expo-example` still press, cancel on leave and respect `hitSlop`/`testID`, including when those props are toggled or removed after mount.
- Verified recycled buttons in a long list do not inherit the previous item's handler config.
- Checked `enabled` changes still reach the handler.
