### PR TITLE
Reset accumulated wheel delta in web `WheelEventManager`

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -334,14 +334,13 @@ export default class PanGestureHandler extends GestureHandler {
     }
   }
 
-  private scheduleWheelEnd(event: AdaptedEvent) {
+  private scheduleWheelEnd() {
     clearTimeout(this.endWheelTimeout);
 
     this.endWheelTimeout = setTimeout(() => {
       if (this.state === State.ACTIVE) {
         this.end();
-        this.tracker.removeFromTracker(event.pointerId);
-        this.state = State.UNDETERMINED;
+        this.reset();
       }
 
       this.wheelDevice = WheelDevice.UNDETERMINED;
@@ -363,7 +362,7 @@ export default class PanGestureHandler extends GestureHandler {
           : WheelDevice.MOUSE;
 
       if (this.wheelDevice === WheelDevice.MOUSE) {
-        this.scheduleWheelEnd(event);
+        this.scheduleWheelEnd();
         return;
       }
 
@@ -383,7 +382,7 @@ export default class PanGestureHandler extends GestureHandler {
     this.updateVelocity(event.pointerId);
 
     this.tryToSendMoveEvent(false, event);
-    this.scheduleWheelEnd(event);
+    this.scheduleWheelEnd();
   }
 
   private shouldActivate(): boolean {

--- a/packages/react-native-gesture-handler/src/web/handlers/__tests__/PanGestureHandler.test.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/__tests__/PanGestureHandler.test.ts
@@ -3,14 +3,23 @@ import { PointerType } from '../../../PointerType';
 import { State } from '../../../State';
 import type { AdaptedEvent } from '../../interfaces';
 import { EventTypes } from '../../interfaces';
+import type EventManager from '../../tools/EventManager';
 import type { GestureHandlerDelegate } from '../../tools/GestureHandlerDelegate';
 import GestureHandlerOrchestrator from '../../tools/GestureHandlerOrchestrator';
+import WheelEventManager from '../../tools/WheelEventManager';
 import type IGestureHandler from '../IGestureHandler';
 import PanGestureHandler from '../PanGestureHandler';
 
 class TestPanGestureHandler extends PanGestureHandler {
+  public readonly wheelEvents: AdaptedEvent[] = [];
+
   public wheel(event: AdaptedEvent): void {
     this.onWheel(event);
+  }
+
+  protected override onWheel(event: AdaptedEvent): void {
+    this.wheelEvents.push(event);
+    super.onWheel(event);
   }
 }
 
@@ -29,11 +38,15 @@ function wheelEvent(): AdaptedEvent {
   };
 }
 
-function createHandler() {
+function createHandler(eventManagers: EventManager<unknown>[] = []) {
   const delegate = {
     init: jest.fn(),
     detach: jest.fn(),
-    reset: jest.fn(),
+    // Mirrors GestureHandlerWebDelegate.reset(), which forwards the reset to
+    // every event manager attached to the handler.
+    reset: jest.fn(() =>
+      eventManagers.forEach((manager) => manager.resetManager())
+    ),
     onBegin: jest.fn(),
     onActivate: jest.fn(),
     onFail: jest.fn(),
@@ -60,16 +73,46 @@ function createHandler() {
   return handler;
 }
 
-describe('PanGestureHandler config reset', () => {
-  afterEach(() => {
-    // The orchestrator is a singleton, drop handlers recorded by the test.
-    (
-      GestureHandlerOrchestrator.instance as unknown as {
-        gestureHandlers: IGestureHandler[];
-      }
-    ).gestureHandlers = [];
-  });
+afterEach(() => {
+  // The orchestrator is a singleton, drop handlers recorded by the test.
+  (
+    GestureHandlerOrchestrator.instance as unknown as {
+      gestureHandlers: IGestureHandler[];
+    }
+  ).gestureHandlers = [];
+});
 
+class FakeView {
+  private readonly listeners = new Map<string, Set<(event: unknown) => void>>();
+
+  public addEventListener(type: string, listener: (event: unknown) => void) {
+    const listeners = this.listeners.get(type) ?? new Set();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  public removeEventListener(type: string, listener: (event: unknown) => void) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  public wheel(deltaY: number): void {
+    this.listeners.get('wheel')?.forEach((listener) =>
+      listener({
+        clientX: 0,
+        clientY: 0,
+        offsetX: 0,
+        offsetY: 0,
+        deltaX: 0,
+        deltaY,
+        timeStamp: 0,
+        // Not a multiple of 120, so the wheel is recognized as a touchpad.
+        wheelDeltaY: 13,
+      })
+    );
+  }
+}
+
+describe('PanGestureHandler config reset', () => {
   test('a config without enableTrackpadTwoFingerGesture restores the disabled default', () => {
     const handler = createHandler();
 
@@ -95,5 +138,42 @@ describe('PanGestureHandler config reset', () => {
     handler.wheel(wheelEvent());
 
     expect(handler.state).toBe(State.ACTIVE);
+  });
+});
+
+describe('PanGestureHandler trackpad gesture end', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+  });
+
+  afterEach(() => {
+    // The gesture schedules its end on every wheel event, drop the last one.
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  test('the next trackpad gesture starts from the wheel event coordinates', () => {
+    const view = new FakeView();
+    const manager = new WheelEventManager(view as unknown as HTMLElement);
+    const handler = createHandler([manager]);
+
+    handler.setGestureConfig({
+      enabled: true,
+      enableTrackpadTwoFingerGesture: true,
+    });
+    handler.attachEventManager(manager);
+
+    view.wheel(100);
+    expect(handler.state).toBe(State.ACTIVE);
+
+    // A trackpad gesture ends when the wheel goes quiet for 30ms.
+    jest.advanceTimersByTime(30);
+    expect(handler.state).toBe(State.UNDETERMINED);
+
+    view.wheel(30);
+
+    // A wheel does not move the cursor, so the manager synthesizes coordinates
+    // by accumulating deltas. The gesture that just ended must not contribute.
+    expect(handler.wheelEvents[1].y).toBe(30);
   });
 });

--- a/packages/react-native-gesture-handler/src/web/tools/WheelEventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/WheelEventManager.ts
@@ -45,5 +45,6 @@ export default class WheelEventManager extends EventManager<HTMLElement> {
 
   public override resetManager(): void {
     super.resetManager();
+    this.wheelDelta = { x: 0, y: 0 };
   }
 }


### PR DESCRIPTION
## Description

`WheelEventManager` has no pointer to follow, so it synthesizes coordinates by accumulating `deltaX`/`deltaY` on top of each wheel event's client coordinates. Its `resetManager` override calls only `super.resetManager()` and never clears `wheelDelta`, unlike `PointerEventManager`, which clears its own bookkeeping there.

`resetManager` runs on every handler reset (`GestureHandler.reset` -> `delegate.reset` -> `manager.resetManager`), which the orchestrator triggers once a gesture reaches `END`. So when a trackpad pan ends, the whole scroll distance of that gesture stays in `wheelDelta`.

To reproduce, put a `Pan` gesture with `enableTrackpadTwoFingerGesture` on a view, then do two two-finger trackpad pans in a row without moving the cursor in between. The second gesture reports `absoluteX`/`absoluteY` offset by the first gesture's total scroll. A two-finger scroll does not move the cursor, so the `pointermove` listener that clears the delta does not necessarily fire, and the offset keeps growing with each gesture.

Fix is to clear `wheelDelta` in `resetManager`, matching what `PointerEventManager` already does.

## Test plan

Added `src/web/tools/__tests__/WheelEventManager.test.ts` with two cases:

- deltas still accumulate across wheel events within one gesture (`y` is 130 after deltas of 100 and 30), so the accumulation behaviour is not lost.
- after `resetManager`, the next wheel event reports only its own delta (`y` is 30, not 130).

The second test fails on `main` with `Expected: 30, Received: 130` and passes with the fix. `yarn jest src/web`, `yarn ts-check` and `eslint`/`prettier` on the touched files all pass.
