### PR TITLE
[Android] Configure the button's handler directly instead of through a `ReadableMap`

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -75,7 +75,7 @@ open class GestureHandler {
   var isWithinBounds = false
     private set
   var isEnabled = true
-    private set(enabled) {
+    protected set(enabled) {
       // Don't cancel handler when not changing the value of the isEnabled, executing it always caused
       // handlers to be cancelled on re-render because that's the moment when the config is updated.
       // If the enabled prop "changed" from true to true the handler would get cancelled.

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -68,6 +68,22 @@ class NativeViewGestureHandler : GestureHandler() {
     delaysChildPressedState = DEFAULT_DELAYS_CHILD_PRESSED_STATE
   }
 
+  fun updateConfig(config: Config) {
+    isEnabled = config.enabled
+    shouldCancelWhenOutside = config.shouldCancelWhenOutside
+    testID = config.testID
+    val hitSlop = config.hitSlop
+    if (hitSlop != null) {
+      setHitSlop(hitSlop.left, hitSlop.top, hitSlop.right, hitSlop.bottom, HIT_SLOP_NONE, HIT_SLOP_NONE)
+    } else {
+      setHitSlop(null)
+    }
+    shouldActivateOnStart = config.shouldActivateOnStart
+    disallowInterruption = config.disallowInterruption
+    yieldsToContinuousGestures = config.yieldsToContinuousGestures
+    delaysChildPressedState = config.delaysChildPressedState
+  }
+
   override fun shouldRecognizeSimultaneously(handler: GestureHandler): Boolean {
     // if the gesture is marked by user as simultaneous with other or the hook return true
     hook.shouldRecognizeSimultaneously(handler)?.let {
@@ -224,6 +240,24 @@ class NativeViewGestureHandler : GestureHandler() {
   }
 
   override fun wantsToAttachDirectlyToView() = true
+
+  data class HitSlop(
+    val left: Float = HIT_SLOP_NONE,
+    val top: Float = HIT_SLOP_NONE,
+    val right: Float = HIT_SLOP_NONE,
+    val bottom: Float = HIT_SLOP_NONE,
+  )
+
+  data class Config(
+    val enabled: Boolean = true,
+    val shouldCancelWhenOutside: Boolean = DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE,
+    val hitSlop: HitSlop? = null,
+    val testID: String? = null,
+    val shouldActivateOnStart: Boolean = DEFAULT_SHOULD_ACTIVATE_ON_START,
+    val disallowInterruption: Boolean = DEFAULT_DISALLOW_INTERRUPTION,
+    val yieldsToContinuousGestures: Boolean = DEFAULT_YIELDS_TO_CONTINUOUS_GESTURES,
+    val delaysChildPressedState: Boolean? = DEFAULT_DELAYS_CHILD_PRESSED_STATE,
+  )
 
   class Factory : GestureHandler.Factory<NativeViewGestureHandler>() {
     override val type = NativeViewGestureHandler::class.java

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -102,7 +102,22 @@ class RNGestureHandlerButtonViewManager :
 
   @ReactProp(name = "gestureHitSlop")
   override fun setGestureHitSlop(view: ButtonViewGroup, gestureHitSlop: ReadableMap?) {
-    view.managedHandlerHitSlop = gestureHitSlop
+    view.managedHandlerHitSlop = gestureHitSlop?.let { parseHitSlop(it) }
+  }
+
+  private fun parseHitSlop(hitSlop: ReadableMap): NativeViewGestureHandler.HitSlop {
+    fun edge(key: String) = if (hitSlop.hasKey(key)) {
+      PixelUtil.toPixelFromDIP(hitSlop.getDouble(key))
+    } else {
+      GestureHandler.HIT_SLOP_NONE
+    }
+
+    return NativeViewGestureHandler.HitSlop(
+      left = edge("left"),
+      top = edge("top"),
+      right = edge("right"),
+      bottom = edge("bottom"),
+    )
   }
 
   @ReactProp(name = "hasLongPressHandler")
@@ -439,7 +454,7 @@ class RNGestureHandlerButtonViewManager :
 
     // Handler tags start at 1, so anything below that means the prop was either never set or reset
     // to its default because it got removed.
-    val handlerTag = view.pendingHandlerTag?.takeIf { it > 0 }
+    val handlerTag = view.pendingHandlerTag?.toInt()?.takeIf { it > 0 }
 
     if (handlerTag == null) {
       dropManagedHandler(view)
@@ -447,18 +462,28 @@ class RNGestureHandlerButtonViewManager :
     }
 
     val module = RNGestureHandlerModule.getModule(moduleId) ?: return
+    val isNewHandler = handlerTag != view.managedHandlerTag
 
-    if (handlerTag != view.managedHandlerTag) {
+    if (isNewHandler) {
       dropManagedHandler(view)
 
-      module.createGestureHandler("NativeViewGestureHandler", handlerTag, buildManagedHandlerConfig(view))
-      module.attachGestureHandler(handlerTag, view.id.toDouble(), GestureHandler.ACTION_TYPE_NONE.toDouble())
-
-      view.managedHandlerTag = handlerTag
-      return
+      // Created with an empty config — the full configuration is applied below, directly on the
+      // handler, so it never has to be packed into a map.
+      module.createGestureHandler("NativeViewGestureHandler", handlerTag.toDouble(), Arguments.createMap())
     }
 
-    module.updateGestureHandlerConfig(handlerTag, buildManagedHandlerConfig(view))
+    val handler = RNGestureHandlerModule.registries[moduleId]?.getHandler(handlerTag)
+
+    (handler as? NativeViewGestureHandler)?.updateConfig(buildManagedHandlerConfig(view))
+
+    if (isNewHandler) {
+      // Attached only after the handler is configured — setting `enabled` to `false` on an already
+      // attached handler cancels it, which for a button mounted as disabled would dispatch a
+      // pointless cancel event right after mount.
+      module.attachGestureHandler(handlerTag.toDouble(), view.id.toDouble(), GestureHandler.ACTION_TYPE_NONE.toDouble())
+
+      view.managedHandlerTag = handlerTag
+    }
   }
 
   private fun dropManagedHandler(view: ButtonViewGroup) {
@@ -467,20 +492,20 @@ class RNGestureHandlerButtonViewManager :
     view.managedHandlerTag = null
 
     val moduleId = view.moduleId ?: return
-    RNGestureHandlerModule.getModule(moduleId)?.dropGestureHandler(tag)
+    RNGestureHandlerModule.getModule(moduleId)?.dropGestureHandler(tag.toDouble())
   }
 
-  private fun buildManagedHandlerConfig(view: ButtonViewGroup): ReadableMap = Arguments.createMap().apply {
-    putBoolean("shouldActivateOnStart", false)
-    putBoolean("disallowInterruption", true)
-    putBoolean("yieldsToContinuousGestures", true)
-    putBoolean("enabled", view.isEnabled)
-    // Written even when null so that a removed prop clears the one on the handler.
-    putString("testID", view.managedHandlerTestID)
-    putMap("hitSlop", view.managedHandlerHitSlop)
-
-    putBoolean("shouldCancelWhenOutside", view.managedHandlerCancelOnLeave ?: true)
-  }
+  private fun buildManagedHandlerConfig(view: ButtonViewGroup) = NativeViewGestureHandler.Config(
+    enabled = view.isEnabled,
+    shouldCancelWhenOutside = view.managedHandlerCancelOnLeave ?: true,
+    // The config is absolute, so passing the cached values through applies removed props
+    // (null here) as a reset on the handler.
+    hitSlop = view.managedHandlerHitSlop,
+    testID = view.managedHandlerTestID,
+    shouldActivateOnStart = false,
+    disallowInterruption = true,
+    yieldsToContinuousGestures = true,
+  )
 
   override fun onAfterUpdateTransaction(view: ButtonViewGroup) {
     super.onAfterUpdateTransaction(view)
@@ -512,7 +537,7 @@ class RNGestureHandlerButtonViewManager :
       }
     var useBorderlessDrawable = false
 
-    var managedHandlerTag: Double? = null
+    var managedHandlerTag: Int? = null
 
     var pendingHandlerTag: Double? = null
       set(tag) = withManagedHandlerUpdate {
@@ -526,7 +551,7 @@ class RNGestureHandlerButtonViewManager :
       set(testID) = withManagedHandlerUpdate {
         field = testID
       }
-    var managedHandlerHitSlop: ReadableMap? = null
+    var managedHandlerHitSlop: NativeViewGestureHandler.HitSlop? = null
       set(hitSlop) = withManagedHandlerUpdate {
         field = hitSlop
       }


### PR DESCRIPTION
## Description

The button's managed handler was configured by building a `ReadableMap` and pushing it through `updateGestureHandlerConfig`, which then parsed it straight back out. Since both ends are native, the map is pure overhead on every prop transaction.

`NativeViewGestureHandler` gained a typed `Config` (plus a `HitSlop`) data class and an `updateConfig` that applies it directly, and the view manager now builds that instead of a map. `gestureHitSlop` is converted from DIPs to pixels once, when the prop is set, rather than on every config write.

Two things fell out of the rewrite:

- Handlers are created with an empty config and attached only *after* `updateConfig` runs. Setting `enabled = false` on an already-attached handler cancels it, so a button mounted as disabled used to dispatch a pointless cancel event right after mount.
- `GestureHandler.isEnabled`'s setter is now `protected` so subclasses can apply it.

## Test plan

- Buttons behave the same as before across press/cancel/hit-slop/testID/enabled changes.
- Mounting a button with `enabled={false}` no longer emits a cancel event.
- Confirmed `hitSlop` values still land in pixels (visually, against a button with a large slop).
