### PR TITLE
Extract `HoverEffect` to a standalone module

### DIFF
--- a/packages/react-native-gesture-handler/src/HoverEffect.ts
+++ b/packages/react-native-gesture-handler/src/HoverEffect.ts
@@ -1,0 +1,5 @@
+export enum HoverEffect {
+  NONE = 0,
+  LIFT = 1,
+  HIGHLIGHT = 2,
+}

--- a/packages/react-native-gesture-handler/src/handlers/gestures/hoverGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/hoverGesture.ts
@@ -1,3 +1,4 @@
+import type { HoverEffect } from '../../HoverEffect';
 import type { GestureUpdateEvent } from '../gestureHandlerCommon';
 import type { HoverGestureHandlerEventPayload } from '../GestureHandlerEventPayload';
 import type { BaseGestureConfig } from './gesture';
@@ -7,12 +8,6 @@ export type HoverGestureChangeEventPayload = {
   changeX: number;
   changeY: number;
 };
-
-export enum HoverEffect {
-  NONE = 0,
-  LIFT = 1,
-  HIGHLIGHT = 2,
-}
 
 export interface HoverGestureConfig {
   hoverEffect?: HoverEffect;

--- a/packages/react-native-gesture-handler/src/index.ts
+++ b/packages/react-native-gesture-handler/src/index.ts
@@ -127,7 +127,6 @@ export type {
 export { GestureObjects as Gesture } from './handlers/gestures/gestureObjects';
 export type { GestureStateManagerType as LegacyGestureStateManager } from './handlers/gestures/gestureStateManager';
 export type { HoverGestureType as LegacyHoverGesture } from './handlers/gestures/hoverGesture';
-export { HoverEffect } from './handlers/gestures/hoverGesture';
 export type { LongPressGestureType as LegacyLongPressGesture } from './handlers/gestures/longPressGesture';
 export type { ManualGestureType as LegacyManualGesture } from './handlers/gestures/manualGesture';
 export type { PanGestureChangeEventPayload } from './handlers/gestures/panGesture';
@@ -148,6 +147,7 @@ export type { RotationGestureHandlerProps } from './handlers/RotationGestureHand
 export { RotationGestureHandler } from './handlers/RotationGestureHandler';
 export type { TapGestureHandlerProps } from './handlers/TapGestureHandler';
 export { TapGestureHandler } from './handlers/TapGestureHandler';
+export { HoverEffect } from './HoverEffect';
 export { PointerType } from './PointerType';
 export { State } from './State';
 export * from './v3';

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/hover/HoverTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/hover/HoverTypes.ts
@@ -1,5 +1,5 @@
 import type { StylusData } from '../../../../handlers/gestureHandlerCommon';
-import type { HoverEffect } from '../../../../handlers/gestures/hoverGesture';
+import type { HoverEffect } from '../../../../HoverEffect';
 import type {
   BaseGestureConfig,
   ExcludeInternalConfigProps,


### PR DESCRIPTION
## Description

`HoverEffect` moves from `handlers/gestures/hoverGesture.ts` to a standalone `src/HoverEffect.ts`, following the naming pattern of the other root-level shared leaves (`State.ts`, `TouchEventType.ts`). The v3 hover types imported it from the legacy gesture module, pulling the whole v2 class hierarchy into the v3 import graph for the sake of one enum.

## Test plan

- `yarn ts-check` clean; `yarn test` green (103 + 3 new); `yarn lint:js` 0 errors
- Verified on iOS simulator (expo-example, fresh bundle): the v3 hover example — which imports `HoverEffect` from the barrel at module scope and passes `HoverEffect.LIFT` as a config value — mounts and renders cleanly
