### PR TITLE
Add an `exports` map and re-enable the CommonJS build behind the `require` condition

### DIFF
--- a/packages/react-native-gesture-handler/jestSetup.js
+++ b/packages/react-native-gesture-handler/jestSetup.js
@@ -14,6 +14,15 @@ jest.mock('./src/components/touchables', () =>
 jest.mock('./src/v3/detectors/HostGestureDetector', () =>
   require('./src/mocks/hostDetector')
 );
+jest.mock('./src/specs/RNGestureHandlerButtonNativeComponent', () =>
+  require('./src/mocks/nativeComponentSpec')
+);
+jest.mock('./src/specs/RNGestureHandlerDetectorNativeComponent', () =>
+  require('./src/mocks/nativeComponentSpec')
+);
+jest.mock('./src/specs/RNGestureHandlerRootViewNativeComponent', () =>
+  require('./src/mocks/nativeComponentSpec')
+);
 
 jest.mock('./lib/module/RNGestureHandlerModule', () =>
   require('./lib/module/mocks/module')
@@ -32,4 +41,41 @@ jest.mock('./lib/module/components/GestureComponents', () =>
 );
 jest.mock('./lib/module/v3/detectors/HostGestureDetector', () =>
   require('./lib/module/mocks/hostDetector')
+);
+jest.mock('./lib/module/specs/RNGestureHandlerButtonNativeComponent', () =>
+  require('./lib/module/mocks/nativeComponentSpec')
+);
+jest.mock('./lib/module/specs/RNGestureHandlerDetectorNativeComponent', () =>
+  require('./lib/module/mocks/nativeComponentSpec')
+);
+jest.mock('./lib/module/specs/RNGestureHandlerRootViewNativeComponent', () =>
+  require('./lib/module/mocks/nativeComponentSpec')
+);
+
+jest.mock('./lib/commonjs/RNGestureHandlerModule', () =>
+  require('./lib/commonjs/mocks/module')
+);
+jest.mock('./lib/commonjs/components/GestureButtons', () =>
+  require('./lib/commonjs/mocks/GestureButtons')
+);
+jest.mock('./lib/commonjs/components/touchables', () =>
+  require('./lib/commonjs/mocks/Touchables')
+);
+jest.mock('./lib/commonjs/components/Pressable', () =>
+  require('./lib/commonjs/mocks/Pressable')
+);
+jest.mock('./lib/commonjs/components/GestureComponents', () =>
+  require('./lib/commonjs/mocks/gestureComponents')
+);
+jest.mock('./lib/commonjs/v3/detectors/HostGestureDetector', () =>
+  require('./lib/commonjs/mocks/hostDetector')
+);
+jest.mock('./lib/commonjs/specs/RNGestureHandlerButtonNativeComponent', () =>
+  require('./lib/commonjs/mocks/nativeComponentSpec')
+);
+jest.mock('./lib/commonjs/specs/RNGestureHandlerDetectorNativeComponent', () =>
+  require('./lib/commonjs/mocks/nativeComponentSpec')
+);
+jest.mock('./lib/commonjs/specs/RNGestureHandlerRootViewNativeComponent', () =>
+  require('./lib/commonjs/mocks/nativeComponentSpec')
 );

--- a/packages/react-native-gesture-handler/package.json
+++ b/packages/react-native-gesture-handler/package.json
@@ -4,7 +4,7 @@
   "description": "Declarative API exposing native platform touch and gesture system to React Native",
   "scripts": {
     "test": "jest",
-    "build": "yarn tsc -p tsconfig.build.json && bob build",
+    "build": "yarn tsc -p tsconfig.build.json && bob build && node scripts/mark-commonjs-build.js",
     "ts-check": "yarn tsc --noEmit",
     "format-js": "prettier --write --list-different './src/**/*.{js,jsx,ts,tsx}'",
     "format:js": "yarn format-js",
@@ -23,6 +23,40 @@
   "main": "lib/module/index.js",
   "module": "lib/module/index.js",
   "types": "lib/typescript/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./lib/typescript/index.d.ts",
+      "require": "./lib/commonjs/index.js",
+      "react-native": "./src/index.ts",
+      "import": "./lib/module/index.js",
+      "default": "./lib/module/index.js"
+    },
+    "./jest-utils": {
+      "types": "./lib/typescript/jestUtils/index.d.ts",
+      "require": "./lib/commonjs/jestUtils/index.js",
+      "react-native": "./src/jestUtils/index.ts",
+      "import": "./lib/module/jestUtils/index.js",
+      "default": "./lib/module/jestUtils/index.js"
+    },
+    "./ReanimatedSwipeable": {
+      "types": "./lib/typescript/components/ReanimatedSwipeable/index.d.ts",
+      "require": "./lib/commonjs/components/ReanimatedSwipeable/index.js",
+      "react-native": "./src/components/ReanimatedSwipeable/index.ts",
+      "import": "./lib/module/components/ReanimatedSwipeable/index.js",
+      "default": "./lib/module/components/ReanimatedSwipeable/index.js"
+    },
+    "./ReanimatedDrawerLayout": {
+      "types": "./lib/typescript/components/ReanimatedDrawerLayout.d.ts",
+      "require": "./lib/commonjs/components/ReanimatedDrawerLayout.js",
+      "react-native": "./src/components/ReanimatedDrawerLayout.tsx",
+      "import": "./lib/module/components/ReanimatedDrawerLayout.js",
+      "default": "./lib/module/components/ReanimatedDrawerLayout.js"
+    },
+    "./jestSetup": "./jestSetup.js",
+    "./jestSetup.js": "./jestSetup.js",
+    "./package.json": "./package.json",
+    "./*": "./*"
+  },
   "files": [
     "src",
     "lib",
@@ -110,6 +144,7 @@
     "source": "src",
     "output": "lib",
     "targets": [
+      "commonjs",
       "module",
       [
         "typescript",

--- a/packages/react-native-gesture-handler/scripts/mark-commonjs-build.js
+++ b/packages/react-native-gesture-handler/scripts/mark-commonjs-build.js
@@ -1,0 +1,29 @@
+// Run after `bob build`: flips `IS_COMMONJS_BUILD` to `true` in the
+// `lib/commonjs` output so `src/cjsGuard.ts` can detect that the CommonJS
+// artifact ended up inside a React Native app bundle. See that file for why
+// this can't be decided at runtime.
+const fs = require('fs');
+const path = require('path');
+
+const flavorPath = path.join(
+  __dirname,
+  '..',
+  'lib',
+  'commonjs',
+  'cjsBuildFlavor.js'
+);
+
+const source = fs.readFileSync(flavorPath, 'utf8');
+
+if (!source.includes('IS_COMMONJS_BUILD = false')) {
+  throw new Error(
+    `Expected \`IS_COMMONJS_BUILD = false\` in ${flavorPath} — did the shape of src/cjsBuildFlavor.ts change?`
+  );
+}
+
+fs.writeFileSync(
+  flavorPath,
+  source.replace('IS_COMMONJS_BUILD = false', 'IS_COMMONJS_BUILD = true')
+);
+
+console.log('Marked lib/commonjs build (IS_COMMONJS_BUILD = true)');

--- a/packages/react-native-gesture-handler/src/cjsBuildFlavor.ts
+++ b/packages/react-native-gesture-handler/src/cjsBuildFlavor.ts
@@ -1,0 +1,6 @@
+// `false` in the source tree and in every build output except `lib/commonjs`,
+// where `scripts/mark-commonjs-build.js` overwrites it with `true` after
+// `bob build`. Lets `cjsGuard` tell the CommonJS artifact apart from the
+// ESM/source chains, which is impossible at runtime alone — Metro wraps all
+// module formats in CommonJS-style wrappers when bundling.
+export const IS_COMMONJS_BUILD = false;

--- a/packages/react-native-gesture-handler/src/cjsGuard.ts
+++ b/packages/react-native-gesture-handler/src/cjsGuard.ts
@@ -1,0 +1,34 @@
+import { IS_COMMONJS_BUILD } from './cjsBuildFlavor';
+import { tagMessage } from './utils';
+
+// The `lib/commonjs` build exists only for the `require` export condition,
+// which React Native's bundlers never match: Metro resolves the library with
+// the `react-native` condition (the `src` chain), so worklets are workletized
+// from the original sources. If an app bundle evaluates the CommonJS build
+// anyway, its Metro config resolved the `require` condition — worklets from
+// this library would silently misbehave, so leave an actionable warning.
+function isJest(): boolean {
+  // Structural access instead of the `process` global — @types/node is not
+  // part of this package's type program.
+  const maybeProcess = (
+    globalThis as { process?: { env?: Record<string, string | undefined> } }
+  ).process;
+
+  return maybeProcess?.env?.JEST_WORKER_ID !== undefined;
+}
+
+if (
+  IS_COMMONJS_BUILD &&
+  typeof navigator !== 'undefined' &&
+  navigator.product === 'ReactNative' &&
+  !isJest()
+) {
+  console.warn(
+    tagMessage(
+      `The CommonJS build of this library was loaded inside a React Native app. ` +
+        `This build is meant for Node-based tools (e.g. Jest) — bundling it into an app may break worklets. ` +
+        `This usually happens when a custom "unstable_conditionNames" in metro.config.js includes "require". ` +
+        `Please report this at https://github.com/software-mansion/react-native-gesture-handler/issues`
+    )
+  );
+}

--- a/packages/react-native-gesture-handler/src/index.ts
+++ b/packages/react-native-gesture-handler/src/index.ts
@@ -1,3 +1,4 @@
+import './cjsGuard';
 import './globals';
 
 import { initialize } from './init';

--- a/packages/react-native-gesture-handler/src/mocks/nativeComponentSpec.tsx
+++ b/packages/react-native-gesture-handler/src/mocks/nativeComponentSpec.tsx
@@ -1,0 +1,7 @@
+import { View } from 'react-native';
+
+// Runtime stand-in for the codegen native component specs
+// (`src/specs/*NativeComponent.ts`). The spec files ship as raw TypeScript —
+// React Native's codegen parses them from source — so the untransformed
+// `lib/commonjs` build cannot require them under jest.
+export default View;


### PR DESCRIPTION
## Description

This PR adds an `exports` map to the package and brings back the `commonjs` build target (removed in #4069), exposed only through the `require` export condition.

The key order in the map is the mechanism: a resolver picks the first key present in its condition set. Jest presets (`@react-native/jest-preset`, `jest-expo`) resolve with `['require', 'react-native']`, so test suites now load ready-made CommonJS with zero config — no more `transformIgnorePatterns` tweaking. Metro resolves native platforms with `['react-native']` only and web with `['browser']`, so app bundles keep getting the `src` chain (native) or the ESM build (web) and structurally cannot reach the CommonJS artifact. This narrows rather than reverses #4069: the worklet breakage from #4066 required CommonJS inside a Metro bundle, which the condition gate makes unresolvable.

A `"./*": "./*"` catch-all keeps every historical deep path working, since the package never had an `exports` field and all paths were de-facto public.

Defense in depth for the one remaining edge (a consumer Metro config manually adding `"require"` to `unstable_conditionNames`): the CommonJS entry starts with a guard that emits a `console.warn` with an issue link when that build is evaluated inside a React Native app. The build flavor is marked at build time (`scripts/mark-commonjs-build.js`), because Metro wraps all module formats in CommonJS-style wrappers, making runtime detection impossible.

`jestSetup.js` gains `lib/commonjs` twins of the existing mocks, plus mocks for the three codegen component specs — those ship as raw TypeScript (codegen parses them from source), which the untransformed CommonJS chain cannot require.

## Test plan

- Repo gates: `yarn test` (110), `yarn ts-check`, `yarn lint-js`, madge — all green.
- Packed the real tarball and verified consumers:
  - jest with stock `@react-native/jest-preset` (RN 0.86) and stock `jest-expo` (SDK 57): package resolves to `lib/commonjs`, the full barrel loads, jestSetup mocks apply, `jest-utils` works — zero config, which fails on current `main`.
  - Metro bundle (bare RN 0.86) and `expo export` (SDK 55, SDK 57): sourcemap audit shows all bundled modules come from `src/`, zero from either `lib` flavor.
  - `expo export --platform web`, prod and dev mode (the #4066 scenario): all modules resolve to `lib/module` ESM, zero CommonJS.
  - Node: subpath resolution (root, `jest-utils`, `jestSetup`, `package.json`, deep paths), guard silent under Node and jest, warns when `navigator.product` is spoofed to `ReactNative`.
- On-device (iOS simulator, example app): v3 pan gesture with `onUpdate` writing shared values — runs as a worklet on the UI thread (`_WORKLET === true`), box follows the drag.
