### PR TITLE
Fix v3 CI path filter case and remove stale files entry

### DIFF
--- a/.github/workflows/rngh-api-v3.yml
+++ b/.github/workflows/rngh-api-v3.yml
@@ -5,7 +5,7 @@ on:
     paths:
       - packages/react-native-gesture-handler/src/v3/**
       - packages/react-native-gesture-handler/src/__tests__/RelationsTraversal.test.tsx
-      - packages/react-native-gesture-handler/src/__tests__/API_V3.test.tsx
+      - packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
   push:
     branches:
       - main
@@ -35,4 +35,4 @@ jobs:
 
       - name: Run tests
         working-directory: packages/react-native-gesture-handler
-        run: yarn test RelationsTraversal API_V3
+        run: yarn test RelationsTraversal api_v3

--- a/packages/react-native-gesture-handler/package.json
+++ b/packages/react-native-gesture-handler/package.json
@@ -35,7 +35,6 @@
     "android/src/main/AndroidManifest.xml",
     "android/src/main/java/",
     "android/src/main/jni/",
-    "android/common/src/main/java/",
     "android/reanimated/src/main/java/",
     "android/noreanimated/src/main/java/",
     "android/svg",


### PR DESCRIPTION
## Description

Two small cleanups:

- The path filter in `rngh-api-v3.yml` pointed at `API_V3.test.tsx`, but the file is `api_v3.test.tsx` and GitHub path filters are case-sensitive, so a PR touching only the v3 test suite never triggered the workflow. The mismatch has been there since the workflow was added in #3838. Also lowercased the pattern in the `yarn test` step to match the file literally (it worked before only because jest matches patterns case-insensitively).
- Removed `android/common/src/main/java/` from `files` in `package.json` - the directory was deleted in #3544, npm silently ignores the unmatched entry.

## Test plan

- `npx jest --listTests RelationsTraversal api_v3` still selects both test files.
