### PR TITLE
Use `globalThis` instead of bare `global` in utils

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -91,5 +91,23 @@
     "no-alert": "warn",
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error"
-  }
+  },
+  "overrides": [
+    {
+      "files": [
+        "packages/react-native-gesture-handler/src/v3/**",
+        "packages/react-native-gesture-handler/src/web/**",
+        "packages/react-native-gesture-handler/src/*.ts"
+      ],
+      "rules": {
+        "no-restricted-globals": [
+          "error",
+          {
+            "name": "global",
+            "message": "Use the standard `globalThis` — the bare `global` binding is React Native/Node-specific and doesn't exist in browsers."
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/packages/react-native-gesture-handler/src/utils.ts
+++ b/packages/react-native-gesture-handler/src/utils.ts
@@ -35,7 +35,7 @@ export function hasProperty(object: object, key: string) {
 
 export function isTestEnv(): boolean {
   // @ts-ignore Do not use `@types/node` because it will prioritise Node types over RN types which breaks the types (ex. setTimeout) in React Native projects.
-  return hasProperty(global, 'process') && process.env.NODE_ENV === 'test';
+  return hasProperty(globalThis, 'process') && process.env.NODE_ENV === 'test';
 }
 
 export function tagMessage(msg: string) {
@@ -45,8 +45,8 @@ export function tagMessage(msg: string) {
 
 export function isRemoteDebuggingEnabled(): boolean {
   // react-native-reanimated checks if in remote debugging in the same way
-  // @ts-ignore global is available but node types are not included
-  const localGlobal = global as any;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-assignment
+  const localGlobal = globalThis as any;
   return (
     (!localGlobal.nativeCallSyncHook || !!localGlobal.__REMOTEDEV__) &&
     !localGlobal.RN$Bridgeless


### PR DESCRIPTION
## Description

`isTestEnv` and `isRemoteDebuggingEnabled` read the bare `global`, which is React Native/Node-specific and doesn't exist in browsers — `utils.ts` is shared code that also runs on web. Both now use the standard `globalThis`, available in every runtime.

To keep the pattern from coming back, a lint rule (`no-restricted-globals` scoped to `src/v3/**`, `src/web/**`, and root `src/*.ts`) now errors on any bare `global` reference in those files, with `globalThis` named in the message. `declare global` type-declaration blocks are unaffected (the rule counts scope references, not the TS keyword).

## Test plan

- `yarn ts-check` clean; `yarn test` 103/103 (`isTestEnv` is exercised by every v3 hook test via the `disableReanimated` default; `isRemoteDebuggingEnabled` runs during handler creation) — no regression under RN/Node, where `globalThis === global`
- Browser A/B probe (esbuild bundle of `src/utils.ts`, no bundler shims, WebKit): the new `globalThis` implementations return correct values; the old bare-`global` implementations throw `ReferenceError: Can't find variable: global`
- Lint rule verified: baseline clean, fires with the actionable message on a violation, `declare global` blocks in `globals.ts`/`global.d.ts` unaffected
