### PR TITLE
[Docs] Warn that gesture relations can't mix new and old APIs

### DIFF
--- a/packages/docs-gesture-handler/docs/composition/overview.mdx
+++ b/packages/docs-gesture-handler/docs/composition/overview.mdx
@@ -10,6 +10,10 @@ Gesture Handler simplifies gesture interactions through dedicated composition ho
 - If **yes** — use [composition hooks](#composition-hooks). These allow you to bundle multiple gestures — including previously composed ones — into a single object for a [`GestureDetector`](/docs/core-components/gesture-detectors).
 - If **no** — use [relation properties](#cross-component-interactions) to manually define how gestures interact. Since these properties also support composed gestures, you can mix both methods for more complex layouts.
 
+:::danger
+Gesture relations cannot be set between hook-based API and previous APIs.
+:::
+
 ## Composition hooks
 
 - [`useCompetingGestures`](/docs/composition/use-competing-gestures) — only one of the provided gestures can become active at the same time. The first gesture to activate cancels the rest.

--- a/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
+++ b/packages/docs-gesture-handler/docs/guides/upgrading-to-3.mdx
@@ -174,6 +174,10 @@ code2={
 
 ## Migrating relations
 
+:::danger
+Gesture relations cannot be set between hook-based API and previous APIs.
+:::
+
 ### Composed gestures
 
 Previously, composed gestures were created using `Gesture` object. In Gesture Handler 3, relations are set up using relation hooks.


### PR DESCRIPTION
## Description

Adds a `:::danger` admonition noting that relations cannot be set between gestures defined with the new API and those defined  with the old one.

## Test plan 

Read docs 🤓



