### PR TITLE
[iOS] Fix touch events never being delivered to `VirtualDetector` handlers

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -596,7 +596,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 - (void)sendTouchEventInState:(RNGestureHandlerState)state forViewWithTag:(NSNumber *)reactTag
 {
-  if (_actionType == RNGestureHandlerActionTypeNativeDetector) {
+  if ([self usesNativeOrVirtualDetector]) {
     [self.emitter sendNativeTouchEventForGestureHandler:self
                                         withPointerType:_pointerType
                                          forHandlerType:[self eventHandlerType]];

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.mm
@@ -267,9 +267,11 @@
 
   // it may happen that the gesture recognizer is reset after it's been unbound from the view,
   // it that recognizer tried to send event, the app would crash because the target of the event
-  // would be nil.
-  if (_gestureHandler.recognizer.view.reactTag == nil &&
-      _gestureHandler.actionType != RNGestureHandlerActionTypeNativeDetector) {
+  // would be nil. Detector-attached handlers (native and virtual alike) don't route events by
+  // the view's reactTag — they dispatch through the detector view — so a nil tag is not an
+  // obstacle for them. The virtual recognizer's view has no reactTag at all, so without this
+  // exemption virtual handlers would never deliver touch events.
+  if (_gestureHandler.recognizer.view.reactTag == nil && ![_gestureHandler usesNativeOrVirtualDetector]) {
     return;
   }
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.mm
@@ -266,7 +266,7 @@
   }
 
   // it may happen that the gesture recognizer is reset after it's been unbound from the view,
-  // it that recognizer tried to send event, the app would crash because the target of the event
+  // if that recognizer tried to send an event, the app would crash because the target of the event
   // would be nil. Detector-attached handlers (native and virtual alike) don't route events by
   // the view's reactTag — they dispatch through the detector view — so a nil tag is not an
   // obstacle for them. The virtual recognizer's view has no reactTag at all, so without this


### PR DESCRIPTION
## Description

On iOS, handlers attached through `VirtualGestureDetector` never received `onTouches*` callbacks: state events (`onBegin`/`onActivate`/`onFinalize`) arrived, but every pointer-data event was silently dropped. Android and web deliver all of them for the same code.

Two spots in the touch-event path were only half-migrated when the virtual detector joined the native one — both still special-cased `RNGestureHandlerActionTypeNativeDetector` alone:

1. `RNGestureHandler.sendTouchEventInState` routed touch events through the codegen detector path (`sendNativeTouchEventForGestureHandler`, which resolves its target via `findViewForEvents` → `hostDetectorView`) only for the native detector. A virtual handler's touch events fell into the legacy branch that builds a `reactTag`-routed event.
2. `RNGestureHandlerPointerTracker.sendEvent` drops events when the recognizer's view has no `reactTag`, with an exemption only for the native detector. The virtual recognizer's view has no `reactTag`, so the guard swallowed every touch event for virtual handlers unconditionally.

Both checks now use the existing `usesNativeOrVirtualDetector` helper, mirroring how Android's `RNGestureHandlerEventDispatcher` treats the two detector types uniformly (single branch, delivery through the detector view). With (1) in place, detector-attached touch events never involve the view's `reactTag`, which is what makes the widened exemption in (2) safe.

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import React from 'react';
import { StyleSheet, Text, View } from 'react-native';
import {
  GestureDetector,
  InterceptingGestureDetector,
  usePanGesture,
  useTapGesture,
  VirtualGestureDetector,
} from 'react-native-gesture-handler';

export default function EmptyExample() {
  const interceptingTap = useTapGesture({ disableReanimated: true });

  const virtualTapWithTouches = useTapGesture({
    disableReanimated: true,
    onActivate: () => console.log('[virtual-tap-touches] onActivate'),
    onFinalize: () => console.log('[virtual-tap-touches] onFinalize'),
    onTouchesDown: () => console.log('[virtual-tap-touches] onTouchesDown'),
    onTouchesUp: () => console.log('[virtual-tap-touches] onTouchesUp'),
  });

  const nativePan = usePanGesture({
    disableReanimated: true,
    onBegin: () => console.log('[native] onBegin'),
    onActivate: () => console.log('[native] onActivate'),
    onDeactivate: () => console.log('[native] onDeactivate'),
    onFinalize: () => console.log('[native] onFinalize'),
    onTouchesDown: () => console.log('[native] onTouchesDown'),
    onTouchesMove: () => console.log('[native] onTouchesMove'),
    onTouchesUp: () => console.log('[native] onTouchesUp'),
    onTouchesCancel: () => console.log('[native] onTouchesCancel'),
  });

  return (
    <View style={styles.container}>
      <InterceptingGestureDetector gesture={interceptingTap}>
        <Text style={styles.paragraph}>
          Virtual detector target:{' '}
          <VirtualGestureDetector gesture={virtualTapWithTouches}>
            <Text style={styles.virtualTarget}>TAP ME</Text>
          </VirtualGestureDetector>
        </Text>
      </InterceptingGestureDetector>

      <GestureDetector gesture={nativePan}>
        <View style={styles.box}>
          <Text style={styles.boxLabel}>native detector control</Text>
        </View>
      </GestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  container: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: 24, padding: 24 },
  paragraph: { fontSize: 18, textAlign: 'center' },
  virtualTarget: { fontSize: 22, fontWeight: 'bold', color: 'darkgreen' },
  box: {
    width: 220,
    height: 100,
    borderRadius: 12,
    backgroundColor: 'steelblue',
    justifyContent: 'center',
    alignItems: 'center',
  },
  boxLabel: { color: 'white' },
});
```

</details>