### PR TITLE
Extract the RN-free half of `ScrollView` interop from `ScrollViewResponderInterceptor`

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -11,13 +11,13 @@ import GestureHandlerRootView from '../components/GestureHandlerRootView';
 import { fireGestureHandler, getByGestureTestId } from '../jestUtils';
 import { State } from '../State';
 import { Pressable, RectButton, ScrollView, Touchable } from '../v3/components';
-import {
-  isKeyboardDismissingTap,
-  type JSResponderContextValue,
-} from '../v3/components/ScrollViewResponderInterceptor';
 import { GestureDetector } from '../v3/detectors';
 import { useSimultaneousGestures } from '../v3/hooks';
 import { usePanGesture, useTapGesture } from '../v3/hooks/gestures';
+import {
+  isKeyboardDismissingTap,
+  type JSResponderContextValue,
+} from '../v3/scrollViewInterop';
 
 const flushImmediate = () =>
   new Promise((resolve) => {

--- a/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Pressable.tsx
@@ -43,11 +43,11 @@ import {
   useNativeGesture,
   useSimultaneousGestures,
 } from '../hooks';
-import { PureNativeButton } from './GestureButtons';
 import {
   isKeyboardDismissingTap,
   JSResponderContext,
-} from './ScrollViewResponderInterceptor';
+} from '../scrollViewInterop';
+import { PureNativeButton } from './GestureButtons';
 
 const DEFAULT_LONG_PRESS_DURATION = 500;
 const IS_TEST_ENV = isTestEnv();

--- a/packages/react-native-gesture-handler/src/v3/components/ScrollViewResponderInterceptor.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/ScrollViewResponderInterceptor.tsx
@@ -8,14 +8,16 @@ import type {
 } from 'react-native';
 import { Keyboard, Platform, StyleSheet, TextInput, View } from 'react-native';
 
-type KeyboardShouldPersistTaps = RNScrollViewProps['keyboardShouldPersistTaps'];
+import {
+  JSResponderContext,
+  setKeyboardVisibility,
+} from '../scrollViewInterop';
 
 // The listeners are shared by every mounted ScrollView, so attach/detach is
 // reference-counted: we subscribe on the first interceptor and tear down only
 // once the last one unmounts.
 let keyboardTrackerRefCount = 0;
 let keyboardTrackerSubscriptions: EmitterSubscription[] = [];
-let isKeyboardVisible = false;
 
 function keyboardIsOpen(height: number | undefined): boolean {
   return height != null && height > 0;
@@ -29,15 +31,15 @@ function subscribeToKeyboardVisibility() {
   }
 
   const setVisible = (event: KeyboardEvent) => {
-    isKeyboardVisible = keyboardIsOpen(event.endCoordinates?.height);
+    setKeyboardVisibility(keyboardIsOpen(event.endCoordinates?.height));
   };
   const setHidden = () => {
-    isKeyboardVisible = false;
+    setKeyboardVisibility(false);
   };
 
   // Seed from the current keyboard metrics in case it is already open when the
   // first ScrollView mounts (mirrors ScrollView seeding from Keyboard.metrics()).
-  isKeyboardVisible = keyboardIsOpen(Keyboard.metrics?.()?.height);
+  setKeyboardVisibility(keyboardIsOpen(Keyboard.metrics?.()?.height));
 
   keyboardTrackerSubscriptions = [
     Keyboard.addListener('keyboardDidShow', setVisible),
@@ -57,39 +59,7 @@ function unsubscribeFromKeyboardVisibility() {
     subscription.remove();
   }
   keyboardTrackerSubscriptions = [];
-  isKeyboardVisible = false;
-}
-
-export type JSResponderContextValue = {
-  isRNGHResponderEvent: React.MutableRefObject<boolean>;
-  keyboardShouldPersistTaps: KeyboardShouldPersistTaps;
-};
-
-export const JSResponderContext =
-  React.createContext<JSResponderContextValue | null>(null);
-
-export function updateResponderEventValue(
-  jsResponderContext: JSResponderContextValue | null | undefined,
-  value: boolean
-) {
-  const responderEventRef = jsResponderContext?.isRNGHResponderEvent;
-
-  if (responderEventRef) {
-    responderEventRef.current = value;
-  }
-}
-
-export function isKeyboardDismissingTap(
-  jsResponderContext: JSResponderContextValue | null | undefined
-): boolean {
-  if (jsResponderContext == null) {
-    return false;
-  }
-
-  const mode = jsResponderContext.keyboardShouldPersistTaps;
-  const keyboardNeverPersistTaps = !mode || mode === 'never';
-
-  return keyboardNeverPersistTaps && isKeyboardVisible;
+  setKeyboardVisibility(false);
 }
 
 type ScrollViewResponderInterceptorProps = PropsWithChildren<{

--- a/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/Touchable/Touchable.tsx
@@ -10,7 +10,7 @@ import { getNextHandlerTag } from '../../../handlers/getNextHandlerTag';
 import {
   isKeyboardDismissingTap,
   JSResponderContext,
-} from '../ScrollViewResponderInterceptor';
+} from '../../scrollViewInterop';
 import type { AnimationDuration, TouchableProps } from './TouchableProps';
 
 const isAndroid = Platform.OS === 'android';

--- a/packages/react-native-gesture-handler/src/v3/hooks/useJSResponderHandler.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/useJSResponderHandler.ts
@@ -4,7 +4,7 @@ import { Reanimated } from '../../handlers/gestures/reanimatedWrapper';
 import {
   JSResponderContext,
   updateResponderEventValue,
-} from '../components/ScrollViewResponderInterceptor';
+} from '../scrollViewInterop';
 import { type Gesture, type SharedValue, SingleGestureName } from '../types';
 import { isComposedGesture, isGestureEnabled } from './utils';
 import {

--- a/packages/react-native-gesture-handler/src/v3/scrollViewInterop.ts
+++ b/packages/react-native-gesture-handler/src/v3/scrollViewInterop.ts
@@ -1,0 +1,46 @@
+import * as React from 'react';
+
+export type KeyboardShouldPersistTaps =
+  | boolean
+  | 'always'
+  | 'never'
+  | 'handled'
+  | undefined;
+
+export type JSResponderContextValue = {
+  isRNGHResponderEvent: React.MutableRefObject<boolean>;
+  keyboardShouldPersistTaps: KeyboardShouldPersistTaps;
+};
+
+export const JSResponderContext =
+  React.createContext<JSResponderContextValue | null>(null);
+
+export function updateResponderEventValue(
+  jsResponderContext: JSResponderContextValue | null | undefined,
+  value: boolean
+) {
+  const responderEventRef = jsResponderContext?.isRNGHResponderEvent;
+
+  if (responderEventRef) {
+    responderEventRef.current = value;
+  }
+}
+
+let isKeyboardVisible = false;
+
+export function setKeyboardVisibility(visible: boolean) {
+  isKeyboardVisible = visible;
+}
+
+export function isKeyboardDismissingTap(
+  jsResponderContext: JSResponderContextValue | null | undefined
+): boolean {
+  if (jsResponderContext == null) {
+    return false;
+  }
+
+  const mode = jsResponderContext.keyboardShouldPersistTaps;
+  const keyboardNeverPersistTaps = !mode || mode === 'never';
+
+  return keyboardNeverPersistTaps && isKeyboardVisible;
+}


### PR DESCRIPTION
## Description

`useJSResponderHandler` and the v3 press components imported `JSResponderContext`, `updateResponderEventValue`, and `isKeyboardDismissingTap` from `ScrollViewResponderInterceptor` — a module coupled to react-native (`Keyboard`, `TextInput`, `Platform`, `View`). This PR splits the module along that line.

The react-native-free half of the contract between the GH `ScrollView` and the pressables/detectors inside it moves to a new `v3/scrollViewInterop.ts` leaf: the `JSResponderContext` and its value type, `updateResponderEventValue`, the keyboard-visibility state, and the `isKeyboardDismissingTap` policy. Its only dependency is `react`. The interceptor keeps all platform plumbing and feeds keyboard visibility into the leaf through a new `setKeyboardVisibility()` seam from its `Keyboard` listeners, so consumers of the policy never touch the platform API.

`KeyboardShouldPersistTaps` becomes a structural copy of RN's union (including the deprecated boolean form) so the leaf needs no react-native type import. No behavior change; no re-export stubs kept — the module is internal and has no external consumers (checked GitHub code search for the old path).

## Test plan

- `yarn ts-check` clean; `yarn test` 103/103; `yarn lint:js` 0 errors
- The keyboard suites in `api_v3.test.tsx` cover the seam end-to-end in jest: they emit `Keyboard` events through the interceptor's listeners and assert dismissal/persist behavior via the moved logic
- Verified on iOS simulator and Android emulator (expo-example, `keyboardShouldPersistTaps` test screen, real software keyboard): `never` mode — keyboard-dismissing tap on GH Pressable is swallowed and dismisses the keyboard, follow-up tap fires normally; `handled` mode — press fires and the keyboard stays up (responder marking through the moved context)