### PR TITLE
Chore: Wrap FC with ref forwarding for virtualdetector

### DIFF
--- a/apps/common-app/src/new_api/showcase/overlap/index.tsx
+++ b/apps/common-app/src/new_api/showcase/overlap/index.tsx
@@ -9,6 +9,7 @@ import {
 import { COLORS, commonStyles, Feedback } from '../../../common';
 
 function Box(props: {
+  ref?: React.Ref<View>;
   color: string;
   overlap?: boolean;
   children?: React.ReactNode;
@@ -16,6 +17,7 @@ function Box(props: {
 }) {
   return (
     <View
+      ref={props.ref}
       style={[
         commonStyles.box,
         { backgroundColor: props.color },

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/VirtualDetector.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/VirtualDetector.tsx
@@ -1,7 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { findNodeHandle, Platform } from 'react-native';
 
-import { Wrap } from '../../../handlers/gestures/GestureDetector/Wrap';
 import { tagMessage } from '../../../utils';
 import { isComposedGesture } from '../../hooks/utils/relationUtils';
 import type { DetectorCallbacks, VirtualChild } from '../../types';
@@ -13,6 +12,7 @@ import {
   InterceptingDetectorMode,
   useInterceptingDetectorContext,
 } from './useInterceptingDetectorContext';
+import { Wrap } from './Wrap';
 
 function useRequiredInterceptingDetectorContext() {
   const context = useInterceptingDetectorContext();

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/Wrap.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/Wrap.tsx
@@ -1,0 +1,89 @@
+import type { PropsWithChildren, Ref } from 'react';
+import React, { useMemo } from 'react';
+
+import { tagMessage } from '../../../utils';
+
+export type WrapRef = Ref<unknown> | undefined;
+
+export type WrapProps = PropsWithChildren<{ ref?: WrapRef }>;
+
+function isHostInstance(instance: unknown) {
+  return (
+    (instance as { __internalInstanceHandle?: unknown } | null | undefined)
+      ?.__internalInstanceHandle !== undefined
+  );
+}
+
+function preferHostInstance(instance: unknown) {
+  if (instance === null || instance === undefined || isHostInstance(instance)) {
+    return instance;
+  }
+
+  const nativeRef = (
+    instance as { getNativeScrollRef?: () => unknown }
+  ).getNativeScrollRef?.();
+
+  return isHostInstance(nativeRef) ? nativeRef : instance;
+}
+
+function assignRef(ref: WrapRef, instance: unknown) {
+  if (typeof ref === 'function') {
+    return ref(instance as never);
+  }
+  if (ref) {
+    ref.current = instance;
+  }
+  return undefined;
+}
+
+export const Wrap: React.FunctionComponent<WrapProps> = ({ ref, children }) => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  let child: any;
+  try {
+    child = React.Children.only(children);
+  } catch (e) {
+    throw new Error(
+      tagMessage(
+        `GestureDetector got more than one view as a child. If you want the gesture to work on multiple views, wrap them with a common parent and attach the gesture to that view.`
+      )
+    );
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  const childRef = child.props.ref as WrapRef;
+
+  const attachRef = useMemo(
+    () => (instance: unknown) => {
+      const childCleanup = assignRef(childRef, instance);
+      const forwardedCleanup = assignRef(ref, preferHostInstance(instance));
+      const hasCleanup =
+        typeof childCleanup === 'function' ||
+        typeof forwardedCleanup === 'function';
+
+      if (!hasCleanup) {
+        return undefined;
+      }
+
+      return () => {
+        if (typeof childCleanup === 'function') {
+          childCleanup();
+        } else {
+          assignRef(childRef, null);
+        }
+        if (typeof forwardedCleanup === 'function') {
+          forwardedCleanup();
+        } else {
+          assignRef(ref, null);
+        }
+      };
+    },
+    [childRef, ref]
+  );
+
+  return React.cloneElement(
+    child,
+    { collapsable: false, ref: attachRef },
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    child.props.children
+  );
+};

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/Wrap.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/Wrap.tsx
@@ -1,5 +1,5 @@
 import type { PropsWithChildren, Ref } from 'react';
-import React, { useMemo } from 'react';
+import React, { useCallback } from 'react';
 
 import { tagMessage } from '../../../utils';
 
@@ -44,7 +44,7 @@ export const Wrap: React.FunctionComponent<WrapProps> = ({ ref, children }) => {
   } catch (e) {
     throw new Error(
       tagMessage(
-        `GestureDetector got more than one view as a child. If you want the gesture to work on multiple views, wrap them with a common parent and attach the gesture to that view.`
+        `VirtualGestureDetector expects exactly one React element as its child. To use a gesture with multiple views, wrap them in a single parent view and attach the gesture to that.`
       )
     );
   }
@@ -52,8 +52,8 @@ export const Wrap: React.FunctionComponent<WrapProps> = ({ ref, children }) => {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   const childRef = child.props.ref as WrapRef;
 
-  const attachRef = useMemo(
-    () => (instance: unknown) => {
+  const attachRef = useCallback(
+    (instance: unknown) => {
       const childCleanup = assignRef(childRef, instance);
       const forwardedCleanup = assignRef(ref, preferHostInstance(instance));
       const hasCleanup =

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/Wrap.web.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/Wrap.web.tsx
@@ -1,0 +1,1 @@
+export { Wrap } from '../../../handlers/gestures/GestureDetector/Wrap';


### PR DESCRIPTION
## Description

Rewrote Wrap into a function component for the virtualdetector
This enables it to forward the ref to its children, which in turn prevents the need of calling deprecated findhostinstance API

## Test plan

I ran the examples where this is relevant (svg, overlap, nested text, scrollview, flatlist)