### PR TITLE
[iOS] Fix gestures attached via `VirtualGestureDetector` never recognizing continuous gestures

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -854,11 +854,22 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   }
 }
 
+// The logic detector has a virtual view tag set only if the real hierarchy was folded
+// into a single View — only then is hit-testing routed through the virtual view.
+- (BOOL)hasVirtualTarget
+{
+  return _actionType == RNGestureHandlerActionTypeVirtualDetector && _virtualViewTag != nil;
+}
+
+- (BOOL)virtualTargetContainsPoint:(CGPoint)point
+{
+  return [self isVirtualViewTag:_virtualViewTag touchedAtPoint:point inView:_recognizer.view];
+}
+
 - (BOOL)containsPointInView
 {
-  if (_actionType == RNGestureHandlerActionTypeVirtualDetector && _virtualViewTag != nil) {
-    CGPoint point = [_recognizer locationInView:_recognizer.view];
-    return [self isVirtualViewTag:_virtualViewTag touchedAtPoint:point inView:_recognizer.view];
+  if ([self hasVirtualTarget]) {
+    return [self virtualTargetContainsPoint:[_recognizer locationInView:_recognizer.view]];
   }
 
   RNGHUIView *viewToHitTest = _recognizer.view;
@@ -875,9 +886,9 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 - (BOOL)wantsToHandleEventsAtPoint:(CGPoint)point
 {
-  if (_actionType == RNGestureHandlerActionTypeVirtualDetector && _virtualViewTag != nil) {
+  if ([self hasVirtualTarget]) {
     // point is in _recognizer.view (detector) coordinate space; search the whole subtree
-    return [self isVirtualViewTag:_virtualViewTag touchedAtPoint:point inView:_recognizer.view];
+    return [self virtualTargetContainsPoint:point];
   }
 
   RNGHUIView *viewToHitTest = _recognizer.view;
@@ -908,13 +919,15 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
     }
   }
 
-  // Logic detector has a virtual view tag set only if the real hierarchy was folded into a single View
-  if (_actionType == RNGestureHandlerActionTypeVirtualDetector && _virtualViewTag != nil) {
-    CGPoint point = [_recognizer locationInView:_recognizer.view];
-    if (![self isVirtualViewTag:_virtualViewTag touchedAtPoint:point inView:_recognizer.view]) {
-      return NO;
-    }
+#if TARGET_OS_OSX
+  // On iOS this gate lives in gestureRecognizer:shouldReceiveTouch: instead — this delegate method is
+  // also invoked manually by some recognizers (Pan) before any touch is tracked, when locationInView
+  // returns a stale point, and at the Began transition the pointer may have legitimately left the
+  // virtual view already. AppKit has no shouldReceiveTouch equivalent, so macOS keeps the check here.
+  if ([self hasVirtualTarget] && ![self virtualTargetContainsPoint:[_recognizer locationInView:_recognizer.view]]) {
+    return NO;
   }
+#endif
 
   [self reset];
   return YES;
@@ -922,6 +935,16 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldReceiveTouch:(RNGHUITouch *)touch
 {
+#if !TARGET_OS_OSX
+  // Virtual-detector handlers only handle touches that start on their virtual view. This is the
+  // earliest point where the touch's own location is available (the recognizer hasn't received it
+  // yet, so recognizer.locationInView is not usable), matching how Android routes by the initial
+  // touch position at down time.
+  if ([self hasVirtualTarget] && ![self virtualTargetContainsPoint:[touch locationInView:gestureRecognizer.view]]) {
+    return NO;
+  }
+#endif
+
   // If hitSlop is set we use it to determine if a given gesture recognizer should start processing
   // touch stream. This only works for negative values of hitSlop as this method won't be triggered
   // unless touch startes in the bounds of the attached view. To acheve similar effect with positive

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -854,7 +854,7 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   }
 }
 
-// The logic detector has a virtual view tag set only if the real hierarchy was folded
+// The virtual detector has a virtual view tag set only if the real hierarchy was folded
 // into a single View — only then is hit-testing routed through the virtual view.
 - (BOOL)hasVirtualTarget
 {


### PR DESCRIPTION
## Description

A continuous gesture (e.g. `usePanGesture`) attached through `VirtualGestureDetector` to a text span never recognized on iOS - no callbacks at all. Android and web work, and a virtual tap works on iOS.

`RNBetterPanGestureRecognizer` consults `gestureRecognizerShouldBegin:` manually from `touchesBegan`, before the recognizer has processed the touch. `locationInView:` returns a stale point at that moment, so the virtual hit-test fails and the pan sets itself to `Failed` on touch-down. Taps are unaffected because UIKit consults their `shouldBegin` at recognition time, when the location is valid.

The virtual gate now lives in `gestureRecognizer:shouldReceiveTouch:`, where the touch's own location is available - a touch that doesn't start on the virtual view never reaches the recognizer, matching how Android routes by the initial touch position. Deferring the check to the `Began` transition instead would not work: the pointer may have legitimately left a small span by then, and the pan would also begin for touches from other spans. The `shouldBegin` check remains for macOS only, which has no `shouldReceiveTouch` equivalent. The condition and hit-test are extracted into `hasVirtualTarget` / `virtualTargetContainsPoint:`, shared by all call sites.

## Test plan

<details>
<summary>Minimal reproduction:</summary>

```tsx
import React from 'react';
import { StyleSheet, Text, View } from 'react-native';
import {
  InterceptingGestureDetector,
  usePanGesture,
  VirtualGestureDetector,
} from 'react-native-gesture-handler';

export default function EmptyExample() {
  const spanPan = usePanGesture({
    onBegin: () => console.log('[span-pan] onBegin'),
    onActivate: () => console.log('[span-pan] onActivate'),
    onDeactivate: () => console.log('[span-pan] onDeactivate'),
    onFinalize: () => console.log('[span-pan] onFinalize'),
  });

  const viewPan = usePanGesture({
    onBegin: () => console.log('[view-pan] onBegin'),
    onActivate: () => console.log('[view-pan] onActivate'),
    onDeactivate: () => console.log('[view-pan] onDeactivate'),
    onFinalize: () => console.log('[view-pan] onFinalize'),
  });

  return (
    <View style={styles.container}>
      {/* Bug: pan on a folded (virtual) text span — silent on iOS before this fix */}
      <InterceptingGestureDetector>
        <Text style={styles.paragraph}>
          <VirtualGestureDetector gesture={spanPan}>
            <Text style={styles.span}>DRAG ME (virtual text span)</Text>
          </VirtualGestureDetector>
        </Text>
      </InterceptingGestureDetector>

      {/* Control: real View child — attaches directly, works with and without the fix */}
      <InterceptingGestureDetector>
        <VirtualGestureDetector gesture={viewPan}>
          <View style={styles.box}>
            <Text style={styles.boxLabel}>drag me (real View — control)</Text>
          </View>
        </VirtualGestureDetector>
      </InterceptingGestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  container: { flex: 1, justifyContent: 'center', alignItems: 'center', gap: 32, padding: 24 },
  paragraph: { fontSize: 18, textAlign: 'center' },
  span: { fontSize: 22, fontWeight: 'bold', color: 'mediumvioletred' },
  box: {
    width: 240,
    height: 100,
    borderRadius: 12,
    backgroundColor: 'steelblue',
    justifyContent: 'center',
    alignItems: 'center',
  },
  boxLabel: { color: 'white' },
});
```

</details>