### PR TITLE
[CI] Await the example button before tapping it in Argent flows

### DIFF
--- a/.argent/flows/basic-long-press-test.yaml
+++ b/.argent/flows/basic-long-press-test.yaml
@@ -4,6 +4,7 @@ steps:
   - await: { visible: { text: "Empty Example" }, timeout: 15000 }
   - echo: "On the Home list, search for long press example"
   - type: { text: "long", into: { id: "search-examples" } }
+  - await: { visible: { text: "Basic LongPress" } }
   - echo: "Tap the example to open it"
   - tap: "Basic LongPress"
   - echo: "Clear console"

--- a/.argent/flows/basic-tap-test.yaml
+++ b/.argent/flows/basic-tap-test.yaml
@@ -4,6 +4,7 @@ steps:
   - await: { visible: { text: "Empty Example" }, timeout: 15000 }
   - echo: "On the Home list, search for tap example"
   - type: { text: "tap", into: { id: "search-examples" } }
+  - await: { visible: { text: "Basic Tap" } }
   - echo: "Tap the example to open it"
   - tap: "Basic Tap"
   - echo: "Clear console"

--- a/.argent/flows/nested-touchables-test.yaml
+++ b/.argent/flows/nested-touchables-test.yaml
@@ -4,6 +4,7 @@ steps:
   - await: { visible: { text: "Empty Example" }, timeout: 15000 }
   - echo: "On the Home list, search for the nested touchables example"
   - type: { text: "nested touchables", into: { id: "search-examples" } }
+  - await: { visible: { text: "Nested touchables" } }
   - echo: "Tap the example to open it"
   - tap: { text: "Nested touchables" }
   - await: { visible: { id: "level-4" } }

--- a/.argent/flows/shared-value-test.yaml
+++ b/.argent/flows/shared-value-test.yaml
@@ -4,6 +4,7 @@ steps:
   - await: { visible: { text: "Empty Example" }, timeout: 15000 }
   - echo: "On the Home list, search for the shared value example"
   - type: { text: "shared", into: { id: "search-examples" } }
+  - await: { visible: { text: "Shared Value" } }
   - echo: "Tap the example to open it"
   - tap: { text: "Shared Value" }
   - await: { visible: { id: "shared-value-box" } }

--- a/.argent/flows/timer-test.yaml
+++ b/.argent/flows/timer-test.yaml
@@ -4,6 +4,7 @@ steps:
   - await: { visible: { text: "Empty Example" }, timeout: 15000 }
   - echo: "On the Home list, search for the timer example"
   - type: { text: "timer", into: { id: "search-examples" } }
+  - await: { visible: { text: "Timer" } }
   - echo: "Tap the example to open it"
   - tap: { text: "Timer" }
   - await: { idle: true }


### PR DESCRIPTION
## Description

The search results may not be rendered yet when the flow taps the example button right after typing into the search field. Await the button in every flow before tapping it.

## Test plan

Run the flows in `.argent/flows` and check that they pass.