### PR TITLE
Forward press handlers as `testOnly_*` in `PressableWithTouchable`

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/mocks.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/mocks.test.tsx
@@ -24,7 +24,7 @@ import {
   TouchableOpacity,
   TouchableWithoutFeedback,
 } from '../mocks/Touchables';
-import { Touchable } from '../v3/components';
+import { Pressable, Touchable } from '../v3/components';
 
 describe('Jest mocks – legacy components render without crashing', () => {
   test('LegacyRawButton', () => {
@@ -141,4 +141,35 @@ test('Trigger Touchable press', () => {
   });
 
   expect(onPress).toHaveBeenCalled();
+});
+
+test('Pressable exposes its press handlers to testing-library', () => {
+  // `Pressable` renders `PressableWithTouchable` unless a relation prop is
+  // passed. Both engines have to forward the handlers as `testOnly_*` props on
+  // the button, since that is what `fireEvent(element, 'press')` picks up in a
+  // test environment — the press state machine itself runs natively.
+  const onPress = jest.fn();
+  const onPressIn = jest.fn();
+  const onPressOut = jest.fn();
+  const onLongPress = jest.fn();
+
+  render(
+    <GestureHandlerRootView>
+      <Pressable
+        testID="pressable"
+        onPress={onPress}
+        onPressIn={onPressIn}
+        onPressOut={onPressOut}
+        onLongPress={onLongPress}>
+        <Text>Press Me</Text>
+      </Pressable>
+    </GestureHandlerRootView>
+  );
+
+  const button = screen.getByTestId('pressable');
+
+  expect(button.props.testOnly_onPress).toBe(onPress);
+  expect(button.props.testOnly_onPressIn).toBe(onPressIn);
+  expect(button.props.testOnly_onPressOut).toBe(onPressOut);
+  expect(button.props.testOnly_onLongPress).toBe(onLongPress);
 });

--- a/packages/react-native-gesture-handler/src/v3/components/PressableWithTouchable.tsx
+++ b/packages/react-native-gesture-handler/src/v3/components/PressableWithTouchable.tsx
@@ -13,8 +13,11 @@ import {
   numberAsInset,
 } from '../../components/Pressable/utils';
 import { PressabilityDebugView } from '../../handlers/PressabilityDebugView';
+import { isTestEnv } from '../../utils';
 import { pointerStyle } from './pointerStyle';
 import { Touchable } from './Touchable/Touchable';
+
+const IS_TEST_ENV = isTestEnv();
 
 // RN's Pressable default. Touchable's own default is 600ms
 const DEFAULT_LONG_PRESS_DURATION = 500;
@@ -314,7 +317,11 @@ const PressableWithTouchable = (props: PressableProps) => {
       onPress={handlePress}
       onLongPress={handleLongPress}
       onHoverIn={handleHoverIn}
-      onHoverOut={handleHoverOut}>
+      onHoverOut={handleHoverOut}
+      testOnly_onPress={IS_TEST_ENV ? onPress : undefined}
+      testOnly_onPressIn={IS_TEST_ENV ? onPressIn : undefined}
+      testOnly_onPressOut={IS_TEST_ENV ? onPressOut : undefined}
+      testOnly_onLongPress={IS_TEST_ENV ? onLongPress : undefined}>
       {resolvedChildren}
       {__DEV__ ? (
         <PressabilityDebugView color="red" hitSlop={normalizedHitSlop} />


### PR DESCRIPTION
## Description

Fixes #4417.

Since 3.2.0, `Pressable` dispatches between two engines: `StatefulPressable` when one of the
relation props (`simultaneousWith` / `requireToFail` / `block`) is passed, and
`PressableWithTouchable` otherwise — the common case.

Only `StatefulPressable` sets `testOnly_onPress` / `testOnly_onPressIn` / `testOnly_onPressOut` /
`testOnly_onLongPress` on the button. `PressableWithTouchable` doesn't, so for a plain
`<Pressable onPress={...}>` React Native Testing Library finds no handler and
`fireEvent(element, 'press')` silently does nothing.

The press state machine runs natively, so in a test environment those props are the only way to
reach the handlers. This makes the regression silent and fairly wide-reaching: no error is
thrown, tests just stop observing presses. On 3.1.0 the single v3 `Pressable` always forwarded
them, so this is a 3.1.0 → 3.2.0 regression for any app whose Jest suite drives a `Pressable`.

The fix forwards the four handlers from `PressableWithTouchable` too, guarded by `isTestEnv()`,
exactly as `StatefulPressable` does. `Touchable` spreads its remaining props onto
`GestureHandlerButton`, which already declares them in `ButtonProps`, so nothing else needed to
change and the props stay stripped outside a test environment.

Note this is unrelated to #4414, which fixed the `testOnly_pressed` display state.

## Test plan

Added a regression test in `src/__tests__/mocks.test.tsx` asserting the four `testOnly_*` props
are wired on the button for a relation-free `Pressable`. It fails on `main` and passes with the
fix.

The test asserts the props rather than calling `fireEvent(element, 'press')` because this repo is
on `@testing-library/react-native@12.9`, which predates the `testOnly_*` handler lookup (added in
v13). Asserting the props keeps the test meaningful on the pinned version and independent of the
RNTL version.

In `packages/react-native-gesture-handler`:

- `yarn test` — 16 suites, 135 tests passing
- `yarn ts-check` — clean
- `yarn lint:js` — 0 errors
- `yarn format:js` — clean

Also verified end-to-end in a real app (Expo 57 / RN 0.86, RNTL 14.0.1) that had ~3 suites broken
by the 3.1.0 → 3.2.0 bump: with this change applied as a patch, the full suite is green again
(136 suites, 1663 tests, 73 snapshots).
