### PR TITLE
[Android] Fix basic-example `hermesc` path

### DIFF
--- a/apps/basic-example/android/app/build.gradle
+++ b/apps/basic-example/android/app/build.gradle
@@ -60,7 +60,7 @@ react {
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
-    hermesCommand = "../../../../node_modules/react-native/sdks/hermesc/osx-bin/hermesc"
+    hermesCommand = "../../node_modules/hermes-compiler/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]


### PR DESCRIPTION
## Description

I've noticed that release builds of basic example fail on android due to the wrong path of hermesc set.

`hermesc` path is resolved with the working dir set to the app directory and React Native will automatically select the right [OS-specific path](https://github.com/react/react-native/blob/63e9c1544834a43b1b44af4033184b1eab6f2ffa/packages/gradle-plugin/react-native-gradle-plugin/src/main/kotlin/com/facebook/react/utils/PathUtils.kt#L137-L139).

## Test plan

Build the app in release mode or run `./gradlew :app:createBundleReleaseJsAndAssets` before & after this change.
