### PR TITLE
Extract `CALLBACK_TYPE` to shared module

### DIFF
--- a/packages/react-native-gesture-handler/src/CallbackType.ts
+++ b/packages/react-native-gesture-handler/src/CallbackType.ts
@@ -1,0 +1,17 @@
+export const CALLBACK_TYPE = {
+  UNDEFINED: 0,
+  BEGAN: 1,
+  START: 2,
+  UPDATE: 3,
+  CHANGE: 4,
+  END: 5,
+  FINALIZE: 6,
+  TOUCHES_DOWN: 7,
+  TOUCHES_MOVE: 8,
+  TOUCHES_UP: 9,
+  TOUCHES_CANCEL: 10,
+} as const;
+
+// Allow using CALLBACK_TYPE as object and type
+// eslint-disable-next-line @typescript-eslint/no-redeclare
+export type CALLBACK_TYPE = (typeof CALLBACK_TYPE)[keyof typeof CALLBACK_TYPE];

--- a/packages/react-native-gesture-handler/src/CallbackType.ts
+++ b/packages/react-native-gesture-handler/src/CallbackType.ts
@@ -1,4 +1,4 @@
-export const CALLBACK_TYPE = {
+export const CallbackType = {
   UNDEFINED: 0,
   BEGAN: 1,
   START: 2,
@@ -12,6 +12,5 @@ export const CALLBACK_TYPE = {
   TOUCHES_CANCEL: 10,
 } as const;
 
-// Allow using CALLBACK_TYPE as object and type
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export type CALLBACK_TYPE = (typeof CALLBACK_TYPE)[keyof typeof CALLBACK_TYPE];
+// eslint-disable-next-line @typescript-eslint/no-redeclare -- backward compatibility; it can be used as a type and as a value
+export type CallbackType = (typeof CallbackType)[keyof typeof CallbackType];

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useAnimatedGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useAnimatedGesture.ts
@@ -1,3 +1,4 @@
+import { CALLBACK_TYPE } from '../../../CallbackType';
 import { State } from '../../../State';
 import { TouchEventType } from '../../../TouchEventType';
 import { tagMessage } from '../../../utils';
@@ -7,7 +8,6 @@ import type {
   GestureUpdateEvent,
 } from '../../gestureHandlerCommon';
 import type { HandlerCallbacks } from '../gesture';
-import { CALLBACK_TYPE } from '../gesture';
 import type { GestureStateManagerType } from '../gestureStateManager';
 import { GestureStateManager } from '../gestureStateManager';
 import { Reanimated } from '../reanimatedWrapper';

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useAnimatedGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useAnimatedGesture.ts
@@ -1,4 +1,4 @@
-import { CALLBACK_TYPE } from '../../../CallbackType';
+import { CallbackType } from '../../../CallbackType';
 import { State } from '../../../State';
 import { TouchEventType } from '../../../TouchEventType';
 import { tagMessage } from '../../../utils';
@@ -14,53 +14,51 @@ import { Reanimated } from '../reanimatedWrapper';
 import type { AttachedGestureState } from './types';
 
 function getHandler(
-  type: CALLBACK_TYPE,
+  type: CallbackType,
   gesture: HandlerCallbacks<Record<string, unknown>>
 ) {
   'worklet';
   switch (type) {
-    case CALLBACK_TYPE.BEGAN:
+    case CallbackType.BEGAN:
       return gesture.onBegin;
-    case CALLBACK_TYPE.START:
+    case CallbackType.START:
       return gesture.onStart;
-    case CALLBACK_TYPE.UPDATE:
+    case CallbackType.UPDATE:
       return gesture.onUpdate;
-    case CALLBACK_TYPE.CHANGE:
+    case CallbackType.CHANGE:
       return gesture.onChange;
-    case CALLBACK_TYPE.END:
+    case CallbackType.END:
       return gesture.onEnd;
-    case CALLBACK_TYPE.FINALIZE:
+    case CallbackType.FINALIZE:
       return gesture.onFinalize;
-    case CALLBACK_TYPE.TOUCHES_DOWN:
+    case CallbackType.TOUCHES_DOWN:
       return gesture.onTouchesDown;
-    case CALLBACK_TYPE.TOUCHES_MOVE:
+    case CallbackType.TOUCHES_MOVE:
       return gesture.onTouchesMove;
-    case CALLBACK_TYPE.TOUCHES_UP:
+    case CallbackType.TOUCHES_UP:
       return gesture.onTouchesUp;
-    case CALLBACK_TYPE.TOUCHES_CANCEL:
+    case CallbackType.TOUCHES_CANCEL:
       return gesture.onTouchesCancelled;
   }
 }
 
-function touchEventTypeToCallbackType(
-  eventType: TouchEventType
-): CALLBACK_TYPE {
+function touchEventTypeToCallbackType(eventType: TouchEventType): CallbackType {
   'worklet';
   switch (eventType) {
     case TouchEventType.TOUCHES_DOWN:
-      return CALLBACK_TYPE.TOUCHES_DOWN;
+      return CallbackType.TOUCHES_DOWN;
     case TouchEventType.TOUCHES_MOVE:
-      return CALLBACK_TYPE.TOUCHES_MOVE;
+      return CallbackType.TOUCHES_MOVE;
     case TouchEventType.TOUCHES_UP:
-      return CALLBACK_TYPE.TOUCHES_UP;
+      return CallbackType.TOUCHES_UP;
     case TouchEventType.TOUCHES_CANCEL:
-      return CALLBACK_TYPE.TOUCHES_CANCEL;
+      return CallbackType.TOUCHES_CANCEL;
   }
-  return CALLBACK_TYPE.UNDEFINED;
+  return CallbackType.UNDEFINED;
 }
 
 function runWorklet(
-  type: CALLBACK_TYPE,
+  type: CallbackType,
   gesture: HandlerCallbacks<Record<string, unknown>>,
   event: GestureStateChangeEvent | GestureUpdateEvent | GestureTouchEvent,
   ...args: unknown[]
@@ -136,30 +134,30 @@ export function useAnimatedGesture(
           event.oldState === State.UNDETERMINED &&
           event.state === State.BEGAN
         ) {
-          runWorklet(CALLBACK_TYPE.BEGAN, gesture, event);
+          runWorklet(CallbackType.BEGAN, gesture, event);
         } else if (
           (event.oldState === State.BEGAN ||
             event.oldState === State.UNDETERMINED) &&
           event.state === State.ACTIVE
         ) {
-          runWorklet(CALLBACK_TYPE.START, gesture, event);
+          runWorklet(CallbackType.START, gesture, event);
           lastUpdateEvent.value[gesture.handlerTag] = undefined;
         } else if (
           event.oldState !== event.state &&
           event.state === State.END
         ) {
           if (event.oldState === State.ACTIVE) {
-            runWorklet(CALLBACK_TYPE.END, gesture, event, true);
+            runWorklet(CallbackType.END, gesture, event, true);
           }
-          runWorklet(CALLBACK_TYPE.FINALIZE, gesture, event, true);
+          runWorklet(CallbackType.FINALIZE, gesture, event, true);
         } else if (
           (event.state === State.FAILED || event.state === State.CANCELLED) &&
           event.state !== event.oldState
         ) {
           if (event.oldState === State.ACTIVE) {
-            runWorklet(CALLBACK_TYPE.END, gesture, event, false);
+            runWorklet(CallbackType.END, gesture, event, false);
           }
-          runWorklet(CALLBACK_TYPE.FINALIZE, gesture, event, false);
+          runWorklet(CallbackType.FINALIZE, gesture, event, false);
         }
       } else if (isTouchEvent(event)) {
         if (
@@ -178,11 +176,11 @@ export function useAnimatedGesture(
           );
         }
       } else {
-        runWorklet(CALLBACK_TYPE.UPDATE, gesture, event);
+        runWorklet(CallbackType.UPDATE, gesture, event);
 
         if (gesture.onChange && gesture.changeEventCalculator) {
           runWorklet(
-            CALLBACK_TYPE.CHANGE,
+            CallbackType.CHANGE,
             gesture,
             gesture.changeEventCalculator?.(
               event,

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
@@ -1,3 +1,4 @@
+import { CALLBACK_TYPE } from '../../CallbackType';
 import { isRemoteDebuggingEnabled } from '../../utils';
 import type {
   ActiveCursor,
@@ -90,24 +91,6 @@ export type HandlerCallbacks<EventPayloadT extends Record<string, unknown>> = {
   ) => GestureUpdateEvent<Record<string, unknown>>;
   isWorklet: boolean[];
 };
-
-export const CALLBACK_TYPE = {
-  UNDEFINED: 0,
-  BEGAN: 1,
-  START: 2,
-  UPDATE: 3,
-  CHANGE: 4,
-  END: 5,
-  FINALIZE: 6,
-  TOUCHES_DOWN: 7,
-  TOUCHES_MOVE: 8,
-  TOUCHES_UP: 9,
-  TOUCHES_CANCEL: 10,
-} as const;
-
-// Allow using CALLBACK_TYPE as object and type
-// eslint-disable-next-line @typescript-eslint/no-redeclare
-export type CALLBACK_TYPE = (typeof CALLBACK_TYPE)[keyof typeof CALLBACK_TYPE];
 
 export abstract class Gesture {
   /**

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gesture.ts
@@ -1,4 +1,4 @@
-import { CALLBACK_TYPE } from '../../CallbackType';
+import { CallbackType } from '../../CallbackType';
 import { isRemoteDebuggingEnabled } from '../../utils';
 import type {
   ActiveCursor,
@@ -181,7 +181,7 @@ export abstract class BaseGesture<
    */
   onBegin(callback: (event: GestureStateChangeEvent<EventPayloadT>) => void) {
     this.handlers.onBegin = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.BEGAN] = this.isWorklet(callback);
+    this.handlers.isWorklet[CallbackType.BEGAN] = this.isWorklet(callback);
     return this;
   }
 
@@ -191,7 +191,7 @@ export abstract class BaseGesture<
    */
   onStart(callback: (event: GestureStateChangeEvent<EventPayloadT>) => void) {
     this.handlers.onStart = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.START] = this.isWorklet(callback);
+    this.handlers.isWorklet[CallbackType.START] = this.isWorklet(callback);
     return this;
   }
 
@@ -208,7 +208,7 @@ export abstract class BaseGesture<
   ) {
     this.handlers.onEnd = callback;
     // @ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
-    this.handlers.isWorklet[CALLBACK_TYPE.END] = this.isWorklet(callback);
+    this.handlers.isWorklet[CallbackType.END] = this.isWorklet(callback);
     return this;
   }
 
@@ -224,7 +224,7 @@ export abstract class BaseGesture<
   ) {
     this.handlers.onFinalize = callback;
     // @ts-ignore if callback is a worklet, the property will be available, if not then the check will return false
-    this.handlers.isWorklet[CALLBACK_TYPE.FINALIZE] = this.isWorklet(callback);
+    this.handlers.isWorklet[CallbackType.FINALIZE] = this.isWorklet(callback);
     return this;
   }
 
@@ -235,7 +235,7 @@ export abstract class BaseGesture<
   onTouchesDown(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
     this.handlers.onTouchesDown = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_DOWN] =
+    this.handlers.isWorklet[CallbackType.TOUCHES_DOWN] =
       this.isWorklet(callback);
 
     return this;
@@ -248,7 +248,7 @@ export abstract class BaseGesture<
   onTouchesMove(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
     this.handlers.onTouchesMove = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_MOVE] =
+    this.handlers.isWorklet[CallbackType.TOUCHES_MOVE] =
       this.isWorklet(callback);
 
     return this;
@@ -261,8 +261,7 @@ export abstract class BaseGesture<
   onTouchesUp(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
     this.handlers.onTouchesUp = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_UP] =
-      this.isWorklet(callback);
+    this.handlers.isWorklet[CallbackType.TOUCHES_UP] = this.isWorklet(callback);
 
     return this;
   }
@@ -274,7 +273,7 @@ export abstract class BaseGesture<
   onTouchesCancelled(callback: TouchEventHandlerType) {
     this.config.needsPointerData = true;
     this.handlers.onTouchesCancelled = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.TOUCHES_CANCEL] =
+    this.handlers.isWorklet[CallbackType.TOUCHES_CANCEL] =
       this.isWorklet(callback);
 
     return this;
@@ -447,7 +446,7 @@ export abstract class ContinousBaseGesture<
    */
   onUpdate(callback: (event: GestureUpdateEvent<EventPayloadT>) => void) {
     this.handlers.onUpdate = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.UPDATE] = this.isWorklet(callback);
+    this.handlers.isWorklet[CallbackType.UPDATE] = this.isWorklet(callback);
     return this;
   }
 
@@ -462,7 +461,7 @@ export abstract class ContinousBaseGesture<
     ) => void
   ) {
     this.handlers.onChange = callback;
-    this.handlers.isWorklet[CALLBACK_TYPE.CHANGE] = this.isWorklet(callback);
+    this.handlers.isWorklet[CallbackType.CHANGE] = this.isWorklet(callback);
     return this;
   }
 

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/eventHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/eventHandler.ts
@@ -1,5 +1,5 @@
+import { CALLBACK_TYPE } from '../../../CallbackType';
 import type { GestureTouchEvent } from '../../../handlers/gestureHandlerCommon';
