### PR TITLE
[CI] Capture device logs in e2e workflows

### DIFF
--- a/.github/workflows/android-e2e.yml
+++ b/.github/workflows/android-e2e.yml
@@ -146,6 +146,12 @@ jobs:
         with:
           simulator-server-log: debug
 
+      - name: Start logcat capture
+        run: |
+          adb logcat -c
+          nohup adb logcat > logcat.log 2>&1 &
+          echo "LOGCAT_PID=$!" >> "$GITHUB_ENV"
+
       # `screenrecord` stops on its own after 3 minutes, so record in segments
       # until the stop step interrupts it.
       - name: Start screen recording
@@ -182,8 +188,13 @@ jobs:
       - name: Collect logs
         if: ${{ always() }}
         run: |
+          kill "${LOGCAT_PID:-}" 2>/dev/null || true
+          for _ in $(seq 1 10); do
+            kill -0 "${LOGCAT_PID:-}" 2>/dev/null || break
+            sleep 1
+          done
           mkdir -p "$RUNNER_TEMP/e2e-debug/logs"
-          for f in emulator.log screenrecord.log "${ARGENT_SERVER_LOG:-}"; do
+          for f in emulator.log screenrecord.log logcat.log "${ARGENT_SERVER_LOG:-}"; do
             cp "$f" "$RUNNER_TEMP/e2e-debug/logs" 2>/dev/null || true
           done
           ls -lR "$RUNNER_TEMP/e2e-debug"

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -102,6 +102,14 @@ jobs:
       - name: Install Argent and start the tool-server
         uses: ./.github/actions/argent-server
 
+      - name: Start app log capture
+        run: |
+          APP_PROCESS=$(/usr/libexec/PlistBuddy -c 'Print :CFBundleExecutable' "$APP_PATH/Info.plist")
+          nohup xcrun simctl spawn "$SIMULATOR_UDID" log stream --level debug --style compact \
+            --predicate "process == \"$APP_PROCESS\"" > app.log 2>&1 &
+          echo "APP_LOG_PID=$!" >> "$GITHUB_ENV"
+          echo "APP_PROCESS=$APP_PROCESS" >> "$GITHUB_ENV"
+
       # h264 rather than the default hevc, which most browsers cannot play.
       - name: Start screen recording
         run: |
@@ -136,10 +144,18 @@ jobs:
       - name: Collect logs
         if: ${{ always() }}
         run: |
+          kill -INT "${APP_LOG_PID:-}" 2>/dev/null || true
+          for _ in $(seq 1 10); do
+            kill -0 "${APP_LOG_PID:-}" 2>/dev/null || break
+            sleep 1
+          done
           mkdir -p "$RUNNER_TEMP/e2e-debug/logs"
-          for f in recordvideo.log "${ARGENT_SERVER_LOG:-}"; do
+          for f in recordvideo.log app.log "${ARGENT_SERVER_LOG:-}"; do
             cp "$f" "$RUNNER_TEMP/e2e-debug/logs" 2>/dev/null || true
           done
+          # Simulator crash reports are written on the host, not in the sim.
+          mkdir -p "$RUNNER_TEMP/e2e-debug/crashes"
+          cp "$HOME/Library/Logs/DiagnosticReports/${APP_PROCESS:-}"*.ips "$RUNNER_TEMP/e2e-debug/crashes" 2>/dev/null || true
           ls -lR "$RUNNER_TEMP/e2e-debug"
 
       - name: Upload logs and screen recording

--- a/.github/workflows/ios-e2e.yml
+++ b/.github/workflows/ios-e2e.yml
@@ -154,8 +154,10 @@ jobs:
             cp "$f" "$RUNNER_TEMP/e2e-debug/logs" 2>/dev/null || true
           done
           # Simulator crash reports are written on the host, not in the sim.
-          mkdir -p "$RUNNER_TEMP/e2e-debug/crashes"
-          cp "$HOME/Library/Logs/DiagnosticReports/${APP_PROCESS:-}"*.ips "$RUNNER_TEMP/e2e-debug/crashes" 2>/dev/null || true
+          if [ -n "${APP_PROCESS:-}" ]; then
+            mkdir -p "$RUNNER_TEMP/e2e-debug/crashes"
+            cp "$HOME/Library/Logs/DiagnosticReports/${APP_PROCESS}"*.ips "$RUNNER_TEMP/e2e-debug/crashes" 2>/dev/null || true
+          fi
           ls -lR "$RUNNER_TEMP/e2e-debug"
 
       - name: Upload logs and screen recording


### PR DESCRIPTION
## Description

Updates the e2e workflows to save logcat/app log during the test run. Both files land in the existing debug artifact uploaded when the job fails.

## Test plan

Check status