### PR TITLE
[Android] Stop nested scroll when a native handler's gesture ends

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -161,6 +161,9 @@ class NativeViewGestureHandler : GestureHandler() {
         cancel()
       } else {
         hook.sendTouchEvent(view, event)
+        if (shouldStopNestedScroll()) {
+          view.stopNestedScroll()
+        }
 
         if ((state == STATE_UNDETERMINED || state == STATE_BEGAN) && hook.canActivate(view)) {
           activate()
@@ -206,8 +209,18 @@ class NativeViewGestureHandler : GestureHandler() {
       action = MotionEvent.ACTION_CANCEL
     }
     hook.sendTouchEvent(view, event)
+    if (shouldStopNestedScroll()) {
+      view?.stopNestedScroll()
+    }
     event.recycle()
   }
+
+  // Once the handler is active, it delivers touches straight to the view's `onTouchEvent`. Normally
+  // touches arrive through `View.dispatchTouchEvent`, which also ends the nested scroll when the finger
+  // goes up. Because we skip it, the nested scroll stays open and the parent never finds out that the
+  // gesture is over - e.g. SwipeRefreshLayout never fires refresh (#4485). While the handler is not
+  // active, the view still receives touches the regular way, so Android takes care of it.
+  private fun shouldStopNestedScroll() = state == STATE_ACTIVE && hook.shouldStopNestedScroll()
 
   override fun onCancel() = dispatchCancelEventToView()
 
@@ -347,6 +360,12 @@ class NativeViewGestureHandler : GestureHandler() {
      * the gesture will be cancelled.
      */
     fun canBegin(event: MotionEvent) = true
+
+    /**
+     * Whether the view's nested scroll should be stopped when the active gesture ends. Touches
+     * are fed through `onTouchEvent`, so `View.dispatchTouchEvent` never gets to do it.
+     */
+    fun shouldStopNestedScroll() = false
 
     /**
      * Checks whether handler can activate. Used by TextViewHook.
@@ -523,6 +542,10 @@ class NativeViewGestureHandler : GestureHandler() {
 
   private class ScrollViewHook : NativeViewGestureHandlerHook {
     override fun shouldCancelRootViewGestureHandlerIfNecessary() = true
+
+    // ScrollView starts a nested scroll on DOWN but never stops it itself. Without this the
+    // parent's `onStopNestedScroll` never runs, e.g. SwipeRefreshLayout never triggers refresh.
+    override fun shouldStopNestedScroll() = true
   }
 
   private class ReactViewGroupHook : NativeViewGestureHandlerHook {


### PR DESCRIPTION
## Description

`ScrollView` and `FlatList` from Gesture Handler never fire `onRefresh` when given React Native's `RefreshControl` on Android. The spinner follows the pull but stays parked on release, and the refresh only triggers on the next touch anywhere on the screen.

With a `refreshControl` RN wraps the scroll view in a `SwipeRefreshLayout` and enables nested scrolling on it. The pull reaches the layout through the nested-scroll API, and the layout finishes it (fires refresh or snaps back) only in `onStopNestedScroll`. Android calls `stopNestedScroll()` from `View.dispatchTouchEvent` at the end of a gesture, but once `NativeViewGestureHandler` activates it delivers touches straight to the view's `onTouchEvent`, so that cleanup never runs. The nested scroll stays open and the layout is released one touch late, by the CANCEL our root view dispatches on the next DOWN. Gesture Handler's own `RefreshControl` avoids this because its handler drives the `SwipeRefreshLayout` in touch-drag mode, which finishes the spinner in `onTouchEvent` without relying on the nested-scroll cleanup.

The handler now calls `stopNestedScroll()` on the view after feeding it the final UP or the synthetic CANCEL, mirroring `View.dispatchTouchEvent`. It only does so while active, since below that the view still receives the events through regular dispatch, and only for views whose hook opts in through the new `shouldStopNestedScroll()`. `ScrollViewHook` opts in.

Fixes #4485

## Test plan

- Pulled to refresh repeatedly on GH `ScrollView` + RN `RefreshControl`, GH `FlatList` + RN `RefreshControl`, and `Gesture.Native()` around an RN `ScrollView` + RN `RefreshControl`. `onRefresh` fires on every pull and the spinner retracts.
- GH `ScrollView` + GH `RefreshControl` and RN `ScrollView` + RN `RefreshControl` unchanged.
- Nested GH `ScrollView` inside GH `ScrollView`, with and without an RN `RefreshControl` on the outer: scroll handover, fling, and pull-to-refresh from inside the inner list work the same as with RN scroll views.

<details>
<summary>Repro</summary>

```tsx
import React, { useCallback, useState } from 'react';
import { RefreshControl, Text, View } from 'react-native';
import { ScrollView } from 'react-native-gesture-handler';

export default function App() {
  const [refreshing, setRefreshing] = useState(false);
  const onRefresh = useCallback(() => {
    setRefreshing(true);
    setTimeout(() => setRefreshing(false), 1000);
  }, []);

  return (
    <ScrollView
      style={{ flex: 1 }}
      refreshControl={<RefreshControl refreshing={refreshing} onRefresh={onRefresh} />}>
      {Array.from({ length: 40 }, (_, i) => (
        <View key={i} style={{ padding: 20 }}>
          <Text>Row {i}</Text>
        </View>
      ))}
    </ScrollView>
  );
}
```
</details>