### PR TITLE
Lift `ButtonEvent` out of the codegen spec into shared types

### DIFF
--- a/packages/react-native-gesture-handler/__typetests__/buttonEventTest.ts
+++ b/packages/react-native-gesture-handler/__typetests__/buttonEventTest.ts
@@ -1,0 +1,18 @@
+/* eslint-disable @typescript-eslint/no-unused-vars */
+import type { ButtonEvent as SpecButtonEvent } from '../src/specs/RNGestureHandlerButtonNativeComponent';
+import type { ButtonEvent } from '../src/v3/types';
+
+// Instantiate with a conditional type that resolves to `true` — a `false`
+// result fails type-checking at the use site.
+type StaticAssert<T extends true> = T;
+
+// The codegen spec declares its own codegen-typed twin of the shared
+// `ButtonEvent` (specs must stay self-contained for the codegen parser).
+// This fails `ts-check` if the two ever drift apart structurally.
+type ButtonEventMatchesSpec = StaticAssert<
+  SpecButtonEvent extends ButtonEvent
+    ? ButtonEvent extends SpecButtonEvent
+      ? true
+      : false
+    : false
+>;

--- a/packages/react-native-gesture-handler/__typetests__/tsconfig.json
+++ b/packages/react-native-gesture-handler/__typetests__/tsconfig.json
@@ -1,14 +1,9 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "types": [
-      "../src/global.d.ts",
-      "jest"
-    ],
+    "types": ["../src/global.d.ts", "jest"],
     "rootDir": "..",
     "noUnusedLocals": false
   },
-  "include": [
-    "."
-  ]
+  "include": ["."]
 }

--- a/packages/react-native-gesture-handler/__typetests__/tsconfig.json
+++ b/packages/react-native-gesture-handler/__typetests__/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "types": [
+      "../src/global.d.ts",
+      "jest"
+    ],
+    "rootDir": "..",
+    "noUnusedLocals": false
+  },
+  "include": [
+    "."
+  ]
+}

