### PR TITLE
Reset `numberOfPointers` in `LongPressGestureHandler`

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -29,13 +29,14 @@ class LongPressGestureHandler(context: Context) : GestureHandler() {
     val systemDefaultMaxDist = DEFAULT_MAX_DIST_DP * context.resources.displayMetrics.density
     defaultMaxDist = systemDefaultMaxDist
     maxDist = defaultMaxDist
-    numberOfPointersRequired = 1
+    numberOfPointersRequired = DEFAULT_NUMBER_OF_POINTERS_REQUIRED
   }
 
   override fun resetConfig() {
     super.resetConfig()
     minDurationMs = DEFAULT_MIN_DURATION_MS
     maxDist = defaultMaxDist
+    numberOfPointersRequired = DEFAULT_NUMBER_OF_POINTERS_REQUIRED
     shouldCancelWhenOutside = DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE
   }
 
@@ -211,5 +212,6 @@ class LongPressGestureHandler(context: Context) : GestureHandler() {
     private const val DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE = true
     private const val DEFAULT_MIN_DURATION_MS: Long = 500
     private const val DEFAULT_MAX_DIST_DP = 10f
+    private const val DEFAULT_NUMBER_OF_POINTERS_REQUIRED = 1
   }
 }

--- a/packages/react-native-gesture-handler/apple/Handlers/RNLongPressHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNLongPressHandler.m
@@ -236,6 +236,10 @@
 
   recognizer.minimumPressDuration = 0.5;
   recognizer.allowableMovement = 10;
+
+#if !TARGET_OS_TV
+  recognizer.numberOfTouchesRequired = 1;
+#endif
 }
 
 - (void)updateConfig:(NSDictionary *)config

--- a/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
@@ -13,6 +13,7 @@ import type IGestureHandler from './IGestureHandler';
 
 const DEFAULT_MIN_DURATION_MS = 500;
 const DEFAULT_MAX_DIST_DP = 10;
