### PR TITLE
Default `shouldCancelWhenOutside` to `true` in `useTapGesture`

### DIFF
--- a/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/api_v3.test.tsx
@@ -13,7 +13,11 @@ import { State } from '../State';
 import { Pressable, RectButton, ScrollView, Touchable } from '../v3/components';
 import { GestureDetector } from '../v3/detectors';
 import { useSimultaneousGestures } from '../v3/hooks';
-import { usePanGesture, useTapGesture } from '../v3/hooks/gestures';
+import {
+  useLongPressGesture,
+  usePanGesture,
+  useTapGesture,
+} from '../v3/hooks/gestures';
 import {
   isKeyboardDismissingTap,
   type JSResponderContextValue,
@@ -151,6 +155,25 @@ describe('[API v3] Hooks', () => {
     expect(onUpdate).toHaveBeenCalledWith(
       expect.objectContaining({ changeX: 10, changeY: 5 })
     );
+  });
+
+  // Apple and web leave `shouldCancelWhenOutside` off unless the config carries
+  // it, so the default has to come from here to match the documented behavior.
+  test('Tap and long press gestures cancel when outside by default', () => {
+    const tapGesture = renderHook(() => useTapGesture()).result.current;
+    const longPressGesture = renderHook(() => useLongPressGesture()).result
+      .current;
+
+    expect(tapGesture.config.shouldCancelWhenOutside).toBe(true);
+    expect(longPressGesture.config.shouldCancelWhenOutside).toBe(true);
+  });
+
+  test('Tap gesture keeps an explicitly configured shouldCancelWhenOutside', () => {
+    const tapGesture = renderHook(() =>
+      useTapGesture({ shouldCancelWhenOutside: false })
+    ).result.current;
+
+    expect(tapGesture.config.shouldCancelWhenOutside).toBe(false);
   });
 });
 

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/TapTypes.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/TapTypes.ts
@@ -91,6 +91,11 @@ export type TapGestureConfig = ExcludeInternalConfigProps<
   BaseDiscreteGestureConfig<TapGestureProperties, TapHandlerData>
 >;
 
+export type TapGestureInternalConfig = BaseDiscreteGestureConfig<
+  TapGestureInternalProperties,
+  TapHandlerData
+>;
+
 export type TapGestureEvent = GestureEvent<TapHandlerData>;
 export type TapGestureActiveEvent = TapGestureEvent;
 

--- a/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/useTapGesture.ts
+++ b/packages/react-native-gesture-handler/src/v3/hooks/gestures/tap/useTapGesture.ts
@@ -4,6 +4,7 @@ import { useClonedAndRemappedConfig } from '../../utils';
 import type {
   TapGesture,
   TapGestureConfig,
+  TapGestureInternalConfig,
   TapGestureInternalProperties,
   TapGestureProperties,
   TapHandlerData,
@@ -18,6 +19,16 @@ const TapPropsMapping = new Map<
   ['maxDelay', 'maxDelayMs'],
 ]);
 
+function transformTapProps(
+  config: TapGestureConfig & TapGestureInternalConfig
+) {
+  if (config.shouldCancelWhenOutside === undefined) {
+    config.shouldCancelWhenOutside = true;
+  }
+
+  return config;
+}
+
 const EMPTY_TAP_CONFIG: TapGestureConfig = {};
 
 export function useTapGesture(
@@ -27,7 +38,7 @@ export function useTapGesture(
     TapGestureProperties,
     TapHandlerData,
     TapGestureInternalProperties
-  >(config, TapPropsMapping);
+  >(config, TapPropsMapping, transformTapProps);
 
   return useGesture<TapGestureInternalProperties, TapHandlerData>(
     SingleGestureName.Tap,


### PR DESCRIPTION
## Description

`useTapGesture` never sets `shouldCancelWhenOutside`, so a v3 `Tap` keeps recognizing after the finger leaves the view on Apple and web.

Both older APIs send `true` for `Tap`:

* v1: `src/handlers/TapGestureHandler.ts:94` sets `config: { shouldCancelWhenOutside: true }`
* v2: `src/handlers/gestures/tapGesture.ts:16` calls `this.shouldCancelWhenOutside(true)` in the constructor

The docs describe the same contract for the v3 hooks, in `packages/docs-gesture-handler/docs/gestures/_shared/base-gesture-config.mdx:22`:

> Most handlers' `shouldCancelWhenOutside` property defaults to `false` except for the [`LongPress`](/docs/gestures/use-long-press-gesture), [`Tap`](/docs/gestures/use-tap-gesture) and [`Native`](/docs/gestures/use-native-gesture) (on Android and web), which default to `true`.

The value has to come from JS, because only Android defaults it to `true` on its own:

* Android: `TapGestureHandler.kt:33-35` sets it in `init`, and `resetConfig` restores a `true` `DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE` (`TapGestureHandler.kt:193`), shadowing the `false` one in `GestureHandler.kt:1004`
* Apple: `RNGestureHandler.mm:120` sets `_shouldCancelWhenOutside = NO` in `resetConfig`, `setConfig` calls `resetConfig` and then only assigns the property when the key is present (`RNGestureHandler.mm:149-152`), and `RNTapHandler` does not override it
* Web: `src/web/handlers/GestureHandler.ts:45` initializes `_shouldCancelWhenOutside = false`, and the web `TapGestureHandler` does not override it

`useLongPressGesture` already applies its own default through a props transformer (`useLongPressGesture.ts:21-29`); this applies the `Tap` default the same way, so an explicitly configured value still wins.

## Test plan

Two tests added to `src/__tests__/api_v3.test.tsx`:

* `useTapGesture()` and `useLongPressGesture()` both end up with `shouldCancelWhenOutside: true`
* `useTapGesture({ shouldCancelWhenOutside: false })` keeps `false`

The first one fails on `main` with `Expected: true, Received: undefined`, and passes with the change. I also reverted just the two source files with the test kept, and confirmed it goes red for that reason, then restored them.

Commands run in this checkout:

* `yarn workspace react-native-gesture-handler test` -> 19 suites, 161 tests passing (159 before this change)
* `yarn ts-check` from the repository root -> clean
* `yarn workspace react-native-gesture-handler lint-js` -> 0 errors, prettier clean

Not verified on a device or simulator: the change is confined to the JS config that the hook hands to the native side, so the check above is the config assertion rather than an on-device gesture run.
