### PR TITLE
[Docs] Add Privacy Policy link to the footer

### DIFF
--- a/packages/docs-gesture-handler/docusaurus.config.js
+++ b/packages/docs-gesture-handler/docusaurus.config.js
@@ -139,7 +139,7 @@ const config = {
         style: 'light',
         links: [],
         copyright:
-          'All trademarks and copyrights belong to their respective owners. Read about our ',
+          'All trademarks and copyrights belong to their respective owners.',
       },
       prism: {
         additionalLanguages: ['bash', 'groovy'],

--- a/packages/docs-gesture-handler/docusaurus.config.js
+++ b/packages/docs-gesture-handler/docusaurus.config.js
@@ -139,7 +139,7 @@ const config = {
         style: 'light',
         links: [],
         copyright:
-          'All trademarks and copyrights belong to their respective owners.',
+          'All trademarks and copyrights belong to their respective owners. Read about our ',
       },
       prism: {
         additionalLanguages: ['bash', 'groovy'],

--- a/packages/docs-gesture-handler/src/components/FooterBackground/styles.module.css
+++ b/packages/docs-gesture-handler/src/components/FooterBackground/styles.module.css
@@ -1,35 +1,35 @@
 .moonContainer {
   position: relative;
-  margin-top: 106px;
+  margin-top: 122px;
 }
 
 [class*='footerLanding'] {
-  margin-top: -106px;
+  margin-top: -122px;
 }
 
 @media (max-width: 996px) {
   .moonContainer {
-    margin-top: 121px;
+    margin-top: 138px;
   }
   [class*='footerLanding'] {
-    margin-top: -121px;
+    margin-top: -138px;
   }
 }
 
 @media (max-width: 700px) {
   .moonContainer {
-    margin-top: 147px;
+    margin-top: 164px;
   }
   [class*='footerLanding'] {
-    margin-top: -147px;
+    margin-top: -164px;
   }
 }
 
 @media (max-width: 376px) {
   .moonContainer {
-    margin-top: 173px;
+    margin-top: 189px;
   }
   [class*='footerLanding'] {
-    margin-top: -173px;
+    margin-top: -189px;
   }
 }

--- a/packages/docs-gesture-handler/src/css/overrides.css
+++ b/packages/docs-gesture-handler/src/css/overrides.css
@@ -208,3 +208,49 @@ button[class*='DocSearch-Button'] {
 [data-theme='light'] [class*='_badge_'][class*='_deprecated_'] {
   border-color: rgba(90, 100, 134, 0.26);
 }
+
+footer.footer {
+  --ifm-footer-padding-vertical: 35px;
+}
+
+@media (max-width: 996px) {
+  footer.footer {
+    --ifm-footer-padding-vertical: 20px;
+  }
+}
+
+@media (max-width: 768px) {
+  footer.footer {
+    --ifm-footer-padding-vertical: 15px;
+  }
+}
+
+footer .footer__bottom [class*='footer__copyright'] {
+  justify-content: center;
+  padding-bottom: var(--swm-footer-copyright-padding-bottom);
+}
+
+footer .footer__bottom [class*='footer__copyright'] p {
+  text-align: center;
+}
+
+footer .footer__bottom [class*='footer__copyright'] p a[data-privacy-policy] {
+  color: inherit;
+  cursor: pointer;
+  text-decoration: none;
+}
+
+footer
+  .footer__bottom
+  [class*='footer__copyright']
+  p
+  a[data-privacy-policy]:hover {
+  color: inherit;
+  text-decoration: none;
+}
+
+@media (max-width: 996px) {
+  footer .footer__bottom [class*='footer__copyright'] {
+    align-items: center;
+  }
+}

--- a/packages/docs-gesture-handler/src/theme/Footer/index.js
+++ b/packages/docs-gesture-handler/src/theme/Footer/index.js
@@ -10,11 +10,11 @@ export default function Footer(props) {
       return;
     }
 
-    paragraph.appendChild(document.createTextNode(' '));
+    paragraph.appendChild(document.createTextNode(' Read about our '));
     const link = document.createElement('a');
     link.href = PRIVACY_POLICY_URL;
     link.target = '_blank';
-    link.rel = 'noopener noreferrer';
+    link.rel = 'noopener';
     link.dataset.privacyPolicy = '';
     link.textContent = 'Privacy Policy';
     paragraph.appendChild(link);

--- a/packages/docs-gesture-handler/src/theme/Footer/index.js
+++ b/packages/docs-gesture-handler/src/theme/Footer/index.js
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import { Footer as TRexFooter } from '@swmansion/t-rex-ui';
+
+const PRIVACY_POLICY_URL = 'https://swmansion.com/privacy/policy/';
+
+export default function Footer(props) {
+  useEffect(() => {
+    const paragraph = document.querySelector('footer .footer__copyright p');
+    if (!paragraph || paragraph.querySelector('[data-privacy-policy]')) {
+      return;
+    }
+
+    paragraph.appendChild(document.createTextNode(' '));
+    const link = document.createElement('a');
+    link.href = PRIVACY_POLICY_URL;
+    link.target = '_blank';
+    link.rel = 'noopener noreferrer';
+    link.dataset.privacyPolicy = '';
+    link.textContent = 'Privacy Policy';
+    paragraph.appendChild(link);
+    paragraph.appendChild(document.createTextNode('.'));
+  }, []);
+
+  return <TRexFooter {...props} />;
+}


### PR DESCRIPTION
## Summary

* Adds a Privacy Policy link in the docs site footer
* Centers footer copyright content
* Fixes footer bottom padding and landing footer spacing across breakpoints

## Test Plan

- [ ] Confirm the footer shows the Privacy Policy link and opens `https://swmansion.com/privacy/policy/` in a new tab
- [ ] Check copyright text is centered on desktop and mobile
- [ ] Verify footer padding looks correct at common widths (desktop, tablet, phone)
- [ ] On the landing page, confirm footer/background spacing still lines up after the layout tweaks
<img width="1134" height="763" alt="image" src="https://github.com/user-attachments/assets/adf47d83-3aa0-4130-9d48-88682723871a" />
