### PR TITLE
[Docs] Do not highlight wrong `onBegin` transition

### DIFF
--- a/packages/docs-gesture-handler/src/examples/CallbacksFlowExamples/GestureCallbacksExample.tsx
+++ b/packages/docs-gesture-handler/src/examples/CallbacksFlowExamples/GestureCallbacksExample.tsx
@@ -150,7 +150,6 @@ function GestureCallbacksDiagram() {
         // let the onDeactivate pulse land first
         later(() => {
           fire('deactivate_finalize', 'onFinalize');
-          pulse('begin_finalize');
         }, 2 * CAUSAL_DELAY_MS);
       } else {
         pulse('onFinalize');


### PR DESCRIPTION
## Description

I've noticed that arrow leading towards `onFinalize` from `onBegin` even if handler activated. This PR fixes this issue.

### Before

https://github.com/user-attachments/assets/3b35e8e1-137f-4506-bf91-1daa2f75e3c2

### After

https://github.com/user-attachments/assets/8050063e-31ea-4f16-80d9-9deec1780704

## Test plan

Play with example
