### PR TITLE
[Example] Keep "Basic" in example names, add test ids

### DIFF
--- a/apps/common-app/src/console/ConsoleModal.tsx
+++ b/apps/common-app/src/console/ConsoleModal.tsx
@@ -236,6 +236,7 @@ function ConsoleModalContent({ entries, visible, onClose }: ConsoleModalProps) {
             </View>
             <View style={styles.modalActions}>
               <Touchable
+                testID="clear-console-button"
                 accessibilityRole="button"
                 disabled={entries.length === 0}
                 activeOpacity={0.5}
@@ -250,6 +251,7 @@ function ConsoleModalContent({ entries, visible, onClose }: ConsoleModalProps) {
                 </Text>
               </Touchable>
               <Touchable
+                testID="close-console-button"
                 accessibilityRole="button"
                 accessibilityLabel="Close console"
                 activeOpacity={0.5}

--- a/apps/common-app/src/new_api/index.tsx
+++ b/apps/common-app/src/new_api/index.tsx
@@ -54,13 +54,13 @@ export const NEW_EXAMPLES: ExamplesSection[] = [
   {
     sectionTitle: 'Simple Gestures',
     data: [
-      { name: 'Fling', component: FlingExample },
-      { name: 'Tap', component: TapExample },
-      { name: 'LongPress', component: LongPressExample },
-      { name: 'Hover', component: HoverExample },
-      { name: 'Pinch', component: PinchExample },
-      { name: 'Rotation', component: RotationExample },
-      { name: 'Pan', component: PanExample },
+      { name: 'Basic Fling', component: FlingExample },
+      { name: 'Basic Tap', component: TapExample },
+      { name: 'Basic LongPress', component: LongPressExample },
+      { name: 'Basic Hover', component: HoverExample },
+      { name: 'Basic Pinch', component: PinchExample },
+      { name: 'Basic Rotation', component: RotationExample },
+      { name: 'Basic Pan', component: PanExample },
     ],
   },
   {


### PR DESCRIPTION
## Description

"Basic" examples were missing the "Basic" in their labels, making it harder to describe specific examples to e2e tests. Console interaction buttons were missing test ids.

## Test plan

Check Expo example