### PR TITLE
[General] Default GestureDetector moduleId to -1

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerDetectorView.kt
@@ -230,8 +230,7 @@ class RNGestureHandlerDetectorView(context: Context) : ReactViewGroup(context) {
   }
 
   private fun detachNativeGestureHandlers() {
-    val registry = RNGestureHandlerModule.registries[moduleId]
-      ?: throw Exception("Tried to access a non-existent registry")
+    val registry = RNGestureHandlerModule.registries[moduleId] ?: return
 
     for (tag in nativeHandlers) {
       if (!attachedHandlers.contains(tag)) {

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerDetectorNativeComponent.ts
@@ -67,7 +67,7 @@ export interface NativeProps extends ViewProps {
     | undefined;
 
   handlerTags: CodegenTypes.Int32[];
-  moduleId: CodegenTypes.Int32;
+  moduleId?: CodegenTypes.WithDefault<CodegenTypes.Int32, -1>;
   virtualChildren: VirtualChildrenProps[];
 
   pointerEvents?: CodegenTypes.WithDefault<

--- a/packages/react-native-gesture-handler/src/specs/RNGestureHandlerRootViewNativeComponent.ts
+++ b/packages/react-native-gesture-handler/src/specs/RNGestureHandlerRootViewNativeComponent.ts
@@ -7,7 +7,7 @@ export interface RootViewNativeProps extends ViewProps {
 }
 
 interface NativeProps extends ViewProps {
-  moduleId: CodegenTypes.Int32;
+  moduleId?: CodegenTypes.WithDefault<CodegenTypes.Int32, -1>;
   unstable_forceActive?: boolean;
 }
 


### PR DESCRIPTION
## Description

On Android with Fabric props 2.0, `getDiffProps` on CREATE compares against codegen defaults. `moduleId: Int32` defaults to `0`, which is also the first `RNGestureHandlerModule` id, so the prop is omitted. The native field stays at `-1`, attach is skipped, and `removeViewAt` looks up `registries[-1]` and crashes (`Tried to access a non-existent registry`).

Reproduced with `moduleId=-1`, `nativeHandlers=0`, `registryKeys=[0]` — the registry exists; `setModuleId` never ran.

Two changes:

1. **Root cause** — match the button spec: `moduleId?: WithDefault<Int32, -1>` on the detector and root view so `0` is sent on CREATE and `setModuleId` runs.
2. **Safety net** — `detachNativeGestureHandlers` no-ops when the registry is missing (`?: return`), same as `detachAllHandlers()`. `removeViewAt` must not throw even if `moduleId` is still `-1` or the module has already been invalidated.

## Test plan

- [ ] Android, New Architecture, props 2.0 / pull model enabled
- [ ] Mount a `GestureDetector` (e.g. `Gesture.Native()` wrapping a list), then unmount it (navigate away)
- [ ] App does not crash; native gestures still attach
- [ ] Confirm the detector receives `moduleId=0` (not left at `-1`)