### PR TITLE
[iOS] Remove a stale TODO in `State.ts` and the unused constants export

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerModule.mm
@@ -17,7 +17,6 @@
 #import "RNGHRuntimeDecorator.h"
 
 #import "RNGestureHandler.h"
-#import "RNGestureHandlerDirection.h"
 #import "RNGestureHandlerState.h"
 
 #import "RNGestureHandlerButton.h"
@@ -276,28 +275,6 @@ RCT_EXPORT_MODULE()
 - (NSArray<NSString *> *)supportedEvents
 {
   return @[ @"onGestureHandlerEvent", @"onGestureHandlerStateChange" ];
-}
-
-#pragma mark Module Constants
-
-- (NSDictionary *)constantsToExport
-{
-  return @{
-    @"State" : @{
-      @"UNDETERMINED" : @(RNGestureHandlerStateUndetermined),
-      @"BEGAN" : @(RNGestureHandlerStateBegan),
-      @"ACTIVE" : @(RNGestureHandlerStateActive),
-      @"CANCELLED" : @(RNGestureHandlerStateCancelled),
-      @"FAILED" : @(RNGestureHandlerStateFailed),
-      @"END" : @(RNGestureHandlerStateEnd)
-    },
-    @"Direction" : @{
-      @"RIGHT" : @(RNGestureHandlerDirectionRight),
-      @"LEFT" : @(RNGestureHandlerDirectionLeft),
-      @"UP" : @(RNGestureHandlerDirectionUp),
-      @"DOWN" : @(RNGestureHandlerDirectionDown)
-    }
-  };
 }
 
 - (std::shared_ptr<facebook::react::TurboModule>)getTurboModule:

--- a/packages/react-native-gesture-handler/src/State.ts
+++ b/packages/react-native-gesture-handler/src/State.ts
@@ -1,5 +1,3 @@
-// TODO use State from RNModule
-
 export const State = {
   UNDETERMINED: 0,
   FAILED: 1,


### PR DESCRIPTION
## Description

Removes two leftovers that reference each other:

- The `TODO use State from RNModule` comment in `src/State.ts`, added in the TS rewrite (#1327). The idea was to source the `State` object from the native module's exported constants instead of duplicating the values in JS. That's no longer viable: the TurboModule spec has no `getConstants`, web and Jest have no native module to ask, and `as const` literal types have to exist at compile time anyway.

- The `constantsToExport` method in `RNGestureHandlerModule.mm` (the `State` and `Direction` dictionaries, exported since 2017) together with the now-unused `RNGestureHandlerDirection.h` import. Nothing on the JS side reads these - without `getConstants` in the spec they are unreachable on the new architecture.

`requiresMainQueueSetup` stays, as module initialization inserts into the static `_managers` map that component views read on the main thread.

No behavior change.

## Test plan

- Built and ran `basic-example` on the iOS simulator; the app renders and a tap on the `VirtualGestureDetector` text logs `Tapped on first part!`.
- Verified nothing references the exported constants: no `getConstants` in `NativeRNGestureHandlerModule.ts`, no `Module.State` / `Module.Direction` reads in `src/`.
