### PR TITLE
[Android] Properly handle `requestDisallowInterceptTouchEvent` for v3

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -52,7 +52,8 @@ class GestureHandlerOrchestrator(
   // `contains` method on HashSet has O(1) complexity, so calling it inside for loop won't result in O(n^2) (contrary to ArrayList)
   private val awaitingHandlersTags = HashSet<Int>()
 
-  private var isHandlingTouch = false
+  var isHandlingTouch = false
+    private set
   private var handlingChangeSemaphore = 0
   private var finishedHandlersCleanupScheduled = false
   private var activationIndex = 0
@@ -356,6 +357,30 @@ class GestureHandlerOrchestrator(
     }
 
     event.recycle()
+  }
+
+  /**
+   * Cancels all handlers created using API v1 and v2
+   */
+  fun cancelAllLegacyHandlers() {
+    val handlersToProcess = obtainHandlerList()
+    handlersToProcess.addAll(gestureHandlers)
+
+    try {
+      handlersToProcess.forEach {
+        if (it.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API ||
+          it.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API ||
+          it.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET ||
+          it.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT
+        ) {
+          it.cancel()
+        }
+      }
+
+      scheduleFinishedHandlersCleanup()
+    } finally {
+      recycleHandlerList(handlersToProcess)
+    }
   }
 
   /**

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -783,6 +783,24 @@ class RNGestureHandlerButtonViewManager :
       }
     }
 
+    override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+      super.requestDisallowInterceptTouchEvent(disallowIntercept)
+      if (!disallowIntercept) {
+        return
+      }
+
+      val moduleId = moduleId ?: return
+      val managedHandlerTag = managedHandlerTag ?: return
+
+      val orchestrator =
+        RNGestureHandlerRootView.findGestureHandlerRootView(this)?.orchestrator ?: return
+      val handler = RNGestureHandlerModule.registries[moduleId]?.getHandler(managedHandlerTag) ?: return
+
+      if (!orchestrator.isHandlingTouch && handler.view != null) {
+        handler.cancel()
+      }
+    }
+
     override fun onInterceptTouchEvent(event: MotionEvent): Boolean {
       if (super.onInterceptTouchEvent(event)) {
         return true

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
@@ -46,6 +46,28 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
     super.onDetachedFromWindow()
   }
 
+  override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
+    super.requestDisallowInterceptTouchEvent(disallowIntercept)
+    if (!disallowIntercept) {
+      return
+    }
+
+    val orchestrator = RNGestureHandlerRootView.findGestureHandlerRootView(this)?.orchestrator ?: return
+
+    if (!orchestrator.isHandlingTouch) {
+      val currentHandlers = attachedHandlers.mapNotNull { tag ->
+        RNGestureHandlerModule.registries[this.moduleId]?.getHandler(tag)
+      }.filter {
+        // The handler has been recorded
+        it.view != null
+      }
+
+      currentHandlers.forEach {
+        it.cancel()
+      }
+    }
+  }
+
   fun setModuleId(id: Int) {
     if (this.moduleId == id) {
       return

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
@@ -55,16 +55,10 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
     val orchestrator = RNGestureHandlerRootView.findGestureHandlerRootView(this)?.orchestrator ?: return
 
     if (!orchestrator.isHandlingTouch) {
-      val currentHandlers = attachedHandlers.mapNotNull { tag ->
-        RNGestureHandlerModule.registries[this.moduleId]?.getHandler(tag)
-      }.filter {
-        // The handler has been recorded
-        it.view != null
-      }
-
-      currentHandlers.forEach {
-        it.cancel()
-      }
+val registry = RNGestureHandlerModule.registries[moduleId] ?: return
+for (tag in attachedHandlers) {
+  registry.getHandler(tag)?.takeIf { it.view != null }?.cancel()
+}
     }
   }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
@@ -55,10 +55,10 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
     val orchestrator = RNGestureHandlerRootView.findGestureHandlerRootView(this)?.orchestrator ?: return
 
     if (!orchestrator.isHandlingTouch) {
-val registry = RNGestureHandlerModule.registries[moduleId] ?: return
-for (tag in attachedHandlers) {
-  registry.getHandler(tag)?.takeIf { it.view != null }?.cancel()
-}
+      val registry = RNGestureHandlerModule.registries[moduleId] ?: return
+      for (tag in attachedHandlers) {
+        registry.getHandler(tag)?.takeIf { it.view != null }?.cancel()
+      }
     }
   }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -16,7 +16,7 @@ import com.swmansion.gesturehandler.core.GestureHandlerOrchestrator
 import com.swmansion.gesturehandler.core.OnJSResponderCancelListener
 
 class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView: ViewGroup, private val moduleId: Int) {
-  private val orchestrator: GestureHandlerOrchestrator?
+  val orchestrator: GestureHandlerOrchestrator?
   private val jsGestureHandler: GestureHandler?
   val rootView: ViewGroup
   private var shouldIntercept = false
@@ -57,7 +57,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     }
     jsGestureHandler = RootViewGestureHandler(handlerTag = -wrappedViewTag)
     registry.registerHandler(jsGestureHandler)
-    registry.attachHandlerToView(jsGestureHandler.tag, wrappedViewTag, GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API)
+    registry.attachHandlerToView(jsGestureHandler.tag, wrappedViewTag, GestureHandler.ACTION_TYPE_NONE)
     module.registerRootHelper(this)
   }
 
@@ -120,7 +120,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     if (orchestrator != null && !passingTouch) {
       // if we are in the process of delivering touch events via GH orchestrator, we don't want to
       // treat it as a native gesture capturing the lock
-      tryCancelAllHandlers()
+      orchestrator.cancelAllLegacyHandlers()
     }
   }
 
@@ -140,17 +140,6 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     wasIntercepting = shouldIntercept
 
     return shouldIntercept
-  }
-
-  private fun tryCancelAllHandlers() {
-    // In order to cancel handlers we activate handler that is hooked to the root view
-    jsGestureHandler?.apply {
-      if (state == GestureHandler.STATE_BEGAN) {
-        // Try activate main JS handler
-        activate()
-        end()
-      }
-    }
   }
 
   fun activateNativeHandlers(view: View) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
@@ -12,12 +12,16 @@ import com.facebook.react.common.ReactConstants
 import com.facebook.react.uimanager.RootView
 import com.facebook.react.views.view.ReactViewGroup
 import com.swmansion.gesturehandler.core.GestureHandler
+import com.swmansion.gesturehandler.core.GestureHandlerOrchestrator
 
 class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {
   private var moduleId: Int = -1
   private var rootViewEnabled = false
   private var unstableForceActive = false
   private var rootHelper: RNGestureHandlerRootHelper? = null // TODO: resettable lateinit
+
+  val orchestrator: GestureHandlerOrchestrator?
+    get() = rootHelper?.orchestrator
 
   override fun onAttachedToWindow() {
     super.onAttachedToWindow()
@@ -72,7 +76,7 @@ class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {
   }
 
   override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
-    if (rootViewEnabled) {
+    if (rootViewEnabled && disallowIntercept) {
       rootHelper!!.requestDisallowInterceptTouchEvent()
     }
     super.requestDisallowInterceptTouchEvent(disallowIntercept)
@@ -114,6 +118,10 @@ class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {
       while (parent != null) {
         if (parent is RNGestureHandlerRootView) {
           gestureHandlerRootView = parent
+
+          if (parent.rootViewEnabled) {
+            return parent
+          }
         }
         parent = parent.parent
       }


### PR DESCRIPTION
## Description

On Android, when a native view calls `requestDisallowInterceptTouchEvent` (e.g. a pager starting a swipe), `RNGestureHandlerRootView` reacted by cancelling **all** handlers registered on the root. `react-native-pager-view` calls it eagerly on touch down, so any v3 gesture rendered inside a pager (e.g. inside material top tabs) was cancelled before it could activate — a long press nested in top tabs never activated at all.

This PR makes the cancellation targeted:

- The root view now cancels only legacy handlers (v1/v2 action types) via the new `GestureHandlerOrchestrator.cancelAllLegacyHandlers`, instead of the old trick of activating the internal `RootViewGestureHandler`. The root handler is now attached with `ACTION_TYPE_NONE` so it's excluded from that sweep (and no longer sends dead events to JS).
- v3 handlers are cancelled by new `requestDisallowInterceptTouchEvent` overrides on `RNGestureHandlerDetectorView` and `ButtonViewGroup`. Since the request only bubbles upward from the requesting view, only handlers attached to its ancestors are cancelled — handlers below the requester (like the long press under the pager) keep working.
- Cancellation is skipped while the orchestrator is delivering events (`isHandlingTouch`), mirroring the existing `passingTouch` guard, so disallow requests caused by RNGH's own event delivery don't cancel gestures.
- `findGestureHandlerRootView` now returns the nearest *enabled* root view so the checks above consult the orchestrator that actually manages the subtree.

## Test plan

Tested on reproducer from https://github.com/software-mansion/react-native-gesture-handler/issues/2383


https://github.com/user-attachments/assets/4d01dff7-5268-42ff-befa-5c971d39bb4a