### PR TITLE
[iOS] Detach handlers when the detector view is recycled

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
@@ -45,7 +45,7 @@
 - (void)willMoveToWindow:(RNGHWindow *)newWindow
 {
   if (newWindow == nil) {
-    [self detachAndCleanupHandlers];
+    [self detachAllHandlers];
   } else {
     const auto &props = *std::static_pointer_cast<const RNGestureHandlerDetectorProps>(_props);
     [self attachHandlers:props.handlerTags
@@ -59,14 +59,20 @@
 // Detaching in `willMoveToWindow:` alone is not enough - a detector unmounted while
 // its ancestor is already off-window (e.g. an inactive screen) never gets that call,
 // and would enter the recycle pool still carrying recognizers of live handlers.
-- (void)detachAndCleanupHandlers
+- (void)detachAllHandlers
 {
   if (_moduleId == -1) {
     return;
   }
 
   RNGestureHandlerManager *handlerManager = [RNGestureHandlerModule handlerManagerForModuleId:_moduleId];
-  react_native_assert(handlerManager != nullptr && "Tried to access a non-existent handler manager");
+  if (handlerManager == nil) {
+    // A nil manager for a known moduleId means the module was invalidated mid-teardown
+    // and there is nothing left to clean up. An unknown moduleId is a real bug.
+    react_native_assert(
+        [RNGestureHandlerModule hasModuleWithId:_moduleId] && "Tried to access a non-existent handler manager");
+    return;
+  }
 
   [handlerManager.registry cancelAllObservationsForOwner:self];
 
@@ -154,7 +160,7 @@
 {
   [super prepareForRecycle];
 
-  [self detachAndCleanupHandlers];
+  [self detachAllHandlers];
   [self setDefaultProps];
 }
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerDetector.mm
@@ -42,24 +42,10 @@
   return self;
 }
 
-// TODO: I'm not sure whether this is the correct place for cleanup
-// Possibly allowing recycling and doing this in prepareForRecycle would be better
 - (void)willMoveToWindow:(RNGHWindow *)newWindow
 {
   if (newWindow == nil) {
-    RNGestureHandlerManager *handlerManager = [RNGestureHandlerModule handlerManagerForModuleId:_moduleId];
-    react_native_assert(handlerManager != nullptr && "Tried to access a non-existent handler manager");
-
-    [handlerManager.registry cancelAllObservationsForOwner:self];
-
-    for (NSNumber *handlerTag in _attachedHandlers) {
-      [handlerManager.registry detachHandlerWithTag:handlerTag fromHostDetector:self];
-    }
-
-    [_attachedHandlers removeAllObjects];
-    _subscribedVirtualHandlers.clear();
-    [_subscribedHandlers removeAllObjects];
-    [_nativeHandlers removeAllObjects];
+    [self detachAndCleanupHandlers];
   } else {
     const auto &props = *std::static_pointer_cast<const RNGestureHandlerDetectorProps>(_props);
     [self attachHandlers:props.handlerTags
@@ -68,6 +54,30 @@
         subscribedHandlers:_subscribedHandlers];
     [self updateVirtualChildren:props.virtualChildren];
   }
+}
+
+// Detaching in `willMoveToWindow:` alone is not enough - a detector unmounted while
+// its ancestor is already off-window (e.g. an inactive screen) never gets that call,
+// and would enter the recycle pool still carrying recognizers of live handlers.
+- (void)detachAndCleanupHandlers
+{
+  if (_moduleId == -1) {
+    return;
+  }
+
+  RNGestureHandlerManager *handlerManager = [RNGestureHandlerModule handlerManagerForModuleId:_moduleId];
+  react_native_assert(handlerManager != nullptr && "Tried to access a non-existent handler manager");
+
+  [handlerManager.registry cancelAllObservationsForOwner:self];
+
+  for (NSNumber *handlerTag in _attachedHandlers) {
+    [handlerManager.registry detachHandlerWithTag:handlerTag fromHostDetector:self];
+  }
+
+  [_attachedHandlers removeAllObjects];
+  _subscribedVirtualHandlers.clear();
+  [_subscribedHandlers removeAllObjects];
+  [_nativeHandlers removeAllObjects];
 }
 
 - (void)setDefaultProps
@@ -144,6 +154,7 @@
 {
   [super prepareForRecycle];
 
+  [self detachAndCleanupHandlers];
   [self setDefaultProps];
 }
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.h
@@ -10,9 +10,6 @@
     : RCTEventEmitter <NativeRNGestureHandlerModuleSpec, RCTJSDispatcherModule, RCTInitializing>
 
 + (RNGestureHandlerManager *)handlerManagerForModuleId:(int)moduleId;
-
-// Whether a module with this id was ever registered. The manager may still be nil
-// after the module is invalidated - invalidation nulls the entry without erasing it.
 + (BOOL)hasModuleWithId:(int)moduleId;
 
 @end

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.h
@@ -11,4 +11,8 @@
 
 + (RNGestureHandlerManager *)handlerManagerForModuleId:(int)moduleId;
 
+// Whether a module with this id was ever registered. The manager may still be nil
+// after the module is invalidated - invalidation nulls the entry without erasing it.
++ (BOOL)hasModuleWithId:(int)moduleId;
+
 @end

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.mm
@@ -50,7 +50,14 @@ static std::unordered_map<int, RNGestureHandlerManager *> _managers;
 
 + (RNGestureHandlerManager *)handlerManagerForModuleId:(int)moduleId
 {
-  return _managers[moduleId];
+  // Not operator[] - that would insert a null entry on a miss.
+  const auto it = _managers.find(moduleId);
+  return it == _managers.end() ? nil : it->second;
+}
+
++ (BOOL)hasModuleWithId:(int)moduleId
+{
+  return _managers.find(moduleId) != _managers.end();
 }
 
 RCT_EXPORT_MODULE()

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.mm
@@ -70,6 +70,11 @@ RCT_EXPORT_MODULE()
 - (void)invalidate
 {
   RNGestureHandlerManager *handlerManager = [RNGestureHandlerModule handlerManagerForModuleId:_moduleId];
+
+  // Clear observations before the entry is nulled - the async drop below keeps the registry
+  // alive for one main-queue hop, and dropAllHandlers does not touch them.
+  [handlerManager.registry removeAllObservations];
+
   dispatch_async(dispatch_get_main_queue(), ^{
     [handlerManager dropAllGestureHandlers];
   });

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.h
@@ -33,6 +33,7 @@ typedef void (^RNGestureHandlerReadyBlock)(RNGestureHandler *_Nonnull handler);
 
 - (void)cancelObservationForTag:(nonnull NSNumber *)handlerTag owner:(nonnull id)owner;
 - (void)cancelAllObservationsForOwner:(nonnull id)owner;
+- (void)removeAllObservations;
 
 @property (nonatomic, readonly, nonnull) NSDictionary<NSNumber *, RNGestureHandler *> *handlers;
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.m
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerRegistry.m
@@ -97,6 +97,13 @@
   }
 }
 
+- (void)removeAllObservations
+{
+  @synchronized(_handlers) {
+    [_observers removeAllObjects];
+  }
+}
+
 - (void)attachHandlerWithTag:(NSNumber *)handlerTag
                       toView:(RNGHUIView *)view
               withActionType:(RNGestureHandlerActionType)actionType


### PR DESCRIPTION
## Description

`RNGestureHandlerDetector` detaches its handlers and cancels registry observations only in `willMoveToWindow:` when the new window is `nil`. `UIKit` sends that callback only when the view's window actually changes, so a detector that is unmounted while its ancestor is already detached from the window (e.g. an inactive native-stack screen) never receives it. The view then enters Fabric's recycle pool still carrying the recognizers of live handlers and their `hostDetectorView` bindings - `prepareForRecycle` only reset the bookkeeping sets, and the base `RCTViewComponentView` implementation doesn't remove gesture recognizers.

When such a view is reused for a different `GestureDetector`, the stale handler's events are emitted through the new detector's event emitter. If the new detector is a plain one, this throws

```
Expected onGestureHandlerReanimatedEvent listener to be a function, instead got a value of 'object' type
```

 on every gesture frame (the visible half of #4428, see also #4429 which addresses the invalid prop itself). If the new detector is a Reanimated one, the foreign events are silently misrouted instead.

This PR moves the cleanup into `detachAndCleanupHandlers` and calls it from both `willMoveToWindow:` and `prepareForRecycle`. The method is idempotent and skips views that were never configured (`moduleId == -1`), so the common path where `willMoveToWindow:` already ran is a no-op. This also makes iOS consistent with Android, where `onDropViewInstance` already calls `detachAllHandlers()` on unmount regardless of window state, which is why Android is not affected.

## Test plan

- Ran the repro above on the iPhone 17 Pro simulator (iOS 26.4, expo-example, Fabric): before the change the error is thrown on every gesture frame, after the change the flow is clean in repeated runs.
- Checked the regular paths on the same build: Fling and Tap examples, screen push/pop (the `willMoveToWindow:` detach/reattach cycle), Pressable rows and ScrollView on the examples list.


<details>
<summary>Tested on the following code:</summary>

```tsx
import React, { useEffect, useRef, useState } from 'react';
import { Button, StyleSheet, Text, View } from 'react-native';
import {
  NavigationContainer,
  NavigationIndependentTree,
  useNavigation,
} from '@react-navigation/native';
import { createNativeStackNavigator } from '@react-navigation/native-stack';
import {
  GestureDetector,
  usePanGesture,
  useTapGesture,
} from 'react-native-gesture-handler';

// Repro for the visible half of #4428: a handler emitting through a detector
// that is not its own. A worklet pan detector is mounted and unmounted while
// its screen is detached from the window (inactive native-stack screen), so
// RNGestureHandlerDetector's willMoveToWindow:nil cleanup never runs. The
// detector view goes to Fabric's recycle pool still carrying the pan
// recognizer and hostDetectorView binding. A plain-gesture detector mounted
// afterwards recycles that view; panning on it should emit
// onGestureHandlerReanimatedEvent into the plain HostGestureDetector, whose
// prop is Reanimated's handler object -> "Expected onGestureHandlerReanimatedEvent
// listener to be a function" on every frame.

const Stack = createNativeStackNavigator();

function ReproScreen() {
  const navigation = useNavigation<any>();
  const [phase, setPhase] = useState('idle');
  const [showPan, setShowPan] = useState(false);
  const [showTarget, setShowTarget] = useState(false);
  const timers = useRef<ReturnType<typeof setTimeout>[]>([]);

  // Worklet callback -> shouldUseReanimatedDetector=true,
  // dispatchesReanimatedEvents=true on the native handler.
  const pan = usePanGesture({
    onUpdate: (e) => {
      'worklet';
      console.log('pan onUpdate (worklet)', e.translationX);
    },
  });

  // No callbacks: any callback here gets auto-workletized by babel (even when
  // passed by reference), which would flip this to ReanimatedNativeDetector.
  // Callback-less tap keeps the plain HostGestureDetector with the object prop,
  // same as the issue's useNativeGesture() case.
  const tap = useTapGesture({});

  useEffect(() => {
    return () => timers.current.forEach(clearTimeout);
  }, []);

  const at = (ms: number, fn: () => void) => {
    timers.current.push(setTimeout(fn, ms));
  };

  const start = () => {
    setShowPan(false);
    setShowTarget(false);
    setPhase('pushed cover screen');
    navigation.navigate('Cover');
    at(800, () => {
      setPhase('pan detector mounted (detached)');
      setShowPan(true);
    });
    at(1600, () => {
      setPhase('pan detector unmounted (detached) -> dirty pool');
      setShowPan(false);
    });
    at(2400, () => {
      setPhase('popped back');
      navigation.goBack();
    });
    at(3200, () => {
      setPhase('target mounted - PAN ON THE BLUE BOX');
      setShowTarget(true);
    });
  };

  return (
    <View style={styles.container}>
      <Button title="Start repro" onPress={start} />
      <Text style={styles.status}>{phase}</Text>
      {showPan && (
        <GestureDetector gesture={pan}>
          <View style={[styles.box, styles.red]} />
        </GestureDetector>
      )}
      {showTarget && (
        <GestureDetector gesture={tap}>
          <View style={[styles.box, styles.blue]} />
        </GestureDetector>
      )}
    </View>
  );
}

function CoverScreen() {
  return (
    <View style={styles.container}>
      <Text style={styles.status}>
        Cover screen - the repro screen is now detached from the window.
      </Text>
    </View>
  );
}

export default function EmptyExample() {
  return (
    <NavigationIndependentTree>
      <NavigationContainer>
        <Stack.Navigator>
          <Stack.Screen name="Repro" component={ReproScreen} />
          <Stack.Screen name="Cover" component={CoverScreen} />
        </Stack.Navigator>
      </NavigationContainer>
    </NavigationIndependentTree>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    alignItems: 'center',
    gap: 20,
    paddingTop: 40,
  },
  status: {
    fontSize: 16,
    paddingHorizontal: 20,
    textAlign: 'center',
  },
  box: {
    width: 220,
    height: 220,
    borderRadius: 12,
  },
  red: {
    backgroundColor: 'crimson',
  },
  blue: {
    backgroundColor: 'steelblue',
  },
});
```

</details>