--- a/packages/react-native-gesture-handler/package.json
+++ b/packages/react-native-gesture-handler/package.json
@@ -5,7 +5,7 @@
   "scripts": {
     "test": "jest",
     "build": "yarn tsc -p tsconfig.build.json && bob build",
-    "ts-check": "yarn tsc --noEmit",
+    "ts-check": "yarn tsc --noEmit && yarn tsc -p __typetests__ --noEmit",
     "format-js": "prettier --write --list-different './src/**/*.{js,jsx,ts,tsx}'",
     "format:js": "yarn format-js",
     "format:android": "node ../../scripts/format-android.js",

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -9,21 +9,8 @@ import type {
   ViewStyle,
 } from 'react-native';
 
-import RNGestureHandlerButtonNativeComponent, {
-  type ButtonEvent as SpecButtonEvent,
-} from '../specs/RNGestureHandlerButtonNativeComponent';
-import type { StaticAssert } from '../typeUtils';
+import RNGestureHandlerButtonNativeComponent from '../specs/RNGestureHandlerButtonNativeComponent';
 import type { ButtonEvent } from '../v3/types';
-
-// Compile-time guard: the spec's codegen type must stay structurally
-// identical to the shared `ButtonEvent` in `v3/types`
-export type _ButtonEventMatchesSpec = StaticAssert<
-  SpecButtonEvent extends ButtonEvent
-    ? ButtonEvent extends SpecButtonEvent
-      ? true
-      : false
-    : false
->;
 
 export interface ButtonProps extends ViewProps, AccessibilityProps {
   children?: React.ReactNode;

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -13,7 +13,7 @@ import RNGestureHandlerButtonNativeComponent, {
   type ButtonEvent as SpecButtonEvent,
 } from '../specs/RNGestureHandlerButtonNativeComponent';
 import type { StaticAssert } from '../typeUtils';
-import type { ButtonEvent } from '../v3/types/EventTypes';
+import type { ButtonEvent } from '../v3/types';
 
 // Compile-time guard: the spec's codegen type must stay structurally
 // identical to the shared `ButtonEvent` in `v3/types`

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.tsx
@@ -10,8 +10,20 @@ import type {
 } from 'react-native';
 
 import RNGestureHandlerButtonNativeComponent, {
-  type ButtonEvent,
+  type ButtonEvent as SpecButtonEvent,
 } from '../specs/RNGestureHandlerButtonNativeComponent';
+import type { StaticAssert } from '../typeUtils';
+import type { ButtonEvent } from '../v3/types/EventTypes';
+
+// Compile-time guard: the spec's codegen type must stay structurally
+// identical to the shared `ButtonEvent` in `v3/types`
+export type _ButtonEventMatchesSpec = StaticAssert<
+  SpecButtonEvent extends ButtonEvent
+    ? ButtonEvent extends SpecButtonEvent
+      ? true
+      : false
+    : false
+>;
 
 export interface ButtonProps extends ViewProps, AccessibilityProps {
   children?: React.ReactNode;

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
@@ -5,7 +5,7 @@ import { View } from 'react-native';
 import { ActionType } from '../ActionType';
 import RNGestureHandlerModule from '../RNGestureHandlerModule.web';
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
-import type { ButtonEvent } from '../v3/types/EventTypes';
+import type { ButtonEvent } from '../v3/types';
 import type { PropsRef } from '../web/interfaces';
 import { NativeGestureRole } from '../web/interfaces';
 import { ButtonEventName } from '../web/tools/ButtonEvents';

--- a/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureHandlerButton.web.tsx
@@ -4,8 +4,8 @@ import { View } from 'react-native';
 
 import { ActionType } from '../ActionType';
 import RNGestureHandlerModule from '../RNGestureHandlerModule.web';
-import type { ButtonEvent } from '../specs/RNGestureHandlerButtonNativeComponent';
 import { useIsomorphicLayoutEffect } from '../useIsomorphicLayoutEffect';
+import type { ButtonEvent } from '../v3/types/EventTypes';
 import type { PropsRef } from '../web/interfaces';
 import { NativeGestureRole } from '../web/interfaces';
 import { ButtonEventName } from '../web/tools/ButtonEvents';

--- a/packages/react-native-gesture-handler/src/typeUtils.ts
+++ b/packages/react-native-gesture-handler/src/typeUtils.ts
@@ -1,1 +1,3 @@
 export type ValueOf<T> = T[keyof T];
+
+export type StaticAssert<T extends true> = T;

--- a/packages/react-native-gesture-handler/src/typeUtils.ts
+++ b/packages/react-native-gesture-handler/src/typeUtils.ts
@@ -1,3 +1,1 @@
 export type ValueOf<T> = T[keyof T];
-
-export type StaticAssert<T extends true> = T;

--- a/packages/react-native-gesture-handler/src/v3/types/EventTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/EventTypes.ts
@@ -4,6 +4,19 @@ import type { GestureTouchEvent } from '../../handlers/gestureHandlerCommon';
 import type { PointerType } from '../../PointerType';
 import type { State } from '../../State';
 
+// Payload of the managed button's press events. The codegen spec
+// (`specs/RNGestureHandlerButtonNativeComponent`) declares its own
+// codegen type — specs must stay self-contained for the codegen parser
+export type ButtonEvent = Readonly<{
+  pointerInside: boolean;
+  x: number;
+  y: number;
+  absoluteX: number;
+  absoluteY: number;
+  numberOfPointers: number;
+  pointerType: number;
+}>;
+
 type EventPayload = {
   handlerTag: number;
   state: State;

--- a/packages/react-native-gesture-handler/src/v3/types/index.ts
+++ b/packages/react-native-gesture-handler/src/v3/types/index.ts
@@ -11,6 +11,7 @@ export type {
 export type { DetectorCallbacks, VirtualChild } from './DetectorTypes';
 export type {
   AnimatedEvent,
+  ButtonEvent,
   ChangeCalculatorType,
   DiffCalculatorType,
   GestureEndEvent,

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -3,9 +3,8 @@ import { Platform } from 'react-native';
 import { ActionType } from '../../ActionType';
 import { State } from '../../State';
 import type { NativeHandlerData } from '../../v3/hooks/gestures/native/NativeTypes';
-import type { HandlerData } from '../../v3/types';
+import type { ButtonEvent, HandlerData } from '../../v3/types';
 import { SingleGestureName } from '../../v3/types';
-import type { ButtonEvent } from '../../v3/types/EventTypes';
 import {
   DEFAULT_TOUCH_SLOP,
   NATIVE_GESTURE_ROLE_ATTRIBUTE,

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -1,11 +1,11 @@
 import { Platform } from 'react-native';
 
 import { ActionType } from '../../ActionType';
-import type { ButtonEvent } from '../../specs/RNGestureHandlerButtonNativeComponent';
 import { State } from '../../State';
 import type { NativeHandlerData } from '../../v3/hooks/gestures/native/NativeTypes';
 import type { HandlerData } from '../../v3/types';
 import { SingleGestureName } from '../../v3/types';
+import type { ButtonEvent } from '../../v3/types/EventTypes';
 import {
   DEFAULT_TOUCH_SLOP,
   NATIVE_GESTURE_ROLE_ATTRIBUTE,

--- a/packages/react-native-gesture-handler/src/web/tools/ButtonEvents.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/ButtonEvents.ts
@@ -1,4 +1,4 @@
-import type { ButtonEvent } from '../../specs/RNGestureHandlerButtonNativeComponent';
+import type { ButtonEvent } from '../../v3/types/EventTypes';
 
 export const ButtonEventName = {
   Press: 'gh:buttonPress',

--- a/packages/react-native-gesture-handler/src/web/tools/ButtonEvents.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/ButtonEvents.ts
@@ -1,4 +1,4 @@
-import type { ButtonEvent } from '../../v3/types/EventTypes';
+import type { ButtonEvent } from '../../v3/types';
 
 export const ButtonEventName = {
   Press: 'gh:buttonPress',


### PR DESCRIPTION
## Description

The web engine (`web/tools/ButtonEvents.ts`, `web/handlers/NativeViewGestureHandler.ts`) imported `ButtonEvent` from the native codegen spec. The payload type now lives in `v3/types` as a plain-typed shared definition, and the engine has zero `specs/` imports left.

## Test plan

- `yarn ts-check` clean; `yarn test` 103/103; `yarn lint:js` 0 errors
- Drift guard verified: adding a probe field to the shared type fails `ts-check` at the assertion line
- Type-stripped emit comparison vs main: all seven touched files byte-identical — provably zero runtime change
