### PR TITLE
Don't pass dependencies to Reanimated hooks on native

### DIFF
--- a/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
@@ -343,7 +343,7 @@ const DrawerLayout = function DrawerLayout(
 
   useDerivedValue(() => {
     onDrawerSlide && scheduleOnRN(onDrawerSlide, openValue.value);
-  }, []);
+  });
 
   const isDrawerOpen = useSharedValue(false);
 

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -6,7 +6,7 @@ import React, {
   useMemo,
 } from 'react';
 import type { LayoutChangeEvent } from 'react-native';
-import { I18nManager, StyleSheet, View } from 'react-native';
+import { I18nManager, Platform, StyleSheet, View } from 'react-native';
 import Animated, {
   interpolate,
   isSharedValue,
@@ -576,7 +576,7 @@ const Swipeable = (props: SwipeableProps) => {
       transform: [{ translateX: appliedTranslation.value }],
       pointerEvents: rowState.value === 0 ? 'auto' : 'box-only',
     }),
-    [appliedTranslation, rowState]
+    Platform.OS === 'web' ? [appliedTranslation, rowState] : undefined
   );
 
   const swipeableComponent = (


### PR DESCRIPTION
## Description

Since Reanimated 4.6 (software-mansion/react-native-reanimated#10009) the native implementations of `useAnimatedStyle`, `useDerivedValue` and other hooks log a dev warning whenever a dependencies argument is passed, since dependencies are only relevant on web:

```
WARN  [Reanimated] dependencies should only be used in web implementation.
```

We pass dependencies in two places:

- `ReanimatedSwipeable` passes `[appliedTranslation, rowState]` to `useAnimatedStyle`. The dependencies are still needed on web, where bundlers resolve the compiled `lib` output that isn't processed by the Reanimated babel plugin, so they are now passed only when `Platform.OS === 'web'`.
- `ReanimatedDrawerLayout` passed an empty array to `useDerivedValue`. An empty array does nothing on any platform (the web fallback only reads non-empty dependencies), so it's simply removed.

## Test plan

- Open the Swipeable and Drawer examples in the example app on native and check that the warning is no longer logged.
- Check that Swipeable still animates correctly in the example app running on web.
