### PR TITLE
perf: batch MountRegistry mount notifications (O(N²) → O(N))

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/mountRegistryBatching.test.ts
+++ b/packages/react-native-gesture-handler/src/__tests__/mountRegistryBatching.test.ts
@@ -1,0 +1,85 @@
+import { MountRegistry } from '../mountRegistry';
+
+const flushMountBatch = () =>
+  new Promise<void>((resolve) => {
+    setImmediate(resolve);
+  });
+
+const asGesture = (handlerTag: number) => ({ handlerTag }) as never;
+
+describe('MountRegistry mount batching', () => {
+  test('notifies listeners once per tick with the set of mounted tags', async () => {
+    const listener = jest.fn<void, [ReadonlySet<number>]>();
+    const unsubscribe = MountRegistry.addMountListener(listener);
+
+    MountRegistry.gestureWillMount(asGesture(1));
+    MountRegistry.gestureWillMount(asGesture(2));
+    MountRegistry.gestureWillMount(asGesture(3));
+
+    // Nothing is dispatched synchronously — this is what turns the N x N
+    // notification storm into a single pass.
+    expect(listener).not.toHaveBeenCalled();
+
+    await flushMountBatch();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect([...listener.mock.calls[0][0]].sort()).toEqual([1, 2, 3]);
+
+    unsubscribe();
+  });
+
+  test('old API handlers join the same batch', async () => {
+    const listener = jest.fn<void, [ReadonlySet<number>]>();
+    const unsubscribe = MountRegistry.addMountListener(listener);
+
+    MountRegistry.gestureWillMount(asGesture(10));
+    MountRegistry.gestureHandlerWillMount(asGesture(11));
+
+    await flushMountBatch();
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect([...listener.mock.calls[0][0]].sort()).toEqual([10, 11]);
+
+    unsubscribe();
+  });
+
+  test('a later tick starts a new batch', async () => {
+    const listener = jest.fn<void, [ReadonlySet<number>]>();
+    const unsubscribe = MountRegistry.addMountListener(listener);
+
+    MountRegistry.gestureWillMount(asGesture(20));
+    await flushMountBatch();
+    MountRegistry.gestureWillMount(asGesture(21));
+    await flushMountBatch();
+
+    expect(listener).toHaveBeenCalledTimes(2);
+    expect([...listener.mock.calls[0][0]]).toEqual([20]);
+    expect([...listener.mock.calls[1][0]]).toEqual([21]);
+
+    unsubscribe();
+  });
+
+  test('unsubscribed listeners do not receive further batches', async () => {
+    const listener = jest.fn<void, [ReadonlySet<number>]>();
+    const unsubscribe = MountRegistry.addMountListener(listener);
+    unsubscribe();
+
+    MountRegistry.gestureWillMount(asGesture(30));
+    await flushMountBatch();
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  test('unmount notifications stay synchronous and per-gesture', () => {
+    const listener = jest.fn();
+    const unsubscribe = MountRegistry.addUnmountListener(listener);
+
+    const gesture = asGesture(40);
+    MountRegistry.gestureWillUnmount(gesture);
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith(gesture);
+
+    unsubscribe();
+  });
+});

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useMountReactions.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useMountReactions.ts
@@ -7,14 +7,14 @@ import type { AttachedGestureState } from './types';
 
 function shouldUpdateDetector(
   relation: GestureRef[] | undefined,
-  gesture: { handlerTag: number }
+  mountedHandlerTags: ReadonlySet<number>
 ) {
   if (relation === undefined) {
     return false;
   }
 
   for (const tag of transformIntoHandlerTags(relation)) {
-    if (tag === gesture.handlerTag) {
+    if (mountedHandlerTags.has(tag)) {
       return true;
     }
   }
@@ -27,25 +27,27 @@ export function useMountReactions(
   state: AttachedGestureState
 ) {
   useEffect(() => {
-    return MountRegistry.addMountListener((gesture) => {
+    // The listener receives every handler tag that mounted in this tick, so each relation
+    // is resolved once per batch instead of once per mounted gesture.
+    return MountRegistry.addMountListener((mountedHandlerTags) => {
       // The detector may already be unmounted when this fires; bail out to avoid
       // updating a detached detector.
       if (!state.isMounted) {
         return;
       }
 
-      // At this point the ref in the gesture config should be updated, so we can check if one of the gestures
-      // set in a relation with the gesture got mounted. If so, we need to update the detector to propagate
-      // the changes to the native side.
+      // At this point the refs in the gesture configs should be updated, so we can check if one of
+      // the gestures set in a relation with a just-mounted gesture got mounted. If so, we need to
+      // update the detector to propagate the changes to the native side.
       for (const attachedGesture of state.attachedGestures) {
         const blocksHandlers = attachedGesture.config.blocksHandlers;
         const requireToFail = attachedGesture.config.requireToFail;
         const simultaneousWith = attachedGesture.config.simultaneousWith;
 
         if (
-          shouldUpdateDetector(blocksHandlers, gesture) ||
-          shouldUpdateDetector(requireToFail, gesture) ||
-          shouldUpdateDetector(simultaneousWith, gesture)
+          shouldUpdateDetector(blocksHandlers, mountedHandlerTags) ||
+          shouldUpdateDetector(requireToFail, mountedHandlerTags) ||
+          shouldUpdateDetector(simultaneousWith, mountedHandlerTags)
         ) {
           updateDetector();
 

--- a/packages/react-native-gesture-handler/src/mountRegistry.ts
+++ b/packages/react-native-gesture-handler/src/mountRegistry.ts
@@ -1,3 +1,4 @@
+import { ghQueueMicrotask } from './ghQueueMicrotask';
 import type { GestureType } from './handlers/gestures/gesture';
 
 interface ReactComponentWithHandlerTag extends React.Component {
@@ -8,12 +9,26 @@ export type GestureMountListener = (
   gesture: GestureType | ReactComponentWithHandlerTag
 ) => void;
 
+/**
+ * Mount notifications are batched: listeners receive the set of handler tags that
+ * mounted within a single tick, instead of one call per mounting gesture.
+ *
+ * Notifying synchronously per gesture makes a commit that mounts N detectors cost
+ * N x N listener invocations, and every invocation re-resolves relations into handler
+ * tags. Batching lets each listener resolve its relations once per tick.
+ */
+export type GestureMountBatchListener = (
+  mountedHandlerTags: ReadonlySet<number>
+) => void;
+
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class MountRegistry {
-  private static mountListeners = new Set<GestureMountListener>();
+  private static mountListeners = new Set<GestureMountBatchListener>();
   private static unmountListeners = new Set<GestureMountListener>();
+  private static pendingMountedTags = new Set<number>();
+  private static flushScheduled = false;
 
-  static addMountListener(listener: GestureMountListener): () => void {
+  static addMountListener(listener: GestureMountBatchListener): () => void {
     this.mountListeners.add(listener);
 
     return () => {
@@ -29,10 +44,32 @@ export class MountRegistry {
     };
   }
 
+  private static scheduleMountFlush() {
+    if (this.flushScheduled) {
+      return;
+    }
+
+    this.flushScheduled = true;
+
+    ghQueueMicrotask(() => {
+      this.flushScheduled = false;
+
+      const mountedHandlerTags = this.pendingMountedTags;
+      this.pendingMountedTags = new Set<number>();
+
+      if (mountedHandlerTags.size === 0) {
+        return;
+      }
+
+      this.mountListeners.forEach((listener) => listener(mountedHandlerTags));
+    });
+  }
+
   static gestureHandlerWillMount(handler: React.Component) {
-    this.mountListeners.forEach((listener) =>
-      listener(handler as ReactComponentWithHandlerTag)
+    this.pendingMountedTags.add(
+      (handler as ReactComponentWithHandlerTag).handlerTag
     );
+    this.scheduleMountFlush();
   }
 
   static gestureHandlerWillUnmount(handler: React.Component) {
@@ -42,7 +79,8 @@ export class MountRegistry {
   }
 
   static gestureWillMount(gesture: GestureType) {
-    this.mountListeners.forEach((listener) => listener(gesture));
+    this.pendingMountedTags.add(gesture.handlerTag);
+    this.scheduleMountFlush();
   }
 
   static gestureWillUnmount(gesture: GestureType) {


### PR DESCRIPTION
## Description

Fixes #4452.

`MountRegistry` notifies every registered listener synchronously on each mounting gesture, and each listener re-resolves its relations into handler tags. A commit that mounts N `GestureDetector`s therefore costs **N × N** listener invocations, with an array allocation (`toArray` + `map` + `filter`) per innermost call.

The `relation === undefined` fast path in `useMountReactions` does not help for this library's own `Pressable`: `Pressable` composes its gestures with `Gesture.Simultaneous(...)`, which populates `simultaneousWith` on every composed gesture, so the early return is never taken for `Pressable` trees.

This change collects mounting handler tags for a tick and flushes once via `ghQueueMicrotask` — already used in `attachHandlers` to defer relation-dependent work for the same reason ("all refs should be initialized when it's ran"). Listeners now receive the `ReadonlySet<number>` of tags that mounted in that tick, so each relation is resolved **once per batch** instead of once per mounted gesture: O(N) instead of O(N²).

Two incidental correctness benefits:

1. Listeners run after `attachHandlers` assigns `preparedGesture.attachedGestures`. The synchronous broadcast reached a detector's own listener *before* that assignment, so it observed the previous `attachedGestures`.
2. Detectors registered later in the same commit now see the whole batch, instead of missing gestures that mounted before them.

Unmount notifications are unchanged (still synchronous, per-gesture). `addMountListener` has exactly one in-tree consumer (`useMountReactions`), so the listener signature change is contained.

### Alternative considered

Indexing listeners by relation handler tag at registration time does **not** work: `transformIntoHandlerTags` resolves refs/ids at call time and the referenced gesture may not be mounted yet — which is precisely why the broadcast exists. Indexing by ref/testId *identity* would work but is a much larger change; batching gets the same asymptotic win with a contained diff.

## Test plan

- Added `src/__tests__/mountRegistryBatching.test.ts` — batching per tick, old-API handlers joining the same batch, a later tick starting a new batch, unsubscribe, and unmount notifications staying synchronous.
- `yarn test` in `packages/react-native-gesture-handler`: **18 suites / 145 tests pass**.
- `yarn lint-js`: 0 errors.

Measured on a production app (low-end Android, Snapdragon-class, Android 10) with a sampling profiler over one screen transition:

- The commit was dominated by React's layout-effect phase, not render.
- Inside that phase, **54%** of the time was `transformIntoHandlerTags`, reached via `attachHandlers → gestureWillMount → mountListeners.forEach → shouldUpdateDetector → transformIntoHandlerTags`.
- Live mount-listener count on that screen: **112**.
- Neutralising only the broadcast at runtime cut the transition from ~3.9s to ~1.5s.

(Absolute numbers are dev-build upper bounds; the ratio is the transferable part.)
