### PR TITLE
Remove `REACT_NATIVE_MINOR_VERSION` build flag

### DIFF
--- a/packages/react-native-gesture-handler/RNGestureHandler.podspec
+++ b/packages/react-native-gesture-handler/RNGestureHandler.podspec
@@ -5,7 +5,6 @@ is_gh_example_app = ENV["GH_EXAMPLE_APP_NAME"] != nil
 
 compilation_metadata_dir = "CompilationDatabase"
 compilation_metadata_generation_flag = is_gh_example_app ? '-gen-cdb-fragment-path ' + compilation_metadata_dir : ''
-version_flag = "-DREACT_NATIVE_MINOR_VERSION=#{GestureHandlerUtils.get_react_native_minor_version()}"
 use_worklets = GestureHandlerUtils.react_native_worklets_supports_stable_api()
 worklets_flag = use_worklets ? '-DRNGH_USE_WORKLETS=1' : ''
 
@@ -24,7 +23,7 @@ Pod::Spec.new do |s|
   s.requires_arc = true
   s.platforms       = { ios: '15.1', tvos: '15.1', osx: '14.0', visionos: '1.0' }
   s.xcconfig = {
-    "OTHER_CFLAGS" => "$(inherited) #{compilation_metadata_generation_flag} #{version_flag} #{worklets_flag}"
+    "OTHER_CFLAGS" => "$(inherited) #{compilation_metadata_generation_flag} #{worklets_flag}"
   }
 
   install_modules_dependencies(s);

