### PR TITLE
[Android] Skip the underlay drawable when it can never be visible

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -580,11 +580,17 @@ class RNGestureHandlerButtonViewManager :
       get() = if (field < 0f) defaultScale else field
     var hoverUnderlayOpacity: Float = -1f
       get() = if (field < 0f) defaultUnderlayOpacity else field
+      set(value) = withBackgroundUpdate {
+        field = value
+      }
     var underlayColor: Int? = null
       set(color) = withBackgroundUpdate {
         field = color
       }
     var activeUnderlayOpacity: Float = 0f
+      set(value) = withBackgroundUpdate {
+        field = value
+      }
     var defaultUnderlayOpacity: Float = 0f
       set(value) = withBackgroundUpdate {
         field = value
@@ -1055,7 +1061,15 @@ class RNGestureHandlerButtonViewManager :
       }
     }
 
-    private fun createUnderlayDrawable(): PaintDrawable {
+    private fun createUnderlayDrawable(): PaintDrawable? {
+      val isColorTransparent = underlayColor?.let { Color.alpha(it) == 0 } == true
+      val hasVisibleOpacity = defaultUnderlayOpacity != 0f ||
+        activeUnderlayOpacity != 0f ||
+        hoverUnderlayOpacity != 0f
+      if (isColorTransparent || !hasVisibleOpacity) {
+        return null
+      }
+
       val drawable = PaintDrawable(underlayColor ?: Color.BLACK)
       drawable.alpha = (defaultUnderlayOpacity * 255).toInt()
       return drawable
@@ -1072,7 +1086,7 @@ class RNGestureHandlerButtonViewManager :
       val underlay = createUnderlayDrawable()
       underlayDrawable = underlay
       // Set this view as callback so ObjectAnimator alpha changes trigger redraws.
-      underlay.callback = this
+      underlay?.callback = this
 
       if (useDrawableOnForeground && selectable != null) {
         // Explicit foreground mode — View natively forwards state/hotspot.


### PR DESCRIPTION
## Description

`createUnderlayDrawable` always allocated a `PaintDrawable` and installed it as the button's underlay, even when it could not possibly render — a fully transparent `underlayColor`, or every opacity (default, active, hover) left at `0`. That is an allocation and an extra drawable in the layer stack per button, for nothing.

It now returns `null` in those cases and `underlayDrawable` is left unset.

`hoverUnderlayOpacity` and `activeUnderlayOpacity` also needed `withBackgroundUpdate` setters — previously only `defaultUnderlayOpacity` and `underlayColor` triggered a background rebuild, so setting one of the other two after mount could leave the button without an underlay it should now have.

## Test plan

- Buttons with a visible underlay (any of the three opacities non-zero) look and animate unchanged on press and hover.
- Buttons with `underlayColor="transparent"` or all-zero opacities render with no underlay.
- Changing `activeUnderlayOpacity` / `hoverUnderlayOpacity` at runtime rebuilds the background.
