### PR TITLE
Flatten same-type nested compositions in `useComposedGesture`

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/RelationsTraversal.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/RelationsTraversal.test.tsx
@@ -8,7 +8,10 @@ import {
   useSimultaneousGestures,
 } from '../v3/hooks/composition';
 import { useGesture } from '../v3/hooks/useGesture';
-import type { SingleGesture } from '../v3/types';
+import type {
+  GestureHandlerEventWithHandlerData,
+  SingleGesture,
+} from '../v3/types';
 import { SingleGestureName } from '../v3/types';
 
 type AnySingleGesture = SingleGesture<unknown, unknown, unknown>;
@@ -634,6 +637,31 @@ describe('Same-type composition flattening', () => {
     expect(pan4.gestureRelations.simultaneousHandlers.sort()).toStrictEqual(
       [pan1.handlerTag, pan2.handlerTag, pan3.handlerTag].sort()
     );
+  });
+
+  test('JS event handler dispatches to inlined leaves in composition order', () => {
+    const inner = renderHook(() => useSimultaneousGestures(pan2, pan3)).result
+      .current;
+    const outer = renderHook(() => useSimultaneousGestures(pan1, inner, pan4))
+      .result.current;
+
+    const order: number[] = [];
+    for (const pan of [pan1, pan2, pan3, pan4]) {
+      pan.detectorCallbacks.jsEventHandler = () => {
+        order.push(pan.handlerTag);
+      };
+    }
+
+    outer.detectorCallbacks.jsEventHandler?.(
+      {} as GestureHandlerEventWithHandlerData<unknown, unknown>
+    );
+
+    expect(order).toStrictEqual([
+      pan1.handlerTag,
+      pan2.handlerTag,
+      pan3.handlerTag,
+      pan4.handlerTag,
+    ]);
   });
 
   test('Duplicate gestures are still detected after inlining', () => {

--- a/packages/react-native-gesture-handler/src/__tests__/RelationsTraversal.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/RelationsTraversal.test.tsx
@@ -464,6 +464,190 @@ describe('Complex relations with external gestures', () => {
   });
 });
 
