### PR TITLE
Stub the Windows module's `Gestures` map

### DIFF
--- a/packages/react-native-gesture-handler/src/RNGestureHandlerModule.windows.ts
+++ b/packages/react-native-gesture-handler/src/RNGestureHandlerModule.windows.ts
@@ -1,26 +1,19 @@
 import type React from 'react';
 
 import type { ActionType } from './ActionType';
-import FlingGestureHandler from './web/handlers/FlingGestureHandler';
-import LongPressGestureHandler from './web/handlers/LongPressGestureHandler';
-import ManualGestureHandler from './web/handlers/ManualGestureHandler';
-import NativeViewGestureHandler from './web/handlers/NativeViewGestureHandler';
-import PanGestureHandler from './web/handlers/PanGestureHandler';
-import PinchGestureHandler from './web/handlers/PinchGestureHandler';
-import RotationGestureHandler from './web/handlers/RotationGestureHandler';
-import TapGestureHandler from './web/handlers/TapGestureHandler';
+import type { Gestures as WebGestures } from './web/Gestures';
 import type { Config } from './web/interfaces';
 
 export const Gestures = {
-  NativeViewGestureHandler,
-  PanGestureHandler,
-  TapGestureHandler,
-  LongPressGestureHandler,
-  PinchGestureHandler,
-  RotationGestureHandler,
-  FlingGestureHandler,
-  ManualGestureHandler,
-};
+  NativeViewGestureHandler: undefined,
+  PanGestureHandler: undefined,
+  TapGestureHandler: undefined,
+  LongPressGestureHandler: undefined,
+  PinchGestureHandler: undefined,
+  RotationGestureHandler: undefined,
+  FlingGestureHandler: undefined,
+  ManualGestureHandler: undefined,
+} satisfies Partial<Record<keyof typeof WebGestures, undefined>>;
 
 export default {
   createGestureHandler<T>(


### PR DESCRIPTION
## Description

`RNGestureHandlerModule.windows.ts` exists so `react-native-windows` apps compile. Every method is a no-op, yet it value-imported all 8 web-engine handler classes just to build the `Gestures` map, pulling the entire engine into Windows bundles for a module that never instantiates anything.

## Test plan

- `yarn ts-check` clean (the `satisfies` clause pins key names to the web map); `yarn test` 103/103; `yarn lint:js` 0 errors
- Type-stripped emit: zero import statements - the Windows resolution is dependency-free at runtime
