### PR TITLE
Fix `Touchable` not respecting `keyboardShouldPersistTaps="handled"` 

### DIFF
--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -10,6 +10,7 @@ import { getNextHandlerTag } from '../../../handlers/getNextHandlerTag';
 import {
   isKeyboardDismissingTap,
   JSResponderContext,
+  updateResponderEventValue,
 } from '../ScrollViewResponderInterceptor';
 import type { AnimationDuration, TouchableProps } from './TouchableProps';
 
@@ -93,6 +94,18 @@ export const Touchable = (props: TouchableProps) => {
 
   const jsResponderContext = use(JSResponderContext);
   const dropKeyboardTapRef = useRef<boolean | null>(null);
+
+  // The button handles presses natively, without a NativeDetector, so it has
+  // to mark its responder events as RNGH-handled itself — otherwise a tap on
+  // it looks unhandled to an enclosing ScrollView in
+  // keyboardShouldPersistTaps='handled' mode and dismisses the keyboard.
+  const handleStartShouldSetResponderCapture = useCallback(() => {
+    if (!disabled) {
+      updateResponderEventValue(jsResponderContext, true);
+    }
+
+    return false;
+  }, [disabled, jsResponderContext]);
 
   const internalOnPress = useCallback(
     (e: NativeSyntheticEvent<ButtonEvent>) => {
@@ -179,6 +192,7 @@ export const Touchable = (props: TouchableProps) => {
       {...resolvedDurations}
       ref={ref ?? null}
       enabled={!disabled}
+      onStartShouldSetResponderCapture={handleStartShouldSetResponderCapture}
       moduleId={globalThis._RNGH_MODULE_ID}
       handlerTag={handlerTag}
       cancelOnLeave={cancelOnLeave}


### PR DESCRIPTION
## Description

`Touchable` was refactor so now it does not use `NativeDetector` under the hood. While this improved performance, `Touchable` now does not respect `keyboardShouldPersistTaps="handled"` in `ScrollView`.

This PR aims to fix this issue.

## Benchmarks

Mount of a list of 1000 `Touchable`s (median of 8 mount/unmount rounds per run; ranges are across runs):

| Environment | render (`<Profiler>` mount) with fix | without fix |
| --- | --- | --- |
| iOS simulator, debug | 335.9 ms | 333.6 ms |
| Android emulator, debug | 450.2–485.7 ms | 454.5 ms |
| Android emulator, release | 61.2–65.5 ms (5 runs) | 62.5–68.3 ms (4 runs) |

The only environment where the difference exceeds run-to-run variance is iOS debug: **+2.4 ms per 1000 Touchables (~2.4 µs per instance, +0.7%)** - matching what the change adds (one `useCallback` and one JS-side responder prop per instance; no extra views, no native work). In release the ranges fully overlap - the true cost is below the ~±2 ms run-to-run variance.

Measured with React's profiling renderer (`ReactFabric-profiling`) to enable `<Profiler>` in a release build; list mounted in a plain RN `ScrollView`, matching the setup of the original `Touchable` performance benchmark.

 ## Test plan

Existing "Keyboard Should Persist Taps" example
