### PR TITLE
Remove the `@ts-ignore TODO` from the event pipeline in `jestUtils`

### DIFF
--- a/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
+++ b/packages/react-native-gesture-handler/src/jestUtils/jestUtils.ts
@@ -778,16 +778,15 @@ export function fireGestureHandler<THandler extends AllGestures | AllHandlers>(
   _ = _.map(fillMissingDefaultsFor({ handlerTag, handlerType }));
   _ = withPrevAndCurrent(_, fillOldStateChanges);
   _ = withPrevAndCurrent(_, validateStateTransitions);
-  // @ts-ignore TODO
-  _ = _.map(wrapWithNativeEvent);
+  const events = _.map((event) =>
+    wrapWithNativeEvent(event as GestureHandlerTestEvent)
+  );
 
-  const events = _ as unknown as WrappedGestureHandlerTestEvent[];
-
-  const firstEvent = events.shift()!;
+  const [firstEvent, ...restEvents] = events;
 
   emitEvent('onGestureHandlerStateChange', firstEvent);
   let lastSentEvent = firstEvent;
-  for (const event of events) {
+  for (const event of restEvents) {
     const hasChangedState =
       lastSentEvent.nativeEvent.state !== event.nativeEvent.state;
 


### PR DESCRIPTION
## Description

`fireGestureHandler` reused a single `let _` variable for every stage of the event pipeline, so its type was fixed by the first assignment as `EventWithoutStates[]`. The final `_.map(wrapWithNativeEvent)` step didn't type-check against it, which was suppressed with `// @ts-ignore TODO` followed by an `as unknown as` double cast.

This PR collapses the last two steps into a single map with one honest cast (by that point the pipeline has filled in `state` and `oldState`), the same pattern the file already uses in the other `wrapWithNativeEvent` call sites. Also replaces `events.shift()!` with destructuring, which removes a `no-non-null-assertion` lint warning.

No behavior change.

## Test plan

- `yarn ts-check` passes without the suppression
- `yarn test` — 18 suites, 156 tests pass, including calls to `fireGestureHandler` with an empty event list (the only edge where `shift()` could differ)
