### PR TITLE
[iOS] Keep button hit testing within its own subtree

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -1193,6 +1193,11 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 
 - (void)mouseDown:(NSEvent *)event
 {
+  if (!_userEnabled) {
+    return;
+  }
+
+  
   _isTouchInsideBounds = YES;
   [self handleAnimatePressIn];
   [super mouseDown:event];
@@ -1200,6 +1205,10 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 
 - (void)mouseUp:(NSEvent *)event
 {
+  if (!_userEnabled) {
+    return;
+  }
+  
   NSPoint locationInView = [self convertPoint:[event locationInWindow] fromView:nil];
   _isHovered = NSPointInRect(locationInView, self.bounds);
   [self recordHoverSampleForMouseEvent:event];
@@ -1212,6 +1221,10 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 
 - (void)mouseDragged:(NSEvent *)event
 {
+  if (!_userEnabled) {
+    return;
+  }
+  
   NSPoint locationInWindow = [event locationInWindow];
   NSPoint locationInView = [self convertPoint:locationInWindow fromView:nil];
   BOOL currentlyInside = NSPointInRect(locationInView, self.bounds);
@@ -1244,6 +1257,10 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 
 - (BOOL)beginTrackingWithTouch:(UITouch *)touch withEvent:(UIEvent *)event
 {
+  if (!_userEnabled) {
+    return NO;
+  }
+  
   _isTouchInsideBounds = YES;
   // A pencil's hover-out arrives just before touch-down but only schedules the
   // clear, so `_isHovered` still reflects the open hover. Under Reduce Motion
@@ -1469,10 +1486,7 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   }
 
   RNGHUIView *inner = [super hitTest:point withEvent:event];
-  while (inner && ![self shouldHandleTouch:inner atPoint:point]) {
-    if (inner == self) {
-      return nil;
-    }
+  while (inner && inner != self && ![self shouldHandleTouch:inner atPoint:point]) {
     inner = inner.superview;
   }
   return inner;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -1470,6 +1470,9 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
 
   RNGHUIView *inner = [super hitTest:point withEvent:event];
   while (inner && ![self shouldHandleTouch:inner atPoint:point]) {
+    if (inner == self) {
+      return nil;
+    }
     inner = inner.superview;
   }
   return inner;


### PR DESCRIPTION
## Description

Fixes #4494.

When a disabled `RNGestureHandlerButton` has no eligible touch target, the hit-test loop can continue past the button and return an ancestor outside its subtree.

This change returns `nil` when the search reaches the button itself without finding an eligible target. Eligible descendants can still be selected before reaching that boundary.

The guard prevents the SwiftUI-backed blur crash in my device testing. The suspected connection between returning a hosting ancestor and recursive hit testing is described in the linked issue.

## Test plan

Tested the same boundary guard in my app’s test screen on an iPhone 16 Pro running iOS 26.5.2, using an Expo SDK 57 development build with React Native 0.86.3 and Gesture Handler 3.2.1.

React Native’s experimental `enableSwiftUIBasedFilters` flag was enabled.

- Original behaviour: tapping the disabled outer area crashes.
- Boundary guard enabled, pointer-events workaround off: tapping the same area no longer crashes.

Reproduction project and build instructions:
https://github.com/rileysay/rngh-swiftui-hit-test-repro

The standalone project has built successfully on EAS. The device observations above were recorded using the test screen in my original app.

AI assistance: I used Codex to help investigate the native code, prepare the reproduction project, and propose this patch. I personally verified the device observations above.