### PR TITLE
fix(Android): cancel button handlers when a native view takes the touch lock

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -366,9 +366,17 @@ class GestureHandlerOrchestrator(
   }
 
   /**
-   * Cancels all handlers created using API v1 and v2
+   * Cancels the handlers that lose to a native view taking the touch lock: the ones created using
+   * API v1 and v2, and the [NativeViewGestureHandler] a button manages for itself.
+   *
+   * The button's handler is attached with [GestureHandler.ACTION_TYPE_NONE] - it dispatches its
+   * events natively rather than through an action - so an action type check alone leaves it
+   * running. It has to be cancelled here as well, or a touch that a native view claims still ends
+   * the button handler and fires a press. The root view's own handler shares that action type and
+   * must keep running, hence the type check rather than a plain [GestureHandler.ACTION_TYPE_NONE]
+   * one.
    */
-  fun cancelAllLegacyHandlers() {
+  fun cancelHandlersLosingToNativeGesture() {
     val handlersToProcess = obtainHandlerList()
     handlersToProcess.addAll(gestureHandlers)
 
@@ -377,7 +385,8 @@ class GestureHandlerOrchestrator(
         if (it.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_OLD_API ||
           it.actionType == GestureHandler.ACTION_TYPE_JS_FUNCTION_NEW_API ||
           it.actionType == GestureHandler.ACTION_TYPE_REANIMATED_WORKLET ||
-          it.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT
+          it.actionType == GestureHandler.ACTION_TYPE_NATIVE_ANIMATED_EVENT ||
+          (it is NativeViewGestureHandler && it.actionType == GestureHandler.ACTION_TYPE_NONE)
         ) {
           it.cancel()
         }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -120,7 +120,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     if (orchestrator != null && !passingTouch) {
       // if we are in the process of delivering touch events via GH orchestrator, we don't want to
       // treat it as a native gesture capturing the lock
-      orchestrator.cancelAllLegacyHandlers()
+      orchestrator.cancelHandlersLosingToNativeGesture()
     }
   }
 


### PR DESCRIPTION
## Description

Fixes #4432

On Android, a `Pressable` fires `onPress` when the touch was only meant to stop a fling: put a finger down on a list row while the list decelerates, lift it without moving, and the row under the finger gets pressed.

`Pressable` without relation props renders `PressableWithTouchable`, which presses natively through `ButtonViewGroup`. The `NativeViewGestureHandler` the button manages for itself is attached with `ACTION_TYPE_NONE`, so it isn't cancelled when a native view takes the touch lock: `RNGestureHandlerRootHelper.requestDisallowInterceptTouchEvent()` calls `cancelAllLegacyHandlers()`, which only cancels the action-driven handlers (`JS_FUNCTION_OLD_API`, `JS_FUNCTION_NEW_API`, `REANIMATED_WORKLET`, `NATIVE_ANIMATED_EVENT`).

Android's `ScrollView` intercepts the `ACTION_DOWN` while its scroller is still running and calls `requestDisallowInterceptTouchEvent(true)` up the tree, so that path does run — the button handler just isn't part of what it cancels. It then reaches `STATE_END` on the finger lift and dispatches the press. The framework's own `ACTION_CANCEL` doesn't reach the button either, since RNGH delivers touches itself and ignores `onInterceptTouchEvent`.

This cancels `NativeViewGestureHandler`s attached with `ACTION_TYPE_NONE` as well. The root view's handler shares that action type but is not a `NativeViewGestureHandler`, so it keeps running and interception is unaffected.

The v2 `Pressable` went through `GestureDetector`, so its handlers carried a JS action type and were cancelled by this very path — `LegacyPressable` and `StatefulPressable` (any relation prop) are unaffected today, which is a decent A/B when checking the fix.

I also renamed `cancelAllLegacyHandlers` to `cancelHandlersLosingToNativeGesture`, since it no longer cancels only the legacy handlers — happy to drop the rename if you'd rather keep the diff minimal.

## Test plan

Repro app: a `FlatList` (from `react-native`) whose rows are wrapped in `Pressable` from `react-native-gesture-handler`, each row logging its `onPress`.

1. Fling the list hard.
2. While it decelerates, put a finger down on a row to stop the scroll.
3. Lift the finger without moving it.

Before: `onPress` fires for the row under the finger.
After: nothing fires, and a deliberate tap on a settled list still presses normally.
