### PR TITLE
Remove stale TODOs

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
@@ -18,7 +18,7 @@ class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {
   private var moduleId: Int = -1
   private var rootViewEnabled = false
   private var unstableForceActive = false
-  private var rootHelper: RNGestureHandlerRootHelper? = null // TODO: resettable lateinit
+  private var rootHelper: RNGestureHandlerRootHelper? = null
 
   val orchestrator: GestureHandlerOrchestrator?
     get() = rootHelper?.orchestrator

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/events/RNGestureHandlerStateChangeEvent.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/events/RNGestureHandlerStateChangeEvent.kt
@@ -47,10 +47,8 @@ class RNGestureHandlerStateChangeEvent private constructor() : Event<RNGestureHa
     EVENT_NAME
   }
 
-  // TODO: coalescing
   override fun canCoalesce() = false
 
-  // TODO: coalescing
   override fun getCoalescingKey(): Short = 0
 
   override fun getEventData(): WritableMap = if (GestureHandler.usesNativeOrVirtualDetector(actionType)) {

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerEvents.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerEvents.mm
@@ -279,7 +279,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)init)
 
 - (BOOL)canCoalesce
 {
-  // TODO: event coalescing
   return NO;
 }
 

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -32,7 +32,8 @@ export default class NativeViewGestureHandler extends GestureHandler {
   public override readonly isContinuous = true;
   private role: NativeGestureRole | null = null;
 
-  // TODO: Implement logic for activation on start properly
+  // Documented as Android-only; on web it's used internally for the Button
+  // role, while other roles intentionally activate on real interaction.
   private shouldActivateOnStart = false;
   private disallowInterruption = false;
   private yieldsToContinuousGestures = false;


### PR DESCRIPTION
## Description

Removes TODO comments that describe deliberate, final behavior as unfinished work. No logic changes.

- `android/.../react/RNGestureHandlerRootView.kt` - drops the `resettable lateinit` TODO from the 2021 Kotlin conversion; `rootHelper` is assigned at most once and never reset, so the nullable var is the intended shape
- `src/web/handlers/NativeViewGestureHandler.ts` - replaces the activation TODO with a note that `shouldActivateOnStart` is documented as Android-only and on web is honored internally only for the Button role, other roles activate on real interaction on purpose
- `android/.../react/events/RNGestureHandlerStateChangeEvent.kt` - drops two `coalescing` TODOs; state transitions are discrete and each one must reach JS, so they are intentionally never coalesced
- `apple/RNGestureHandlerEvents.mm` - drops the same coalescing TODO from `RNGestureHandlerStateChange` for consistency with Android

## Test plan

Comment-only changes, CI passing is sufficient.