+const DEFAULT_NUMBER_OF_POINTERS = 1;
 const SCALING_FACTOR = 10;
 
 export default class LongPressGestureHandler extends GestureHandler {
@@ -20,7 +21,7 @@ export default class LongPressGestureHandler extends GestureHandler {
   private defaultMaxDistSq = DEFAULT_MAX_DIST_DP * SCALING_FACTOR;
 
   private maxDistSq = this.defaultMaxDistSq;
-  private numberOfPointers = 1;
+  private numberOfPointers = DEFAULT_NUMBER_OF_POINTERS;
   private startX = 0;
   private startY = 0;
 
@@ -77,6 +78,7 @@ export default class LongPressGestureHandler extends GestureHandler {
     super.resetConfig();
     this.minDurationMs = DEFAULT_MIN_DURATION_MS;
     this.maxDistSq = this.defaultMaxDistSq;
+    this.numberOfPointers = DEFAULT_NUMBER_OF_POINTERS;
   }
 
   protected override onStateChange(_newState: State, _oldState: State): void {

--- a/packages/react-native-gesture-handler/src/web/handlers/__tests__/LongPressGestureHandler.test.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/__tests__/LongPressGestureHandler.test.ts
@@ -1,0 +1,90 @@
+import { ActionType } from '../../../ActionType';
+import { PointerType } from '../../../PointerType';
+import { State } from '../../../State';
+import type { AdaptedEvent } from '../../interfaces';
+import { EventTypes } from '../../interfaces';
+import type { GestureHandlerDelegate } from '../../tools/GestureHandlerDelegate';
+import GestureHandlerOrchestrator from '../../tools/GestureHandlerOrchestrator';
+import type IGestureHandler from '../IGestureHandler';
+import LongPressGestureHandler from '../LongPressGestureHandler';
+
+class TestLongPressGestureHandler extends LongPressGestureHandler {
+  public pointerDown(event: AdaptedEvent): void {
+    this.onPointerDown(event);
+  }
+}
+
+function touchEvent(pointerId: number, x: number, y: number): AdaptedEvent {
+  return {
+    x,
+    y,
+    offsetX: x,
+    offsetY: y,
+    pointerId,
+    eventType: EventTypes.DOWN,
+    pointerType: PointerType.TOUCH,
+    time: 0,
+  };
+}
+
+function createHandler() {
+  const delegate = {
+    init: jest.fn(),
+    detach: jest.fn(),
+    reset: jest.fn(),
+    onActivate: jest.fn(),
+    onFail: jest.fn(),
+    onCancel: jest.fn(),
+    onEnd: jest.fn(),
+    onEnabledChange: jest.fn(),
+    updateDOM: jest.fn(),
+  } as unknown as GestureHandlerDelegate<unknown, IGestureHandler>;
+
+  const handler = new TestLongPressGestureHandler(delegate);
+  handler.init(1, { current: {} } as never, ActionType.JS_FUNCTION_OLD_API);
+
+  // The full event pipeline is not under test, silence event emission.
+  handler.sendEvent = jest.fn();
+
+  return handler;
+}
+
+describe('LongPressGestureHandler config reset', () => {
+  afterEach(() => {
+    // The orchestrator is a singleton, drop handlers recorded by the test.
+    (
+      GestureHandlerOrchestrator.instance as unknown as {
+        gestureHandlers: IGestureHandler[];
+      }
+    ).gestureHandlers = [];
+  });
+
+  test('a config without numberOfPointers restores the single pointer default', () => {
+    const handler = createHandler();
+
+    handler.setGestureConfig({
+      enabled: true,
+      minDurationMs: 0,
+      numberOfPointers: 2,
+    });
+    handler.setGestureConfig({ enabled: true, minDurationMs: 0 });
+
+    handler.pointerDown(touchEvent(0, 100, 100));
+
+    expect(handler.state).toBe(State.ACTIVE);
+  });
+
+  test('numberOfPointers still applies while it stays in the config', () => {
+    const handler = createHandler();
+
+    handler.setGestureConfig({
+      enabled: true,
+      minDurationMs: 0,
+      numberOfPointers: 2,
+    });
+
+    handler.pointerDown(touchEvent(0, 100, 100));
+
+    expect(handler.state).toBe(State.BEGAN);
+  });
+});


### PR DESCRIPTION
## Description

`LongPressGestureHandler` accepts `numberOfPointers` but never resets it, so the value survives a config update that no longer sets it.

`setConfig` rebuilds a handler's whole config as `resetConfig()` followed by `updateConfig()`:

* web: `src/web/handlers/GestureHandler.ts:790`
* Apple: `apple/RNGestureHandler.mm:131`
* Android: `android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt:911`

`updateConfig` only assigns properties that are present in the incoming config, so every property it can write has to be cleared by `resetConfig`. `numberOfPointers` was written but never cleared:

* `src/web/handlers/LongPressGestureHandler.ts:127` writes it, `:76` did not reset it
* `android/.../core/LongPressGestureHandler.kt:197` writes it, `:34` did not reset it
* `apple/Handlers/RNLongPressHandler.m:255` writes it, `:232` did not reset it

Every sibling handler already resets its pointer count, which is what made this stand out: `Tap` resets `minNumberOfPointers`, `Fling` resets `numberOfPointersRequired`, `Pan` resets `minPointers`/`maxPointers`.

### What breaks

`GestureDetector` re-sends the full config on every update (`src/handlers/gestures/GestureDetector/updateHandlers.ts:68`), and the config only contains `numberOfPointers` when the gesture actually sets it. So a long press that stops requesting a multi pointer press keeps the stale requirement:

```jsx
const longPress = useLongPressGesture(
  twoFingerMode ? { numberOfPointers: 2 } : {}
);
```

After `twoFingerMode` flips back to `false`, the handler still requires 2 pointers. On web `tryActivate` returns early because `trackedPointersCount !== numberOfPointers` (`src/web/handlers/LongPressGestureHandler.ts:163`), so a normal one finger long press never activates again. The same holds for the v2 `Gesture.LongPress().numberOfPointers(2)` builder and the v1 `<LongPressGestureHandler numberOfPointers={2}>` prop.

The fix resets the value on all three platforms, using a named default in the two places that had a bare literal.

## Test plan

Added `src/web/handlers/__tests__/LongPressGestureHandler.test.ts`, following the existing `GestureHandler.test.ts` / `webNativeViewGestureHandler.test.ts` pattern. One test drives the regression (config with `numberOfPointers: 2`, then a config without it, then a single pointer press), and one control test confirms `numberOfPointers` still applies while it is in the config.

Counterfactual, run in this checkout. With the fix:

```
$ yarn jest src/web/handlers/__tests__/LongPressGestureHandler.test.ts
PASS src/web/handlers/__tests__/LongPressGestureHandler.test.ts
  LongPressGestureHandler config reset
    v a config without numberOfPointers restores the single pointer default (2 ms)
    v numberOfPointers still applies while it stays in the config
```

Then reverting only `src/web/handlers/LongPressGestureHandler.ts` and keeping the test:

```
$ git show HEAD:packages/.../src/web/handlers/LongPressGestureHandler.ts > packages/.../src/web/handlers/LongPressGestureHandler.ts
$ yarn jest src/web/handlers/__tests__/LongPressGestureHandler.test.ts
  x a config without numberOfPointers restores the single pointer default

    expect(received).toBe(expected) // Object.is equality

    Expected: 4
    Received: 2

    > 74 |     expect(handler.state).toBe(State.ACTIVE);

Tests: 1 failed, 1 passed, 2 total
```

`4` is `State.ACTIVE`, `2` is `State.BEGAN`: the handler stayed in `BEGAN` because it was still waiting for a second pointer. Restoring the file turns it green again. The control test passes in both directions, so the failure is specific to the reset.

Checks in this checkout:

* `yarn workspace react-native-gesture-handler test` -> 20 suites, 163 tests passing (162 before this change)
* `yarn workspace react-native-gesture-handler ts-check` -> clean
* `yarn eslint --ext '.js,.ts,.tsx' src/` -> 0 errors, 0 warnings on the touched files
* `yarn prettier --check './src/**/*.{js,jsx,ts,tsx}'` -> all matched files use Prettier code style
* `./android/gradlew -p android spotlessCheck -q` -> exit 0
* `clang-format --style=file` on `RNLongPressHandler.m` -> no diff on the changed lines

The Android and Apple changes mirror the web one and are not covered by the Jest suite; I did not run them on a device.