--- a/packages/react-native-gesture-handler/android/build.gradle
+++ b/packages/react-native-gesture-handler/android/build.gradle
@@ -146,12 +146,6 @@ def reactNativeArchitectures() {
 
 def REACT_NATIVE_DIR = resolveReactNativeDirectory()
 
-def reactProperties = new Properties()
-file("$REACT_NATIVE_DIR/ReactAndroid/gradle.properties").withInputStream { reactProperties.load(it) }
-
-def REACT_NATIVE_VERSION = reactProperties.getProperty("VERSION_NAME")
-def REACT_NATIVE_MINOR_VERSION = REACT_NATIVE_VERSION.split("\\.")[1].toInteger()
-
 repositories {
     mavenCentral()
 }
@@ -177,13 +171,11 @@ android {
     defaultConfig {
         minSdkVersion safeExtGet('minSdkVersion', 24)
         targetSdkVersion safeExtGet('targetSdkVersion', 33)
-        buildConfigField "int", "REACT_NATIVE_MINOR_VERSION", REACT_NATIVE_MINOR_VERSION.toString()
 
         externalNativeBuild {
             cmake {
                 cppFlags "-O2", "-frtti", "-fexceptions", "-Wall", "-Werror", "-std=c++20", "-DANDROID"
                 arguments "-DREACT_NATIVE_DIR=${REACT_NATIVE_DIR}",
-                        "-DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}",
                         "-DRNGH_USE_WORKLETS=${shouldUseRuntimeFromWorklets()}",
                         "-DANDROID_STL=c++_shared",
                         "-DANDROID_SUPPORT_FLEXIBLE_PAGE_SIZES=ON"

--- a/packages/react-native-gesture-handler/android/src/main/jni/CMakeLists.txt
+++ b/packages/react-native-gesture-handler/android/src/main/jni/CMakeLists.txt
@@ -1,17 +1,8 @@
 project(GestureHandler)
 cmake_minimum_required(VERSION 3.9.0)
 
-string(
-  APPEND
-  CMAKE_CXX_FLAGS
-  " -DREACT_NATIVE_MINOR_VERSION=${REACT_NATIVE_MINOR_VERSION}")
-
 set(CMAKE_VERBOSE_MAKEFILE ON)
-if(${REACT_NATIVE_MINOR_VERSION} GREATER_EQUAL 73)
-    set(CMAKE_CXX_STANDARD 20)
-else()
-    set(CMAKE_CXX_STANDARD 17)
-endif()
+set(CMAKE_CXX_STANDARD 20)
 
 set(PACKAGE_NAME "gesturehandler")
 set(RNGH_DIR "${CMAKE_SOURCE_DIR}/../../../../")
@@ -22,6 +13,8 @@ file(GLOB_RECURSE gesture_handler_shared_SRCS CONFIGURE_DEPENDS "${RNGH_DIR}/sha
 
 include(${REACT_ANDROID_DIR}/cmake-utils/folly-flags.cmake)
 add_compile_options(${folly_FLAGS})
+
+include(${REACT_NATIVE_DIR}/ReactCommon/cmake-utils/react-native-flags.cmake)
 
 add_library(${PACKAGE_NAME}
   SHARED
@@ -38,12 +31,10 @@ target_include_directories(
   "${REACT_NATIVE_DIR}/ReactCommon"
 )
 
-if(ReactAndroid_VERSION_MINOR GREATER_EQUAL 80)
-  target_compile_reactnative_options(${LIB_TARGET_NAME} PRIVATE)
-endif()
-
 find_package(ReactAndroid REQUIRED CONFIG)
 find_package(fbjni REQUIRED CONFIG)
+
+target_compile_reactnative_options(${PACKAGE_NAME} PRIVATE)
 
 target_link_libraries(
   ${PACKAGE_NAME}

--- a/packages/react-native-gesture-handler/scripts/gesture_handler_utils.rb
+++ b/packages/react-native-gesture-handler/scripts/gesture_handler_utils.rb
@@ -5,34 +5,6 @@ module GestureHandlerUtils
 
     MIN_REACT_NATIVE_WORKLETS_VERSION = Gem::Version.new('0.8.0')
 
-    def try_to_parse_react_native_package_json(react_native_dir)
-        react_native_package_json_path = File.join(react_native_dir, 'package.json')
-
-        if !File.exist?(react_native_package_json_path)
-            return nil
-        end
-
-        return JSON.parse(File.read(react_native_package_json_path))
-    end
-
-    def get_react_native_minor_version()
-        react_native_dir = File.dirname(`cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('react-native/package.json')"`)
-        react_native_json = try_to_parse_react_native_package_json(react_native_dir)
-
-        if react_native_json == nil
-            node_modules_dir = ENV["REACT_NATIVE_NODE_MODULES_DIR"]
-            if node_modules_dir != nil
-                react_native_json = try_to_parse_react_native_package_json(File.join(node_modules_dir, 'react-native'))
-            end
-        end
-
-        if react_native_json == nil
-            raise '[react-native-gesture-handler] Unable to recognize your `react-native` version. Please set environmental variable with `react-native` location: `export REACT_NATIVE_NODE_MODULES_DIR="<path to react-native>" && pod install`.'
-        end
-
-        return react_native_json['version'].split('.')[1].to_i
-    end
-
     def node_package_dir(package_name)
         package_json_path = `cd "#{Pod::Config.instance.installation_root.to_s}" && node --print "require.resolve('#{package_name}/package.json')" 2>/dev/null`.strip
 

--- a/packages/react-native-gesture-handler/shared/runtime/RNGHRuntimeDecorator.cpp
+++ b/packages/react-native-gesture-handler/shared/runtime/RNGHRuntimeDecorator.cpp
@@ -32,12 +32,8 @@ void RNGHRuntimeDecorator::installRNRuntimeBindings(
           return jsi::Value::null();
         }
 
-#if REACT_NATIVE_MINOR_VERSION >= 81
         auto shadowNode = Bridging<std::shared_ptr<const ShadowNode>>::fromJs(
             runtime, args[0]);
-#else
-        auto shadowNode = shadowNodeFromValue(runtime, args[0]);
-#endif
 
 #ifndef ANDROID
         if (dynamic_pointer_cast<const ParagraphShadowNode>(shadowNode)) {


### PR DESCRIPTION
## Description

This PR removes the `REACT_NATIVE_MINOR_VERSION` build flag and fixes the `target_compile_reactnative_options` call in the Android `CMakeLists`.

The only consumer of `REACT_NATIVE_MINOR_VERSION` was a >= 81 check in `RNGHRuntimeDecorator.cpp`, which is always true on supported react-native versions. If a version check becomes necessary in the future, react-native ships `<cxxreact/ReactNativeVersion.h>` with the `REACT_NATIVE_VERSION_MINOR` macro, available on all platforms and build systems.

The `target_compile_reactnative_options` block added in #3688 never executed: it ran before `find_package(ReactAndroid)` defines `ReactAndroid_VERSION_MINOR`, referenced an undefined `LIB_TARGET_NAME`, and was missing the include of `react-native-flags.cmake` that defines the function. This PR fixes it to match how reanimated and worklets use it. Note that this applies RN_SERIALIZABLE_STATE and HERMES_V1_ENABLED=1 to our JNI target for the first time, matching how ReactAndroid itself is built.

## Test plan

- basic-example builds and launches on iOS (pod install + yarn ios)
- basic-example builds on Android (assembleDebug, -Wall -Werror, no new warnings)
- compile_commands.json confirms RN_SERIALIZABLE_STATE and HERMES_V1_ENABLED=1 are applied to all translation units
- basic-example builds under the experimental SwiftPM setup from react-native 0.87
- pod ipc spec evaluates the modified podspec cleanly