-import { CALLBACK_TYPE } from '../../../handlers/gestures/gesture';
 import type { ReanimatedContext } from '../../../handlers/gestures/reanimatedWrapper';
 import { State } from '../../../State';
 import { TouchEventType } from '../../../TouchEventType';

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/eventHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/eventHandler.ts
@@ -1,4 +1,4 @@
-import { CALLBACK_TYPE } from '../../../CallbackType';
+import { CallbackType } from '../../../CallbackType';
 import type { GestureTouchEvent } from '../../../handlers/gestureHandlerCommon';
 import type { ReanimatedContext } from '../../../handlers/gestures/reanimatedWrapper';
 import { State } from '../../../State';
@@ -37,13 +37,13 @@ function handleStateChangeEvent<
   const event = flattenAndFilterEvent(eventWithData);
 
   if (oldState === State.UNDETERMINED && state === State.BEGAN) {
-    runCallback(CALLBACK_TYPE.BEGAN, callbacks, event);
+    runCallback(CallbackType.BEGAN, callbacks, event);
   } else if (
     (oldState === State.BEGAN || oldState === State.UNDETERMINED) &&
     state === State.ACTIVE
   ) {
     fillInDefaultValues?.(event as GestureEvent<TExtendedHandlerData>);
-    runCallback(CALLBACK_TYPE.START, callbacks, event);
+    runCallback(CallbackType.START, callbacks, event);
   } else if (
     oldState !== state &&
     (state === State.END || state === State.FAILED || state === State.CANCELLED)
@@ -57,13 +57,13 @@ function handleStateChangeEvent<
     if (oldState === State.ACTIVE) {
       fillInDefaultValues?.(endEvent as GestureEndEvent<TExtendedHandlerData>);
       runCallback<THandlerData, TExtendedHandlerData>(
-        CALLBACK_TYPE.END,
+        CallbackType.END,
         callbacks,
         endEvent
       );
     }
     runCallback<THandlerData, TExtendedHandlerData>(
-      CALLBACK_TYPE.FINALIZE,
+      CallbackType.FINALIZE,
       callbacks,
       endEvent
     );
@@ -92,7 +92,7 @@ export function handleUpdateEvent<
     : eventWithData;
 
   const event = flattenAndFilterEvent(eventWithChanges);
-  runCallback(CALLBACK_TYPE.UPDATE, handlers, event);
+  runCallback(CallbackType.UPDATE, handlers, event);
 
   if (context) {
     context.lastUpdateEvent = eventWithData;

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/eventHandlersUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/eventHandlersUtils.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { CALLBACK_TYPE } from '../../../handlers/gestures/gesture';
+import { CALLBACK_TYPE } from '../../../CallbackType';
 import { TouchEventType } from '../../../TouchEventType';
 import type {
   GestureCallbacks,

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/eventHandlersUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/eventHandlersUtils.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 
-import { CALLBACK_TYPE } from '../../../CallbackType';
+import { CallbackType } from '../../../CallbackType';
 import { TouchEventType } from '../../../TouchEventType';
 import type {
   GestureCallbacks,
@@ -62,7 +62,7 @@ export function useMemoizedGestureCallbacks<
 }
 
 function getHandler<THandlerData, TExtendedHandlerData extends THandlerData>(
-  type: CALLBACK_TYPE,
+  type: CallbackType,
   callbacks: GestureCallbacks<THandlerData, TExtendedHandlerData>
 ):
   | GestureEventCallback<THandlerData>
@@ -73,42 +73,42 @@ function getHandler<THandlerData, TExtendedHandlerData extends THandlerData>(
   | undefined {
   'worklet';
   switch (type) {
-    case CALLBACK_TYPE.BEGAN:
+    case CallbackType.BEGAN:
       return callbacks.onBegin;
-    case CALLBACK_TYPE.START:
+    case CallbackType.START:
       return callbacks.onActivate;
-    case CALLBACK_TYPE.UPDATE:
+    case CallbackType.UPDATE:
       return callbacks.onUpdate as GestureEventCallback<TExtendedHandlerData>; // Animated event is handled in different place.
-    case CALLBACK_TYPE.END:
+    case CallbackType.END:
       return callbacks.onDeactivate;
-    case CALLBACK_TYPE.FINALIZE:
+    case CallbackType.FINALIZE:
       return callbacks.onFinalize;
-    case CALLBACK_TYPE.TOUCHES_DOWN:
+    case CallbackType.TOUCHES_DOWN:
       return callbacks.onTouchesDown;
-    case CALLBACK_TYPE.TOUCHES_MOVE:
+    case CallbackType.TOUCHES_MOVE:
       return callbacks.onTouchesMove;
-    case CALLBACK_TYPE.TOUCHES_UP:
+    case CallbackType.TOUCHES_UP:
       return callbacks.onTouchesUp;
-    case CALLBACK_TYPE.TOUCHES_CANCEL:
+    case CallbackType.TOUCHES_CANCEL:
       return callbacks.onTouchesCancel;
   }
 }
 
 export function touchEventTypeToCallbackType(
   eventType: TouchEventType
-): CALLBACK_TYPE {
+): CallbackType {
   'worklet';
   switch (eventType) {
     case TouchEventType.TOUCHES_DOWN:
-      return CALLBACK_TYPE.TOUCHES_DOWN;
+      return CallbackType.TOUCHES_DOWN;
     case TouchEventType.TOUCHES_MOVE:
-      return CALLBACK_TYPE.TOUCHES_MOVE;
+      return CallbackType.TOUCHES_MOVE;
     case TouchEventType.TOUCHES_UP:
-      return CALLBACK_TYPE.TOUCHES_UP;
+      return CallbackType.TOUCHES_UP;
     case TouchEventType.TOUCHES_CANCEL:
-      return CALLBACK_TYPE.TOUCHES_CANCEL;
+      return CallbackType.TOUCHES_CANCEL;
   }
-  return CALLBACK_TYPE.UNDEFINED;
+  return CallbackType.UNDEFINED;
 }
 
 type SingleParameterCallback<T> = (event: T) => void;
@@ -117,7 +117,7 @@ export function runCallback<
   THandlerData,
   TExtendedHandlerData extends THandlerData,
 >(
-  type: CALLBACK_TYPE,
+  type: CallbackType,
   callbacks: GestureCallbacks<THandlerData, TExtendedHandlerData>,
   event: UnpackedGestureHandlerEvent<THandlerData>
 ) {


### PR DESCRIPTION
## Description

Extracts `CALLBACK_TYPE` from `handlers/gestures/gesture.ts` into a standalone `src/CallbackType.ts` module and renames it to `CallbackType`.

## Test plan

Tested on example app 
