### PR TITLE
De-couple the web handlers from React Native

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -91,5 +91,23 @@
     "no-alert": "warn",
     "simple-import-sort/imports": "error",
     "simple-import-sort/exports": "error"
-  }
+  },
+  "overrides": [
+    {
+      "files": ["packages/react-native-gesture-handler/src/web/**"],
+      "rules": {
+        "no-restricted-imports": [
+          "error",
+          {
+            "paths": [
+              {
+                "name": "react-native",
+                "message": "The web handlers are platform-agnostic engine code — they must not depend on react-native. Guard on runtime capabilities (e.g. DOM availability) instead."
+              }
+            ]
+          }
+        ]
+      }
+    }
+  ]
 }

--- a/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
@@ -27,7 +27,7 @@ export default class LongPressGestureHandler extends GestureHandler {
   private startTime = 0;
   private previousTime = 0;
 
-  private activationTimeout: number | undefined;
+  private activationTimeout: ReturnType<typeof setTimeout> | undefined;
 
   public constructor(
     delegate: GestureHandlerDelegate<unknown, IGestureHandler>

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -1,5 +1,3 @@
-import { Platform } from 'react-native';
-
 import { ActionType } from '../../ActionType';
 import type { ButtonEvent } from '../../specs/RNGestureHandlerButtonNativeComponent';
 import { State } from '../../State';
@@ -27,6 +25,7 @@ import {
   dispatchGestureLifecycleEvent,
   GestureLifecycleEvent,
 } from '../tools/GestureLifecycleEvents';
+import { canUseDOM } from '../utils';
 import GestureHandler from './GestureHandler';
 import type IGestureHandler from './IGestureHandler';
 
@@ -68,13 +67,15 @@ export default class NativeViewGestureHandler extends GestureHandler {
 
     this.shouldCancelWhenOutside = true;
 
-    if (Platform.OS !== 'web') {
+    const view = this.delegate.view;
+
+    // `Element` rather than `HTMLElement`: the delegate's view may also be an
+    // SVGElement (see GestureHandlerWebDelegate.init).
+    if (!canUseDOM() || !(view instanceof Element)) {
       return;
     }
 
-    const view = this.delegate.view as HTMLElement;
-
-    this.restoreViewStyles(view);
+    this.restoreViewStyles(view as HTMLElement);
 
     if (this.usesNativeOrVirtualDetector()) {
       this.role =

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -25,7 +25,7 @@ import {
   dispatchGestureLifecycleEvent,
   GestureLifecycleEvent,
 } from '../tools/GestureLifecycleEvents';
-import { canUseDOM } from '../utils';
+import { isStylableElement } from '../utils';
 import GestureHandler from './GestureHandler';
 import type IGestureHandler from './IGestureHandler';
 
@@ -69,13 +69,11 @@ export default class NativeViewGestureHandler extends GestureHandler {
 
     const view = this.delegate.view;
 
-    // `Element` rather than `HTMLElement`: the delegate's view may also be an
-    // SVGElement (see GestureHandlerWebDelegate.init).
-    if (!canUseDOM() || !(view instanceof Element)) {
+    if (!isStylableElement(view)) {
       return;
     }
 
-    this.restoreViewStyles(view as HTMLElement);
+    this.restoreViewStyles(view);
 
     if (this.usesNativeOrVirtualDetector()) {
       this.role =
@@ -110,11 +108,13 @@ export default class NativeViewGestureHandler extends GestureHandler {
       this.longPressDuration = config.longPressDuration;
     }
 
-    const view = this.delegate.view as HTMLElement;
-    this.restoreViewStyles(view);
+    const view = this.delegate.view;
+    if (isStylableElement(view)) {
+      this.restoreViewStyles(view);
+    }
   }
 
-  private restoreViewStyles(view: HTMLElement) {
+  private restoreViewStyles(view: HTMLElement | SVGElement) {
     if (!view) {
       return;
     }

--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -48,10 +48,10 @@ export default class PanGestureHandler extends GestureHandler {
   private stylusData: StylusData | undefined;
 
   private activateAfterLongPress = 0;
-  private activationTimeout = 0;
+  private activationTimeout: ReturnType<typeof setTimeout> | undefined;
 
   private enableTrackpadTwoFingerGesture = false;
-  private endWheelTimeout = 0;
+  private endWheelTimeout: ReturnType<typeof setTimeout> | undefined;
   private wheelDevice = WheelDevice.UNDETERMINED;
 
   private hasCustomActivationCriteria = false;

--- a/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
@@ -29,8 +29,8 @@ export default class TapGestureHandler extends GestureHandler {
   private lastX = 0;
   private lastY = 0;
 
-  private waitTimeout: number | undefined;
-  private delayTimeout: number | undefined;
+  private waitTimeout: ReturnType<typeof setTimeout> | undefined;
+  private delayTimeout: ReturnType<typeof setTimeout> | undefined;
 
   private tapsSoFar = 0;
 

--- a/packages/react-native-gesture-handler/src/web/utils.ts
+++ b/packages/react-native-gesture-handler/src/web/utils.ts
@@ -2,6 +2,21 @@ import type { StylusData } from '../handlers/gestureHandlerCommon';
 import { PointerType } from '../PointerType';
 import type { GestureHandlerRef, Point, SVGRef } from './interfaces';
 
+// Duplicate of the check in `src/useIsomorphicLayoutEffect.tsx` — kept as a
+// separate copy on purpose, since the web engine is its own compilation unit
+// and must not import from the react-native side. Keep the two in sync.
+//
+// The web handlers also run under react-native-windows, where RN aliases
+// `window` to `global` but there is no DOM — so checking `window` alone is
+// not enough.
+export function canUseDOM(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.document !== 'undefined' &&
+    typeof window.document.createElement !== 'undefined'
+  );
+}
+
 export function hasDisplayContents(view: HTMLElement): boolean {
   return (
     view.style.display === 'contents' ||

--- a/packages/react-native-gesture-handler/src/web/utils.ts
+++ b/packages/react-native-gesture-handler/src/web/utils.ts
@@ -17,6 +17,16 @@ export function canUseDOM(): boolean {
   );
 }
 
+// Narrows to an element whose inline styles (and DOM attributes) are safe to
+// touch.
+export function isStylableElement(
+  view: unknown
+): view is HTMLElement | SVGElement {
+  return (
+    canUseDOM() && (view instanceof HTMLElement || view instanceof SVGElement)
+  );
+}
+
 export function hasDisplayContents(view: HTMLElement): boolean {
   return (
     view.style.display === 'contents' ||


### PR DESCRIPTION
## Description

Removes the last react-native dependency from `src/web`:

- `NativeViewGestureHandler` used `Platform.OS !== 'web'` to guard its DOM-touching `init()` logic from react-native-windows. The guard is now `!canUseDOM() || !(view instanceof Element)` — `canUseDOM()` is a new engine-local duplicate of the `useIsomorphicLayoutEffect` check (checking `window` alone isn't enough, RN defines it on every platform), and `Element` covers SVG-backed views, replacing the `as HTMLElement` cast with real narrowing.
- Five timeout fields in the Pan/LongPress/Tap handlers become `ReturnType<typeof setTimeout> | undefined` — `number` breaks compilation for consumers with `@types/node` in their TS program. Pan's `= 0` sentinels are dropped (`clearTimeout(undefined)` is the same no-op).
- New lint rule: no react-native imports in `src/web/**`.

## Test plan

- `yarn ts-check` clean; `yarn test` 103/103; `yarn lint:js` 0 errors; lint rule verified firing
- Verified on react-native-web (expo-example web in Safari): rendering + native-button role detection through the new guard; LongPress activation (the retyped timeout firing); Pan drag incl. the finalize path that clears the never-assigned timeout — the one runtime-visible change
