### PR TITLE
[Android] Resolve the button event dispatcher by react tag

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -786,6 +786,7 @@ class RNGestureHandlerButtonViewManager :
 
     private fun dispatchJSEvent(type: EventType, handler: NativeViewGestureHandler) {
       val reactContext = context as? ReactContext ?: return
+      // TODO: deprecated, but its replacement is unavailable before RN 0.85 — drop when possible
       val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, this.id) ?: return
       eventDispatcher.dispatchEvent(RNGestureHandlerButtonEvent.obtain(this, handler, type))
 
@@ -1163,6 +1164,7 @@ class RNGestureHandlerButtonViewManager :
     private fun dispatchHoverEvent(type: EventType) {
       val sample = lastHoverSample ?: return
       val reactContext = context as? ReactContext ?: return
+      // TODO: deprecated, but its replacement is unavailable before RN 0.85 — drop when possible
       val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, this.id) ?: return
 
       eventDispatcher.dispatchEvent(RNGestureHandlerButtonEvent.obtain(this, sample, type))

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -786,7 +786,7 @@ class RNGestureHandlerButtonViewManager :
 
     private fun dispatchJSEvent(type: EventType, handler: NativeViewGestureHandler) {
       val reactContext = context as? ReactContext ?: return
-      val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext) ?: return
+      val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, this.id) ?: return
       eventDispatcher.dispatchEvent(RNGestureHandlerButtonEvent.obtain(this, handler, type))
 
       if (type == EventType.PressIn) {
@@ -1163,7 +1163,7 @@ class RNGestureHandlerButtonViewManager :
     private fun dispatchHoverEvent(type: EventType) {
       val sample = lastHoverSample ?: return
       val reactContext = context as? ReactContext ?: return
-      val eventDispatcher = UIManagerHelper.getEventDispatcher(reactContext) ?: return
+      val eventDispatcher = UIManagerHelper.getEventDispatcherForReactTag(reactContext, this.id) ?: return
 
       eventDispatcher.dispatchEvent(RNGestureHandlerButtonEvent.obtain(this, sample, type))
     }


### PR DESCRIPTION
## Description

Changes `getEventDispatcher(reactContext)` to `getEventDispatcherForReactTag(reactContext, this.id)` in order to fix builds on RN < 0.85

## Test plan

Build 0.87, 0.84 and 0.83