### PR TITLE
Chore: ref forwarding to child in wrap v2

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/legacyWrapRef.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/legacyWrapRef.test.tsx
@@ -105,6 +105,33 @@ describe('Legacy GestureDetector ref forwarding', () => {
     expect(childRef.mock.calls[0][0]).not.toBeNull();
   });
 
+  test('moves the child instance when its ref is replaced', () => {
+    const gesture = Gesture.Tap();
+    const firstRef = jest.fn();
+    const secondRef = jest.fn();
+
+    function App({ useSecondRef }: { useSecondRef: boolean }) {
+      return (
+        <GestureHandlerRootView>
+          <GestureDetector gesture={gesture}>
+            <View ref={useSecondRef ? secondRef : firstRef} />
+          </GestureDetector>
+        </GestureHandlerRootView>
+      );
+    }
+
+    const { rerender } = render(<App useSecondRef={false} />);
+
+    const childInstance = firstRef.mock.calls[0][0];
+    expect(childInstance).not.toBeNull();
+    firstRef.mockClear();
+
+    rerender(<App useSecondRef />);
+
+    expect(firstRef).toHaveBeenCalledWith(null);
+    expect(secondRef).toHaveBeenCalledWith(childInstance);
+  });
+
   test('does not reattach gestures on re-render', () => {
     const gesture = Gesture.Tap();
 

--- a/packages/react-native-gesture-handler/src/__tests__/legacyWrapRef.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/legacyWrapRef.test.tsx
@@ -1,0 +1,129 @@
+import { cleanup, render } from '@testing-library/react-native';
+import React from 'react';
+import { findNodeHandle, View } from 'react-native';
+
+import { Gesture, GestureDetector, GestureHandlerRootView } from '../index';
+import RNGestureHandlerModule from '../RNGestureHandlerModule';
+
+jest.mock('react-native/Libraries/ReactNative/RendererProxy', () => ({
+  findNodeHandle: jest.fn(),
+}));
+
+const VIEW_TAG = 123;
+
+function ChildIgnoringRef(props: { children?: React.ReactNode }) {
+  return <View>{props.children}</View>;
+}
+
+class ChildWithHostInstance extends React.Component<{
+  children?: React.ReactNode;
+}> {
+  // eslint-disable-next-line @eslint-react/no-unused-class-component-members
+  public __internalInstanceHandle = {};
+
+  override render() {
+    return <View>{this.props.children}</View>;
+  }
+}
+
+describe('Legacy GestureDetector ref forwarding', () => {
+  let attachSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+    (findNodeHandle as jest.Mock).mockReturnValue(VIEW_TAG);
+    attachSpy = jest.spyOn(RNGestureHandlerModule, 'attachGestureHandler');
+  });
+
+  afterEach(() => {
+    attachSpy.mockRestore();
+  });
+
+  test('resolves the tag from the child host instance when its ref resolves', () => {
+    render(
+      <GestureHandlerRootView>
+        <GestureDetector gesture={Gesture.Tap()}>
+          <ChildWithHostInstance />
+        </GestureDetector>
+      </GestureHandlerRootView>
+    );
+
+    const resolvedRefs = (findNodeHandle as jest.Mock).mock.calls.map(
+      (call) => call[0]
+    );
+
+    expect(resolvedRefs.length).toBeGreaterThan(0);
+    expect(
+      resolvedRefs.every(
+        (ref) => ref instanceof ChildWithHostInstance && ref !== null
+      )
+    ).toBe(true);
+    expect(attachSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      VIEW_TAG,
+      expect.any(Number)
+    );
+  });
+
+  test('attaches gestures when the child ignores its ref', () => {
+    render(
+      <GestureHandlerRootView>
+        <GestureDetector gesture={Gesture.Tap()}>
+          <ChildIgnoringRef />
+        </GestureDetector>
+      </GestureHandlerRootView>
+    );
+
+    const resolvedRefs = (findNodeHandle as jest.Mock).mock.calls.map(
+      (call) => call[0]
+    );
+
+    expect(resolvedRefs.length).toBeGreaterThan(0);
+    expect(
+      resolvedRefs.every((ref) => ref instanceof ChildWithHostInstance)
+    ).toBe(false);
+    expect(attachSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      VIEW_TAG,
+      expect.any(Number)
+    );
+  });
+
+  test('does not clobber a ref the child already has', () => {
+    const childRef = jest.fn();
+
+    render(
+      <GestureHandlerRootView>
+        <GestureDetector gesture={Gesture.Tap()}>
+          <View ref={childRef} />
+        </GestureDetector>
+      </GestureHandlerRootView>
+    );
+
+    expect(childRef).toHaveBeenCalled();
+    expect(childRef.mock.calls[0][0]).not.toBeNull();
+  });
+
+  test('does not reattach gestures on re-render', () => {
+    const gesture = Gesture.Tap();
+
+    function App() {
+      return (
+        <GestureHandlerRootView>
+          <GestureDetector gesture={gesture}>
+            <View />
+          </GestureDetector>
+        </GestureHandlerRootView>
+      );
+    }
+
+    const { rerender } = render(<App />);
+    expect(attachSpy).toHaveBeenCalledTimes(1);
+
+    rerender(<App />);
+    rerender(<App />);
+
+    expect(attachSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native-gesture-handler/src/getShadowNodeFromRef.ts
+++ b/packages/react-native-gesture-handler/src/getShadowNodeFromRef.ts
@@ -1,3 +1,5 @@
+import { isHostInstance } from './hostInstance';
+
 // Used by GestureDetector (unsupported on web at the moment) to check whether the
 // attached view may get flattened on Fabric. This implementation causes errors
 // on web due to the static resolution of `require` statements by webpack breaking
@@ -8,8 +10,10 @@ let getInternalInstanceHandleFromPublicInstance: (ref: unknown) => {
 };
 
 export function getShadowNodeFromRef(ref: unknown) {
+  const isAlreadyHostInstance = isHostInstance(ref);
+
   // Load findHostInstance_DEPRECATED lazily because it may not be available before render
-  if (findHostInstance_DEPRECATED === undefined) {
+  if (!isAlreadyHostInstance && findHostInstance_DEPRECATED === undefined) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const ReactFabric = require('react-native/Libraries/Renderer/shims/ReactFabric');
@@ -43,8 +47,11 @@ export function getShadowNodeFromRef(ref: unknown) {
     }
   }
 
+  const hostInstance = isAlreadyHostInstance
+    ? ref
+    : findHostInstance_DEPRECATED(ref);
+
   // @ts-ignore Fabric
-  return getInternalInstanceHandleFromPublicInstance(
-    findHostInstance_DEPRECATED(ref)
-  ).stateNode.node;
+  return getInternalInstanceHandleFromPublicInstance(hostInstance).stateNode
+    .node;
 }

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/Wrap.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/Wrap.tsx
@@ -1,22 +1,13 @@
 import React from 'react';
 
-import { isHostInstance, preferHostInstance } from '../../../hostInstance';
+import type { WrapRef } from '../../../hostInstance';
+import {
+  assignRef,
+  isHostInstance,
+  preferHostInstance,
+} from '../../../hostInstance';
 import { tagMessage } from '../../../utils';
 import { Reanimated } from '../reanimatedWrapper';
-
-type WrapRef = React.Ref<unknown> | undefined;
-
-function assignRef(ref: WrapRef, instance: unknown) {
-  if (typeof ref === 'function') {
-    return ref(instance as never);
-  }
-
-  if (ref) {
-    ref.current = instance;
-  }
-
-  return undefined;
-}
 
 export class Wrap extends React.Component<{
   onGestureHandlerEvent?: unknown;
@@ -48,8 +39,7 @@ export class Wrap extends React.Component<{
   private attachChildRef(instance: unknown) {
     this.attachedChildRef = this.childRef;
 
-    const cleanup = assignRef(this.attachedChildRef, instance);
-    this.childRefCleanup = typeof cleanup === 'function' ? cleanup : undefined;
+    this.childRefCleanup = assignRef(this.attachedChildRef, instance);
   }
 
   private handleChildRef = (instance: unknown) => {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/Wrap.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/Wrap.tsx
@@ -1,27 +1,92 @@
 import React from 'react';
 
+import { isHostInstance, preferHostInstance } from '../../../hostInstance';
 import { tagMessage } from '../../../utils';
 import { Reanimated } from '../reanimatedWrapper';
+
+type WrapRef = React.Ref<unknown> | undefined;
+
+function assignRef(ref: WrapRef, instance: unknown) {
+  if (typeof ref === 'function') {
+    return ref(instance as never);
+  }
+
+  if (ref) {
+    ref.current = instance;
+  }
+
+  return undefined;
+}
 
 export class Wrap extends React.Component<{
   onGestureHandlerEvent?: unknown;
   // Implicit `children` prop has been removed in @types/react^18.0.0
   children?: React.ReactNode;
 }> {
+  private childInstance: unknown = null;
+  private hostInstance: unknown = null;
+  private childRef: WrapRef = undefined;
+  private attachedChildRef: WrapRef = undefined;
+  private childRefCleanup: (() => void) | undefined = undefined;
+
+  // eslint-disable-next-line @eslint-react/no-unused-class-component-members
+  public getHostInstance() {
+    return this.hostInstance;
+  }
+
+  private detachChildRef() {
+    if (this.childRefCleanup !== undefined) {
+      this.childRefCleanup();
+    } else if (this.attachedChildRef) {
+      assignRef(this.attachedChildRef, null);
+    }
+
+    this.childRefCleanup = undefined;
+    this.attachedChildRef = undefined;
+  }
+
+  private attachChildRef(instance: unknown) {
+    this.attachedChildRef = this.childRef;
+
+    const cleanup = assignRef(this.attachedChildRef, instance);
+    this.childRefCleanup = typeof cleanup === 'function' ? cleanup : undefined;
+  }
+
+  private handleChildRef = (instance: unknown) => {
+    this.childInstance = instance;
+
+    const resolved = preferHostInstance(instance);
+    this.hostInstance = isHostInstance(resolved) ? resolved : null;
+
+    this.detachChildRef();
+
+    if (instance !== null && instance !== undefined) {
+      this.attachChildRef(instance);
+    }
+  };
+
+  override componentDidUpdate() {
+    if (
+      this.childRef === this.attachedChildRef ||
+      this.childInstance === null
+    ) {
+      return;
+    }
+
+    this.detachChildRef();
+    this.attachChildRef(this.childInstance);
+  }
+
   override render() {
+    // I don't think that fighting with types over such a simple function is worth it
+    // The only thing it does is add 'collapsable: false' to the child component
+    // to make sure it is in the native view hierarchy so the detector can find
+    // correct viewTag to attach to.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let child: any;
+
     try {
-      // I don't think that fighting with types over such a simple function is worth it
-      // The only thing it does is add 'collapsable: false' to the child component
-      // to make sure it is in the native view hierarchy so the detector can find
-      // correct viewTag to attach to.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const child: any = React.Children.only(this.props.children);
-      return React.cloneElement(
-        child,
-        { collapsable: false },
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        child.props.children
-      );
+      child = React.Children.only(this.props.children);
     } catch (e) {
       throw new Error(
         tagMessage(
@@ -29,6 +94,16 @@ export class Wrap extends React.Component<{
         )
       );
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    this.childRef = child.props.ref as WrapRef;
+
+    return React.cloneElement(
+      child,
+      { collapsable: false, ref: this.handleChildRef },
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      child.props.children
+    );
   }
 }
 

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx
@@ -2,6 +2,7 @@
 import React, { useEffect, useMemo, useRef } from 'react';
 
 import findNodeHandle from '../../../findNodeHandle';
+import { resolveHostInstance } from '../../../hostInstance';
 import { useIsomorphicLayoutEffect } from '../../../useIsomorphicLayoutEffect';
 import type { TouchAction, UserSelect } from '../../gestureHandlerCommon';
 import type { GestureType } from '../gesture';
@@ -139,7 +140,9 @@ export const GestureDetector = (props: GestureDetectorProps) => {
   useAnimatedGesture(preparedGesture, needsToRebuildReanimatedEvent);
 
   useIsomorphicLayoutEffect(() => {
-    const viewTag = findNodeHandle(state.viewRef) as number;
+    const viewTag = findNodeHandle(
+      resolveHostInstance(state.viewRef)
+    ) as number;
     preparedGesture.isMounted = true;
 
     attachHandlers({

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useDetectorUpdater.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useDetectorUpdater.ts
@@ -2,6 +2,7 @@ import type React from 'react';
 import { useCallback } from 'react';
 
 import findNodeHandle from '../../../findNodeHandle';
+import { resolveHostInstance } from '../../../hostInstance';
 import type { PropsRef } from '../../../web/interfaces';
 import type { GestureType } from '../gesture';
 import type { ComposedGesture } from '../gestureComposition';
@@ -27,7 +28,9 @@ export function useDetectorUpdater(
     // skipConfigUpdate is used to prevent unnecessary updates when only checking if the view has changed
     (skipConfigUpdate?: boolean) => {
       // If the underlying view has changed we need to reattach handlers to the new view
-      const viewTag = findNodeHandle(state.viewRef) as number;
+      const viewTag = findNodeHandle(
+        resolveHostInstance(state.viewRef)
+      ) as number;
       const didUnderlyingViewChange = viewTag !== state.previousViewTag;
 
       if (

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useViewRefHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useViewRefHandler.ts
@@ -3,6 +3,7 @@ import { useCallback } from 'react';
 
 import findNodeHandle from '../../../findNodeHandle';
 import { getShadowNodeFromRef } from '../../../getShadowNodeFromRef';
+import { resolveHostInstance } from '../../../hostInstance';
 import { tagMessage } from '../../../utils';
 import type { GestureDetectorState } from './types';
 
@@ -27,7 +28,9 @@ export function useViewRefHandler(
 
       // if it's the first render, also set the previousViewTag to prevent reattaching gestures when not needed
       if (state.previousViewTag === -1) {
-        state.previousViewTag = findNodeHandle(state.viewRef) as number;
+        state.previousViewTag = findNodeHandle(
+          resolveHostInstance(state.viewRef)
+        ) as number;
       }
 
       // Pass true as `skipConfigUpdate`. Here we only want to trigger the eventual reattaching of handlers
@@ -37,7 +40,7 @@ export function useViewRefHandler(
       }
 
       if (__DEV__ && global._isViewFlatteningDisabled) {
-        const node = getShadowNodeFromRef(ref);
+        const node = getShadowNodeFromRef(resolveHostInstance(ref));
         if (global._isViewFlatteningDisabled(node) === false) {
           console.error(
             tagMessage(

--- a/packages/react-native-gesture-handler/src/hostInstance.ts
+++ b/packages/react-native-gesture-handler/src/hostInstance.ts
@@ -1,0 +1,37 @@
+export function isHostInstance(instance: unknown) {
+  return (
+    (instance as { __internalInstanceHandle?: unknown } | null | undefined)
+      ?.__internalInstanceHandle !== undefined
+  );
+}
+
+export function preferHostInstance(instance: unknown) {
+  if (instance === null || instance === undefined || isHostInstance(instance)) {
+    return instance;
+  }
+
+  const nativeRef = (
+    instance as { getNativeScrollRef?: () => unknown }
+  ).getNativeScrollRef?.();
+
+  return isHostInstance(nativeRef) ? nativeRef : instance;
+}
+
+export interface HostInstanceProvider {
+  getHostInstance: () => unknown;
+}
+
+function providesHostInstance(ref: unknown): ref is HostInstanceProvider {
+  return (
+    typeof (ref as HostInstanceProvider | null | undefined)?.getHostInstance ===
+    'function'
+  );
+}
+
+export function resolveHostInstance<T>(ref: T): T {
+  if (!providesHostInstance(ref)) {
+    return ref;
+  }
+
+  return (ref.getHostInstance() ?? ref) as T;
+}

--- a/packages/react-native-gesture-handler/src/hostInstance.ts
+++ b/packages/react-native-gesture-handler/src/hostInstance.ts
@@ -1,3 +1,23 @@
+import type { Ref } from 'react';
+
+export type WrapRef = Ref<unknown> | undefined;
+
+export function assignRef(
+  ref: WrapRef,
+  instance: unknown
+): (() => void) | undefined {
+  if (typeof ref === 'function') {
+    const cleanup = ref(instance as never);
+    return typeof cleanup === 'function' ? cleanup : undefined;
+  }
+
+  if (ref) {
+    ref.current = instance;
+  }
+
+  return undefined;
+}
+
 export function isHostInstance(instance: unknown) {
   return (
     (instance as { __internalInstanceHandle?: unknown } | null | undefined)

--- a/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/Wrap.tsx
+++ b/packages/react-native-gesture-handler/src/v3/detectors/VirtualDetector/Wrap.tsx
@@ -1,40 +1,13 @@
-import type { PropsWithChildren, Ref } from 'react';
+import type { PropsWithChildren } from 'react';
 import React, { useCallback } from 'react';
 
+import type { WrapRef } from '../../../hostInstance';
+import { assignRef, preferHostInstance } from '../../../hostInstance';
 import { tagMessage } from '../../../utils';
 
-export type WrapRef = Ref<unknown> | undefined;
+export type { WrapRef };
 
 export type WrapProps = PropsWithChildren<{ ref?: WrapRef }>;
-
-function isHostInstance(instance: unknown) {
-  return (
-    (instance as { __internalInstanceHandle?: unknown } | null | undefined)
-      ?.__internalInstanceHandle !== undefined
-  );
-}
-
-function preferHostInstance(instance: unknown) {
-  if (instance === null || instance === undefined || isHostInstance(instance)) {
-    return instance;
-  }
-
-  const nativeRef = (
-    instance as { getNativeScrollRef?: () => unknown }
-  ).getNativeScrollRef?.();
-
-  return isHostInstance(nativeRef) ? nativeRef : instance;
-}
-
-function assignRef(ref: WrapRef, instance: unknown) {
-  if (typeof ref === 'function') {
-    return ref(instance as never);
-  }
-  if (ref) {
-    ref.current = instance;
-  }
-  return undefined;
-}
 
 export const Wrap: React.FunctionComponent<WrapProps> = ({ ref, children }) => {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any


### PR DESCRIPTION
This will help with strictmode adoption, as using refs can help avoid the erroring path of findHostInstance / getNodeHandle

This PR aims to be non-breaking