### PR TITLE
[Web] Restore enabled on a full config replace

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/GestureHandler.ts
@@ -789,7 +789,7 @@ export default abstract class GestureHandler implements IGestureHandler {
 
   public setGestureConfig(config: Config) {
     this.resetConfig();
-    this.updateGestureConfig(config);
+    this.updateGestureConfig({ ...config, enabled: config.enabled ?? true });
   }
 
   public updateGestureConfig(config: Partial<Config>): void {

--- a/packages/react-native-gesture-handler/src/web/handlers/__tests__/GestureHandler.test.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/__tests__/GestureHandler.test.ts
@@ -1,3 +1,4 @@
+import type { Config } from '../../interfaces';
 import EventManager from '../../tools/EventManager';
 import type { GestureHandlerDelegate } from '../../tools/GestureHandlerDelegate';
 import GestureHandler from '../GestureHandler';
@@ -24,6 +25,16 @@ function createHandler(enabled: boolean) {
 
   return handler;
 }
+
+describe('GestureHandler web config reset', () => {
+  test('a config without enabled restores the enabled default', () => {
+    const handler = createHandler(false);
+
+    handler.setGestureConfig({} as Config);
+
+    expect(handler.enabled).toBe(true);
+  });
+});
 
 describe('GestureHandler web event manager attachment', () => {
   test('registers listeners for an initially enabled handler', () => {


### PR DESCRIPTION
## Description

The web GestureHandler kept the previous enabled value when a full config replace did not carry the key. It now falls back to true, matching Android and iOS.

## Test plan

Added a test in `GestureHandler.test.ts`.