### PR TITLE
Fix Errors.test.tsx failing with Reanimated 4.6.0

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/Errors.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/Errors.test.tsx
@@ -15,6 +15,28 @@ jest.mock('react-native-worklets', () =>
   require('react-native-worklets/src/mock')
 );
 
+// Reanimated 4.6.0 throws on import under Jest (`setCSSEventHandler` is not
+// available in JSReanimated), which reanimatedWrapper silently turns into
+// `Reanimated = undefined`. Mock the wrapper so gestures with worklet
+// callbacks still take the Reanimated detector path these tests rely on.
+//
+// TODO: Remove after fixed in Reanimated
+jest.mock('../handlers/gestures/reanimatedWrapper', () => ({
+  Reanimated: {
+    useHandler: jest.fn(() => ({
+      doDependenciesDiffer: false,
+      context: { lastUpdateEvent: undefined },
+    })),
+    useEvent: jest.fn(() => jest.fn()),
+    useComposedEventHandler: jest.fn(() => jest.fn()),
+    isSharedValue: (value: unknown): boolean =>
+      value !== null && typeof value === 'object' && 'value' in value,
+    useSharedValue: <T,>(value: T) => ({ value }),
+    setGestureState: jest.fn(),
+  },
+  Worklets: undefined,
+}));
+
 beforeEach(() => cleanup());
 jest.mock('react-native/Libraries/ReactNative/RendererProxy', () => ({
   findNodeHandle: jest.fn(),


### PR DESCRIPTION
## Description

Since Reanimated 4.6.0 (software-mansion/react-native-reanimated#10107), importing `react-native-reanimated` under Jest throws during module evaluation:

```
    [Reanimated] `setCSSEventHandler` is not available in JSReanimated.
      at initializeReanimatedModule (src/initializers.native.ts:22)
      at Object.<anonymous> (src/index.ts:11)
```

Under `Jest`, `Reanimated` selects its `JSReanimated` module (`IS_JEST` check in `reanimatedModuleInstance.native.ts`), whose `setCSSEventHandler` stub throws, and `initializers.native.ts` calls it unconditionally as an import side effect. Our `reanimatedWrapper` catches the error and silently falls back to `Reanimated = undefined`.



This PR mocks `reanimatedWrapper` in `Errors.test.tsx` (same pattern as `runOnJSReanimatedHandlers.test.tsx`), which makes the suite independent of whether the real Reanimated can be imported under Jest. The mock additionally provides `useComposedEventHandler`, which `InterceptingGestureDetector` calls.

## Test plan

- yarn test — 19/19 suites, 159/159 tests pass (Errors.test.tsx was failing on main before this change)
