### PR TITLE
Add issue triage comments workflow

### DIFF
--- a/.github/scripts/issue-triage-comments.js
+++ b/.github/scripts/issue-triage-comments.js
@@ -6,12 +6,12 @@
 //
 // Invoked from .github/workflows/issue-triage-comments.yml via actions/github-script.
 
+const greeting = (author) => `Hey @${author}! 👋`;
+
 const RESPONSES = {
   'Missing repro': {
     marker: '<!-- rngh-triage:missing-repro -->',
     body: [
-      'Hey! 👋',
-      '',
       "The issue doesn't seem to contain a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example).",
       '',
       'Could you provide a [snack](https://snack.expo.dev/), a [gist](https://gist.github.com/) or a link to a GitHub repository that reproduces the problem?',
@@ -20,8 +20,6 @@ const RESPONSES = {
   'Missing info': {
     marker: '<!-- rngh-triage:missing-info -->',
     body: [
-      'Hey! 👋',
-      '',
       'Some of the required information in this issue is missing, incomplete or invalid. Could you take another look at the template and make sure each of these is filled in with something we can act on?',
       '',
       '- **Description** - what happens, and what you expected to happen instead',
@@ -82,7 +80,7 @@ module.exports = async ({ github, context, core }) => {
     await github.rest.issues.createComment({
       ...context.repo,
       issue_number: issue.number,
-      body: `${response.marker}\n${response.body}`,
+      body: `${response.marker}\n${greeting(issue.user.login)}\n\n${response.body}`,
     });
 
     core.notice(`Posted "${label.name}" response.`);

--- a/.github/scripts/issue-triage-comments.js
+++ b/.github/scripts/issue-triage-comments.js
@@ -1,0 +1,110 @@
+// Turns the triage labels applied by CodeRabbit into comments, replacing the
+// responses that used to be sent by software-mansion-labs/swmansion-bot.
+//
+// One comment per label: a run only ever touches the comment belonging to the
+// label that triggered it.
+//
+// Invoked from .github/workflows/issue-triage-comments.yml via actions/github-script.
+
+const RESPONSES = {
+  'Missing repro': {
+    marker: '<!-- rngh-triage:missing-repro -->',
+    body: [
+      'Hey! 👋',
+      '',
+      "The issue doesn't seem to contain a [minimal reproduction](https://stackoverflow.com/help/minimal-reproducible-example).",
+      '',
+      'Could you provide a [snack](https://snack.expo.dev/), a [gist](https://gist.github.com/) or a link to a GitHub repository that reproduces the problem?',
+    ].join('\n'),
+  },
+  'Missing info': {
+    marker: '<!-- rngh-triage:missing-info -->',
+    body: [
+      'Hey! 👋',
+      '',
+      'Some of the required information in this issue is missing, incomplete or invalid. Could you take another look at the template and make sure each of these is filled in with something we can act on?',
+      '',
+      '- **Description** - what happens, and what you expected to happen instead',
+      '- **Steps to reproduce** - steps somebody else can follow, not just numbering',
+      '- **Gesture Handler version** - the exact version from your `package.json` or lockfile',
+      '- **React Native version** - the exact version from your `package.json` or lockfile',
+      '- **Versions of related libraries** you mention (Reanimated, Worklets, Screens, Expo) - the versions actually installed',
+      '- **Platforms** - the platforms you actually see the bug on',
+      '',
+      'Once the issue is updated we will take another look. Thanks!',
+    ].join('\n'),
+  },
+};
+
+// Mirrors `check-issues-only-created-after` from the old bot.
+const IGNORE_ISSUES_CREATED_BEFORE = '2022-02-01';
+
+// Maintainers apply this when opening an issue and are not nagged about it.
+const MAINTAINER_LABEL = 'Maintainer issue';
+
+module.exports = async ({ github, context, core }) => {
+  const { issue, label, action } = context.payload;
+  const response = RESPONSES[label?.name];
+
+  if (!response) {
+    core.notice(`No response configured for "${label?.name}". Skipping.`);
+    return;
+  }
+
+  if (issue.pull_request) {
+    core.notice('Triggered on a pull request. Skipping.');
+    return;
+  }
+
+  if (issue.state === 'closed') {
+    core.notice('Triggered on a closed issue. Skipping.');
+    return;
+  }
+
+  if (new Date(issue.created_at) < new Date(IGNORE_ISSUES_CREATED_BEFORE)) {
+    core.notice(`Issue predates ${IGNORE_ISSUES_CREATED_BEFORE}. Skipping.`);
+    return;
+  }
+
+  if (issue.labels.some(({ name }) => name === MAINTAINER_LABEL)) {
+    core.notice(`Issue is labelled "${MAINTAINER_LABEL}". Skipping.`);
+    return;
+  }
+
+  const existing = await findResponse({ github, context, issue, marker: response.marker });
+
+  if (action === 'labeled') {
+    if (existing) {
+      core.notice('Response already posted. Skipping.');
+      return;
+    }
+
+    await github.rest.issues.createComment({
+      ...context.repo,
+      issue_number: issue.number,
+      body: `${response.marker}\n${response.body}`,
+    });
+
+    core.notice(`Posted "${label.name}" response.`);
+    return;
+  }
+
+  // Label removed - retract the response, as the old bot did.
+  if (!existing) {
+    core.notice('No response to retract. Skipping.');
+    return;
+  }
+
+  await github.rest.issues.deleteComment({ ...context.repo, comment_id: existing.id });
+  core.notice(`Retracted "${label.name}" response.`);
+};
+
+async function findResponse({ github, context, issue, marker }) {
+  const comments = await github.paginate(github.rest.issues.listComments, {
+    ...context.repo,
+    issue_number: issue.number,
+    per_page: 100,
+  });
+
+  return comments.find((comment) => comment.user.type === 'Bot' && comment.body.includes(marker));
+}

--- a/.github/scripts/issue-triage-comments.js
+++ b/.github/scripts/issue-triage-comments.js
@@ -54,6 +54,22 @@ module.exports = async ({ github, context, core }) => {
     return;
   }
 
+  // Retraction runs before the checks below: those decide whether to nag, not
+  // whether to clean up. A response must still be removed when the issue was
+  // closed or labelled `Maintainer issue` after it was posted.
+  if (action === 'unlabeled') {
+    const posted = await findResponse({ github, context, issue, marker: response.marker });
+
+    if (!posted) {
+      core.notice('No response to retract. Skipping.');
+      return;
+    }
+
+    await github.rest.issues.deleteComment({ ...context.repo, comment_id: posted.id });
+    core.notice(`Retracted "${label.name}" response.`);
+    return;
+  }
+
   if (issue.state === 'closed') {
     core.notice('Triggered on a closed issue. Skipping.');
     return;
@@ -71,30 +87,18 @@ module.exports = async ({ github, context, core }) => {
 
   const existing = await findResponse({ github, context, issue, marker: response.marker });
 
-  if (action === 'labeled') {
-    if (existing) {
-      core.notice('Response already posted. Skipping.');
-      return;
-    }
-
-    await github.rest.issues.createComment({
-      ...context.repo,
-      issue_number: issue.number,
-      body: `${response.marker}\n${greeting(issue.user.login)}\n\n${response.body}`,
-    });
-
-    core.notice(`Posted "${label.name}" response.`);
+  if (existing) {
+    core.notice('Response already posted. Skipping.');
     return;
   }
 
-  // Label removed - retract the response, as the old bot did.
-  if (!existing) {
-    core.notice('No response to retract. Skipping.');
-    return;
-  }
+  await github.rest.issues.createComment({
+    ...context.repo,
+    issue_number: issue.number,
+    body: `${response.marker}\n${greeting(issue.user.login)}\n\n${response.body}`,
+  });
 
-  await github.rest.issues.deleteComment({ ...context.repo, comment_id: existing.id });
-  core.notice(`Retracted "${label.name}" response.`);
+  core.notice(`Posted "${label.name}" response.`);
 };
 
 async function findResponse({ github, context, issue, marker }) {

--- a/.github/workflows/issue-triage-comments.yml
+++ b/.github/workflows/issue-triage-comments.yml
@@ -1,0 +1,33 @@
+name: Issue triage comments
+
+on:
+  issues:
+    types: [labeled, unlabeled]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  comment:
+    if: >-
+      ${{ github.repository == 'software-mansion/react-native-gesture-handler'
+      && contains(fromJSON('["Missing repro", "Missing info"]'), github.event.label.name) }}
+    runs-on: ubuntu-latest
+    concurrency:
+      group: triage-comment-${{ github.event.issue.number }}
+      cancel-in-progress: false
+
+    steps:
+      - name: Checkout triage script
+        uses: actions/checkout@v4
+        with:
+          sparse-checkout: .github/scripts
+          sparse-checkout-cone-mode: false
+
+      - name: Post or retract triage response
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const triage = require(`${process.env.GITHUB_WORKSPACE}/.github/scripts/issue-triage-comments.js`);
+            await triage({ github, context, core });


### PR DESCRIPTION
## Description

Adds a workflow that posts triage comments based on issue labels. Labels are now applied by @coderabbitai, which only replies when @-mentioned and so cannot post them itself.

Removes `needs-repro.yml`, `needs-more-info.yml` and `platforms.yml`, which previously did both the labeling and the commenting. They are already disabled in the repository settings. `close-when-stale.yml` is unchanged.

## Test plan

Workflows only run from the default branch, so after merge: open an issue with no reproduction and confirm the comment appears, then remove the label and confirm it is deleted.
