### PR TITLE
[Docs] Document Touchable hover callbacks

### DIFF
--- a/packages/docs-gesture-handler/docs/components/touchable.mdx
+++ b/packages/docs-gesture-handler/docs/components/touchable.mdx
@@ -373,13 +373,16 @@ label="Show composed types definitions"
 expandedLabel="Hide composed types definitions"
 lineBounds={[0, 1]}
 src={`
-onPressIn?: (e: GestureEvent<NativeHandlerData>) => void;
+onPressIn?: (e: ButtonEvent) => void;
 
-type GestureEvent<NativeHandlerData> = {
-    handlerTag: number;
+type ButtonEvent = {
+    pointerInside: boolean;
+    x: number;
+    y: number;
+    absoluteX: number;
+    absoluteY: number;
     numberOfPointers: number;
     pointerType: PointerType;
-    pointerInside: boolean;
 }
 
 enum PointerType {
@@ -400,13 +403,16 @@ label="Show composed types definitions"
 expandedLabel="Hide composed types definitions"
 lineBounds={[0, 1]}
 src={`
-onPressOut?: (e: GestureEvent<NativeHandlerData>) => void;
+onPressOut?: (e: ButtonEvent) => void;
 
-type GestureEvent<NativeHandlerData> = {
-    handlerTag: number;
+type ButtonEvent = {
+    pointerInside: boolean;
+    x: number;
+    y: number;
+    absoluteX: number;
+    absoluteY: number;
     numberOfPointers: number;
     pointerType: PointerType;
-    pointerInside: boolean;
 }
 
 enum PointerType {
@@ -427,13 +433,16 @@ label="Show composed types definitions"
 expandedLabel="Hide composed types definitions"
 lineBounds={[0, 1]}
 src={`
-onPress?: (e: GestureEvent<NativeHandlerData>) => void;
+onPress?: (e: ButtonEvent) => void;
 
-type GestureEvent<NativeHandlerData> = {
-    handlerTag: number;
+type ButtonEvent = {
+    pointerInside: boolean;
+    x: number;
+    y: number;
+    absoluteX: number;
+    absoluteY: number;
     numberOfPointers: number;
     pointerType: PointerType;
-    pointerInside: boolean;
 }
 
 enum PointerType {
@@ -449,12 +458,93 @@ Triggered when the button gets pressed (analogous to `onPress` in `Pressable` fr
 
 ### onLongPress
 
-```ts
-onLongPress?: () => void;
-```
+<CollapsibleCode 
+label="Show composed types definitions"
+expandedLabel="Hide composed types definitions"
+lineBounds={[0, 1]}
+src={`
+onLongPress?: (e: ButtonEvent) => void;
+
+type ButtonEvent = {
+    pointerInside: boolean;
+    x: number;
+    y: number;
+    absoluteX: number;
+    absoluteY: number;
+    numberOfPointers: number;
+    pointerType: PointerType;
+}
+
+enum PointerType {
+    TOUCH,
+    STYLUS,
+    MOUSE,
+    KEY,
+    OTHER,
+}
+`}/>
 
 Triggered when the button gets pressed for at least [`delayLongPress`](#delaylongpress) milliseconds.
 
+### onHoverIn
+
+<CollapsibleCode 
+label="Show composed types definitions"
+expandedLabel="Hide composed types definitions"
+lineBounds={[0, 1]}
+src={`
+onHoverIn?: (e: ButtonEvent) => void;
+
+type ButtonEvent = {
+    pointerInside: boolean;
+    x: number;
+    y: number;
+    absoluteX: number;
+    absoluteY: number;
+    numberOfPointers: number;
+    pointerType: PointerType;
+}
+
+enum PointerType {
+    TOUCH,
+    STYLUS,
+    MOUSE,
+    KEY,
+    OTHER,
+}
+`}/>
+
+Triggered when a non-touch pointer - a mouse, a trackpad cursor, or a hovering stylus - moves over the button (analogous to `onHoverIn` in `Pressable` from RN core). Touch pointers never report hover.
+
+### onHoverOut
+
+<CollapsibleCode 
+label="Show composed types definitions"
+expandedLabel="Hide composed types definitions"
+lineBounds={[0, 1]}
+src={`
+onHoverOut?: (e: ButtonEvent) => void;
+
+type ButtonEvent = {
+    pointerInside: boolean;
+    x: number;
+    y: number;
+    absoluteX: number;
+    absoluteY: number;
+    numberOfPointers: number;
+    pointerType: PointerType;
+}
+
+enum PointerType {
+    TOUCH,
+    STYLUS,
+    MOUSE,
+    KEY,
+    OTHER,
+}
+`}/>
+
+Triggered when the hovering pointer leaves the button (analogous to `onHoverOut` in `Pressable` from RN core).
 
 ### delayLongPress
 


### PR DESCRIPTION
## Description

Documents `onHoverIn`/`onHoverOut` on the `Touchable` page, together
with the behaviour that isn't obvious from the signature: how the two
pair up, what `disabled` does to an open hover, which platforms report
the crossings during a press, tvOS driving hover from focus, and hover
state not surviving an unmount or a detach.

## Test plan

`yarn start` in `packages/docs-gesture-handler`.