+describe('Same-type composition flattening', () => {
+  let pan1: AnySingleGesture,
+    pan2: AnySingleGesture,
+    pan3: AnySingleGesture,
+    pan4: AnySingleGesture;
+
+  beforeEach(() => {
+    [pan1, pan2, pan3, pan4] = Array.from(
+      { length: 4 },
+      () =>
+        renderHook(() =>
+          useGesture(SingleGestureName.Pan, { disableReanimated: true })
+        ).result.current
+    );
+  });
+
+  test('Nested Simultaneous is inlined', () => {
+    const inner = renderHook(() => useSimultaneousGestures(pan2, pan3)).result
+      .current;
+    const outer = renderHook(() => useSimultaneousGestures(pan1, inner)).result
+      .current;
+
+    expect(outer.gestures).toStrictEqual([pan1, pan2, pan3]);
+
+    configureRelations(outer);
+
+    expect(pan1.gestureRelations.simultaneousHandlers.sort()).toStrictEqual(
+      [pan2.handlerTag, pan3.handlerTag].sort()
+    );
+    expect(pan2.gestureRelations.simultaneousHandlers.sort()).toStrictEqual(
+      [pan1.handlerTag, pan3.handlerTag].sort()
+    );
+    expect(pan3.gestureRelations.simultaneousHandlers.sort()).toStrictEqual(
+      [pan1.handlerTag, pan2.handlerTag].sort()
+    );
+  });
+
+  test('Nested Exclusive is inlined and produces no repeated waitFor entries', () => {
+    const inner = renderHook(() => useExclusiveGestures(pan2, pan3)).result
+      .current;
+    const outer = renderHook(() => useExclusiveGestures(pan1, inner, pan4))
+      .result.current;
+
+    expect(outer.gestures).toStrictEqual([pan1, pan2, pan3, pan4]);
+
+    configureRelations(outer);
+
+    expect(pan1.gestureRelations.waitFor).toStrictEqual([]);
+    expect(pan2.gestureRelations.waitFor).toStrictEqual([pan1.handlerTag]);
+    expect(pan3.gestureRelations.waitFor).toStrictEqual([
+      pan1.handlerTag,
+      pan2.handlerTag,
+    ]);
+    expect(pan4.gestureRelations.waitFor).toStrictEqual([
+      pan1.handlerTag,
+      pan2.handlerTag,
+      pan3.handlerTag,
+    ]);
+  });
+
+  test('Multiple levels of nesting are inlined', () => {
+    const level1 = renderHook(() => useSimultaneousGestures(pan1, pan2)).result
+      .current;
+    const level2 = renderHook(() => useSimultaneousGestures(level1, pan3))
+      .result.current;
+    const level3 = renderHook(() => useSimultaneousGestures(level2, pan4))
+      .result.current;
+
+    expect(level2.gestures).toStrictEqual([pan1, pan2, pan3]);
+    expect(level3.gestures).toStrictEqual([pan1, pan2, pan3, pan4]);
+  });
+
+  test('Multiple same-type compositions at the same level are inlined', () => {
+    const inner1 = renderHook(() => useExclusiveGestures(pan1, pan2)).result
+      .current;
+    const inner2 = renderHook(() => useExclusiveGestures(pan3, pan4)).result
+      .current;
+    const outer = renderHook(() => useExclusiveGestures(inner1, inner2)).result
+      .current;
+
+    expect(outer.gestures).toStrictEqual([pan1, pan2, pan3, pan4]);
+
+    configureRelations(outer);
+
+    expect(pan1.gestureRelations.waitFor).toStrictEqual([]);
+    expect(pan2.gestureRelations.waitFor).toStrictEqual([pan1.handlerTag]);
+    expect(pan3.gestureRelations.waitFor).toStrictEqual([
+      pan1.handlerTag,
+      pan2.handlerTag,
+    ]);
+    expect(pan4.gestureRelations.waitFor).toStrictEqual([
+      pan1.handlerTag,
+      pan2.handlerTag,
+      pan3.handlerTag,
+    ]);
+  });
+
+  test('Same-type composition nested under a different type is kept but stays flat', () => {
+    const simultaneous = renderHook(() => useSimultaneousGestures(pan1, pan2))
+      .result.current;
+    const exclusive = renderHook(() => useExclusiveGestures(simultaneous, pan3))
+      .result.current;
+    const outer = renderHook(() => useExclusiveGestures(exclusive, pan4)).result
+      .current;
+
+    // `exclusive` is inlined into `outer`, `simultaneous` is kept as a subtree.
+    expect(outer.gestures).toStrictEqual([simultaneous, pan3, pan4]);
+
+    configureRelations(outer);
+
+    expect(pan1.gestureRelations.simultaneousHandlers).toStrictEqual([
+      pan2.handlerTag,
+    ]);
+    expect(pan3.gestureRelations.waitFor).toStrictEqual([
+      pan1.handlerTag,
+      pan2.handlerTag,
+    ]);
+    expect(pan4.gestureRelations.waitFor).toStrictEqual([
+      pan1.handlerTag,
+      pan2.handlerTag,
+      pan3.handlerTag,
+    ]);
+  });
+
+  test('Nested composition of a different type is kept', () => {
+    const inner = renderHook(() => useExclusiveGestures(pan2, pan3)).result
+      .current;
+    const outer = renderHook(() => useSimultaneousGestures(pan1, inner)).result
+      .current;
+
+    expect(outer.gestures).toStrictEqual([pan1, inner]);
+  });
+
+  test('Alternating types are kept nested - Sim(Exc(Sim(a, b), c), d)', () => {
+    const innerSimultaneous = renderHook(() =>
+      useSimultaneousGestures(pan1, pan2)
+    ).result.current;
+    const exclusive = renderHook(() =>
+      useExclusiveGestures(innerSimultaneous, pan3)
+    ).result.current;
+    const outer = renderHook(() => useSimultaneousGestures(exclusive, pan4))
+      .result.current;
+
+    expect(outer.gestures).toStrictEqual([exclusive, pan4]);
+    expect(exclusive.gestures).toStrictEqual([innerSimultaneous, pan3]);
+
+    configureRelations(outer);
+
+    expect(pan1.gestureRelations.waitFor).toStrictEqual([]);
+    expect(pan1.gestureRelations.simultaneousHandlers.sort()).toStrictEqual(
+      [pan2.handlerTag, pan4.handlerTag].sort()
+    );
+
+    expect(pan2.gestureRelations.waitFor).toStrictEqual([]);
+    expect(pan2.gestureRelations.simultaneousHandlers.sort()).toStrictEqual(
+      [pan1.handlerTag, pan4.handlerTag].sort()
+    );
+
+    expect(pan3.gestureRelations.waitFor).toStrictEqual([
+      pan1.handlerTag,
+      pan2.handlerTag,
+    ]);
+    expect(pan3.gestureRelations.simultaneousHandlers).toStrictEqual([
+      pan4.handlerTag,
+    ]);
+
+    expect(pan4.gestureRelations.waitFor).toStrictEqual([]);
+    expect(pan4.gestureRelations.simultaneousHandlers.sort()).toStrictEqual(
+      [pan1.handlerTag, pan2.handlerTag, pan3.handlerTag].sort()
+    );
+  });
+
+  test('Duplicate gestures are still detected after inlining', () => {
+    const inner = renderHook(() => useSimultaneousGestures(pan1, pan2)).result
+      .current;
+
+    expect(() => useSimultaneousGestures(pan1, inner)).toThrow(
+      tagMessage(
+        'Each gesture can be used only once in the gesture composition.'
+      )
+    );
+  });
+});
+
 describe('External relations with composed gestures', () => {
   test('Case 1', () => {
     const pan1 = renderHook(() =>

--- a/packages/react-native-gesture-handler/src/v3/hooks/composition/useComposedGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/composition/useComposedGesture.ts
@@ -9,12 +9,20 @@ import type {
 } from '../../types';
 import { containsDuplicates, isComposedGesture } from '../utils';
 
-// TODO: Simplify repeated relations (Simultaneous with Simultaneous, Exclusive with Exclusive, etc.)
 export function useComposedGesture(
   type: ComposedGestureName,
   ...gestures: AnyGesture[]
 ): ComposedGesture {
-  const handlerTags = gestures.flatMap((gesture) =>
+  // Nesting compositions of the same type is redundant, e.g. Simultaneous(a, Simultaneous(b, c))
+  // is equivalent to Simultaneous(a, b, c). Same-type children are inlined to keep the tree shallow.
+  // They come from this hook, so they are already flattened themselves.
+  const flattenedGestures = gestures.flatMap((gesture) =>
+    isComposedGesture(gesture) && gesture.type === type
+      ? gesture.gestures
+      : [gesture]
+  );
+
+  const handlerTags = flattenedGestures.flatMap((gesture) =>
     isComposedGesture(gesture) ? gesture.handlerTags : [gesture.handlerTag]
   );
 
@@ -27,10 +35,10 @@ export function useComposedGesture(
   }
 
   const config: ComposedGestureConfig = {
-    shouldUseReanimatedDetector: gestures.some(
+    shouldUseReanimatedDetector: flattenedGestures.some(
       (gesture) => gesture.config.shouldUseReanimatedDetector
     ),
-    dispatchesAnimatedEvents: gestures.some(
+    dispatchesAnimatedEvents: flattenedGestures.some(
       (gesture) => gesture.config.dispatchesAnimatedEvents
     ),
   };
@@ -46,7 +54,7 @@ export function useComposedGesture(
   const jsEventHandler = (
     event: GestureHandlerEventWithHandlerData<unknown, unknown>
   ) => {
-    for (const gesture of gestures) {
+    for (const gesture of flattenedGestures) {
       if (gesture.detectorCallbacks.jsEventHandler) {
         gesture.detectorCallbacks.jsEventHandler(event);
       }
@@ -54,14 +62,14 @@ export function useComposedGesture(
   };
 
   const reanimatedEventHandler = Reanimated?.useComposedEventHandler(
-    gestures.map(
+    flattenedGestures.map(
       (gesture) => gesture.detectorCallbacks.reanimatedEventHandler || null
     )
   );
 
   let animatedEventHandler;
 
-  const gesturesWithAnimatedEvent = gestures.filter(
+  const gesturesWithAnimatedEvent = flattenedGestures.filter(
     (gesture) => gesture.detectorCallbacks.animatedEventHandler !== undefined
   );
 
@@ -88,6 +96,6 @@ export function useComposedGesture(
       animatedEventHandler,
     },
     externalSimultaneousHandlers: [],
-    gestures,
+    gestures: flattenedGestures,
   };
 }


### PR DESCRIPTION
## Description

Implements the TODO left in #3693. Nesting a composition inside a composition of the same type is redundant, e.g. `Simultaneous(a, Simultaneous(b, c))` is equivalent to `Simultaneous(a, b, c)`, so `useComposedGesture` now inlines same-type children into the parent when the composed gesture is created. One level of inlining is enough - every composed gesture comes from this hook, so its children are already flattened with respect to their own type.

Besides simplifying the tree, this fixes duplicated `waitFor` tags produced by same-type `Exclusive` nesting: in `Exclusive(a, Exclusive(b, c), d)` the traversal pushed the inner tags twice, so d ended up with `waitFor = [a, b, c, b, c]`.

Different-type nesting, e.g. `Simultaneous(Exclusive(Simultaneous(a, b), c), d)`, is semantically meaningful and stays untouched. Relations, handler tag order and event handler order are unchanged - the only observable difference is that composedGesture.gestures now contains the inlined children instead of the same-type composed node.

## Test plan

<details>
<summary>Tested on the following code:</summary>

```tsx
import { useRef, useState } from 'react';
import { ScrollView, StyleSheet, Text, View } from 'react-native';
import {
  GestureDetector,
  GestureHandlerRootView,
  useExclusiveGestures,
  useLongPressGesture,
  usePanGesture,
  usePinchGesture,
  useRotationGesture,
  useSimultaneousGestures,
  useTapGesture,
} from 'react-native-gesture-handler';

// Test screen for same-type composition flattening in `useComposedGesture`.
// Each section shows the runtime composition tree (read from `gesture.gestures`),
// so the flattening is directly visible on screen:
//  1. Sim(Pan, Sim(Rotation, Pinch))     -> should render flat: Simultaneous(Pan, Rotation, Pinch)
//  2. Exc(Exc(Tap2, Tap), LongPress)     -> should render flat: Exclusive(Tap, Tap, LongPress)
//  3. Sim(Exc(Sim(Pinch, Rotation), Pan), Tap) -> alternating types, must stay nested
export default function App() {
  return (
    <GestureHandlerRootView style={styles.container}>
      <ScrollView contentContainerStyle={styles.content}>
        <NestedSimultaneousSection />
        <NestedExclusiveSection />
        <AlternatingSection />
      </ScrollView>
    </GestureHandlerRootView>
  );
}

// Renders a composed gesture tree as text, e.g. "Exclusive(Tap, Tap, LongPress)".
// eslint-disable-next-line @typescript-eslint/no-explicit-any
function describeGesture(gesture: any): string {
  if ('handlerTags' in gesture) {
    const name = String(gesture.type).replace('Gesture', '');
    return `${name}(${gesture.gestures.map(describeGesture).join(', ')})`;
  }
  return String(gesture.type).replace('GestureHandler', '');
}

// ---------------------------------------------------------------------------
// 1. Sim(Pan, Sim(Rotation, Pinch)) — inner Sim should be inlined.
//    Expected behavior: drag, rotate and pinch all work at the same time.
// ---------------------------------------------------------------------------
function NestedSimultaneousSection() {
  const [transform, setTransform] = useState({
    x: 0,
    y: 0,
    rotation: 0,
    scale: 1,
  });

  const panBase = useRef({ x: 0, y: 0 });
  const rotationBase = useRef(0);
  const scaleBase = useRef(1);

  const pan = usePanGesture({
    disableReanimated: true,
    averageTouches: true,
    onUpdate: (e) => {
      setTransform((current) => ({
        ...current,
        x: panBase.current.x + e.translationX,
        y: panBase.current.y + e.translationY,
      }));
    },
    onDeactivate: (e) => {
      if (!e.canceled) {
        panBase.current = {
          x: panBase.current.x + e.translationX,
          y: panBase.current.y + e.translationY,
        };
      }
    },
  });

  const rotation = useRotationGesture({
    disableReanimated: true,
    onUpdate: (e) => {
      setTransform((current) => ({
        ...current,
        rotation: rotationBase.current + e.rotation,
      }));
    },
    onDeactivate: (e) => {
      if (!e.canceled) {
        rotationBase.current = rotationBase.current + e.rotation;
      }
    },
  });

  const pinch = usePinchGesture({
    disableReanimated: true,
    onUpdate: (e) => {
      setTransform((current) => ({
        ...current,
        scale: scaleBase.current * e.scale,
      }));
    },
    onDeactivate: (e) => {
      if (!e.canceled) {
        scaleBase.current = scaleBase.current * e.scale;
      }
    },
  });

  const inner = useSimultaneousGestures(rotation, pinch);
  const composed = useSimultaneousGestures(pan, inner);

  return (
    <View style={styles.section}>
      <Text style={styles.title}>1. Sim(Pan, Sim(Rotation, Pinch))</Text>
      <Text style={styles.tree}>{describeGesture(composed)}</Text>
      <Text style={styles.caption}>
        Expected tree: Simultaneous(Pan, Rotation, Pinch){'\n'}
        Drag + rotate + pinch must all work at once
      </Text>
      <GestureDetector gesture={composed}>
        <View
          style={[
            styles.box,
            styles.boxSimultaneous,
            {
              transform: [
                { translateX: transform.x },
                { translateY: transform.y },
                { rotate: `${transform.rotation}rad` },
                { scale: transform.scale },
              ],
            },
          ]}
        />
      </GestureDetector>
    </View>
  );
}

// ---------------------------------------------------------------------------
// 2. Exc(Exc(DoubleTap, SingleTap), LongPress) — inner Exc should be inlined.
//    Expected behavior: double tap wins over single tap, single tap fires
//    after the double-tap window, holding fires long press after taps fail.
//    Before the fix this shape sent duplicated waitFor tags to LongPress.
// ---------------------------------------------------------------------------
function NestedExclusiveSection() {
  const [lastWinner, setLastWinner] = useState('none yet');

  const doubleTap = useTapGesture({
    disableReanimated: true,
    numberOfTaps: 2,
    onDeactivate: (e) => {
      if (!e.canceled) {
        setLastWinner('Double tap');
      }
    },
  });

  const singleTap = useTapGesture({
    disableReanimated: true,
    onDeactivate: (e) => {
      if (!e.canceled) {
        setLastWinner('Single tap');
      }
    },
  });

  const longPress = useLongPressGesture({
    disableReanimated: true,
    minDuration: 600,
    onDeactivate: (e) => {
      if (!e.canceled) {
        setLastWinner('Long press');
      }
    },
  });

  const inner = useExclusiveGestures(doubleTap, singleTap);
  const composed = useExclusiveGestures(inner, longPress);

  return (
    <View style={styles.section}>
      <Text style={styles.title}>
        2. Exc(Exc(DoubleTap, SingleTap), LongPress)
      </Text>
      <Text style={styles.tree}>{describeGesture(composed)}</Text>
      <Text style={styles.caption}>
        Expected tree: Exclusive(Tap, Tap, LongPress){'\n'}
        Double tap beats single tap, hold fires long press{'\n'}
        Last winner: {lastWinner}
      </Text>
      <GestureDetector gesture={composed}>
        <View style={[styles.box, styles.boxExclusive]} />
      </GestureDetector>
    </View>
  );
}

// ---------------------------------------------------------------------------
// 3. Sim(Exc(Sim(Pinch, Rotation), Tap), Pan) — alternating types, nothing
//    may be flattened here. Two fingers pinch + rotate together, dragging
//    always pans (outer Sim), a quick tap activates once pinch/rotation fail
//    on finger-up. Tap is the exclusive fallback because pinch/rotation only
//    fail when the touch ends - a continuous gesture (like pan) placed there
//    would be blocked for the whole touch.
// ---------------------------------------------------------------------------
function AlternatingSection() {
  const [transform, setTransform] = useState({
    x: 0,
    y: 0,
    rotation: 0,
    scale: 1,
  });
  const [tapCount, setTapCount] = useState(0);

  const panBase = useRef({ x: 0, y: 0 });
  const rotationBase = useRef(0);
  const scaleBase = useRef(1);

  const pinch = usePinchGesture({
    disableReanimated: true,
    onUpdate: (e) => {
      setTransform((current) => ({
        ...current,
        scale: scaleBase.current * e.scale,
      }));
    },
    onDeactivate: (e) => {
      if (!e.canceled) {
        scaleBase.current = scaleBase.current * e.scale;
      }
    },
  });

  const rotation = useRotationGesture({
    disableReanimated: true,
    onUpdate: (e) => {
      setTransform((current) => ({
        ...current,
        rotation: rotationBase.current + e.rotation,
      }));
    },
    onDeactivate: (e) => {
      if (!e.canceled) {
        rotationBase.current = rotationBase.current + e.rotation;
      }
    },
  });

  const pan = usePanGesture({
    disableReanimated: true,
    onUpdate: (e) => {
      setTransform((current) => ({
        ...current,
        x: panBase.current.x + e.translationX,
        y: panBase.current.y + e.translationY,
      }));
    },
    onDeactivate: (e) => {
      if (!e.canceled) {
        panBase.current = {
          x: panBase.current.x + e.translationX,
          y: panBase.current.y + e.translationY,
        };
      }
    },
  });

  const tap = useTapGesture({
    disableReanimated: true,
    onDeactivate: (e) => {
      if (!e.canceled) {
        setTapCount((count) => count + 1);
      }
    },
  });

  const innerSimultaneous = useSimultaneousGestures(pinch, rotation);
  const exclusive = useExclusiveGestures(innerSimultaneous, tap);
  const composed = useSimultaneousGestures(exclusive, pan);

  return (
    <View style={styles.section}>
      <Text style={styles.title}>
        3. Sim(Exc(Sim(Pinch, Rotation), Tap), Pan)
      </Text>
      <Text style={styles.tree}>{describeGesture(composed)}</Text>
      <Text style={styles.caption}>
        Expected tree: unchanged (alternating types){'\n'}
        Drag always pans, two fingers pinch + rotate too{'\n'}
        Quick tap counts once pinch/rotation fail — Tap count: {tapCount}
      </Text>
      <GestureDetector gesture={composed}>
        <View
          style={[
            styles.box,
            styles.boxAlternating,
            {
              transform: [
                { translateX: transform.x },
                { translateY: transform.y },
                { rotate: `${transform.rotation}rad` },
                { scale: transform.scale },
              ],
            },
          ]}
        />
      </GestureDetector>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
  },
  content: {
    paddingVertical: 32,
    paddingHorizontal: 16,
    gap: 40,
  },
  section: {
    alignItems: 'center',
    gap: 8,
  },
  title: {
    fontSize: 15,
    fontWeight: '700',
    color: '#111111',
    textAlign: 'center',
  },
  tree: {
    fontSize: 12,
    fontFamily: 'monospace',
    color: '#0a5c36',
    textAlign: 'center',
  },
  caption: {
    fontSize: 12,
    color: '#3a3a3a',
    textAlign: 'center',
  },
  box: {
    width: 140,
    height: 140,
    borderWidth: 3,
    borderColor: '#1f1f1f',
  },
  boxSimultaneous: {
    backgroundColor: '#f6b914',
  },
  boxExclusive: {
    backgroundColor: '#21a37c',
  },
  boxAlternating: {
    backgroundColor: '#4f89ff',
  },
});
```

</details>