### PR TITLE
Reset `enableTrackpadTwoFingerGesture` in web `PanGestureHandler`

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -170,6 +170,7 @@ export default class PanGestureHandler extends GestureHandler {
     this.maxPointers = DEFAULT_MAX_POINTERS;
 
     this.activateAfterLongPress = 0;
+    this.enableTrackpadTwoFingerGesture = false;
 
     this.hasCustomActivationCriteria = false;
   }

--- a/packages/react-native-gesture-handler/src/web/handlers/__tests__/PanGestureHandler.test.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/__tests__/PanGestureHandler.test.ts
@@ -1,0 +1,99 @@
+import { ActionType } from '../../../ActionType';
+import { PointerType } from '../../../PointerType';
+import { State } from '../../../State';
+import type { AdaptedEvent } from '../../interfaces';
+import { EventTypes } from '../../interfaces';
+import type { GestureHandlerDelegate } from '../../tools/GestureHandlerDelegate';
+import GestureHandlerOrchestrator from '../../tools/GestureHandlerOrchestrator';
+import type IGestureHandler from '../IGestureHandler';
+import PanGestureHandler from '../PanGestureHandler';
+
+class TestPanGestureHandler extends PanGestureHandler {
+  public wheel(event: AdaptedEvent): void {
+    this.onWheel(event);
+  }
+}
+
+function wheelEvent(): AdaptedEvent {
+  return {
+    x: 100,
+    y: 100,
+    offsetX: 100,
+    offsetY: 100,
+    pointerId: 0,
+    eventType: EventTypes.MOVE,
+    pointerType: PointerType.OTHER,
+    time: 0,
+    // Not a multiple of 120, so the wheel is recognized as a touchpad.
+    wheelDeltaY: 13,
+  };
+}
+
+function createHandler() {
+  const delegate = {
+    init: jest.fn(),
+    detach: jest.fn(),
+    reset: jest.fn(),
+    onBegin: jest.fn(),
+    onActivate: jest.fn(),
+    onFail: jest.fn(),
+    onCancel: jest.fn(),
+    onEnd: jest.fn(),
+    onEnabledChange: jest.fn(),
+    updateDOM: jest.fn(),
+    isPointerInBounds: jest.fn().mockReturnValue(true),
+    measureView: jest.fn().mockReturnValue({
+      pageX: 0,
+      pageY: 0,
+      width: 100,
+      height: 100,
+    }),
+    absoluteToLocal: jest.fn((x: number, y: number) => ({ x, y })),
+  } as unknown as GestureHandlerDelegate<unknown, IGestureHandler>;
+
+  const handler = new TestPanGestureHandler(delegate);
+  handler.init(1, { current: {} } as never, ActionType.JS_FUNCTION_OLD_API);
+
+  // The full event pipeline is not under test, silence event emission.
+  handler.sendEvent = jest.fn();
+
+  return handler;
+}
+
+describe('PanGestureHandler config reset', () => {
+  afterEach(() => {
+    // The orchestrator is a singleton, drop handlers recorded by the test.
+    (
+      GestureHandlerOrchestrator.instance as unknown as {
+        gestureHandlers: IGestureHandler[];
+      }
+    ).gestureHandlers = [];
+  });
+
+  test('a config without enableTrackpadTwoFingerGesture restores the disabled default', () => {
+    const handler = createHandler();
+
+    handler.setGestureConfig({
+      enabled: true,
+      enableTrackpadTwoFingerGesture: true,
+    });
+    handler.setGestureConfig({ enabled: true });
+
+    handler.wheel(wheelEvent());
+
+    expect(handler.state).toBe(State.UNDETERMINED);
+  });
+
+  test('enableTrackpadTwoFingerGesture still applies while it stays in the config', () => {
+    const handler = createHandler();
+
+    handler.setGestureConfig({
+      enabled: true,
+      enableTrackpadTwoFingerGesture: true,
+    });
+
+    handler.wheel(wheelEvent());
+
+    expect(handler.state).toBe(State.ACTIVE);
+  });
+});


### PR DESCRIPTION
## Description

On web, `PanGestureHandler.updateGestureConfig` writes `enableTrackpadTwoFingerGesture`, but `resetConfig` never restores it.

`setGestureConfig` is a full config replace (`resetConfig` then `updateGestureConfig`), and it is what `updateHandlers` / `useGesture` call whenever the gesture config changes. So once a pan gesture has been configured with `enableTrackpadTwoFingerGesture: true`, a later config that no longer carries the prop keeps two-finger trackpad panning enabled, and a wheel event from a trackpad still activates the gesture.

Every other field the web `PanGestureHandler` reads from the config is restored in `resetConfig`; this one was missed. iOS is already correct: `RNPanHandler`'s `resetConfig` sets `recognizer.allowedScrollTypesMask = 0`, which is the same property. Android does not support the prop, so this is web only.

## Test plan

Added `src/web/handlers/__tests__/PanGestureHandler.test.ts` with two cases:

- configure the handler with `enableTrackpadTwoFingerGesture: true`, then apply a config without it, and feed a touchpad wheel event: the handler must stay `UNDETERMINED`.
- configure it with `enableTrackpadTwoFingerGesture: true` and feed the same event: the handler must reach `ACTIVE`, so the flag itself keeps working.

Without the one-line change in `resetConfig`, the first test fails with `Expected: 0 / Received: 4` (the gesture activates from stale config). The second one passes both ways.

`yarn test`, `yarn lint-js` and `yarn ts-check` are green in `packages/react-native-gesture-handler`.
