### PR TITLE
Resolve `DrawerLayoutAndroid` lazily to avoid RN deprecation warning on import

### DIFF
--- a/packages/react-native-gesture-handler/src/components/GestureComponents.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureComponents.tsx
@@ -1,6 +1,7 @@
 import type { PropsWithChildren, ReactElement } from 'react';
 import * as React from 'react';
 import type {
+  DrawerLayoutAndroid as RNDrawerLayoutAndroid,
   DrawerLayoutAndroidProps as RNDrawerLayoutAndroidProps,
   FlatListProps as RNFlatListProps,
   ScrollViewProps as RNScrollViewProps,
@@ -8,7 +9,6 @@ import type {
   TextInputProps as RNTextInputProps,
 } from 'react-native';
 import {
-  DrawerLayoutAndroid as RNDrawerLayoutAndroid,
   FlatList as RNFlatList,
   RefreshControl as RNRefreshControl,
   ScrollView as RNScrollView,
@@ -96,18 +96,39 @@ export const LegacyTextInput =
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type LegacyTextInput = typeof LegacyTextInput & RNTextInput;
 
+// RN's `DrawerLayoutAndroid` export is a getter that logs a deprecation
+// warning on access, so resolve it at render time instead of module load.
+// `require` is used on purpose: `import * as RN` would read every export
+// eagerly under Metro's `experimentalImportSupport`.
+const LazyDrawerLayoutAndroid = (
+  props: PropsWithChildren<RNDrawerLayoutAndroidProps> & {
+    ref?: React.Ref<React.ComponentRef<typeof RNDrawerLayoutAndroid> | null>;
+  }
+) => {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { DrawerLayoutAndroid } = require('react-native') as {
+    DrawerLayoutAndroid: typeof RNDrawerLayoutAndroid;
+  };
+  return <DrawerLayoutAndroid {...props} />;
+};
+LazyDrawerLayoutAndroid.displayName = 'DrawerLayoutAndroid';
+
 /**
  * @deprecated use `DrawerLayoutAndroid` instead
  */
 export const LegacyDrawerLayoutAndroid: React.ComponentType<
-  PropsWithChildren<RNDrawerLayoutAndroidProps> & NativeViewGestureHandlerProps
+  PropsWithChildren<RNDrawerLayoutAndroidProps> &
+    NativeViewGestureHandlerProps & {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ref?: React.Ref<React.ComponentType<any> | null>;
+    }
 > = createNativeWrapper<PropsWithChildren<RNDrawerLayoutAndroidProps>>(
-  RNDrawerLayoutAndroid,
+  LazyDrawerLayoutAndroid,
   { disallowInterruption: true }
 );
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type LegacyDrawerLayoutAndroid = typeof LegacyDrawerLayoutAndroid &
-  RNDrawerLayoutAndroid;
+  React.ComponentRef<typeof RNDrawerLayoutAndroid>;
 
 /**
  * @deprecated use `FlatList` instead

--- a/packages/react-native-gesture-handler/src/components/GestureComponents.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureComponents.tsx
@@ -97,19 +97,24 @@ export const LegacyTextInput =
 export type LegacyTextInput = typeof LegacyTextInput & RNTextInput;
 
 // RN's `DrawerLayoutAndroid` export is a getter that logs a deprecation
-// warning on access, so resolve it at render time instead of module load.
+// warning on access, so resolve it on first render instead of module load.
 // `require` is used on purpose: `import * as RN` would read every export
 // eagerly under Metro's `experimentalImportSupport`.
+let DrawerLayoutAndroidImpl: typeof RNDrawerLayoutAndroid | undefined;
+
 const LazyDrawerLayoutAndroid = (
   props: PropsWithChildren<RNDrawerLayoutAndroidProps> & {
     ref?: React.Ref<React.ComponentRef<typeof RNDrawerLayoutAndroid> | null>;
   }
 ) => {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { DrawerLayoutAndroid } = require('react-native') as {
-    DrawerLayoutAndroid: typeof RNDrawerLayoutAndroid;
-  };
-  return <DrawerLayoutAndroid {...props} />;
+  if (!DrawerLayoutAndroidImpl) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { DrawerLayoutAndroid } = require('react-native') as {
+      DrawerLayoutAndroid: typeof RNDrawerLayoutAndroid;
+    };
+    DrawerLayoutAndroidImpl = DrawerLayoutAndroid;
+  }
+  return <DrawerLayoutAndroidImpl {...props} />;
 };
 LazyDrawerLayoutAndroid.displayName = 'DrawerLayoutAndroid';
 


### PR DESCRIPTION
## Description

Since React Native 0.87 the `DrawerLayoutAndroid` export is a getter that logs `DrawerLayoutAndroid is deprecated and will be removed in a future release` through `warnOnce` on first access. `GestureComponents.tsx` imported it at module level to build `LegacyDrawerLayoutAndroid`, so every app that imports gesture-handler saw the warning at startup, even if it never rendered a drawer.

`LegacyDrawerLayoutAndroid` now wraps a small component that reads `DrawerLayoutAndroid` from `react-native` on first render and caches it in a module-level variable, so the warning appears only for apps that actually render the deprecated wrapper. The read uses `require` rather than `import * as RN`, because Metro's `experimentalImportSupport` (enabled by default in Expo) copies every export eagerly and would trigger all of RN's deprecation getters at once.

Fixes #4491 

## Test plan

- `yarn ts-check`, `yarn test` and `yarn lint:js` in the package
- `yarn ts-check` in `apps/basic-example`
- `basic-example` on Android: no deprecation warning at startup, one warning when opening the `Drawer Layout` screen; open/close via edge swipe and via ref buttons, drawer callbacks and `RectButton` presses work
