### PR TITLE
[macOS] Fix `Fling` not sending touch events and begin/end states consistently

### DIFF
--- a/packages/react-native-gesture-handler/apple/Handlers/RNFlingHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNFlingHandler.m
@@ -143,12 +143,28 @@
   [_gestureHandler handleGesture:self];
 }
 
+- (void)triggerAction
+{
+  [_gestureHandler handleGesture:self fromReset:NO fromManualStateChange:NO];
+}
+
+- (void)triggerActionFromReset
+{
+  [_gestureHandler handleGesture:self fromReset:YES fromManualStateChange:NO];
+}
+
 - (void)mouseDown:(NSEvent *)event
 {
+  [_gestureHandler setCurrentPointerTypeToMouse];
+  [_gestureHandler reset];
   [super mouseDown:event];
 
   startPosition = [self locationInView:self.view];
   startTime = CACurrentMediaTime();
+
+  [_gestureHandler.pointerTracker touchesBegan:[NSSet setWithObject:event] withEvent:event];
+  // Send the BEGAN event, mirroring what the iOS recognizer does in touchesBegan.
+  [self triggerAction];
 
   self.state = NSGestureRecognizerStatePossible;
 
@@ -172,6 +188,8 @@
 {
   [super mouseDragged:event];
 
+  [_gestureHandler.pointerTracker touchesMoved:[NSSet setWithObject:event] withEvent:event];
+
   NSPoint currentPosition = [self locationInView:self.view];
   double currentTime = CACurrentMediaTime();
 
@@ -191,10 +209,20 @@
 {
   [super mouseUp:event];
 
+  [_gestureHandler.pointerTracker touchesEnded:[NSSet setWithObject:event] withEvent:event];
+
   dispatch_block_cancel(failFlingAction);
 
   self.state =
       self.state == NSGestureRecognizerStateChanged ? NSGestureRecognizerStateEnded : NSGestureRecognizerStateFailed;
+}
+
+- (void)reset
+{
+  [self triggerActionFromReset];
+  [_gestureHandler.pointerTracker reset];
+  [super reset];
+  [_gestureHandler reset];
 }
 
 - (void)tryActivate:(RNGHVector *)velocityVector

--- a/packages/react-native-gesture-handler/apple/Handlers/RNFlingHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNFlingHandler.m
@@ -205,13 +205,21 @@
   [self tryActivate:velocityVector];
 }
 
+- (void)cancelFailFlingAction
+{
+  if (failFlingAction != nil) {
+    dispatch_block_cancel(failFlingAction);
+    failFlingAction = nil;
+  }
+}
+
 - (void)mouseUp:(NSEvent *)event
 {
   [super mouseUp:event];
 
   [_gestureHandler.pointerTracker touchesEnded:[NSSet setWithObject:event] withEvent:event];
 
-  dispatch_block_cancel(failFlingAction);
+  [self cancelFailFlingAction];
 
   self.state =
       self.state == NSGestureRecognizerStateChanged ? NSGestureRecognizerStateEnded : NSGestureRecognizerStateFailed;
@@ -221,6 +229,9 @@
 {
   [self triggerActionFromReset];
   [_gestureHandler.pointerTracker reset];
+  // The gesture may end without a mouse-up (view unmount, cancellation) — a still-scheduled
+  // fail block would fire later and set the state to Failed during the next gesture.
+  [self cancelFailFlingAction];
   [super reset];
   [_gestureHandler reset];
 }

--- a/packages/react-native-gesture-handler/apple/Handlers/RNFlingHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNFlingHandler.m
@@ -101,7 +101,8 @@
 #else
 
 @interface RNBetterSwipeGestureRecognizer : NSGestureRecognizer {
-  dispatch_block_t failFlingAction;
+  // scheduled on mouseDown; fails the gesture if the fling doesn't complete within maxDuration
+  dispatch_block_t maxDurationTimeout;
   int maxDuration;
   int minVelocity;
   double defaultAlignmentCone;
@@ -170,7 +171,7 @@
 
   __weak typeof(self) weakSelf = self;
 
-  failFlingAction = dispatch_block_create(0, ^{
+  maxDurationTimeout = dispatch_block_create(0, ^{
     __strong typeof(self) strongSelf = weakSelf;
 
     if (strongSelf) {
@@ -181,7 +182,7 @@
   dispatch_after(
       dispatch_time(DISPATCH_TIME_NOW, (int64_t)(maxDuration * NSEC_PER_SEC)),
       dispatch_get_main_queue(),
-      failFlingAction);
+      maxDurationTimeout);
 }
 
 - (void)mouseDragged:(NSEvent *)event
@@ -205,11 +206,11 @@
   [self tryActivate:velocityVector];
 }
 
-- (void)cancelFailFlingAction
+- (void)cancelMaxDurationTimeout
 {
-  if (failFlingAction != nil) {
-    dispatch_block_cancel(failFlingAction);
-    failFlingAction = nil;
+  if (maxDurationTimeout != nil) {
+    dispatch_block_cancel(maxDurationTimeout);
+    maxDurationTimeout = nil;
   }
 }
 
@@ -219,7 +220,7 @@
 
   [_gestureHandler.pointerTracker touchesEnded:[NSSet setWithObject:event] withEvent:event];
 
-  [self cancelFailFlingAction];
+  [self cancelMaxDurationTimeout];
 
   self.state =
       self.state == NSGestureRecognizerStateChanged ? NSGestureRecognizerStateEnded : NSGestureRecognizerStateFailed;
@@ -230,8 +231,8 @@
   [self triggerActionFromReset];
   [_gestureHandler.pointerTracker reset];
   // The gesture may end without a mouse-up (view unmount, cancellation) — a still-scheduled
-  // fail block would fire later and set the state to Failed during the next gesture.
-  [self cancelFailFlingAction];
+  // timeout would fire later and set the state to Failed during the next gesture.
+  [self cancelMaxDurationTimeout];
   [super reset];
   [_gestureHandler reset];
 }


### PR DESCRIPTION
## Description

The macOS `Fling` recognizer is a separate `NSGestureRecognizer` implementation with several gaps compared to its iOS counterpart:

- it never fed `pointerTracker`, so `onTouches*` callbacks never fired;
- it never dispatched BEGAN itself — on successful flicks `onBegin` only arrived at activation time (AppKit coerces the recognizer's `Possible → Changed` transition into `Began` first, which accidentally supplies it mid-drag instead of at touch-down);
- failed gestures (click, slow drag, too-slow flick) produced no events at all — no `onBegin`, no `onFinalize` — breaking the begin/finalize pairing, because the fail path fires no action and there was no `reset` override to deliver the final state;
- it never set the pointer type.

All of this is now mirrored from the iOS recognizer: tracker calls in `mouseDown`/`mouseDragged`/`mouseUp`, a BEGAN `triggerAction` on mouse-down, a `reset` override with `triggerActionFromReset`, and `setCurrentPointerTypeToMouse`.

Touch-event delivery on macOS additionally requires #4390 (pointer tracker matching `NSEvent`s); there is no code dependency between the two PRs.

## Test plan

Tested in `macos-example` (with #4390 merged locally) using a v3 `useFlingGesture` with all state and touch callbacks:

- fast flick: `onTouchesDown` → `onBegin` → `onTouchesMove`s → `onActivate` → `onTouchesUp` → `onDeactivate` → `onFinalize canceled=false`;
- slow drag: fails via the max-duration timer, `onFinalize canceled=true` (previously: no events at all);
- plain click: `onTouchesDown` → `onBegin` → `onTouchesUp` → `onFinalize canceled=true` (previously: no events at all);
- repeated gestures behave identically (reset works).

In the timer-fail path `onTouchesCancel` arrives after `onFinalize` — the same reset ordering the iOS recognizer produces.
