### PR TITLE
[Web] Fix `delayTimeout` type `FlingGestureHandler`

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/FlingGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/FlingGestureHandler.ts
@@ -23,7 +23,7 @@ export default class FlingGestureHandler extends GestureHandler {
 
   private maxDurationMs = DEFAULT_MAX_DURATION_MS;
   private minVelocity = DEFAULT_MIN_VELOCITY;
-  private delayTimeout!: number;
+  private delayTimeout!: ReturnType<typeof setTimeout>;
 
   private maxNumberOfPointersSimultaneously = 0;
   private keyPointer = NaN;

--- a/packages/react-native-gesture-handler/src/web/handlers/FlingGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/FlingGestureHandler.ts
@@ -23,7 +23,7 @@ export default class FlingGestureHandler extends GestureHandler {
 
   private maxDurationMs = DEFAULT_MAX_DURATION_MS;
   private minVelocity = DEFAULT_MIN_VELOCITY;
-  private delayTimeout!: ReturnType<typeof setTimeout>;
+  private delayTimeout: ReturnType<typeof setTimeout> | undefined;
 
   private maxNumberOfPointersSimultaneously = 0;
   private keyPointer = NaN;


### PR DESCRIPTION
## Description

Leftover from #4381: the web handlers' timeout fields were changed to `ReturnType<typeof setTimeout>`. `FlingGestureHandler` was the one that PR missed.

## Test plan

`yarn ts-check` passes
