### PR TITLE
Fix dead presses in `"never"` mode when the keyboard belongs to a native field

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -511,7 +511,13 @@ describe('[API v3] Components', () => {
       expect(TextInput.State.currentlyFocusedInput()).toBeNull();
       expect(isKeyboardDismissingTap(makeContext('never'))).toBe(false);
 
+      // Focus moving to an RN input while the keyboard stays up makes the
+      // tap dismissible again.
+      const focusSpy = focusInput();
+      expect(isKeyboardDismissingTap(makeContext('never'))).toBe(true);
+
       addListenerSpy.mockRestore();
+      focusSpy.mockRestore();
     });
 
     test('isKeyboardDismissingTap is false for a detached (height 0) keyboard', async () => {

--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -5,7 +5,7 @@ import {
   screen,
 } from '@testing-library/react-native';
 import { act } from 'react';
-import { Keyboard, View } from 'react-native';
+import { Keyboard, TextInput, View } from 'react-native';
 
 import GestureHandlerRootView from '../components/GestureHandlerRootView';
 import { fireGestureHandler, getByGestureTestId } from '../jestUtils';
@@ -454,8 +454,17 @@ describe('[API v3] Components', () => {
       keyboardShouldPersistTaps,
     });
 
+    // The drop requires a focused RN TextInput to blur.
+    const focusInput = () =>
+      jest
+        .spyOn(TextInput.State, 'currentlyFocusedInput')
+        .mockReturnValue(
+          {} as ReturnType<typeof TextInput.State.currentlyFocusedInput>
+        );
+
     test('isKeyboardDismissingTap is true only in never mode while the keyboard is visible', async () => {
       const addListenerSpy = jest.spyOn(Keyboard, 'addListener');
+      const focusSpy = focusInput();
 
       render(
         <GestureHandlerRootView>
@@ -476,6 +485,31 @@ describe('[API v3] Components', () => {
       expect(isKeyboardDismissingTap(makeContext('always'))).toBe(false);
       // Outside an RNGH ScrollView there is no context, so nothing is dropped.
       expect(isKeyboardDismissingTap(null)).toBe(false);
+
+      // The verdict must survive the dismissal blurring the input mid-tap.
+      focusSpy.mockReturnValue(undefined);
+      expect(isKeyboardDismissingTap(makeContext('never'))).toBe(true);
+
+      addListenerSpy.mockRestore();
+      focusSpy.mockRestore();
+    });
+
+    test('isKeyboardDismissingTap is false when no RN TextInput is focused (native field keyboard)', async () => {
+      const addListenerSpy = jest.spyOn(Keyboard, 'addListener');
+
+      render(
+        <GestureHandlerRootView>
+          <ScrollView keyboardShouldPersistTaps="never" />
+        </GestureHandlerRootView>
+      );
+      await act(flushImmediate);
+
+      // Keyboard up for a native field (e.g. a native-stack search bar) -
+      // no RN TextInput to blur, so the tap must not be dropped.
+      showKeyboard(addListenerSpy);
+
+      expect(TextInput.State.currentlyFocusedInput()).toBeNull();
+      expect(isKeyboardDismissingTap(makeContext('never'))).toBe(false);
 
       addListenerSpy.mockRestore();
     });
@@ -500,6 +534,7 @@ describe('[API v3] Components', () => {
 
     test('Touchable does NOT fire any press callback on the keyboard-dismissing tap (never)', async () => {
       const addListenerSpy = jest.spyOn(Keyboard, 'addListener');
+      const focusSpy = focusInput();
       const onPress = jest.fn();
       const onPressIn = jest.fn();
       const onPressOut = jest.fn();
@@ -519,6 +554,10 @@ describe('[API v3] Components', () => {
       await act(flushImmediate);
       showKeyboard(addListenerSpy);
 
+      // The 'never' responder blurs the input at touch-down, before the
+      // press events arrive - mirror that ordering.
+      focusSpy.mockReturnValue(undefined);
+
       // Includes a re-entry PressIn (finger dragged out and back in) so the
       // capture-once verdict path is exercised too.
       const button = screen.getByTestId('touchable');
@@ -535,6 +574,7 @@ describe('[API v3] Components', () => {
       expect(onPressIn).not.toHaveBeenCalled();
       expect(onPressOut).not.toHaveBeenCalled();
       addListenerSpy.mockRestore();
+      focusSpy.mockRestore();
     });
 
     test('Touchable fires onPress in never mode when the keyboard is not visible', async () => {

--- a/packages/react-native-gesture-handler/src/v3/scrollViewInterop.ts
+++ b/packages/react-native-gesture-handler/src/v3/scrollViewInterop.ts
@@ -1,4 +1,5 @@
 import * as React from 'react';
+import { TextInput } from 'react-native';
 
 export type KeyboardShouldPersistTaps =
   | boolean
@@ -27,9 +28,15 @@ export function updateResponderEventValue(
 }
 
 let isKeyboardVisible = false;
+let keyboardOpenedForRNInput = false;
 
 export function setKeyboardVisibility(visible: boolean) {
   isKeyboardVisible = visible;
+
+  // Snapshotted at show-time: the dismissal blurs the input at touch-down,
+  // before the press events get checked
+  keyboardOpenedForRNInput =
+    visible && TextInput.State.currentlyFocusedInput?.() != null;
 }
 
 export function isKeyboardDismissingTap(
@@ -42,5 +49,14 @@ export function isKeyboardDismissingTap(
   const mode = jsResponderContext.keyboardShouldPersistTaps;
   const keyboardNeverPersistTaps = !mode || mode === 'never';
 
-  return keyboardNeverPersistTaps && isKeyboardVisible;
+  // Drop only taps that can dismiss the keyboard, i.e. an RN TextInput is (or
+  // was at show-time) focused - mirrors RN ScrollView's `_keyboardIsDismissible`.
+  // A native field's keyboard (e.g. a native-stack search bar) can't be
+  // blurred, so dropping there would leave presses permanently dead
+  return (
+    keyboardNeverPersistTaps &&
+    isKeyboardVisible &&
+    (keyboardOpenedForRNInput ||
+      TextInput.State.currentlyFocusedInput?.() != null)
+  );
 }


### PR DESCRIPTION
## Description

With a Gesture Handler `ScrollView` in the default (`never`) `keyboardShouldPersistTaps` mode, a keyboard opened by a native field (e.g. a native-stack `headerSearchBarOptions` search bar) made every RNGH `Pressable`/`Touchable` inside dead, with no way to dismiss the keyboard by tapping. The keyboard-dismissing tap drop (#992) checks only keyboard visibility, but the dismissal blurs `TextInput.State.currentlyFocusedInput()`, which is `null` for native fields - the tap was consumed while nothing could be dismissed.

Now the tap is dropped only when an RN `TextInput` is focused, mirroring RN ScrollView's `_keyboardIsDismissible`. Focus is snapshotted when the keyboard shows, since the dismissal blurs the input at touch-down, before the press events are checked; a live check is OR-ed in for focus moving to an RN input while the keyboard is already up. With a native-field keyboard, presses now behave like RN's `Pressable`: they fire and the keyboard stays.


## Test plan

- `yarn test` — added cases: no drop when the keyboard is up without a focused RN input; the drop verdict survives the input being blurred mid-tap; existing `never`-drop tests updated to mock a focused input.
- iOS simulator and Android emulator, repro below with RNGH and RN `Pressable` side by side:
  - search bar active: both fire, keyboard stays (previously the RNGH one was dead)
  - RN `TextInput` focused: both are dropped and the tap dismisses the keyboard (#992 behavior unchanged)

<details>
<summary>Repro</summary>

```tsx
import React, { useState } from 'react';
import { Pressable as RNPressable, StyleSheet, Text, TextInput, View } from 'react-native';
import { NavigationContainer, NavigationIndependentTree } from '@react-navigation/native';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import { Pressable, ScrollView } from 'react-native-gesture-handler';

const ROUTES = ['12', '17', '25', '42', '58', '73', '81', '99'];

function RoutesScreen() {
  const [pressCount, setPressCount] = useState(0);
  const [lastPressed, setLastPressed] = useState<string | null>(null);

  const press = (label: string) => () => {
    setPressCount((c) => c + 1);
    setLastPressed(label);
  };

  return (
    <ScrollView contentInsetAdjustmentBehavior="automatic">
      <TextInput placeholder="RN TextInput (control)" style={styles.input} />
      <Text style={styles.status}>
        {`onPress count: ${pressCount}` + (lastPressed ? ` (last: ${lastPressed})` : '')}
      </Text>
      {ROUTES.map((route) => (
        <View key={route} style={styles.routeRow}>
          <Pressable style={styles.row} onPress={press(`GH ${route}`)}>
            <Text>{`GH ${route}`}</Text>
          </Pressable>
          <RNPressable style={styles.row} onPress={press(`RN ${route}`)}>
            <Text>{`RN ${route}`}</Text>
          </RNPressable>
        </View>
      ))}
    </ScrollView>
  );
}

const Stack = createNativeStackNavigator();

export default function Example() {
  return (
    <NavigationIndependentTree>
      <NavigationContainer>
        <Stack.Navigator>
          <Stack.Screen
            name="Routes"
            component={RoutesScreen}
            options={{
              headerSearchBarOptions: { placeholder: 'Search routes', hideWhenScrolling: false },
            }}
          />
        </Stack.Navigator>
      </NavigationContainer>
    </NavigationIndependentTree>
  );
}

const styles = StyleSheet.create({
  status: { fontSize: 16, fontWeight: 'bold', padding: 16 },
  input: { borderColor: '#ccd', borderRadius: 8, borderWidth: 1, margin: 16, padding: 12 },
  routeRow: { flexDirection: 'row', gap: 8, marginHorizontal: 16, marginVertical: 4 },
  row: { backgroundColor: '#eef', borderRadius: 8, flex: 1, padding: 16 },
});
```

</details>