### PR TITLE
Don't evaluate `__DEV__` or `Reanimated` at module scope

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -91,5 +91,23 @@
     "no-alert": "warn",
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error"
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "packages/react-native-gesture-handler/src/v3/**",
+        "packages/react-native-gesture-handler/src/web/**",
+        "packages/react-native-gesture-handler/src/*.ts"
+      ],
+      "rules": {
+        "no-restricted-syntax": [
+          "error",
+          {
+            "selector": "Identifier[name='__DEV__']:not(:function *)",
+            "message": "Don't read __DEV__ at module scope — the global may not be defined yet outside Metro when modules are evaluated. Read it lazily inside a function instead."
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/packages/react-native-gesture-handler/src/__tests__/propsWhiteList.test.ts
+++ b/packages/react-native-gesture-handler/src/__tests__/propsWhiteList.test.ts
@@ -1,0 +1,53 @@
+import type * as PropsWhiteListModule from '../v3/hooks/utils/propsWhiteList';
+
+function setDEV(value: boolean) {
+  (globalThis as Record<string, unknown>).__DEV__ = value;
+}
+
+function loadFreshModule(): typeof PropsWhiteListModule {
+  let module!: typeof PropsWhiteListModule;
+  jest.isolateModules(() => {
+    module = require('../v3/hooks/utils/propsWhiteList');
+  });
+  return module;
+}
+
+describe('applyProductionTestIDFilter', () => {
+  afterEach(() => {
+    setDEV(true);
+    jest.resetModules();
+  });
+
+  test('keeps testID deliverable to the native side in dev', () => {
+    const { allowedNativeProps, applyProductionTestIDFilter, PropsToFilter } =
+      loadFreshModule();
+
+    applyProductionTestIDFilter();
+
+    expect(allowedNativeProps.has('testID')).toBe(true);
+    expect(PropsToFilter.has('testID')).toBe(false);
+  });
+
+  test('strips testID from native props in production', () => {
+    setDEV(false);
+    const { allowedNativeProps, applyProductionTestIDFilter, PropsToFilter } =
+      loadFreshModule();
+
+    applyProductionTestIDFilter();
+
+    expect(allowedNativeProps.has('testID')).toBe(false);
+    expect(PropsToFilter.has('testID')).toBe(true);
+  });
+
+  test('applies the filter once and stays stable across repeated calls', () => {
+    setDEV(false);
+    const { allowedNativeProps, applyProductionTestIDFilter, PropsToFilter } =
+      loadFreshModule();
+
+    applyProductionTestIDFilter();
+    applyProductionTestIDFilter();
+
+    expect(allowedNativeProps.has('testID')).toBe(false);
+    expect(PropsToFilter.has('testID')).toBe(true);
+  });
+});

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/useReanimatedEventHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/useReanimatedEventHandler.ts
@@ -24,14 +24,29 @@ const workletNOOP = () => {
   // no-op
 };
 
-const lastUpdateEventMap = Reanimated?.makeMutable(
-  new Map<number, ReanimatedContext<unknown>>()
-);
+function createLastUpdateEventMap() {
+  return Reanimated?.makeMutable(new Map<number, ReanimatedContext<unknown>>());
+}
 
-function deleteHandlerEventEntry(handlerTag: number) {
+// Created lazily instead of at module scope so importing this module doesn't
+// call into Reanimated during module evaluation.
+let lastUpdateEventMap: ReturnType<typeof createLastUpdateEventMap>;
+
+function getLastUpdateEventMap() {
+  lastUpdateEventMap ??= createLastUpdateEventMap();
+  return lastUpdateEventMap;
+}
+
+function deleteHandlerEventEntry(
+  map: ReturnType<typeof createLastUpdateEventMap>,
+  handlerTag: number
+) {
   'worklet';
-  // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-  lastUpdateEventMap!.value.delete(handlerTag);
+  if (map === undefined) {
+    return;
+  }
+
+  map.value.delete(handlerTag);
 }
 
 export function useReanimatedEventHandler<
@@ -59,6 +74,10 @@ export function useReanimatedEventHandler<
     return handlers;
   }, [handlers]);
 
+  // Obtained on the JS thread during render so the worklet below captures the
+  // initialized map rather than the lazy module binding.
+  const updateEventMap = getLastUpdateEventMap();
+
   const callback = (
     event: UnpackedGestureHandlerEventWithHandlerData<
       THandlerData,
@@ -66,13 +85,16 @@ export function useReanimatedEventHandler<
     >
   ) => {
     'worklet';
-    // If we're on Reanimated path, lastUpdateEventMap should always be defined
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-    let context = lastUpdateEventMap!.value.get(event.handlerTag);
+    // Undefined only when Reanimated is absent — and then this callback is
+    // never registered (`Reanimated?.useEvent` below short-circuits).
+    if (updateEventMap === undefined) {
+      return;
+    }
+
+    let context = updateEventMap.value.get(event.handlerTag);
     if (context === undefined) {
       context = { lastUpdateEvent: undefined };
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      lastUpdateEventMap!.value.set(event.handlerTag, context);
+      updateEventMap.value.set(event.handlerTag, context);
     }
 
     eventHandler(
@@ -100,9 +122,12 @@ export function useReanimatedEventHandler<
     prevHandlerTagRef.current = handlerTag;
 
     return () => {
-      Reanimated?.runOnUI?.(deleteHandlerEventEntry)(handlerTag);
+      Reanimated?.runOnUI?.(deleteHandlerEventEntry)(
+        updateEventMap,
+        handlerTag
+      );
     };
-  }, [handlerTag]);
+  }, [handlerTag, updateEventMap]);
 
   const reanimatedEvent = Reanimated?.useEvent(
     callback,

--- a/packages/react-native-gesture-handler/src/v3/hooks/callbacks/useReanimatedEventHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/callbacks/useReanimatedEventHandler.ts
@@ -37,6 +37,12 @@ function getLastUpdateEventMap() {
   return lastUpdateEventMap;
 }
 
+// Takes the map as an argument on purpose: reading the lazy `let` from this
+// module-scope worklet would snapshot its value at module evaluation — before
+// the first `getLastUpdateEventMap()` call — so the UI-runtime copy would stay
+// `undefined` forever and the cleanup would silently never run. `runOnUI`
+// arguments are serialized fresh on every call, so they always carry the
+// initialized map.
 function deleteHandlerEventEntry(
   map: ReturnType<typeof createLastUpdateEventMap>,
   handlerTag: number

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/configUtils.ts
@@ -11,6 +11,7 @@ import type {
 import { isNativeAnimatedEvent, shouldHandleTouchEvents } from './eventUtils';
 import {
   allowedNativeProps,
+  applyProductionTestIDFilter,
   EMPTY_WHITE_LIST,
   PropsToFilter,
   PropsWhiteLists,
@@ -90,6 +91,8 @@ export function prepareConfigForNativeSide<
   handlerType: SingleGestureName,
   config: BaseGestureConfig<TConfig, THandlerData, TExtendedHandlerData>
 ) {
+  applyProductionTestIDFilter();
+
   // @ts-ignore Seems like TypeScript can't infer the type here properly because of generic
   const filteredConfig: BaseGestureConfig<
     TConfig,

--- a/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/utils/propsWhiteList.ts
@@ -81,10 +81,22 @@ export const PropsToFilter = new Set<
   'activeOffsetX',
 ]);
 
-// Don't pass testID to the native side in production
-if (!__DEV__) {
-  allowedNativeProps.delete('testID');
-  PropsToFilter.add('testID');
+let productionTestIDFilterApplied = false;
+
+// Don't pass testID to the native side in production. Applied lazily instead
+// of at module scope so importing this module never reads `__DEV__` during
+// module evaluation — the value may not be defined yet in non-Metro
+// environments where the global is set up by an entrypoint side effect.
+export function applyProductionTestIDFilter() {
+  if (productionTestIDFilterApplied) {
+    return;
+  }
+  productionTestIDFilterApplied = true;
+
+  if (!__DEV__) {
+    allowedNativeProps.delete('testID');
+    PropsToFilter.add('testID');
+  }
 }
 
 export const PropsWhiteLists = new Map<


### PR DESCRIPTION
## Description

Importing a v3 module currently executes environment-dependent code during module evaluation in two places. That's harmless under Metro (where `__DEV__` is a compile-time constant), but breaks when modules are evaluated in environments where `__DEV__` is a runtime global (e.g. web bundlers, where `sideEffects`-aware optimization can evaluate leaf modules before any entry-point setup runs):

- `propsWhiteList` read `__DEV__` at module scope to strip `testID` from the native-prop whitelists in production. The filter is now applied lazily (idempotent `applyProductionTestIDFilter()`), called on first `prepareConfigForNativeSide`. Same observable behavior, but the decision moves from import time to first use, which also makes it testable.
- `useReanimatedEventHandler` called `Reanimated?.makeMutable()` at module scope to create `lastUpdateEventMap`. The map is now created lazily on first use. Worklet-capture safety: the event-handler worklet captures the initialized map obtained on the JS thread during render, and the cleanup worklet receives the map as a `runOnUI` argument. Capturing the lazy module binding directly would snapshot `undefined` at workletization time.

To keep the pattern from coming back, a lint rule (scoped to `src/v3/**`, `src/web/**`, and root `src/*.ts`) now errors on any `__DEV__` read outside a function body.

## Test plan

- `yarn ts-check` clean; `yarn test` 106/106; `yarn lint:js` 0 errors
- New `propsWhiteList.test.ts`: `testID` delivered in dev, stripped in production (`__DEV__ = false`)
- Lint rule verified on fixtures: flags top-level reads, passes function/arrow/method reads
- Verified on iOS simulator (expo-example, Reanimated worklet path): pan with `changeX`/`changeY` deltas (map-backed change-calculator context), unmount cleanup (`runOnUI` with map argument), remount with a fresh handler
