### PR TITLE
[Apple] Remove trailing semicolons from `RNGHGestureRecognizerState*` macros

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGHUIKit.h
+++ b/packages/react-native-gesture-handler/apple/RNGHUIKit.h
@@ -9,11 +9,11 @@ typedef UITouch RNGHUITouch;
 typedef UIScrollView RNGHUIScrollView;
 typedef UIColor RNGHColor;
 
-#define RNGHGestureRecognizerStateFailed UIGestureRecognizerStateFailed;
-#define RNGHGestureRecognizerStatePossible UIGestureRecognizerStatePossible;
-#define RNGHGestureRecognizerStateCancelled UIGestureRecognizerStateCancelled;
-#define RNGHGestureRecognizerStateBegan UIGestureRecognizerStateBegan;
-#define RNGHGestureRecognizerStateEnded UIGestureRecognizerStateEnded;
+#define RNGHGestureRecognizerStateFailed UIGestureRecognizerStateFailed
+#define RNGHGestureRecognizerStatePossible UIGestureRecognizerStatePossible
+#define RNGHGestureRecognizerStateCancelled UIGestureRecognizerStateCancelled
+#define RNGHGestureRecognizerStateBegan UIGestureRecognizerStateBegan
+#define RNGHGestureRecognizerStateEnded UIGestureRecognizerStateEnded
 
 #else // TARGET_OS_OSX [
 
@@ -26,10 +26,10 @@ typedef RCTUITouch RNGHUITouch;
 typedef NSScrollView RNGHUIScrollView;
 typedef NSColor RNGHColor;
 
-#define RNGHGestureRecognizerStateFailed NSGestureRecognizerStateFailed;
-#define RNGHGestureRecognizerStatePossible NSGestureRecognizerStatePossible;
-#define RNGHGestureRecognizerStateCancelled NSGestureRecognizerStateCancelled;
-#define RNGHGestureRecognizerStateBegan NSGestureRecognizerStateBegan;
-#define RNGHGestureRecognizerStateEnded NSGestureRecognizerStateEnded;
+#define RNGHGestureRecognizerStateFailed NSGestureRecognizerStateFailed
+#define RNGHGestureRecognizerStatePossible NSGestureRecognizerStatePossible
+#define RNGHGestureRecognizerStateCancelled NSGestureRecognizerStateCancelled
+#define RNGHGestureRecognizerStateBegan NSGestureRecognizerStateBegan
+#define RNGHGestureRecognizerStateEnded NSGestureRecognizerStateEnded
 
 #endif // ] TARGET_OS_OSX


### PR DESCRIPTION
## Description

The `RNGHGestureRecognizerState*` compatibility macros in `RNGHUIKit.h` carried a trailing semicolon in their definitions, e.g. `#define RNGHGestureRecognizerStateFailed UIGestureRecognizerStateFailed;`. Any expression-context usage, such as `if (state == RNGHGestureRecognizerStateFailed)`, expands to `if (state == UIGestureRecognizerStateFailed;)` and fails to compile with a confusing `unexpected ';' before ')'` error. Removing the semicolons makes the macros usable in any context; existing call sites are unaffected.

## Test plan

- Verified the failure mode before the fix: an expression-context usage added to `RNGestureHandlerModule.mm` fails to compile, with clang's note pointing at the semicolon in the macro definition;
- Verified after the fix: the same expression-context usage compiles, and the existing statement usages behave identically (single semicolon instead of a double one after expansion).
