### PR TITLE
[Release] 2.33.0 Cherry-pick thread

### DIFF
--- a/apps/basic-example/android/app/build.gradle
+++ b/apps/basic-example/android/app/build.gradle
@@ -45,7 +45,7 @@ react {
 
     /* Hermes Commands */
     //   The hermes compiler command to run. By default it is 'hermesc'
-    hermesCommand = "../../../../node_modules/react-native/sdks/hermesc/osx-bin/hermesc"
+    hermesCommand = "../../node_modules/hermes-compiler/hermesc/%OS-BIN%/hermesc"
     //
     //   The list of flags to pass to the Hermes compiler. By default is "-O", "-output-source-map"
     // hermesFlags = ["-O", "-output-source-map"]

--- a/packages/docs-gesture-handler/docs/fundamentals/installation.md
+++ b/packages/docs-gesture-handler/docs/fundamentals/installation.md
@@ -101,18 +101,6 @@ export function CustomModal({ children, ...rest }) {
 }
 ```
 
-##### Kotlin
-
-Gesture Handler on Android is implemented in Kotlin. If you need to set a specific Kotlin version to be used by the library, set the `kotlinVersion` ext property in `android/build.gradle` file and RNGH will use that version:
-
-```groovy
-buildscript {
-    ext {
-        kotlinVersion = "1.6.21"
-    }
-}
-```
-
 #### iOS
 
 While developing for iOS, make sure to install [pods](https://cocoapods.org/) first before running the app:

--- a/packages/docs-gesture-handler/docs/gesture-handlers/pan-gh.md
+++ b/packages/docs-gesture-handler/docs/gesture-handlers/pan-gh.md
@@ -52,6 +52,18 @@ See [set of properties inherited from base handler class](/docs/gesture-handlers
 
 Minimum distance the finger (or multiple finger) need to travel before the handler [activates](/docs/under-the-hood/state#active). Expressed in points.
 
+### `minVelocity`
+
+Minimum speed the pointer has to reach in order for the handler to [activate](/docs/2.x/under-the-hood/state#active). Expressed in points per second.
+
+### `minVelocityX`
+
+Minimum speed along X axis the pointer has to reach in order for the handler to [activate](/docs/2.x/under-the-hood/state#active). Expressed in points per second.
+
+### `minVelocityY`
+
+Minimum speed along Y axis the pointer has to reach in order for the handler to [activate](/docs/2.x/under-the-hood/state#active). Expressed in points per second.
+
 ### `minPointers`
 
 A number of fingers that is required to be placed before handler can [activate](/docs/under-the-hood/state#active). Should be a higher or equal to 0 integer.

--- a/packages/docs-gesture-handler/docs/gesture-handlers/pan-gh.md
+++ b/packages/docs-gesture-handler/docs/gesture-handlers/pan-gh.md
@@ -54,15 +54,15 @@ Minimum distance the finger (or multiple finger) need to travel before the handl
 
 ### `minVelocity`
 
-Minimum speed the pointer has to reach in order for the handler to [activate](/docs/2.x/under-the-hood/state#active). Expressed in points per second.
+Minimum speed the pointer has to reach in order for the handler to [activate](/docs/under-the-hood/state#active). Expressed in points per second.
 
 ### `minVelocityX`
 
-Minimum speed along X axis the pointer has to reach in order for the handler to [activate](/docs/2.x/under-the-hood/state#active). Expressed in points per second.
+Minimum speed along X axis the pointer has to reach in order for the handler to [activate](/docs/under-the-hood/state#active). Expressed in points per second.
 
 ### `minVelocityY`
 
-Minimum speed along Y axis the pointer has to reach in order for the handler to [activate](/docs/2.x/under-the-hood/state#active). Expressed in points per second.
+Minimum speed along Y axis the pointer has to reach in order for the handler to [activate](/docs/under-the-hood/state#active). Expressed in points per second.
 
 ### `minPointers`
 

--- a/packages/docs-gesture-handler/docs/gestures/pan-gesture.md
+++ b/packages/docs-gesture-handler/docs/gestures/pan-gesture.md
@@ -130,6 +130,18 @@ If you wish to track the "center of mass" virtual pointer and account for its ch
 
 Minimum distance the finger (or multiple finger) need to travel before the gesture [activates](/docs/fundamentals/states-events#active). Expressed in points.
 
+### `minVelocity(value: number)`
+
+Minimum speed the pointer has to reach in order for the gesture to [activate](/docs/2.x/fundamentals/states-events#active). Expressed in points per second.
+
+### `minVelocityX(value: number)`
+
+Minimum speed along X axis the pointer has to reach in order for the gesture to [activate](/docs/2.x/fundamentals/states-events#active). Expressed in points per second.
+
+### `minVelocityY(value: number)`
+
+Minimum speed along Y axis the pointer has to reach in order for the gesture to [activate](/docs/2.x/fundamentals/states-events#active). Expressed in points per second.
+
 ### `minPointers(value: number)`
 
 A number of fingers that is required to be placed before gesture can [activate](/docs/fundamentals/states-events#active). Should be a higher or equal to 0 integer.

--- a/packages/docs-gesture-handler/docs/gestures/pan-gesture.md
+++ b/packages/docs-gesture-handler/docs/gestures/pan-gesture.md
@@ -132,15 +132,15 @@ Minimum distance the finger (or multiple finger) need to travel before the gestu
 
 ### `minVelocity(value: number)`
 
-Minimum speed the pointer has to reach in order for the gesture to [activate](/docs/2.x/fundamentals/states-events#active). Expressed in points per second.
+Minimum speed the pointer has to reach in order for the gesture to [activate](/docs/fundamentals/states-events#active). Expressed in points per second.
 
 ### `minVelocityX(value: number)`
 
-Minimum speed along X axis the pointer has to reach in order for the gesture to [activate](/docs/2.x/fundamentals/states-events#active). Expressed in points per second.
+Minimum speed along X axis the pointer has to reach in order for the gesture to [activate](/docs/fundamentals/states-events#active). Expressed in points per second.
 
 ### `minVelocityY(value: number)`
 
-Minimum speed along Y axis the pointer has to reach in order for the gesture to [activate](/docs/2.x/fundamentals/states-events#active). Expressed in points per second.
+Minimum speed along Y axis the pointer has to reach in order for the gesture to [activate](/docs/fundamentals/states-events#active). Expressed in points per second.
 
 ### `minPointers(value: number)`
 

--- a/packages/docs-gesture-handler/static/examples/LongPressGestureBasic.js
+++ b/packages/docs-gesture-handler/static/examples/LongPressGestureBasic.js
@@ -4,8 +4,9 @@ import {
   GestureDetector,
   GestureHandlerRootView,
 } from 'react-native-gesture-handler';
-import { Easing, StyleSheet } from 'react-native';
+import { StyleSheet } from 'react-native';
 import Animated, {
+  Easing,
   interpolateColor,
   useAnimatedStyle,
   useSharedValue,

--- a/packages/react-native-gesture-handler/android/build.gradle
+++ b/packages/react-native-gesture-handler/android/build.gradle
@@ -2,17 +2,18 @@ import groovy.json.JsonSlurper
 import com.android.build.gradle.tasks.ExternalNativeBuildJsonTask
 
 buildscript {
-    def kotlin_version = rootProject.ext.has('kotlinVersion') ? rootProject.ext.get('kotlinVersion') : project.properties['RNGH_kotlinVersion']
-
     repositories {
         mavenCentral()
         google()
     }
 
     dependencies {
-        classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
-        classpath("com.android.tools.build:gradle:8.10.1")
-        classpath("com.diffplug.spotless:spotless-plugin-gradle:7.0.4")
+        if (project == rootProject) {
+            def kotlin_version = project.properties['RNGH_kotlinVersion']
+            classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version")
+            classpath("com.android.tools.build:gradle:8.10.1")
+            classpath("com.diffplug.spotless:spotless-plugin-gradle:7.0.4")
+        }
     }
 }
 

--- a/packages/react-native-gesture-handler/android/build.gradle
+++ b/packages/react-native-gesture-handler/android/build.gradle
@@ -63,7 +63,22 @@ if (isNewArchitectureEnabled()) {
 }
 
 apply plugin: 'com.android.library'
-apply plugin: 'kotlin-android'
+
+def shouldEnableAgpFallback() {
+    def agpMajorVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0].toInteger()
+    if (agpMajorVersion <= 8) {
+        return true
+    }
+
+    def propertyVal = providers.gradleProperty("android.builtInKotlin").orNull
+    def isBuiltInKotlinEnabled = propertyVal != null ? propertyVal.toBoolean() : true
+
+    return !isBuiltInKotlinEnabled
+}
+
+if (shouldEnableAgpFallback()) {
+    apply plugin: 'kotlin-android'
+}
 
 if (project == rootProject) {
     apply from: "spotless.gradle"
@@ -191,17 +206,17 @@ android {
     }
 
     sourceSets.main {
-        java {
+        kotlin {
             if (shouldUseCommonInterfaceFromReanimated()) {
-                srcDirs += 'reanimated/src/main/java'
+                directories.add('reanimated/src/main/java')
             } else {
-                srcDirs += 'noreanimated/src/main/java'
+                directories.add('noreanimated/src/main/java')
             }
 
             if (shouldUseCommonInterfaceFromRNSVG()) {
-                srcDirs += 'svg/src/main/java'
+                directories.add('svg/src/main/java')
             } else {
-                srcDirs += 'nosvg/src/main/java'
+                directories.add('nosvg/src/main/java')
             }
 
             if (isNewArchitectureEnabled()) {

--- a/packages/react-native-gesture-handler/android/gradle.properties
+++ b/packages/react-native-gesture-handler/android/gradle.properties
@@ -16,4 +16,4 @@ org.gradle.jvmargs=-Xmx2048m -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemor
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects
 # org.gradle.parallel=true
-RNGH_kotlinVersion=2.0.21
+RNGH_kotlinVersion=2.2.0

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/FlingGestureHandler.kt
@@ -88,7 +88,7 @@ class FlingGestureHandler : GestureHandler() {
   }
 
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
-    if (!shouldActivateWithMouse(sourceEvent)) {
+    if (shouldSkipEvent(sourceEvent)) {
       return
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -982,7 +982,8 @@ open class GestureHandler {
     const val POINTER_TYPE_TOUCH = 0
     const val POINTER_TYPE_STYLUS = 1
     const val POINTER_TYPE_MOUSE = 2
-    const val POINTER_TYPE_OTHER = 3
+    const val POINTER_TYPE_KEY = 3
+    const val POINTER_TYPE_OTHER = 4
     private const val MAX_POINTERS_COUNT = 12
     private lateinit var pointerProps: Array<PointerProperties?>
     private lateinit var pointerCoords: Array<PointerCoords?>

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -425,10 +425,15 @@ open class GestureHandler {
   }
 
   private fun dispatchTouchUpEvent(event: MotionEvent, sourceEvent: MotionEvent) {
+    val pointerId = event.getPointerId(event.actionIndex)
+
+    if (trackedPointers[pointerId] == null) {
+      return
+    }
+
     extractAllPointersData()
     changedTouchesPayload = null
     touchEventType = RNGestureHandlerTouchEvent.EVENT_TOUCH_UP
-    val pointerId = event.getPointerId(event.actionIndex)
     val offsetX = sourceEvent.rawX - sourceEvent.x
     val offsetY = sourceEvent.rawY - sourceEvent.y
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandler.kt
@@ -4,7 +4,6 @@ import android.app.Activity
 import android.content.Context
 import android.content.ContextWrapper
 import android.graphics.PointF
-import android.os.Build
 import android.view.MotionEvent
 import android.view.MotionEvent.PointerCoords
 import android.view.MotionEvent.PointerProperties
@@ -754,44 +753,38 @@ open class GestureHandler {
     return clickedButton and mouseButton != 0
   }
 
-  protected fun shouldActivateWithMouse(sourceEvent: MotionEvent): Boolean {
-    // While using mouse, we get both sets of events, for example ACTION_DOWN and ACTION_BUTTON_PRESS. That's why we want to take actions to only one of them.
-    // On API >= 23, we will use events with infix BUTTON, otherwise we use standard action events (like ACTION_DOWN).
+  // Decides whether the gesture should ignore this event. While using a mouse we receive both the
+  // touch-compatible stream (ACTION_DOWN/UP/...) and the BUTTON_* events, so we act on only the
+  // latter, and we drop events coming from a button other than the configured `mouseButton`.
+  // Non-mouse input is never skipped here.
+  protected fun shouldSkipEvent(sourceEvent: MotionEvent): Boolean {
+    if (sourceEvent.getToolType(0) != MotionEvent.TOOL_TYPE_MOUSE) {
+      return false
+    }
 
     with(sourceEvent) {
-      // To use actionButton, we need API >= 23.
-      if (getToolType(0) == MotionEvent.TOOL_TYPE_MOUSE &&
-        Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+      // While using mouse, we want to ignore default events for touch.
+      if (actionMasked == MotionEvent.ACTION_DOWN ||
+        actionMasked == MotionEvent.ACTION_UP ||
+        actionMasked == MotionEvent.ACTION_POINTER_UP ||
+        actionMasked == MotionEvent.ACTION_POINTER_DOWN
       ) {
-        // While using mouse, we want to ignore default events for touch.
-        if (action == MotionEvent.ACTION_DOWN ||
-          action == MotionEvent.ACTION_UP ||
-          action == MotionEvent.ACTION_POINTER_UP ||
-          action == MotionEvent.ACTION_POINTER_DOWN
-        ) {
-          return@shouldActivateWithMouse false
-        }
+        return@shouldSkipEvent true
+      }
 
-        // We don't want to do anything if wrong button was clicked. If we received event for BUTTON, we have to use actionButton to get which one was clicked.
-        if (action != MotionEvent.ACTION_MOVE && !isButtonInConfig(actionButton)) {
-          return@shouldActivateWithMouse false
-        }
+      // Skip events from a button other than the configured one. For BUTTON_* events the clicked
+      // button is read from `actionButton`.
+      if (actionMasked != MotionEvent.ACTION_MOVE && !isButtonInConfig(actionButton)) {
+        return@shouldSkipEvent true
+      }
 
-        // When we receive ACTION_MOVE, we have to check buttonState field.
-        if (action == MotionEvent.ACTION_MOVE && !isButtonInConfig(buttonState)) {
-          return@shouldActivateWithMouse false
-        }
-      } else if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-        // We do not fully support mouse below API 23, so we will ignore BUTTON events.
-        if (action == MotionEvent.ACTION_BUTTON_PRESS ||
-          action == MotionEvent.ACTION_BUTTON_RELEASE
-        ) {
-          return@shouldActivateWithMouse false
-        }
+      // For ACTION_MOVE the pressed button is read from `buttonState`.
+      if (actionMasked == MotionEvent.ACTION_MOVE && !isButtonInConfig(buttonState)) {
+        return@shouldSkipEvent true
       }
     }
 
-    return true
+    return false
   }
 
   /**

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -156,6 +156,13 @@ class GestureHandlerOrchestrator(
   /*package*/
   fun onHandlerStateChange(handler: GestureHandler, newState: Int, prevState: Int) {
     handlingChangeSemaphore += 1
+
+    if (handler.isAwaiting &&
+      (newState == GestureHandler.STATE_CANCELLED || newState == GestureHandler.STATE_FAILED)
+    ) {
+      handler.isAwaiting = false
+    }
+
     if (isFinished(newState)) {
       // We have to loop through copy in order to avoid modifying collection
       // while iterating over its elements

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -330,7 +330,7 @@ class GestureHandlerOrchestrator(
     if (!handler.isAwaiting || action != MotionEvent.ACTION_MOVE) {
       val isFirstEvent = handler.state == 0
       handler.handle(event, sourceEvent)
-      if (handler.isActive) {
+      if (handler.state == GestureHandler.STATE_ACTIVE && handler.isActive) {
         // After handler is done waiting for other one to fail its progress should be
         // reset, otherwise there may be a visible jump in values sent by the handler.
         // When handler is waiting it's already activated but the `isAwaiting` flag

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -2,6 +2,7 @@ package com.swmansion.gesturehandler.core
 
 import android.graphics.Matrix
 import android.graphics.PointF
+import android.util.SparseArray
 import android.view.MotionEvent
 import android.view.View
 import android.view.ViewGroup
@@ -28,6 +29,10 @@ class GestureHandlerOrchestrator(
   private val awaitingHandlers = arrayListOf<GestureHandler>()
   private val preparedHandlers = arrayListOf<GestureHandler>()
 
+  // Used by `cancelTouchesInInterceptedViews`.
+  private val viewsToCancel = arrayListOf<View>()
+  private val pointerDownPoints = SparseArray<PointF>()
+
   // In `onHandlerStateChange` method we iterate through `awaitingHandlers`, but calling `tryActivate` may modify this list.
   // To avoid `ConcurrentModificationException` we iterate through copy. There is one more problem though - if handler was
   // removed from `awaitingHandlers`, it was still present in copy of original list. This hashset helps us identify which handlers
@@ -46,6 +51,7 @@ class GestureHandlerOrchestrator(
   fun onTouchEvent(event: MotionEvent): Boolean {
     isHandlingTouch = true
     val action = event.actionMasked
+    trackPointerDownPoints(event)
     if (action == MotionEvent.ACTION_DOWN ||
       action == MotionEvent.ACTION_POINTER_DOWN ||
       action == MotionEvent.ACTION_HOVER_MOVE
@@ -618,6 +624,112 @@ class GestureHandlerOrchestrator(
           return true
         }
       }
+    }
+    return false
+  }
+
+  private fun trackPointerDownPoints(event: MotionEvent) {
+    val index = event.actionIndex
+    when (event.actionMasked) {
+      MotionEvent.ACTION_DOWN, MotionEvent.ACTION_POINTER_DOWN ->
+        pointerDownPoints.put(event.getPointerId(index), PointF(event.getX(index), event.getY(index)))
+      MotionEvent.ACTION_POINTER_UP ->
+        pointerDownPoints.remove(event.getPointerId(index))
+      MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL ->
+        pointerDownPoints.clear()
+    }
+  }
+
+  fun cancelTouchesInInterceptedViews(event: MotionEvent) {
+    viewsToCancel.clear()
+    for (i in 0 until pointerDownPoints.size()) {
+      val point = pointerDownPoints.valueAt(i)
+      tempCoords[0] = point.x
+      tempCoords[1] = point.y
+      collectViewsAtPoint(wrapperView, tempCoords, viewsToCancel)
+    }
+
+    if (viewsToCancel.isEmpty()) {
+      return
+    }
+
+    val activeHandlers = gestureHandlers.filter { it.isActive }
+    val cancelEvent = MotionEvent.obtain(event).apply { action = MotionEvent.ACTION_CANCEL }
+
+    for (view in viewsToCancel) {
+      if (view === wrapperView || isViewDrivenByActiveNativeGesture(view, activeHandlers)) {
+        continue
+      }
+      view.onTouchEvent(cancelEvent)
+    }
+
+    cancelEvent.recycle()
+    viewsToCancel.clear()
+  }
+
+  // Whether the view's touch is still owned by a NativeViewGestureHandler that survived arbitration.
+  // Only those are fed through `onTouchEvent`, so only those break if cancelled. Other handlers are
+  // orchestrator-driven and unaffected.
+  private fun isViewDrivenByActiveNativeGesture(view: View, activeHandlers: List<GestureHandler>) =
+    handlerRegistry.getHandlersForView(view)?.let { handlers ->
+      synchronized(handlers) {
+        handlers.any { nativeGestureSurvivesArbitration(it, activeHandlers) }
+      }
+    } ?: false
+
+  // A native handler survives arbitration if it is active, or it does not conflict with any active handler.
+  private fun nativeGestureSurvivesArbitration(handler: GestureHandler, activeHandlers: List<GestureHandler>) =
+    handler is NativeViewGestureHandler &&
+      (handler.isActive || activeHandlers.none { shouldHandlerBeCancelledBy(handler, it) })
+
+  // Collects the view path under the point (topmost child first, like touch dispatch), leaf to root.
+  private fun collectViewsAtPoint(view: View, coords: FloatArray, out: MutableList<View>): Boolean {
+    if (shouldIgnoreSubtreeIfGestureHandlerRootView(view)) {
+      // A nested active root view manages its own subtree (and its own interception cancellation).
+      return false
+    }
+
+    val pointerEvents = viewConfigHelper.getPointerEventsConfigForView(view)
+    if (pointerEvents == PointerEventsConfig.NONE) {
+      return false
+    }
+
+    var found = false
+    if (view is ViewGroup && pointerEvents != PointerEventsConfig.BOX_ONLY) {
+      for (i in view.childCount - 1 downTo 0) {
+        val child = view.getChildAt(i)
+        if (!canReceiveEvents(child)) {
+          continue
+        }
+        val childPoint = tempPoint
+        transformPointToChildViewCoords(coords[0], coords[1], view, child, childPoint)
+        if (isClipping(child) && !isTransformedTouchPointInView(childPoint.x, childPoint.y, child)) {
+          continue
+        }
+        val restoreX = coords[0]
+        val restoreY = coords[1]
+        coords[0] = childPoint.x
+        coords[1] = childPoint.y
+        found = collectViewsAtPoint(child, coords, out)
+        coords[0] = restoreX
+        coords[1] = restoreY
+
+        if (found) {
+          break
+        }
+      }
+    }
+
+    // BOX_NONE views can't be the target themselves, only their children can
+    val selfIsTarget = pointerEvents != PointerEventsConfig.BOX_NONE &&
+      isTransformedTouchPointInView(coords[0], coords[1], view)
+
+    if (found || selfIsTarget) {
+      // `out` may already contain this view when several pointers share part of their path.
+      if (!out.contains(view)) {
+        out.add(view)
+      }
+      return true
     }
     return false
   }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -27,7 +27,16 @@ class GestureHandlerOrchestrator(
   var minimumAlphaForTraversal = DEFAULT_MIN_ALPHA_FOR_TRAVERSAL
   private val gestureHandlers = arrayListOf<GestureHandler>()
   private val awaitingHandlers = arrayListOf<GestureHandler>()
-  private val preparedHandlers = arrayListOf<GestureHandler>()
+
+  // Pool of reusable lists for snapshotting `gestureHandlers` during event delivery.
+  private val handlerListPool = ArrayDeque<ArrayList<GestureHandler>>()
+
+  private fun obtainHandlerList() = handlerListPool.pollLast() ?: ArrayList<GestureHandler>()
+
+  private fun recycleHandlerList(list: ArrayList<GestureHandler>) {
+    list.clear()
+    handlerListPool.addLast(list)
+  }
 
   // Used by `cancelTouchesInInterceptedViews`.
   private val viewsToCancel = arrayListOf<View>()
@@ -258,20 +267,24 @@ class GestureHandlerOrchestrator(
   }
 
   private fun deliverEventToGestureHandlers(event: MotionEvent) {
-    // Copy handlers to "prepared handlers" array, because the list of active handlers can change
-    // as a result of state updates
-    preparedHandlers.clear()
-    preparedHandlers.addAll(gestureHandlers)
+    // Snapshot handlers into a pooled list, because the list of active handlers can change
+    // as a result of state updates (and delivery can be re-entrant).
+    val handlersToProcess = obtainHandlerList()
+    handlersToProcess.addAll(gestureHandlers)
 
     // We want to deliver events to active handlers first in order of their activation (handlers
     // that activated first will first get event delivered). Otherwise we deliver events in the
     // order in which handlers has been added ("most direct" children goes first). Therefore we rely
     // on Arrays.sort providing a stable sort (as children are registered in order in which they
     // should be tested)
-    preparedHandlers.sortWith(handlersComparator)
+    handlersToProcess.sortWith(handlersComparator)
 
-    for (handler in preparedHandlers) {
-      deliverEventToGestureHandler(handler, event)
+    try {
+      for (handler in handlersToProcess) {
+        deliverEventToGestureHandler(handler, event)
+      }
+    } finally {
+      recycleHandlerList(handlersToProcess)
     }
   }
 
@@ -282,12 +295,9 @@ class GestureHandlerOrchestrator(
       handler.cancel()
     }
 
-    // Copy handlers to "prepared handlers" array, because the list of active handlers can change
+    // Iterate over a copy, because the list of active handlers can change
     // as a result of state updates
-    preparedHandlers.clear()
-    preparedHandlers.addAll(gestureHandlers)
-
-    for (handler in gestureHandlers.asReversed()) {
+    for (handler in gestureHandlers.reversed()) {
       handler.cancel()
     }
   }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/GestureHandlerOrchestrator.kt
@@ -120,7 +120,7 @@ class GestureHandlerOrchestrator(
 
   private fun shouldBeCancelledByActiveHandler(handler: GestureHandler) = gestureHandlers.any {
     handler.hasCommonPointers(it) &&
-      it.state == GestureHandler.STATE_ACTIVE &&
+      it.isActive &&
       !canRunSimultaneously(handler, it) &&
       handler.isDescendantOf(it)
   }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -29,13 +29,14 @@ class LongPressGestureHandler(context: Context) : GestureHandler() {
     val systemDefaultMaxDist = DEFAULT_MAX_DIST_DP * context.resources.displayMetrics.density
     defaultMaxDist = systemDefaultMaxDist
     maxDist = defaultMaxDist
-    numberOfPointersRequired = 1
+    numberOfPointersRequired = DEFAULT_NUMBER_OF_POINTERS_REQUIRED
   }
 
   override fun resetConfig() {
     super.resetConfig()
     minDurationMs = DEFAULT_MIN_DURATION_MS
     maxDist = defaultMaxDist
+    numberOfPointersRequired = DEFAULT_NUMBER_OF_POINTERS_REQUIRED
     shouldCancelWhenOutside = DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE
   }
 
@@ -208,5 +209,6 @@ class LongPressGestureHandler(context: Context) : GestureHandler() {
     private const val DEFAULT_SHOULD_CANCEL_WHEN_OUTSIDE = true
     private const val DEFAULT_MIN_DURATION_MS: Long = 500
     private const val DEFAULT_MAX_DIST_DP = 10f
+    private const val DEFAULT_NUMBER_OF_POINTERS_REQUIRED = 1
   }
 }

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/LongPressGestureHandler.kt
@@ -66,7 +66,7 @@ class LongPressGestureHandler(context: Context) : GestureHandler() {
   }
 
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
-    if (!shouldActivateWithMouse(sourceEvent)) {
+    if (shouldSkipEvent(sourceEvent)) {
       return
     }
 
@@ -99,7 +99,8 @@ class LongPressGestureHandler(context: Context) : GestureHandler() {
       currentPointers == numberOfPointersRequired &&
       (
         sourceEvent.actionMasked == MotionEvent.ACTION_DOWN ||
-          sourceEvent.actionMasked == MotionEvent.ACTION_POINTER_DOWN
+          sourceEvent.actionMasked == MotionEvent.ACTION_POINTER_DOWN ||
+          sourceEvent.actionMasked == MotionEvent.ACTION_BUTTON_PRESS
         )
     ) {
       handler = Handler(Looper.getMainLooper())

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/NativeViewGestureHandler.kt
@@ -109,6 +109,9 @@ class NativeViewGestureHandler : GestureHandler() {
         cancel()
       } else {
         hook.sendTouchEvent(view, event)
+        if (shouldStopNestedScroll()) {
+          view.stopNestedScroll()
+        }
 
         if ((state == STATE_UNDETERMINED || state == STATE_BEGAN) && hook.canActivate(view)) {
           activate()
@@ -156,8 +159,18 @@ class NativeViewGestureHandler : GestureHandler() {
       action = MotionEvent.ACTION_CANCEL
     }
     hook.sendTouchEvent(view, event)
+    if (shouldStopNestedScroll()) {
+      view?.stopNestedScroll()
+    }
     event.recycle()
   }
+
+  // Once the handler is active, it delivers touches straight to the view's `onTouchEvent`. Normally
+  // touches arrive through `View.dispatchTouchEvent`, which also ends the nested scroll when the finger
+  // goes up. Because we skip it, the nested scroll stays open and the parent never finds out that the
+  // gesture is over - e.g. SwipeRefreshLayout never fires refresh (#4485). While the handler is not
+  // active, the view still receives touches the regular way, so Android takes care of it.
+  private fun shouldStopNestedScroll() = state == STATE_ACTIVE && hook.shouldStopNestedScroll()
 
   override fun onCancel() = dispatchCancelEventToView()
 
@@ -210,6 +223,12 @@ class NativeViewGestureHandler : GestureHandler() {
      * the gesture will be cancelled.
      */
     fun canBegin(event: MotionEvent) = true
+
+    /**
+     * Whether the view's nested scroll should be stopped when the active gesture ends. Touches
+     * are fed through `onTouchEvent`, so `View.dispatchTouchEvent` never gets to do it.
+     */
+    fun shouldStopNestedScroll() = false
 
     /**
      * Checks whether handler can activate. Used by TextViewHook.
@@ -336,6 +355,10 @@ class NativeViewGestureHandler : GestureHandler() {
 
   private class ScrollViewHook : NativeViewGestureHandlerHook {
     override fun shouldCancelRootViewGestureHandlerIfNecessary() = true
+
+    // ScrollView starts a nested scroll on DOWN but never stops it itself. Without this the
+    // parent's `onStopNestedScroll` never runs, e.g. SwipeRefreshLayout never triggers refresh.
+    override fun shouldStopNestedScroll() = true
   }
 
   private class ReactViewGroupHook : NativeViewGestureHandlerHook {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
@@ -11,6 +11,7 @@ import com.facebook.react.uimanager.PixelUtil
 import com.swmansion.gesturehandler.core.GestureUtils.getLastPointerX
 import com.swmansion.gesturehandler.core.GestureUtils.getLastPointerY
 import com.swmansion.gesturehandler.react.eventbuilders.PanGestureHandlerEventDataBuilder
+import kotlin.math.abs
 
 class PanGestureHandler(context: Context?) : GestureHandler() {
   var velocityX = 0f
@@ -113,15 +114,11 @@ class PanGestureHandler(context: Context?) : GestureHandler() {
       return true
     }
     val vx = velocityX
-    if (minVelocityX != MIN_VALUE_IGNORE &&
-      (minVelocityX < 0 && vx <= minVelocityX || minVelocityX in 0.0f..vx)
-    ) {
+    if (minVelocityX != MIN_VALUE_IGNORE && abs(vx) >= abs(minVelocityX)) {
       return true
     }
     val vy = velocityY
-    if (minVelocityY != MIN_VALUE_IGNORE &&
-      (minVelocityY < 0 && vx <= minVelocityY || minVelocityY in 0.0f..vx)
-    ) {
+    if (minVelocityY != MIN_VALUE_IGNORE && abs(vy) >= abs(minVelocityY)) {
       return true
     }
     val velocitySq = vx * vx + vy * vy

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/PanGestureHandler.kt
@@ -149,7 +149,7 @@ class PanGestureHandler(context: Context?) : GestureHandler() {
   }
 
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
-    if (!shouldActivateWithMouse(sourceEvent)) {
+    if (shouldSkipEvent(sourceEvent)) {
       return
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/core/TapGestureHandler.kt
@@ -82,7 +82,7 @@ class TapGestureHandler : GestureHandler() {
   }
 
   override fun onHandle(event: MotionEvent, sourceEvent: MotionEvent) {
-    if (!shouldActivateWithMouse(sourceEvent)) {
+    if (shouldSkipEvent(sourceEvent)) {
       return
     }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/Extensions.kt
@@ -19,3 +19,6 @@ fun Context.isScreenReaderOn() =
 fun MotionEvent.isHoverAction(): Boolean = action == MotionEvent.ACTION_HOVER_MOVE ||
   action == MotionEvent.ACTION_HOVER_ENTER ||
   action == MotionEvent.ACTION_HOVER_EXIT
+
+fun MotionEvent.isButtonAction(): Boolean = actionMasked == MotionEvent.ACTION_BUTTON_PRESS ||
+  actionMasked == MotionEvent.ACTION_BUTTON_RELEASE

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -554,6 +554,8 @@ class RNGestureHandlerButtonViewManager :
       // by default Viewgroup would pass hotspot change events
     }
 
+    override fun shouldDelayChildPressedState(): Boolean = false
+
     private fun findGestureHandlerRootView(): RNGestureHandlerRootView? {
       var parent: ViewParent? = this.parent
       var gestureHandlerRootView: RNGestureHandlerRootView? = null

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootHelper.kt
@@ -19,6 +19,7 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
   private val jsGestureHandler: GestureHandler?
   val rootView: ViewGroup
   private var shouldIntercept = false
+  private var wasIntercepting = false
   private var passingTouch = false
 
   init {
@@ -118,6 +119,14 @@ class RNGestureHandlerRootHelper(private val context: ReactContext, wrappedView:
     passingTouch = true
     orchestrator!!.onTouchEvent(event)
     passingTouch = false
+
+    // On the transition into interception, cancel the native views the pointers landed on - the
+    // framework's ACTION_CANCEL never reaches them since RNGH ignores `onInterceptTouchEvent`
+    if (shouldIntercept && !wasIntercepting) {
+      orchestrator!!.cancelTouchesInInterceptedViews(event)
+    }
+    wasIntercepting = shouldIntercept
+
     return shouldIntercept
   }
 

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerRootView.kt
@@ -40,12 +40,14 @@ class RNGestureHandlerRootView(context: Context?) : ReactViewGroup(context) {
     super.dispatchTouchEvent(event)
   }
 
-  override fun dispatchGenericMotionEvent(ev: MotionEvent) =
-    if (rootViewEnabled && ev.isHoverAction() && rootHelper!!.dispatchTouchEvent(ev)) {
-      true
-    } else {
-      super.dispatchGenericMotionEvent(ev)
-    }
+  override fun dispatchGenericMotionEvent(ev: MotionEvent) = if (rootViewEnabled &&
+    (ev.isHoverAction() || ev.isButtonAction()) &&
+    rootHelper!!.dispatchTouchEvent(ev)
+  ) {
+    true
+  } else {
+    super.dispatchGenericMotionEvent(ev)
+  }
 
   override fun requestDisallowInterceptTouchEvent(disallowIntercept: Boolean) {
     if (rootViewEnabled) {

--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerTouchEvent.kt
@@ -54,13 +54,8 @@ class RNGestureHandlerTouchEvent private constructor() : Event<RNGestureHandlerT
       putInt("eventType", handler.touchEventType)
       putInt("pointerType", handler.pointerType)
 
-      handler.consumeChangedTouchesPayload()?.let {
-        putArray("changedTouches", it)
-      }
-
-      handler.consumeAllTouchesPayload()?.let {
-        putArray("allTouches", it)
-      }
+      putArray("changedTouches", handler.consumeChangedTouchesPayload() ?: Arguments.createArray())
+      putArray("allTouches", handler.consumeAllTouchesPayload() ?: Arguments.createArray())
 
       if (handler.isAwaiting && handler.state == GestureHandler.STATE_ACTIVE) {
         putInt("state", GestureHandler.STATE_BEGAN)

--- a/packages/react-native-gesture-handler/apple/Handlers/RNFlingHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNFlingHandler.m
@@ -95,7 +95,8 @@
 #else
 
 @interface RNBetterSwipeGestureRecognizer : NSGestureRecognizer {
-  dispatch_block_t failFlingAction;
+  // scheduled on mouseDown; fails the gesture if the fling doesn't complete within maxDuration
+  dispatch_block_t maxDurationTimeout;
   int maxDuration;
   int minVelocity;
   double defaultAlignmentCone;
@@ -137,18 +138,34 @@
   [_gestureHandler handleGesture:self];
 }
 
+- (void)triggerAction
+{
+  [_gestureHandler handleGesture:self fromReset:NO];
+}
+
+- (void)triggerActionFromReset
+{
+  [_gestureHandler handleGesture:self fromReset:YES];
+}
+
 - (void)mouseDown:(NSEvent *)event
 {
+  [_gestureHandler setCurrentPointerTypeToMouse];
+  [_gestureHandler reset];
   [super mouseDown:event];
 
   startPosition = [self locationInView:self.view];
   startTime = CACurrentMediaTime();
 
+  [_gestureHandler.pointerTracker touchesBegan:[NSSet setWithObject:event] withEvent:event];
+  // Send the BEGAN event, mirroring what the iOS recognizer does in touchesBegan.
+  [self triggerAction];
+
   self.state = NSGestureRecognizerStatePossible;
 
   __weak typeof(self) weakSelf = self;
 
-  failFlingAction = dispatch_block_create(0, ^{
+  maxDurationTimeout = dispatch_block_create(0, ^{
     __strong typeof(self) strongSelf = weakSelf;
 
     if (strongSelf) {
@@ -159,12 +176,14 @@
   dispatch_after(
       dispatch_time(DISPATCH_TIME_NOW, (int64_t)(maxDuration * NSEC_PER_SEC)),
       dispatch_get_main_queue(),
-      failFlingAction);
+      maxDurationTimeout);
 }
 
 - (void)mouseDragged:(NSEvent *)event
 {
   [super mouseDragged:event];
+
+  [_gestureHandler.pointerTracker touchesMoved:[NSSet setWithObject:event] withEvent:event];
 
   NSPoint currentPosition = [self locationInView:self.view];
   double currentTime = CACurrentMediaTime();
@@ -180,14 +199,35 @@
   [self tryActivate:velocityVector];
 }
 
+- (void)cancelMaxDurationTimeout
+{
+  if (maxDurationTimeout != nil) {
+    dispatch_block_cancel(maxDurationTimeout);
+    maxDurationTimeout = nil;
+  }
+}
+
 - (void)mouseUp:(NSEvent *)event
 {
   [super mouseUp:event];
 
-  dispatch_block_cancel(failFlingAction);
+  [_gestureHandler.pointerTracker touchesEnded:[NSSet setWithObject:event] withEvent:event];
+
+  [self cancelMaxDurationTimeout];
 
   self.state =
       self.state == NSGestureRecognizerStateChanged ? NSGestureRecognizerStateEnded : NSGestureRecognizerStateFailed;
+}
+
+- (void)reset
+{
+  [self triggerActionFromReset];
+  [_gestureHandler.pointerTracker reset];
+  // The gesture may end without a mouse-up (view unmount, cancellation) — a still-scheduled
+  // timeout would fire later and set the state to Failed during the next gesture.
+  [self cancelMaxDurationTimeout];
+  [super reset];
+  [_gestureHandler reset];
 }
 
 - (void)tryActivate:(Vector *)velocityVector

--- a/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
@@ -132,8 +132,9 @@ API_AVAILABLE(ios(13.4))
 {
 #if CHECK_TARGET(13_4)
   if (@available(iOS 13.4, *)) {
-    [super unbindFromView];
+    // Remove the interaction before [super unbindFromView] detaches the recognizer and nils recognizer.view.
     [self.recognizer.view removeInteraction:_pointerInteraction];
+    [super unbindFromView];
   }
 #endif
 }

--- a/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNHoverHandler.m
@@ -219,33 +219,30 @@ API_AVAILABLE(ios(13.4))
   _view = nil;
 }
 
-- (void)mouseEntered:(NSEvent *)event
+- (RNGestureHandlerEventExtraData *)extraDataForEvent:(NSEvent *)event
 {
-  [self sendEventsInState:RNGestureHandlerStateBegan
-           forViewWithTag:_view.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES
-                                                       withNumberOfTouches:1
-                                                           withPointerType:_pointerType]];
-  [self sendEventsInState:RNGestureHandlerStateActive
-           forViewWithTag:_view.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:YES
-                                                       withNumberOfTouches:1
-                                                           withPointerType:_pointerType]];
+  CGPoint windowLocation = [event locationInWindow];
+  CGPoint relativePos = [_view convertPoint:windowLocation fromView:nil];
+  CGPoint absolutePos = [_view.window.contentView convertPoint:windowLocation fromView:nil];
+
+  return [RNGestureHandlerEventExtraData forPosition:relativePos
+                                withAbsolutePosition:absolutePos
+                                 withNumberOfTouches:1
+                                     withPointerType:_pointerType];
 }
 
-- (void)mouseExited:(NSEvent *)theEvent
+- (void)mouseEntered:(NSEvent *)event
 {
-  [self sendEventsInState:RNGestureHandlerStateEnd
-           forViewWithTag:_view.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
-                                                       withNumberOfTouches:1
-                                                           withPointerType:_pointerType]];
+  RNGestureHandlerEventExtraData *extraData = [self extraDataForEvent:event];
+  [self sendEventsInState:RNGestureHandlerStateBegan forViewWithTag:_view.reactTag withExtraData:extraData];
+  [self sendEventsInState:RNGestureHandlerStateActive forViewWithTag:_view.reactTag withExtraData:extraData];
+}
 
-  [self sendEventsInState:RNGestureHandlerStateUndetermined
-           forViewWithTag:_view.reactTag
-            withExtraData:[RNGestureHandlerEventExtraData forPointerInside:NO
-                                                       withNumberOfTouches:1
-                                                           withPointerType:_pointerType]];
+- (void)mouseExited:(NSEvent *)event
+{
+  RNGestureHandlerEventExtraData *extraData = [self extraDataForEvent:event];
+  [self sendEventsInState:RNGestureHandlerStateEnd forViewWithTag:_view.reactTag withExtraData:extraData];
+  [self sendEventsInState:RNGestureHandlerStateUndetermined forViewWithTag:_view.reactTag withExtraData:extraData];
 }
 
 @end

--- a/packages/react-native-gesture-handler/apple/Handlers/RNLongPressHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNLongPressHandler.m
@@ -225,6 +225,10 @@
 
   recognizer.minimumPressDuration = 0.5;
   recognizer.allowableMovement = 10;
+
+#if !TARGET_OS_TV
+  recognizer.numberOfTouchesRequired = 1;
+#endif
 }
 
 - (void)configure:(NSDictionary *)config

--- a/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
@@ -42,7 +42,9 @@
 
 @implementation RNBetterPanGestureRecognizer {
   __weak RNGestureHandler *_gestureHandler;
-#if !TARGET_OS_OSX
+#if TARGET_OS_OSX
+  BOOL _blockAutomaticActivation;
+#else
   NSUInteger _realMinimumNumberOfTouches;
 #endif
   BOOL _hasCustomActivationCriteria;
@@ -114,6 +116,9 @@
 
 - (void)activateAfterLongPress
 {
+#if TARGET_OS_OSX
+  _blockAutomaticActivation = NO;
+#endif
   self.state = UIGestureRecognizerStateBegan;
   // Send event in ACTIVE state because UIGestureRecognizerStateBegan is mapped to RNGestureHandlerStateBegan
   [_gestureHandler handleGesture:self inState:RNGestureHandlerStateActive];
@@ -139,6 +144,11 @@
 #endif
 
 #if TARGET_OS_OSX
+  // NSPanGestureRecognizer transitions to the Began state on mouse-down, without any
+  // built-in movement hysteresis. To honor the custom activation criteria (minDist,
+  // activeOffsets, minVelocity) we hold the recognizer in the Possible state until
+  // they are met in interactionsMoved.
+  _blockAutomaticActivation = _hasCustomActivationCriteria;
   [super mouseDown:event];
 #else
   [super touchesBegan:touches withEvent:event];
@@ -176,7 +186,14 @@
     }
   }
 
-#if !TARGET_OS_TV && !TARGET_OS_OSX
+#if TARGET_OS_OSX
+  if (_hasCustomActivationCriteria && self.state == UIGestureRecognizerStatePossible &&
+      [self shouldActivateUnderCustomCriteria]) {
+    _blockAutomaticActivation = NO;
+    self.state = UIGestureRecognizerStateBegan;
+    [self setTranslation:CGPointMake(0, 0) inView:self.view];
+  }
+#elif !TARGET_OS_TV
   if (_hasCustomActivationCriteria && self.state == UIGestureRecognizerStatePossible &&
       [self shouldActivateUnderCustomCriteria]) {
     super.minimumNumberOfTouches = _realMinimumNumberOfTouches;
@@ -208,6 +225,23 @@
 }
 
 #if TARGET_OS_OSX
+
+- (void)setState:(NSGestureRecognizerState)state
+{
+  if (_blockAutomaticActivation) {
+    if (state == NSGestureRecognizerStateBegan || state == NSGestureRecognizerStateChanged) {
+      // Hold the recognizer in the Possible state until the custom activation criteria
+      // are met — the superclass keeps tracking the mouse regardless, so translation
+      // and velocity stay valid for the criteria checks.
+      return;
+    }
+    if (state == NSGestureRecognizerStateEnded) {
+      // Mouse released before the activation criteria were met — the gesture failed.
+      state = NSGestureRecognizerStateFailed;
+    }
+  }
+  [super setState:state];
+}
 
 - (void)mouseDown:(NSEvent *)event
 {
@@ -265,6 +299,9 @@
   [_gestureHandler.pointerTracker reset];
   [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(activateAfterLongPress) object:nil];
   self.enabled = YES;
+#if TARGET_OS_OSX
+  _blockAutomaticActivation = NO;
+#endif
   [super reset];
   [_gestureHandler reset];
 

--- a/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
@@ -405,9 +405,9 @@
 
 #if !TARGET_OS_OSX && !TARGET_OS_TV && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130400
   if (@available(iOS 13.4, *)) {
-    bool enableTrackpadTwoFingerGesture = [RCTConvert BOOL:config[@"enableTrackpadTwoFingerGesture"]];
-    if (enableTrackpadTwoFingerGesture) {
-      recognizer.allowedScrollTypesMask = UIScrollTypeMaskAll;
+    id enableTrackpadTwoFingerGesture = config[@"enableTrackpadTwoFingerGesture"];
+    if (enableTrackpadTwoFingerGesture != nil) {
+      recognizer.allowedScrollTypesMask = [RCTConvert BOOL:enableTrackpadTwoFingerGesture] ? UIScrollTypeMaskAll : 0;
     }
   }
 

--- a/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNPanHandler.m
@@ -333,10 +333,10 @@
   }
 
   CGPoint velocity = [self velocityInView:self.view];
-  if (TEST_MIN_IF_NOT_NAN(velocity.x, _minVelocityX)) {
+  if (TEST_ABS_MIN_IF_NOT_NAN(velocity.x, _minVelocityX)) {
     return YES;
   }
-  if (TEST_MIN_IF_NOT_NAN(velocity.y, _minVelocityY)) {
+  if (TEST_ABS_MIN_IF_NOT_NAN(velocity.y, _minVelocityY)) {
     return YES;
   }
   if (TEST_MIN_IF_NOT_NAN(VEC_LEN_SQ(velocity), _minVelocitySq)) {

--- a/packages/react-native-gesture-handler/apple/Handlers/RNTapHandler.m
+++ b/packages/react-native-gesture-handler/apple/Handlers/RNTapHandler.m
@@ -38,6 +38,12 @@
   NSUInteger _tapsSoFar;
   CGPoint _initPosition;
   NSInteger _maxNumberOfTouches;
+  // Pending `cancel` invocations scheduled via dispatch_after. We use dispatch blocks instead of
+  // performSelector:afterDelay: because the latter schedules its timer in NSDefaultRunLoopMode only,
+  // which means it is starved while a sibling UIScrollView keeps the run loop in UITrackingRunLoopMode
+  // (during a drag or momentum deceleration). dispatch_after fires regardless of run loop mode, so the
+  // tap can still fail/finalize on time while a list is scrolling. See issue #3471.
+  NSMutableArray<dispatch_block_t> *_pendingCancellations;
 }
 
 static const NSUInteger defaultNumberOfTaps = 1;
@@ -57,8 +63,31 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
     _maxDeltaX = NAN;
     _maxDeltaY = NAN;
     _maxDistSq = NAN;
+    _pendingCancellations = [NSMutableArray array];
   }
   return self;
+}
+
+- (void)scheduleCancelAfterDelay:(NSTimeInterval)delay
+{
+  __weak typeof(self) weakSelf = self;
+
+  dispatch_block_t block = dispatch_block_create(0, ^{
+    [weakSelf cancel];
+  });
+
+  [_pendingCancellations addObject:block];
+
+  dispatch_after(dispatch_time(DISPATCH_TIME_NOW, (int64_t)(delay * NSEC_PER_SEC)), dispatch_get_main_queue(), block);
+}
+
+- (void)cancelPendingCancellations
+{
+  for (dispatch_block_t block in _pendingCancellations) {
+    dispatch_block_cancel(block);
+  }
+
+  [_pendingCancellations removeAllObjects];
 }
 
 - (void)triggerAction
@@ -93,14 +122,14 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
   }
   _tapsSoFar++;
   if (_tapsSoFar) {
-    [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
+    [self cancelPendingCancellations];
   }
   NSInteger numberOfTouches = [touches count];
   if (numberOfTouches > _maxNumberOfTouches) {
     _maxNumberOfTouches = numberOfTouches;
   }
   if (!isnan(_maxDuration)) {
-    [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDuration];
+    [self scheduleCancelAfterDelay:_maxDuration];
   }
   self.state = UIGestureRecognizerStatePossible;
   [self triggerAction];
@@ -132,10 +161,12 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 {
   [_gestureHandler.pointerTracker touchesEnded:touches withEvent:event];
 
+  [self cancelPendingCancellations];
+
   if (_numberOfTaps == _tapsSoFar && _maxNumberOfTouches >= _minPointers) {
     self.state = UIGestureRecognizerStateEnded;
   } else {
-    [self performSelector:@selector(cancel) withObject:nil afterDelay:_maxDelay];
+    [self scheduleCancelAfterDelay:_maxDelay];
   }
 }
 
@@ -250,7 +281,7 @@ static const NSTimeInterval defaultMaxDuration = 0.5;
 
   [_gestureHandler.pointerTracker reset];
 
-  [NSObject cancelPreviousPerformRequestsWithTarget:self selector:@selector(cancel) object:nil];
+  [self cancelPendingCancellations];
   _tapsSoFar = 0;
   _maxNumberOfTouches = 0;
   self.enabled = YES;

--- a/packages/react-native-gesture-handler/apple/RNGHUIKit.h
+++ b/packages/react-native-gesture-handler/apple/RNGHUIKit.h
@@ -6,11 +6,11 @@ typedef UIView RNGHUIView;
 typedef UITouch RNGHUITouch;
 typedef UIScrollView RNGHUIScrollView;
 
-#define RNGHGestureRecognizerStateFailed UIGestureRecognizerStateFailed;
-#define RNGHGestureRecognizerStatePossible UIGestureRecognizerStatePossible;
-#define RNGHGestureRecognizerStateCancelled UIGestureRecognizerStateCancelled;
-#define RNGHGestureRecognizerStateBegan UIGestureRecognizerStateBegan;
-#define RNGHGestureRecognizerStateEnded UIGestureRecognizerStateEnded;
+#define RNGHGestureRecognizerStateFailed UIGestureRecognizerStateFailed
+#define RNGHGestureRecognizerStatePossible UIGestureRecognizerStatePossible
+#define RNGHGestureRecognizerStateCancelled UIGestureRecognizerStateCancelled
+#define RNGHGestureRecognizerStateBegan UIGestureRecognizerStateBegan
+#define RNGHGestureRecognizerStateEnded UIGestureRecognizerStateEnded
 
 #else // TARGET_OS_OSX [
 
@@ -20,10 +20,10 @@ typedef RCTUIView RNGHUIView;
 typedef RCTUITouch RNGHUITouch;
 typedef NSScrollView RNGHUIScrollView;
 
-#define RNGHGestureRecognizerStateFailed NSGestureRecognizerStateFailed;
-#define RNGHGestureRecognizerStatePossible NSGestureRecognizerStatePossible;
-#define RNGHGestureRecognizerStateCancelled NSGestureRecognizerStateCancelled;
-#define RNGHGestureRecognizerStateBegan NSGestureRecognizerStateBegan;
-#define RNGHGestureRecognizerStateEnded NSGestureRecognizerStateEnded;
+#define RNGHGestureRecognizerStateFailed NSGestureRecognizerStateFailed
+#define RNGHGestureRecognizerStatePossible NSGestureRecognizerStatePossible
+#define RNGHGestureRecognizerStateCancelled NSGestureRecognizerStateCancelled
+#define RNGHGestureRecognizerStateBegan NSGestureRecognizerStateBegan
+#define RNGHGestureRecognizerStateEnded NSGestureRecognizerStateEnded
 
 #endif // ] TARGET_OS_OSX

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.h
@@ -14,6 +14,8 @@
 #define TEST_MIN_IF_NOT_NAN(value, limit) \
   (!isnan(limit) && ((limit < 0 && value <= limit) || (limit >= 0 && value >= limit)))
 
+#define TEST_ABS_MIN_IF_NOT_NAN(value, limit) (!isnan(limit) && fabs(value) >= fabs(limit))
+
 #define TEST_MAX_IF_NOT_NAN(value, max) (!isnan(max) && ((max < 0 && value < max) || (max >= 0 && value > max)))
 
 #define APPLY_PROP(recognizer, config, type, prop, propName) \

--- a/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandler.mm
@@ -253,6 +253,24 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
 
 - (void)unbindFromView
 {
+  // If the gesture is still in flight - e.g. the view is being unmounted mid-gesture - deliver
+  // the final event now, while the recognizer is still attached and the target view is known.
+  // Otherwise the onBegin/onFinalize and onActivate/onDeactivate guarantees would be broken
+  // and `_lastState` would never be cleared by `reset`.
+  if (self.recognizer.view != nil &&
+      (_lastState == RNGestureHandlerStateBegan || _lastState == RNGestureHandlerStateActive)) {
+    if ([self eventTagForRecognizer:self.recognizer] != nil) {
+      [self handleGesture:self.recognizer
+                  inState:_lastState == RNGestureHandlerStateActive ? RNGestureHandlerStateCancelled
+                                                                    : RNGestureHandlerStateFailed];
+    } else {
+      // The event has no tag to be dispatched with, so it cannot be delivered on any path - reset
+      // the bookkeeping so the handler doesn't stay in-flight forever.
+      _lastState = RNGestureHandlerStateUndetermined;
+      _state = RNGestureHandlerStateBegan;
+    }
+  }
+
   [self.recognizer.view removeGestureRecognizer:self.recognizer];
   self.recognizer.delegate = nil;
   self.viewTag = nil;
@@ -314,21 +332,38 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   //
   // While this solution is not great, we decided to check whether sending events was triggered from `reset` method.
   // This way we can detect double Began mapping by checking previous sent state and current state of recognizer.
-  if (fromReset && _lastState == RNGestureHandlerStateBegan &&
-      self.recognizer.state == UIGestureRecognizerStatePossible) {
-    _state = RNGestureHandlerStateFailed;
+  //
+  // The same applies to gestures interrupted mid-flight, e.g. when the view is unmounted during an active
+  // gesture the recognizer may be reset without its cancel action ever firing.
+  // If the last sent state is not final, synthesize the missing final event so that the
+  // `onBegin`/`onFinalize` and `onActivate`/`onDeactivate` guarantees hold.
+  if (fromReset && self.recognizer.state == UIGestureRecognizerStatePossible) {
+    if (_lastState == RNGestureHandlerStateBegan) {
+      _state = RNGestureHandlerStateFailed;
+    } else if (_lastState == RNGestureHandlerStateActive) {
+      _state = RNGestureHandlerStateCancelled;
+    } else {
+      // The final event was already delivered; mapping Possible to Began here would emit a stray
+      // BEGAN event after the gesture has finished.
+      return;
+    }
   }
 
   [self handleGesture:recognizer inState:_state];
+}
+
+- (nullable NSNumber *)eventTagForRecognizer:(UIGestureRecognizer *)recognizer
+{
+  return [self chooseViewForInteraction:recognizer].reactTag;
 }
 
 - (void)handleGesture:(UIGestureRecognizer *)recognizer inState:(RNGestureHandlerState)state
 {
   _state = state;
   RNGestureHandlerEventExtraData *eventData = [self eventExtraData:recognizer];
-  RNGHUIView *view = [self chooseViewForInteraction:recognizer];
+  NSNumber *tag = [self eventTagForRecognizer:recognizer];
 
-  [self sendEventsInState:self.state forViewWithTag:view.reactTag withExtraData:eventData];
+  [self sendEventsInState:self.state forViewWithTag:tag withExtraData:eventData];
 }
 
 - (void)sendEventsInState:(RNGestureHandlerState)state
@@ -636,7 +671,13 @@ static NSHashTable<RNGestureHandler *> *allGestureHandlers;
   // might be called after some pointers are down, and after state manipulation by the user.
   // Pointer tracker calls this method when it resets, and in that case it no longer tracks
   // any pointers, thus entering this if
-  if (!_needsPointerData || _pointerTracker.trackedPointersCount == 0) {
+  //
+  // Also do not clear _lastState while the gesture is in flight (BEGAN/ACTIVE) - the final
+  // state-change event hasn't been dispatched yet. When the view is removed mid-gesture,
+  // the pointer tracker resets before the recognizer's cancel action fires; clearing _lastState
+  // here would corrupt the prevState of the outgoing CANCELLED event and break the onActivate/onDeactivate guarantee.
+  if ((!_needsPointerData || _pointerTracker.trackedPointersCount == 0) && _lastState != RNGestureHandlerStateBegan &&
+      _lastState != RNGestureHandlerStateActive) {
     _lastState = RNGestureHandlerStateUndetermined;
     _state = RNGestureHandlerStateBegan;
   }

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -118,7 +118,7 @@
   }
 
   RNGHUIView *inner = [super hitTest:point withEvent:event];
-  while (inner && ![self shouldHandleTouch:inner]) {
+  while (inner && inner != self && ![self shouldHandleTouch:inner]) {
     inner = inner.superview;
   }
   return inner;

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -62,7 +62,8 @@
 {
   if ([view isKindOfClass:[RNGestureHandlerButton class]]) {
     RNGestureHandlerButton *button = (RNGestureHandlerButton *)view;
-    return button.userEnabled;
+    return button.userEnabled && button.pointerEvents != RNGestureHandlerPointerEventsBoxNone &&
+        button.pointerEvents != RNGestureHandlerPointerEventsNone;
   }
 
   // Certain subviews such as RCTViewComponentView have been observed to have disabled
@@ -105,7 +106,8 @@
       if (!subview.isHidden && subview.alpha > 0) {
         CGPoint convertedPoint = [subview convertPoint:point fromView:self];
         UIView *hitView = [subview hitTest:convertedPoint withEvent:event];
-        if (hitView != nil && [self shouldHandleTouch:hitView]) {
+        if (hitView != nil &&
+            ([hitView isKindOfClass:[RNGestureHandlerButton class]] || [self shouldHandleTouch:hitView])) {
           return hitView;
         }
       }

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerManager.mm
@@ -274,20 +274,50 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 
 #pragma mark Root Views Management
 
+#ifdef RCT_NEW_ARCH_ENABLED
+#if !TARGET_OS_OSX
+static BOOL RNGHIsScreensTouchHandlerHost(RNGHUIView *view)
+{
+  static Class fullWindowOverlayContainerClass;
+  static Class screenViewClass;
+  static SEL isModalSelector;
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    fullWindowOverlayContainerClass = NSClassFromString(@"RNSFullWindowOverlayContainer");
+    screenViewClass = NSClassFromString(@"RNSScreenView");
+    isModalSelector = NSSelectorFromString(@"isModal");
+  });
+
+  if (fullWindowOverlayContainerClass != nil && [view isKindOfClass:fullWindowOverlayContainerClass]) {
+    return YES;
+  }
+
+  if (screenViewClass != nil && [view isKindOfClass:screenViewClass]) {
+    // For now we consider only modals
+    return [view respondsToSelector:isModalSelector] && [[view valueForKey:@"isModal"] boolValue];
+  }
+
+  return NO;
+}
+#endif // !TARGET_OS_OSX
+#endif // RCT_NEW_ARCH_ENABLED
+
 - (void)registerViewWithGestureRecognizerAttachedIfNeeded:(RNGHUIView *)childView
+{
+  [self registerViewWithGestureRecognizerAttachedIfNeeded:childView isRetry:NO];
+}
+
+- (void)registerViewWithGestureRecognizerAttachedIfNeeded:(RNGHUIView *)childView isRetry:(BOOL)isRetry
 {
 #ifdef RCT_NEW_ARCH_ENABLED
   RNGHUIView *touchHandlerView = childView;
 
 #if !TARGET_OS_OSX
-  Class fullWindowOverlayContainerClass = NSClassFromString(@"RNSFullWindowOverlayContainer");
-
   if ([[childView reactViewController] isKindOfClass:[RCTFabricModalHostViewController class]]) {
     touchHandlerView = [childView reactViewController].view;
   } else {
-    while (
-        touchHandlerView != nil && ![touchHandlerView isKindOfClass:[RCTSurfaceView class]] &&
-        (fullWindowOverlayContainerClass == nil || ![touchHandlerView isKindOfClass:fullWindowOverlayContainerClass])) {
+    while (touchHandlerView != nil && ![touchHandlerView isKindOfClass:[RCTSurfaceView class]] &&
+           !RNGHIsScreensTouchHandlerHost(touchHandlerView)) {
       touchHandlerView = touchHandlerView.superview;
     }
   }
@@ -323,6 +353,19 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
 #endif // RCT_NEW_ARCH_ENABLED
 
   if (touchHandlerView == nil) {
+#ifdef RCT_NEW_ARCH_ENABLED
+#if !TARGET_OS_OSX
+    // Handlers are attached while the mounting transaction is still in progress — the view's
+    // ancestor chain may not be assembled yet (Fabric connects subtrees children-first), in
+    // which case the walk above dead-ends before reaching any touch-handling root. Retry once
+    // on the next run loop turn, when mounting has finished and the hierarchy is connected.
+    if (!isRetry) {
+      dispatch_async(dispatch_get_main_queue(), ^{
+        [self registerViewWithGestureRecognizerAttachedIfNeeded:childView isRetry:YES];
+      });
+    }
+#endif // !TARGET_OS_OSX
+#endif // RCT_NEW_ARCH_ENABLED
     return;
   }
 
@@ -381,6 +424,21 @@ constexpr int NEW_ARCH_NUMBER_OF_ATTACH_RETRIES = 25;
       break;
     }
   }
+
+#ifdef RCT_NEW_ARCH_ENABLED
+#if !TARGET_OS_OSX
+  if (touchHandler == nil && [viewWithTouchHandler respondsToSelector:NSSelectorFromString(@"touchHandler")]) {
+    // An RNSScreenView may not have the touch handler attached directly (e.g. touches on it are
+    // still driven by an ancestor's touch handler) — ask react-native-screens for the one
+    // responsible for this screen.
+    id screenTouchHandler = [viewWithTouchHandler valueForKey:@"touchHandler"];
+    if ([screenTouchHandler isKindOfClass:[RCTSurfaceTouchHandler class]]) {
+      touchHandler = screenTouchHandler;
+    }
+  }
+#endif // !TARGET_OS_OSX
+#endif // RCT_NEW_ARCH_ENABLED
+
   [touchHandler setEnabled:NO];
   [touchHandler setEnabled:YES];
 }

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.m
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.m
@@ -115,18 +115,25 @@
   _eventType = RNGHTouchEventTypePointerDown;
 
   NSDictionary *data[touches.count];
+  int changedCount = 0;
 
   for (int i = 0; i < [touches count]; i++) {
     RNGHUITouch *touch = [[touches allObjects] objectAtIndex:i];
     int index = [self registerTouch:touch];
-    if (index >= 0) {
-      _trackedPointersCount++;
+
+    if (index < 0) {
+      continue;
     }
 
-    data[i] = [self extractPointerData:index forTouch:touch];
+    _trackedPointersCount++;
+    data[changedCount++] = [self extractPointerData:index forTouch:touch];
   }
 
-  _changedPointersData = [[NSArray alloc] initWithObjects:data count:[touches count]];
+  if (changedCount == 0) {
+    return;
+  }
+
+  _changedPointersData = [[NSArray alloc] initWithObjects:data count:changedCount];
   // extract all touches last to include the ones that were just added
   [self extractAllTouches];
   [self sendEvent];
@@ -141,14 +148,24 @@
   _eventType = RNGHTouchEventTypePointerMove;
 
   NSDictionary *data[touches.count];
+  int changedCount = 0;
 
   for (int i = 0; i < [touches count]; i++) {
     RNGHUITouch *touch = [[touches allObjects] objectAtIndex:i];
     int index = [self findTouchIndex:touch];
-    data[i] = [self extractPointerData:index forTouch:touch];
+
+    if (index < 0) {
+      continue;
+    }
+
+    data[changedCount++] = [self extractPointerData:index forTouch:touch];
   }
 
-  _changedPointersData = [[NSArray alloc] initWithObjects:data count:[touches count]];
+  if (changedCount == 0) {
+    return;
+  }
+
+  _changedPointersData = [[NSArray alloc] initWithObjects:data count:changedCount];
   [self extractAllTouches];
   [self sendEvent];
 }
@@ -165,18 +182,25 @@
   _eventType = RNGHTouchEventTypePointerUp;
 
   NSDictionary *data[touches.count];
+  int changedCount = 0;
 
   for (int i = 0; i < [touches count]; i++) {
     RNGHUITouch *touch = [[touches allObjects] objectAtIndex:i];
     int index = [self unregisterTouch:touch];
-    if (index >= 0) {
-      _trackedPointersCount--;
+
+    if (index < 0) {
+      continue;
     }
 
-    data[i] = [self extractPointerData:index forTouch:touch];
+    _trackedPointersCount--;
+    data[changedCount++] = [self extractPointerData:index forTouch:touch];
   }
 
-  _changedPointersData = [[NSArray alloc] initWithObjects:data count:[touches count]];
+  if (changedCount == 0) {
+    return;
+  }
+
+  _changedPointersData = [[NSArray alloc] initWithObjects:data count:changedCount];
   [self sendEvent];
 }
 

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.m
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerTracker.m
@@ -38,7 +38,14 @@
 - (int)unregisterTouch:(RNGHUITouch *)touch
 {
   for (int index = 0; index < MAX_POINTERS_COUNT; index++) {
+#if TARGET_OS_OSX
+    // A macOS mouse sequence delivers a fresh NSEvent per event, so identity matching
+    // (valid on iOS, where a UITouch is one stable object for the whole touch) never
+    // matches. There is only one mouse pointer — match the tracked slot instead.
+    if (_trackedPointers[index] != nil) {
+#else
     if (_trackedPointers[index] == touch) {
+#endif
       _trackedPointers[index] = nil;
       return index;
     }
@@ -50,7 +57,12 @@
 - (int)findTouchIndex:(RNGHUITouch *)touch
 {
   for (int index = 0; index < MAX_POINTERS_COUNT; index++) {
+#if TARGET_OS_OSX
+    // See unregisterTouch: — identity matching cannot work for NSEvents.
+    if (_trackedPointers[index] != nil) {
+#else
     if (_trackedPointers[index] == touch) {
+#endif
       return index;
     }
   }
@@ -158,6 +170,12 @@
       continue;
     }
 
+#if TARGET_OS_OSX
+    // Replace the stored mouse-down event with the latest one so extractAllTouches
+    // reads the pointer's current position, not where the sequence started.
+    _trackedPointers[index] = touch;
+#endif
+
     data[changedCount++] = [self extractPointerData:index forTouch:touch];
   }
 
@@ -175,6 +193,18 @@
   if (!_gestureHandler.needsPointerData) {
     return;
   }
+
+#if TARGET_OS_OSX
+  // Refresh the tracked slot with the ending event so extractAllTouches below reports
+  // the pointer's final position. On iOS the stored UITouch is a live object that
+  // always reads its current location; a stored NSEvent is a stale snapshot.
+  for (RNGHUITouch *touch in touches) {
+    int index = [self findTouchIndex:touch];
+    if (index >= 0) {
+      _trackedPointers[index] = touch;
+    }
+  }
+#endif
 
   // extract all touches first to include the ones that were just lifted
   [self extractAllTouches];

--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerType.h
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerPointerType.h
@@ -4,5 +4,6 @@ typedef NS_ENUM(NSInteger, RNGestureHandlerPointerType) {
   RNGestureHandlerTouch = 0,
   RNGestureHandlerStylus,
   RNGestureHandlerMouse,
+  RNGestureHandlerKey,
   RNGestureHandlerOtherPointer,
 };

--- a/packages/react-native-gesture-handler/apple/RNManualActivationRecognizer.m
+++ b/packages/react-native-gesture-handler/apple/RNManualActivationRecognizer.m
@@ -22,24 +22,31 @@
 - (void)handleGesture:(UIGestureRecognizer *)recognizer
 {
   if (recognizer.state == UIGestureRecognizerStateBegan) {
+#if TARGET_OS_OSX
+    // On iOS, this recognizer completing is enough to deny the handler's recognizer —
+    // UIKit fails a recognizer whose required-to-fail dependency recognizes. AppKit
+    // does not do this reliably: completing the blocker can flush the dependent
+    // recognizer's buffered recognition instead of discarding it.
+    _handler.recognizer.state = UIGestureRecognizerStateFailed;
+#endif
     self.state = UIGestureRecognizerStateEnded;
     [self reset];
   }
 }
 
 #if TARGET_OS_OSX
-- (void)mouseUp:(NSEvent *)event
-{
-  [super mouseUp:event];
-
-  _activePointers -= 1;
-}
-
 - (void)mouseDown:(NSEvent *)event
 {
   [super mouseDown:event];
 
   _activePointers += 1;
+}
+
+- (void)mouseUp:(NSEvent *)event
+{
+  [super mouseUp:event];
+
+  _activePointers -= 1;
 
   if (_activePointers == 0) {
     self.state = UIGestureRecognizerStateBegan;
@@ -80,6 +87,7 @@
 - (void)reset
 {
   self.enabled = YES;
+  _activePointers = 0;
   [super reset];
 }
 
@@ -105,5 +113,16 @@
 
   return NO;
 }
+
+#if TARGET_OS_OSX
+// On iOS the method above is a UIGestureRecognizer subclass override, called by the system
+// to establish the failure requirement. NSGestureRecognizer has no such subclass hook —
+// AppKit only consults the delegate, so forward the delegate callback to the shared logic.
+- (BOOL)gestureRecognizer:(NSGestureRecognizer *)gestureRecognizer
+    shouldBeRequiredToFailByGestureRecognizer:(NSGestureRecognizer *)otherGestureRecognizer
+{
+  return [self shouldBeRequiredToFailByGestureRecognizer:otherGestureRecognizer];
+}
+#endif
 
 @end

--- a/packages/react-native-gesture-handler/src/__tests__/legacyWrapRef.test.tsx
+++ b/packages/react-native-gesture-handler/src/__tests__/legacyWrapRef.test.tsx
@@ -1,0 +1,156 @@
+import { cleanup, render } from '@testing-library/react-native';
+import React from 'react';
+import { findNodeHandle, View } from 'react-native';
+
+import { Gesture, GestureDetector, GestureHandlerRootView } from '../index';
+import RNGestureHandlerModule from '../RNGestureHandlerModule';
+
+jest.mock('react-native/Libraries/ReactNative/RendererProxy', () => ({
+  findNodeHandle: jest.fn(),
+}));
+
+const VIEW_TAG = 123;
+
+function ChildIgnoringRef(props: { children?: React.ReactNode }) {
+  return <View>{props.children}</View>;
+}
+
+class ChildWithHostInstance extends React.Component<{
+  children?: React.ReactNode;
+}> {
+  // eslint-disable-next-line @eslint-react/no-unused-class-component-members
+  public __internalInstanceHandle = {};
+
+  override render() {
+    return <View>{this.props.children}</View>;
+  }
+}
+
+describe('Legacy GestureDetector ref forwarding', () => {
+  let attachSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    cleanup();
+    jest.clearAllMocks();
+    (findNodeHandle as jest.Mock).mockReturnValue(VIEW_TAG);
+    attachSpy = jest.spyOn(RNGestureHandlerModule, 'attachGestureHandler');
+  });
+
+  afterEach(() => {
+    attachSpy.mockRestore();
+  });
+
+  test('resolves the tag from the child host instance when its ref resolves', () => {
+    render(
+      <GestureHandlerRootView>
+        <GestureDetector gesture={Gesture.Tap()}>
+          <ChildWithHostInstance />
+        </GestureDetector>
+      </GestureHandlerRootView>
+    );
+
+    const resolvedRefs = (findNodeHandle as jest.Mock).mock.calls.map(
+      (call) => call[0]
+    );
+
+    expect(resolvedRefs.length).toBeGreaterThan(0);
+    expect(
+      resolvedRefs.every(
+        (ref) => ref instanceof ChildWithHostInstance && ref !== null
+      )
+    ).toBe(true);
+    expect(attachSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      VIEW_TAG,
+      expect.any(Number)
+    );
+  });
+
+  test('attaches gestures when the child ignores its ref', () => {
+    render(
+      <GestureHandlerRootView>
+        <GestureDetector gesture={Gesture.Tap()}>
+          <ChildIgnoringRef />
+        </GestureDetector>
+      </GestureHandlerRootView>
+    );
+
+    const resolvedRefs = (findNodeHandle as jest.Mock).mock.calls.map(
+      (call) => call[0]
+    );
+
+    expect(resolvedRefs.length).toBeGreaterThan(0);
+    expect(
+      resolvedRefs.every((ref) => ref instanceof ChildWithHostInstance)
+    ).toBe(false);
+    expect(attachSpy).toHaveBeenCalledWith(
+      expect.any(Number),
+      VIEW_TAG,
+      expect.any(Number)
+    );
+  });
+
+  test('does not clobber a ref the child already has', () => {
+    const childRef = jest.fn();
+
+    render(
+      <GestureHandlerRootView>
+        <GestureDetector gesture={Gesture.Tap()}>
+          <View ref={childRef} />
+        </GestureDetector>
+      </GestureHandlerRootView>
+    );
+
+    expect(childRef).toHaveBeenCalled();
+    expect(childRef.mock.calls[0][0]).not.toBeNull();
+  });
+
+  test('moves the child instance when its ref is replaced', () => {
+    const gesture = Gesture.Tap();
+    const firstRef = jest.fn();
+    const secondRef = jest.fn();
+
+    function App({ useSecondRef }: { useSecondRef: boolean }) {
+      return (
+        <GestureHandlerRootView>
+          <GestureDetector gesture={gesture}>
+            <View ref={useSecondRef ? secondRef : firstRef} />
+          </GestureDetector>
+        </GestureHandlerRootView>
+      );
+    }
+
+    const { rerender } = render(<App useSecondRef={false} />);
+
+    const childInstance = firstRef.mock.calls[0][0];
+    expect(childInstance).not.toBeNull();
+    firstRef.mockClear();
+
+    rerender(<App useSecondRef />);
+
+    expect(firstRef).toHaveBeenCalledWith(null);
+    expect(secondRef).toHaveBeenCalledWith(childInstance);
+  });
+
+  test('does not reattach gestures on re-render', () => {
+    const gesture = Gesture.Tap();
+
+    function App() {
+      return (
+        <GestureHandlerRootView>
+          <GestureDetector gesture={gesture}>
+            <View />
+          </GestureDetector>
+        </GestureHandlerRootView>
+      );
+    }
+
+    const { rerender } = render(<App />);
+    expect(attachSpy).toHaveBeenCalledTimes(1);
+
+    rerender(<App />);
+    rerender(<App />);
+
+    expect(attachSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
+++ b/packages/react-native-gesture-handler/src/components/GestureButtonsProps.ts
@@ -89,6 +89,20 @@ export interface RawButtonProps
    */
   // eslint-disable-next-line @typescript-eslint/ban-types
   testOnly_onLongPress?: Function | null | undefined;
+
+  /**
+   * Used for testing-library compatibility, not passed to the native component.
+   * @deprecated test-only props are deprecated and will be removed in the future.
+   */
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  testOnly_onHoverIn?: Function | null | undefined;
+
+  /**
+   * Used for testing-library compatibility, not passed to the native component.
+   * @deprecated test-only props are deprecated and will be removed in the future.
+   */
+  // eslint-disable-next-line @typescript-eslint/ban-types
+  testOnly_onHoverOut?: Function | null | undefined;
 }
 interface ButtonWithRefProps {
   innerRef?: React.ForwardedRef<React.ComponentType<any>> | undefined;

--- a/packages/react-native-gesture-handler/src/components/GestureComponents.tsx
+++ b/packages/react-native-gesture-handler/src/components/GestureComponents.tsx
@@ -5,6 +5,8 @@ import {
   RefAttributes,
   ReactElement,
 } from 'react';
+// Type-only: the value export is a deprecation-warning getter on RN 0.87+ (see below).
+import type { DrawerLayoutAndroid as RNDrawerLayoutAndroid } from 'react-native';
 import {
   ScrollView as RNScrollView,
   ScrollViewProps as RNScrollViewProps,
@@ -12,7 +14,6 @@ import {
   SwitchProps as RNSwitchProps,
   TextInput as RNTextInput,
   TextInputProps as RNTextInputProps,
-  DrawerLayoutAndroid as RNDrawerLayoutAndroid,
   DrawerLayoutAndroidProps as RNDrawerLayoutAndroidProps,
   FlatList as RNFlatList,
   FlatListProps as RNFlatListProps,
@@ -85,15 +86,41 @@ export const TextInput = createNativeWrapper<RNTextInputProps>(RNTextInput);
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type TextInput = typeof TextInput & RNTextInput;
 
+// RN's `DrawerLayoutAndroid` export is a getter that logs a deprecation
+// warning on access, so resolve it on first render instead of module load.
+// `require` is used on purpose: `import * as RN` would read every export
+// eagerly under Metro's `experimentalImportSupport`.
+let DrawerLayoutAndroidImpl: typeof RNDrawerLayoutAndroid | undefined;
+
+const LazyDrawerLayoutAndroid = (
+  props: PropsWithChildren<RNDrawerLayoutAndroidProps> & {
+    ref?: React.Ref<React.ComponentRef<typeof RNDrawerLayoutAndroid> | null>;
+  }
+) => {
+  if (!DrawerLayoutAndroidImpl) {
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { DrawerLayoutAndroid } = require('react-native') as {
+      DrawerLayoutAndroid: typeof RNDrawerLayoutAndroid;
+    };
+    DrawerLayoutAndroidImpl = DrawerLayoutAndroid;
+  }
+  return <DrawerLayoutAndroidImpl {...props} />;
+};
+LazyDrawerLayoutAndroid.displayName = 'DrawerLayoutAndroid';
+
 export const DrawerLayoutAndroid: React.ComponentType<
-  PropsWithChildren<RNDrawerLayoutAndroidProps> & NativeViewGestureHandlerProps
+  PropsWithChildren<RNDrawerLayoutAndroidProps> &
+    NativeViewGestureHandlerProps & {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      ref?: React.Ref<React.ComponentType<any> | null>;
+    }
 > = createNativeWrapper<PropsWithChildren<RNDrawerLayoutAndroidProps>>(
-  RNDrawerLayoutAndroid,
+  LazyDrawerLayoutAndroid,
   { disallowInterruption: true }
 );
 // eslint-disable-next-line @typescript-eslint/no-redeclare
 export type DrawerLayoutAndroid = typeof DrawerLayoutAndroid &
-  RNDrawerLayoutAndroid;
+  React.ComponentRef<typeof RNDrawerLayoutAndroid>;
 
 export const FlatList = React.forwardRef((props, ref) => {
   const refreshControlGestureRef = React.useRef<RefreshControl>(null);

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -218,6 +218,24 @@ const Pressable = (props: PressableProps) => {
   const hoverInTimeout = useRef<number | null>(null);
   const hoverOutTimeout = useRef<number | null>(null);
 
+  useEffect(
+    () => () => {
+      if (longPressTimeoutRef.current) {
+        clearTimeout(longPressTimeoutRef.current);
+      }
+      if (pressDelayTimeoutRef.current) {
+        clearTimeout(pressDelayTimeoutRef.current);
+      }
+      if (hoverInTimeout.current) {
+        clearTimeout(hoverInTimeout.current);
+      }
+      if (hoverOutTimeout.current) {
+        clearTimeout(hoverOutTimeout.current);
+      }
+    },
+    []
+  );
+
   const hoverGesture = useMemo(
     () =>
       Gesture.Hover()

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -421,7 +421,9 @@ const Pressable = (props: PressableProps) => {
         testOnly_onPress={IS_TEST_ENV ? onPress : undefined}
         testOnly_onPressIn={IS_TEST_ENV ? onPressIn : undefined}
         testOnly_onPressOut={IS_TEST_ENV ? onPressOut : undefined}
-        testOnly_onLongPress={IS_TEST_ENV ? onLongPress : undefined}>
+        testOnly_onLongPress={IS_TEST_ENV ? onLongPress : undefined}
+        testOnly_onHoverIn={IS_TEST_ENV ? onHoverIn : undefined}
+        testOnly_onHoverOut={IS_TEST_ENV ? onHoverOut : undefined}>
         {childrenProp}
         {__DEV__ ? (
           <PressabilityDebugView color="red" hitSlop={normalizedHitSlop} />

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -417,6 +417,8 @@ const Pressable = (props: PressableProps) => {
         touchSoundDisabled={android_disableSound ?? undefined}
         rippleColor={rippleColor}
         rippleRadius={android_ripple?.radius ?? undefined}
+        borderless={android_ripple?.borderless ?? undefined}
+        foreground={android_ripple?.foreground ?? undefined}
         style={[pointerStyle, styleProp]}
         testOnly_onPress={IS_TEST_ENV ? onPress : undefined}
         testOnly_onPressIn={IS_TEST_ENV ? onPressIn : undefined}

--- a/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
+++ b/packages/react-native-gesture-handler/src/components/Pressable/Pressable.tsx
@@ -79,7 +79,7 @@ const Pressable = (props: PressableProps) => {
     blocksExternalGesture,
   };
 
-  const [pressedState, setPressedState] = useState(testOnly_pressed ?? false);
+  const [pressedState, setPressedState] = useState(false);
 
   const longPressTimeoutRef = useRef<number | null>(null);
   const pressDelayTimeoutRef = useRef<number | null>(null);
@@ -372,12 +372,17 @@ const Pressable = (props: PressableProps) => {
   const pointerStyle: StyleProp<ViewStyle> =
     Platform.OS === 'web' ? { cursor: 'pointer' } : {};
 
+  // `testOnly_pressed` forces the pressed state for snapshots/tests. Derive the
+  // displayed value from it each render, keeping the interactive `pressedState`
+  // independent (seeded to false) so clearing the prop doesn't leave it stuck.
+  const displayPressed = testOnly_pressed ?? pressedState;
+
   const styleProp =
-    typeof style === 'function' ? style({ pressed: pressedState }) : style;
+    typeof style === 'function' ? style({ pressed: displayPressed }) : style;
 
   const childrenProp =
     typeof children === 'function'
-      ? children({ pressed: pressedState })
+      ? children({ pressed: displayPressed })
       : children;
 
   const rippleColor = useMemo(() => {

--- a/packages/react-native-gesture-handler/src/components/Pressable/index.ts
+++ b/packages/react-native-gesture-handler/src/components/Pressable/index.ts
@@ -1,4 +1,5 @@
 export type {
+  PressableEvent,
   PressableProps,
   PressableStateCallbackType,
 } from './PressableProps';

--- a/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
@@ -422,6 +422,7 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
         );
       },
       [
+        animationSpeedProp,
         openValue,
         emitStateChanged,
         isDrawerOpen,

--- a/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedDrawerLayout.tsx
@@ -322,7 +322,7 @@ const DrawerLayout = forwardRef<DrawerLayoutMethods, DrawerLayoutProps>(
 
     useDerivedValue(() => {
       onDrawerSlide && runOnJS(onDrawerSlide)(openValue.value);
-    }, []);
+    });
 
     const isDrawerOpen = useSharedValue(false);
 

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -6,7 +6,13 @@ import {
   useState,
   useRef,
 } from 'react';
-import { LayoutChangeEvent, View, I18nManager, StyleSheet } from 'react-native';
+import {
+  LayoutChangeEvent,
+  View,
+  I18nManager,
+  Platform,
+  StyleSheet,
+} from 'react-native';
 import Animated, {
   useSharedValue,
   interpolate,
@@ -603,7 +609,7 @@ const Swipeable = (props: SwipeableProps) => {
       transform: [{ translateX: appliedTranslation.value }],
       pointerEvents: rowState.value === 0 ? 'auto' : 'box-only',
     }),
-    [appliedTranslation, rowState]
+    Platform.OS === 'web' ? [appliedTranslation, rowState] : undefined
   );
 
   const swipeableComponent = (

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -4,6 +4,7 @@ import {
   useImperativeHandle,
   ForwardedRef,
   useState,
+  useRef,
 } from 'react';
 import { LayoutChangeEvent, View, I18nManager, StyleSheet } from 'react-native';
 import Animated, {
@@ -42,6 +43,21 @@ const DEFAULT_OVERSHOOT_FRICTION = 1;
 const DEFAULT_DRAG_OFFSET = 10;
 const DEFAULT_ENABLE_TRACKING_TWO_FINGER_GESTURE = false;
 
+function useEventCallback<Args extends unknown[]>(
+  callback: ((...args: Args) => void) | undefined
+): ((...args: Args) => void) | undefined {
+  const callbackRef = useRef(callback);
+  callbackRef.current = callback;
+
+  const stableCallback = useCallback((...args: Args) => {
+    callbackRef.current?.(...args);
+  }, []);
+
+  // Keep a stable wrapper only while a user callback exists, so the existing
+  // truthiness checks can still skip `runOnJS` when the prop is absent.
+  return callback ? stableCallback : undefined;
+}
+
 const Swipeable = (props: SwipeableProps) => {
   const {
     ref,
@@ -60,12 +76,12 @@ const Swipeable = (props: SwipeableProps) => {
     dragOffsetFromRightEdge = DEFAULT_DRAG_OFFSET,
     friction = DEFAULT_FRICTION,
     overshootFriction = DEFAULT_OVERSHOOT_FRICTION,
-    onSwipeableOpenStartDrag,
-    onSwipeableCloseStartDrag,
-    onSwipeableWillOpen,
-    onSwipeableWillClose,
-    onSwipeableOpen,
-    onSwipeableClose,
+    onSwipeableOpenStartDrag: onSwipeableOpenStartDragProp,
+    onSwipeableCloseStartDrag: onSwipeableCloseStartDragProp,
+    onSwipeableWillOpen: onSwipeableWillOpenProp,
+    onSwipeableWillClose: onSwipeableWillCloseProp,
+    onSwipeableOpen: onSwipeableOpenProp,
+    onSwipeableClose: onSwipeableCloseProp,
     renderLeftActions,
     renderRightActions,
     simultaneousWithExternalGesture,
@@ -87,6 +103,17 @@ const Swipeable = (props: SwipeableProps) => {
       simultaneousWithExternalGesture,
     ]
   );
+
+  const onSwipeableOpenStartDrag = useEventCallback(
+    onSwipeableOpenStartDragProp
+  );
+  const onSwipeableCloseStartDrag = useEventCallback(
+    onSwipeableCloseStartDragProp
+  );
+  const onSwipeableWillOpen = useEventCallback(onSwipeableWillOpenProp);
+  const onSwipeableWillClose = useEventCallback(onSwipeableWillCloseProp);
+  const onSwipeableOpen = useEventCallback(onSwipeableOpenProp);
+  const onSwipeableClose = useEventCallback(onSwipeableCloseProp);
 
   const [shouldEnableTap, setShouldEnableTap] = useState(false);
   const rowState = useSharedValue<number>(0);

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -371,7 +371,6 @@ const Swipeable = (props: SwipeableProps) => {
 
   const leftActionAnimation = useAnimatedStyle(() => {
     return {
-      opacity: showLeftProgress.value === 0 ? 0 : 1,
       // Both action containers use `absoluteFill` and overlap, so the
       // inactive one must not intercept touches meant for the visible
       // actions.
@@ -405,7 +404,6 @@ const Swipeable = (props: SwipeableProps) => {
 
   const rightActionAnimation = useAnimatedStyle(() => {
     return {
-      opacity: showRightProgress.value === 0 ? 0 : 1,
       // Both action containers use `absoluteFill` and overlap, so the
       // inactive one must not intercept touches meant for the visible
       // actions.

--- a/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
+++ b/packages/react-native-gesture-handler/src/components/ReanimatedSwipeable/ReanimatedSwipeable.tsx
@@ -372,6 +372,10 @@ const Swipeable = (props: SwipeableProps) => {
   const leftActionAnimation = useAnimatedStyle(() => {
     return {
       opacity: showLeftProgress.value === 0 ? 0 : 1,
+      // Both action containers use `absoluteFill` and overlap, so the
+      // inactive one must not intercept touches meant for the visible
+      // actions.
+      pointerEvents: showLeftProgress.value === 0 ? 'none' : 'auto',
     };
   });
 
@@ -402,6 +406,10 @@ const Swipeable = (props: SwipeableProps) => {
   const rightActionAnimation = useAnimatedStyle(() => {
     return {
       opacity: showRightProgress.value === 0 ? 0 : 1,
+      // Both action containers use `absoluteFill` and overlap, so the
+      // inactive one must not intercept touches meant for the visible
+      // actions.
+      pointerEvents: showRightProgress.value === 0 ? 'none' : 'auto',
     };
   });
 

--- a/packages/react-native-gesture-handler/src/getShadowNodeFromRef.ts
+++ b/packages/react-native-gesture-handler/src/getShadowNodeFromRef.ts
@@ -1,3 +1,5 @@
+import { isHostInstance } from './hostInstance';
+
 // Used by GestureDetector (unsupported on web at the moment) to check whether the
 // attached view may get flattened on Fabric. This implementation causes errors
 // on web due to the static resolution of `require` statements by webpack breaking
@@ -8,8 +10,10 @@ let getInternalInstanceHandleFromPublicInstance: (ref: unknown) => {
 };
 
 export function getShadowNodeFromRef(ref: unknown) {
+  const isAlreadyHostInstance = isHostInstance(ref);
+
   // Load findHostInstance_DEPRECATED lazily because it may not be available before render
-  if (findHostInstance_DEPRECATED === undefined) {
+  if (!isAlreadyHostInstance && findHostInstance_DEPRECATED === undefined) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-var-requires
       const ReactFabric = require('react-native/Libraries/Renderer/shims/ReactFabric');
@@ -43,8 +47,11 @@ export function getShadowNodeFromRef(ref: unknown) {
     }
   }
 
+  const hostInstance = isAlreadyHostInstance
+    ? ref
+    : findHostInstance_DEPRECATED(ref);
+
   // @ts-ignore Fabric
-  return getInternalInstanceHandleFromPublicInstance(
-    findHostInstance_DEPRECATED(ref)
-  ).stateNode.node;
+  return getInternalInstanceHandleFromPublicInstance(hostInstance).stateNode
+    .node;
 }

--- a/packages/react-native-gesture-handler/src/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/PanGestureHandler.ts
@@ -65,9 +65,24 @@ interface CommonPanProperties {
    */
   maxPointers?: number;
 
+  /**
+   * Minimum speed the pointer has to reach in order to activate the handler.
+   * Expressed in points per second.
+   */
   minVelocity?: number;
+
+  /**
+   * Minimum speed along X axis the pointer has to reach in order to activate
+   * the handler. Expressed in points per second.
+   */
   minVelocityX?: number;
+
+  /**
+   * Minimum speed along Y axis the pointer has to reach in order to activate
+   * the handler. Expressed in points per second.
+   */
   minVelocityY?: number;
+
   activateAfterLongPress?: number;
 }
 

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/Wrap.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/Wrap.tsx
@@ -1,4 +1,10 @@
 import React from 'react';
+import type { WrapRef } from '../../../hostInstance';
+import {
+  assignRef,
+  isHostInstance,
+  preferHostInstance,
+} from '../../../hostInstance';
 import { Reanimated } from '../reanimatedWrapper';
 import { tagMessage } from '../../../utils';
 
@@ -7,20 +13,69 @@ export class Wrap extends React.Component<{
   // Implicit `children` prop has been removed in @types/react^18.0.0
   children?: React.ReactNode;
 }> {
-  render() {
+  private childInstance: unknown = null;
+  private hostInstance: unknown = null;
+  private childRef: WrapRef = undefined;
+  private attachedChildRef: WrapRef = undefined;
+  private childRefCleanup: (() => void) | undefined = undefined;
+
+  // eslint-disable-next-line @eslint-react/no-unused-class-component-members
+  public getHostInstance() {
+    return this.hostInstance;
+  }
+
+  private detachChildRef() {
+    if (this.childRefCleanup !== undefined) {
+      this.childRefCleanup();
+    } else if (this.attachedChildRef) {
+      assignRef(this.attachedChildRef, null);
+    }
+
+    this.childRefCleanup = undefined;
+    this.attachedChildRef = undefined;
+  }
+
+  private attachChildRef(instance: unknown) {
+    this.attachedChildRef = this.childRef;
+
+    this.childRefCleanup = assignRef(this.attachedChildRef, instance);
+  }
+
+  private handleChildRef = (instance: unknown) => {
+    this.childInstance = instance;
+
+    const resolved = preferHostInstance(instance);
+    this.hostInstance = isHostInstance(resolved) ? resolved : null;
+
+    this.detachChildRef();
+
+    if (instance !== null && instance !== undefined) {
+      this.attachChildRef(instance);
+    }
+  };
+
+  override componentDidUpdate() {
+    if (
+      this.childRef === this.attachedChildRef ||
+      this.childInstance === null
+    ) {
+      return;
+    }
+
+    this.detachChildRef();
+    this.attachChildRef(this.childInstance);
+  }
+
+  override render() {
+    // I don't think that fighting with types over such a simple function is worth it
+    // The only thing it does is add 'collapsable: false' to the child component
+    // to make sure it is in the native view hierarchy so the detector can find
+    // correct viewTag to attach to.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let child: any;
+
     try {
-      // I don't think that fighting with types over such a simple function is worth it
-      // The only thing it does is add 'collapsable: false' to the child component
-      // to make sure it is in the native view hierarchy so the detector can find
-      // correct viewTag to attach to.
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const child: any = React.Children.only(this.props.children);
-      return React.cloneElement(
-        child,
-        { collapsable: false },
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
-        child.props.children
-      );
+      child = React.Children.only(this.props.children);
     } catch (e) {
       throw new Error(
         tagMessage(
@@ -28,6 +83,16 @@ export class Wrap extends React.Component<{
         )
       );
     }
+
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+    this.childRef = child.props.ref as WrapRef;
+
+    return React.cloneElement(
+      child,
+      { collapsable: false, ref: this.handleChildRef },
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      child.props.children
+    );
   }
 }
 

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/index.tsx
@@ -6,6 +6,7 @@ import { GestureType } from '../gesture';
 import { UserSelect, TouchAction } from '../../gestureHandlerCommon';
 import { ComposedGesture } from '../gestureComposition';
 import { isTestEnv } from '../../../utils';
+import { resolveHostInstance } from '../../../hostInstance';
 
 import GestureHandlerRootViewContext from '../../../GestureHandlerRootViewContext';
 import { AttachedGestureState, GestureDetectorState } from './types';
@@ -149,7 +150,9 @@ export const GestureDetector = (props: GestureDetectorProps) => {
   useAnimatedGesture(preparedGesture, needsToRebuildReanimatedEvent);
 
   useIsomorphicLayoutEffect(() => {
-    const viewTag = findNodeHandle(state.viewRef) as number;
+    const viewTag = findNodeHandle(
+      resolveHostInstance(state.viewRef)
+    ) as number;
     preparedGesture.isMounted = true;
 
     attachHandlers({

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useDetectorUpdater.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useDetectorUpdater.ts
@@ -2,6 +2,7 @@ import React, { useCallback } from 'react';
 import { GestureType } from '../gesture';
 import { ComposedGesture } from '../gestureComposition';
 
+import { resolveHostInstance } from '../../../hostInstance';
 import {
   AttachedGestureState,
   GestureDetectorState,
@@ -29,7 +30,9 @@ export function useDetectorUpdater(
     // skipConfigUpdate is used to prevent unnecessary updates when only checking if the view has changed
     (skipConfigUpdate?: boolean) => {
       // If the underlying view has changed we need to reattach handlers to the new view
-      const viewTag = findNodeHandle(state.viewRef) as number;
+      const viewTag = findNodeHandle(
+        resolveHostInstance(state.viewRef)
+      ) as number;
       const didUnderlyingViewChange = viewTag !== state.previousViewTag;
 
       if (

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useMountReactions.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useMountReactions.ts
@@ -27,6 +27,12 @@ export function useMountReactions(
 ) {
   useEffect(() => {
     return MountRegistry.addMountListener((gesture) => {
+      // The detector may already be unmounted when this fires; bail out to avoid
+      // updating a detached detector.
+      if (!state.isMounted) {
+        return;
+      }
+
       // At this point the ref in the gesture config should be updated, so we can check if one of the gestures
       // set in a relation with the gesture got mounted. If so, we need to update the detector to propagate
       // the changes to the native side.

--- a/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useViewRefHandler.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/GestureDetector/useViewRefHandler.ts
@@ -4,6 +4,7 @@ import { getShadowNodeFromRef } from '../../../getShadowNodeFromRef';
 import { GestureDetectorState } from './types';
 import React, { useCallback } from 'react';
 import findNodeHandle from '../../../findNodeHandle';
+import { resolveHostInstance } from '../../../hostInstance';
 
 declare const global: {
   isViewFlatteningDisabled: (node: unknown) => boolean | null; // JSI function
@@ -26,7 +27,9 @@ export function useViewRefHandler(
 
       // if it's the first render, also set the previousViewTag to prevent reattaching gestures when not needed
       if (state.previousViewTag === -1) {
-        state.previousViewTag = findNodeHandle(state.viewRef) as number;
+        state.previousViewTag = findNodeHandle(
+          resolveHostInstance(state.viewRef)
+        ) as number;
       }
 
       // Pass true as `skipConfigUpdate`. Here we only want to trigger the eventual reattaching of handlers
@@ -36,7 +39,7 @@ export function useViewRefHandler(
       }
 
       if (__DEV__ && isFabric() && global.isViewFlatteningDisabled) {
-        const node = getShadowNodeFromRef(ref);
+        const node = getShadowNodeFromRef(resolveHostInstance(ref));
         if (global.isViewFlatteningDisabled(node) === false) {
           console.error(
             tagMessage(

--- a/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.web.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/gestureStateManager.web.ts
@@ -1,5 +1,13 @@
 import NodeManager from '../../web/tools/NodeManager';
-import { GestureStateManagerType } from './gestureStateManager';
+
+export interface GestureStateManagerType {
+  begin: () => void;
+  activate: () => void;
+  fail: () => void;
+  end: () => void;
+  /** @internal */
+  handlerTag: number;
+}
 
 export const GestureStateManager = {
   create(handlerTag: number): GestureStateManagerType {

--- a/packages/react-native-gesture-handler/src/handlers/gestures/panGesture.ts
+++ b/packages/react-native-gesture-handler/src/handlers/gestures/panGesture.ts
@@ -147,7 +147,8 @@ export class PanGesture extends ContinousBaseGesture<
   }
 
   /**
-   * Minimum velocity the finger has to reach in order to activate handler.
+   * Minimum speed the pointer has to reach in order to activate handler.
+   * Expressed in points per second.
    * @param velocity
    */
   minVelocity(velocity: number) {
@@ -156,7 +157,8 @@ export class PanGesture extends ContinousBaseGesture<
   }
 
   /**
-   * Minimum velocity along X axis the finger has to reach in order to activate handler.
+   * Minimum speed along X axis the pointer has to reach in order to activate handler.
+   * Expressed in points per second.
    * @param velocity
    */
   minVelocityX(velocity: number) {
@@ -165,7 +167,8 @@ export class PanGesture extends ContinousBaseGesture<
   }
 
   /**
-   * Minimum velocity along Y axis the finger has to reach in order to activate handler.
+   * Minimum speed along Y axis the pointer has to reach in order to activate handler.
+   * Expressed in points per second.
    * @param velocity
    */
   minVelocityY(velocity: number) {

--- a/packages/react-native-gesture-handler/src/hostInstance.ts
+++ b/packages/react-native-gesture-handler/src/hostInstance.ts
@@ -1,0 +1,57 @@
+import type { Ref } from 'react';
+
+export type WrapRef = Ref<unknown> | undefined;
+
+export function assignRef(
+  ref: WrapRef,
+  instance: unknown
+): (() => void) | undefined {
+  if (typeof ref === 'function') {
+    const cleanup = ref(instance as never);
+    return typeof cleanup === 'function' ? cleanup : undefined;
+  }
+
+  if (ref) {
+    ref.current = instance;
+  }
+
+  return undefined;
+}
+
+export function isHostInstance(instance: unknown) {
+  return (
+    (instance as { __internalInstanceHandle?: unknown } | null | undefined)
+      ?.__internalInstanceHandle !== undefined
+  );
+}
+
+export function preferHostInstance(instance: unknown) {
+  if (instance === null || instance === undefined || isHostInstance(instance)) {
+    return instance;
+  }
+
+  const nativeRef = (
+    instance as { getNativeScrollRef?: () => unknown }
+  ).getNativeScrollRef?.();
+
+  return isHostInstance(nativeRef) ? nativeRef : instance;
+}
+
+export interface HostInstanceProvider {
+  getHostInstance: () => unknown;
+}
+
+function providesHostInstance(ref: unknown): ref is HostInstanceProvider {
+  return (
+    typeof (ref as HostInstanceProvider | null | undefined)?.getHostInstance ===
+    'function'
+  );
+}
+
+export function resolveHostInstance<T>(ref: T): T {
+  if (!providesHostInstance(ref)) {
+    return ref;
+  }
+
+  return (ref.getHostInstance() ?? ref) as T;
+}

--- a/packages/react-native-gesture-handler/src/index.ts
+++ b/packages/react-native-gesture-handler/src/index.ts
@@ -146,6 +146,7 @@ export type {
 export type { SwipeableProps } from './components/Swipeable';
 export { default as Swipeable } from './components/Swipeable';
 export type {
+  PressableEvent,
   PressableProps,
   PressableStateCallbackType,
 } from './components/Pressable';

--- a/packages/react-native-gesture-handler/src/web/detectors/RotationGestureDetector.ts
+++ b/packages/react-native-gesture-handler/src/web/detectors/RotationGestureDetector.ts
@@ -163,6 +163,6 @@ export default class RotationGestureDetector
   }
 
   public get timeDelta() {
-    return this.currentTime + this.previousTime;
+    return this.currentTime - this.previousTime;
   }
 }

--- a/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/LongPressGestureHandler.ts
@@ -5,6 +5,7 @@ import GestureHandler from './GestureHandler';
 
 const DEFAULT_MIN_DURATION_MS = 500;
 const DEFAULT_MAX_DIST_DP = 10;
+const DEFAULT_NUMBER_OF_POINTERS = 1;
 const SCALING_FACTOR = 10;
 
 export default class LongPressGestureHandler extends GestureHandler {
@@ -12,7 +13,7 @@ export default class LongPressGestureHandler extends GestureHandler {
   private defaultMaxDistSq = DEFAULT_MAX_DIST_DP * SCALING_FACTOR;
 
   private maxDistSq = this.defaultMaxDistSq;
-  private numberOfPointers = 1;
+  private numberOfPointers = DEFAULT_NUMBER_OF_POINTERS;
   private startX = 0;
   private startY = 0;
 
@@ -56,6 +57,7 @@ export default class LongPressGestureHandler extends GestureHandler {
     super.resetConfig();
     this.minDurationMs = DEFAULT_MIN_DURATION_MS;
     this.maxDistSq = this.defaultMaxDistSq;
+    this.numberOfPointers = DEFAULT_NUMBER_OF_POINTERS;
   }
 
   protected onStateChange(_newState: State, _oldState: State): void {

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -20,8 +20,6 @@ export default class NativeViewGestureHandler extends GestureHandler {
   public init(ref: number, propsRef: React.RefObject<unknown>): void {
     super.init(ref, propsRef);
 
-    this.shouldCancelWhenOutside = true;
-
     if (Platform.OS !== 'web') {
       return;
     }
@@ -44,6 +42,14 @@ export default class NativeViewGestureHandler extends GestureHandler {
 
     const view = this.delegate.view as HTMLElement;
     this.restoreViewStyles(view);
+  }
+
+  protected override resetConfig(): void {
+    super.resetConfig();
+
+    this.shouldCancelWhenOutside = true;
+    this.shouldActivateOnStart = false;
+    this.disallowInterruption = false;
   }
 
   private restoreViewStyles(view: HTMLElement) {

--- a/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/NativeViewGestureHandler.ts
@@ -31,6 +31,9 @@ export default class NativeViewGestureHandler extends GestureHandler {
   }
 
   public updateGestureConfig({ enabled = true, ...props }: Config): void {
+    // Config updates are full replaces, so restore the defaults first - the
+    // module never calls `resetConfig` on its own.
+    this.resetConfig();
     super.updateGestureConfig({ enabled: enabled, ...props });
 
     if (this.config.shouldActivateOnStart !== undefined) {

--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -190,6 +190,7 @@ export default class PanGestureHandler extends GestureHandler {
     this.maxPointers = DEFAULT_MAX_POINTERS;
 
     this.activateAfterLongPress = 0;
+    this.enableTrackpadTwoFingerGesture = false;
   }
 
   protected transformNativeEvent() {

--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -82,8 +82,7 @@ export default class PanGestureHandler extends GestureHandler {
     }
 
     if (this.config.minVelocity !== undefined) {
-      this.minVelocityX = this.config.minVelocity;
-      this.minVelocityY = this.config.minVelocity;
+      this.minVelocitySq = this.config.minVelocity * this.config.minVelocity;
     }
 
     if (this.config.minVelocityX !== undefined) {
@@ -452,8 +451,7 @@ export default class PanGestureHandler extends GestureHandler {
 
     if (
       this.minVelocityX !== Number.MAX_SAFE_INTEGER &&
-      ((this.minVelocityX < 0 && vx <= this.minVelocityX) ||
-        (this.minVelocityX >= 0 && this.minVelocityX <= vx))
+      Math.abs(vx) >= Math.abs(this.minVelocityX)
     ) {
       return true;
     }
@@ -461,8 +459,7 @@ export default class PanGestureHandler extends GestureHandler {
     const vy: number = this.velocityY;
     if (
       this.minVelocityY !== Number.MAX_SAFE_INTEGER &&
-      ((this.minVelocityY < 0 && vy <= this.minVelocityY) ||
-        (this.minVelocityY >= 0 && this.minVelocityY <= vy))
+      Math.abs(vy) >= Math.abs(this.minVelocityY)
     ) {
       return true;
     }

--- a/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/PanGestureHandler.ts
@@ -354,14 +354,13 @@ export default class PanGestureHandler extends GestureHandler {
     }
   }
 
-  private scheduleWheelEnd(event: AdaptedEvent) {
+  private scheduleWheelEnd() {
     clearTimeout(this.endWheelTimeout);
 
     this.endWheelTimeout = setTimeout(() => {
       if (this.state === State.ACTIVE) {
         this.end();
-        this.tracker.removeFromTracker(event.pointerId);
-        this.state = State.UNDETERMINED;
+        this.reset();
       }
 
       this.wheelDevice = WheelDevice.UNDETERMINED;
@@ -383,7 +382,7 @@ export default class PanGestureHandler extends GestureHandler {
           : WheelDevice.MOUSE;
 
       if (this.wheelDevice === WheelDevice.MOUSE) {
-        this.scheduleWheelEnd(event);
+        this.scheduleWheelEnd();
         return;
       }
 
@@ -403,7 +402,7 @@ export default class PanGestureHandler extends GestureHandler {
     this.updateVelocity(event.pointerId);
 
     this.tryToSendMoveEvent(false, event);
-    this.scheduleWheelEnd(event);
+    this.scheduleWheelEnd();
   }
 
   private shouldActivate(): boolean {

--- a/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/TapGestureHandler.ts
@@ -159,7 +159,7 @@ export default class TapGestureHandler extends GestureHandler {
     this.tracker.removeFromTracker(event.pointerId);
 
     this.offsetX += this.lastX - this.startX;
-    this.offsetY += this.lastY = this.startY;
+    this.offsetY += this.lastY - this.startY;
 
     this.updateLastCoords();
 

--- a/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
@@ -264,7 +264,26 @@ export default class GestureHandlerOrchestrator {
     handler.activationIndex = this.activationIndex++;
   }
 
+  // A handler whose pointer sequence ended before it began (e.g. a press
+  // outside a negative hit slop) never reaches a finished state, so
+  // `cleanupFinishedHandlers` never drops it and it would block or park every
+  // later gesture. Drop such idle entries before a new gesture consults them.
+  private dropIdleHandlers(): void {
+    for (let i = this.gestureHandlers.length - 1; i >= 0; --i) {
+      const handler = this.gestureHandlers[i];
+
+      if (
+        handler.state === State.UNDETERMINED &&
+        handler.tracker.trackedPointersCount === 0
+      ) {
+        this.removeHandlerFromOrchestrator(handler);
+      }
+    }
+  }
+
   public recordHandlerIfNotPresent(handler: IGestureHandler): void {
+    this.dropIdleHandlers();
+
     if (this.gestureHandlers.includes(handler)) {
       return;
     }

--- a/packages/react-native-gesture-handler/src/web/tools/WheelEventManager.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/WheelEventManager.ts
@@ -44,5 +44,6 @@ export default class WheelEventManager extends EventManager<HTMLElement> {
 
   public resetManager(): void {
     super.resetManager();
+    this.wheelDelta = { x: 0, y: 0 };
   }
 }


### PR DESCRIPTION
## Description

Cherry pick thread for release 2.33

## List of PRs

| PR | Original commit | Picked commit | Without conflict | Notes |
|:----------:|:-------------:|:------:|:--------:|:------:|
| [[Android] Do not set explicit versions in `build.gradle`](https://github.com/software-mansion/react-native-gesture-handler/pull/4248) | [a96cf17](https://github.com/software-mansion/react-native-gesture-handler/commit/a96cf179d080b51ab861835bb0e0bd629e15e0a3) | [4a625df](https://github.com/software-mansion/react-native-gesture-handler/commit/4a625df5277eba5349df8146af978cf1c8ff3e8e) | ❌ | Dropped the Kotlin override section from the v2 docs (main has `.mdx`) |
| [[Android] Fix mouse interactions](https://github.com/software-mansion/react-native-gesture-handler/pull/4265) | [f748e81](https://github.com/software-mansion/react-native-gesture-handler/commit/f748e811a710fe5c4efd9b25b554db7ea38a84d7) | [a5553ef](https://github.com/software-mansion/react-native-gesture-handler/commit/a5553efc91d491c12cd43cbbebc38f2e405527c4) | ❌ | Kept `isButtonAction`; dropped unrelated `Display.minimumFrameTime` context |
| [[Android \| Web] Disable pointer events on hidden `Swipeable` actions container](https://github.com/software-mansion/react-native-gesture-handler/pull/4192) | [7453280](https://github.com/software-mansion/react-native-gesture-handler/commit/74532809b9de46a64e323e580d2535b2cce834e3) | [ec6e694](https://github.com/software-mansion/react-native-gesture-handler/commit/ec6e6942e65adbc46c8c86e9d9f1eaa25b92e55c) | ✅ |  |
| [Remove `opacity` from `Swipeable` action panels](https://github.com/software-mansion/react-native-gesture-handler/pull/4271) | [708f99a](https://github.com/software-mansion/react-native-gesture-handler/commit/708f99a0d464d1abdb05c22609a62f838b1718c3) | [a2dbfd2](https://github.com/software-mansion/react-native-gesture-handler/commit/a2dbfd2a0b586153ba78ce87390f8659c44495a6) | ✅ |  |
| [[Android] Fix text getting selected during gestures](https://github.com/software-mansion/react-native-gesture-handler/pull/4273) | [3b11fdd](https://github.com/software-mansion/react-native-gesture-handler/commit/3b11fdd9d6b4783c8ffd74451ec4ab7f489f6fb2) | [c77ef2d](https://github.com/software-mansion/react-native-gesture-handler/commit/c77ef2d50ecb7e1ac510b6e5b2c3fc1ec551bad0) | ✅ |  |
| [[iOS] Move `Tap` cancelation to `dispatch_after`](https://github.com/software-mansion/react-native-gesture-handler/pull/4280) | [571e3cc](https://github.com/software-mansion/react-native-gesture-handler/commit/571e3cc9f3b44c0b72cbb687b046555f544a2c8a) | [5916a43](https://github.com/software-mansion/react-native-gesture-handler/commit/5916a43ccd4d5b5aea073e88530051648a9e9c14) | ✅ |  |
| [[Android] Fix ConcurrentModificationException in GestureHandlerOrchestrator](https://github.com/software-mansion/react-native-gesture-handler/pull/4274) | [d2bd181](https://github.com/software-mansion/react-native-gesture-handler/commit/d2bd181fd1d4d076b0bb594da288201eafd35130) | [d146bd8](https://github.com/software-mansion/react-native-gesture-handler/commit/d146bd80ae020eebdde8523cb860d022fdad2b25) | ✅ |  |
| [fix: remove UIPointerInteraction from the view when unbinding the hover handler](https://github.com/software-mansion/react-native-gesture-handler/pull/4291) | [52e082f](https://github.com/software-mansion/react-native-gesture-handler/commit/52e082f8ee0ad3bfc0d49505e956b9df365a5058) | [2642f13](https://github.com/software-mansion/react-native-gesture-handler/commit/2642f13fd42a02e433e41fc425311cfc9ec464b7) | ✅ |  |
| [[Android] Don't delay child pressed state in buttons](https://github.com/software-mansion/react-native-gesture-handler/pull/4296) | [12cb193](https://github.com/software-mansion/react-native-gesture-handler/commit/12cb193a63dd48a21af3557bf63461b5732c1c3b) | [b888946](https://github.com/software-mansion/react-native-gesture-handler/commit/b888946b61aa09964d6847a71b57d505942acbc2) | ❌ | Override placed by hand; dropped `hasOverlappingRendering` (v3 context) |
| [[macOS] Add coordinates to `Hover` events](https://github.com/software-mansion/react-native-gesture-handler/pull/4304) | [8bfaefa](https://github.com/software-mansion/react-native-gesture-handler/commit/8bfaefac6c5aa94b23458e0330f6a0c0fef53538) | [9bd5731](https://github.com/software-mansion/react-native-gesture-handler/commit/9bd5731b01ce340ce80430c29c3c961ef66a78d3) | ✅ |  |
| [[iOS] Fix js responder cancelation in modals](https://github.com/software-mansion/react-native-gesture-handler/pull/4306) | [5b70c4b](https://github.com/software-mansion/react-native-gesture-handler/commit/5b70c4bd75f5e2e00a3530096840723477a406d0) | [4d2fc01](https://github.com/software-mansion/react-native-gesture-handler/commit/4d2fc0159e4d4fd8dff4984efa6c504327688484) | ❌ | All new code gated under `RCT_NEW_ARCH_ENABLED`; Paper path untouched |
| [Fix Easing import in LongPress example](https://github.com/software-mansion/react-native-gesture-handler/pull/4298) | [950dc8e](https://github.com/software-mansion/react-native-gesture-handler/commit/950dc8e01ca133dc00e91d4a493cb0f63a58a28b) | [e0b9785](https://github.com/software-mansion/react-native-gesture-handler/commit/e0b978561d153307668387d9e3f4b483a5221bb0) | ✅ |  |
| [[iOS] Fix gesture callback guarantees when view is detached mid-gesture](https://github.com/software-mansion/react-native-gesture-handler/pull/4321) | [1e4378b](https://github.com/software-mansion/react-native-gesture-handler/commit/1e4378b06063afb43ccfbaaae4d035689c2cb322) | [e290b95](https://github.com/software-mansion/react-native-gesture-handler/commit/e290b95618860af210d961d2733380eb9392c5e8) | ❌ | Tag helper reduced to `chooseViewForInteraction`; dropped v3 `fromManualStateChange` / `shouldSuppressActiveEvent` |
| [Export `PressableEvent` type](https://github.com/software-mansion/react-native-gesture-handler/pull/4324) | [f922b3b](https://github.com/software-mansion/react-native-gesture-handler/commit/f922b3b23c23ae9e5d77e6d716f7d6f8c02fe9b5) | [a723d65](https://github.com/software-mansion/react-native-gesture-handler/commit/a723d65d10929ca347c5a562560e2b1dacd64f23) | ❌ | Kept only `PressableEvent`; dropped `Legacy*` exports (v3) |
| [[Web] Fix incorrectly calculated `timeDelta`](https://github.com/software-mansion/react-native-gesture-handler/pull/4329) | [5fd06ba](https://github.com/software-mansion/react-native-gesture-handler/commit/5fd06baf425642e36c84aff5f4664696f74cea34) | [1ad48b8](https://github.com/software-mansion/react-native-gesture-handler/commit/1ad48b85fd4b46e2cb12411f78f7b6e29d5bda82) | ✅ |  |
| [[Web] Fix incorrect `Tap` offset](https://github.com/software-mansion/react-native-gesture-handler/pull/4330) | [ed6e159](https://github.com/software-mansion/react-native-gesture-handler/commit/ed6e15912b2a1c34920547e7cecf91200fa243fa) | [8515250](https://github.com/software-mansion/react-native-gesture-handler/commit/85152504b7ff31a788fb224a83d8c7783afe4bbb) | ✅ |  |
| [[Android] Guard update events to only be dispatched in ACTIVE state](https://github.com/software-mansion/react-native-gesture-handler/pull/4332) | [0bbd40f](https://github.com/software-mansion/react-native-gesture-handler/commit/0bbd40f43ec56406d4bb6d1bc6c9640e53242682) | [58e083c](https://github.com/software-mansion/react-native-gesture-handler/commit/58e083ce4b40f23b6135eba256aaca47c3251151) | ❌ | Applied the guard only; kept `isFirstEvent` (still used on 2.x) |
| [Fix fatal crash `Cannot read property 'translationX' of undefined` when a touch event is serialized without `allTouches`](https://github.com/software-mansion/react-native-gesture-handler/pull/4316) | [13d0070](https://github.com/software-mansion/react-native-gesture-handler/commit/13d0070c0df937fe7badee2d2f7188b0e34cb83c) | [35a0723](https://github.com/software-mansion/react-native-gesture-handler/commit/35a0723bec4d2c94f65c1dc7ae5ed0ee8473b675) | ❌ | Android hunk only; dropped v3 TS guards and tests |
| [Don't dispatch orphaned touch events](https://github.com/software-mansion/react-native-gesture-handler/pull/4341) | [6b0ca7b](https://github.com/software-mansion/react-native-gesture-handler/commit/6b0ca7bd7a9fba740bd10e834e40f492cdb24c88) | [55a28fd](https://github.com/software-mansion/react-native-gesture-handler/commit/55a28fd4e907072bffd83e61f9cac2a943ee5b82) | ✅ | Rename-detected into `RNGestureHandlerPointerTracker.m` |
| [Fix `minVelocity` props behavior](https://github.com/software-mansion/react-native-gesture-handler/pull/4327) | [bd9650f](https://github.com/software-mansion/react-native-gesture-handler/commit/bd9650fc0978c4d0b99a0776b2ecec63c3bf6336) | [3fc18b4](https://github.com/software-mansion/react-native-gesture-handler/commit/3fc18b4bc7383556236d3f4219ae77e3133d4d30) | ❌ | Web `minVelocity` mapped to `minVelocitySq` by hand; dropped v3 `PanTypes.ts` and hooks docs. Behavior change: per-axis velocity compared as absolute |
| [[iOS] Check if `enableTrackpadTwoFingerGesture` is `nil` before applying](https://github.com/software-mansion/react-native-gesture-handler/pull/4349) | [c4064f9](https://github.com/software-mansion/react-native-gesture-handler/commit/c4064f986cde6f95f9f1cffd0aa85904fe00f4f6) | [3892be4](https://github.com/software-mansion/react-native-gesture-handler/commit/3892be4ea9c283943551db4f5bafdb8c406c50d5) | ❌ | Kept 2.x `@available(iOS 13.4)` wrapper |
| [[Android] Fix basic-example `hermesc` path](https://github.com/software-mansion/react-native-gesture-handler/pull/4371) | [35a0aea](https://github.com/software-mansion/react-native-gesture-handler/commit/35a0aea4e5a9eaf64a95610bdeebd070c3904e71) | [4919e24](https://github.com/software-mansion/react-native-gesture-handler/commit/4919e24c18a87ede358a7e834b99a609f0e69b58) | ✅ |  |
| [[Apple] Remove trailing semicolons from `RNGHGestureRecognizerState*` macros](https://github.com/software-mansion/react-native-gesture-handler/pull/4391) | [787f165](https://github.com/software-mansion/react-native-gesture-handler/commit/787f16581744a82b9966694185e7834ad0f21d67) | [fc2c566](https://github.com/software-mansion/react-native-gesture-handler/commit/fc2c566d6d038339f1f7c4fa5ffa3ad2c9284d97) | ✅ |  |
| [[macOS] Fix touch events never being delivered](https://github.com/software-mansion/react-native-gesture-handler/pull/4390) | [bc605eb](https://github.com/software-mansion/react-native-gesture-handler/commit/bc605eb9be8d8638daf901d0298eb2d7cdfe7d6b) | [362c68f](https://github.com/software-mansion/react-native-gesture-handler/commit/362c68f5fcc29b0b46360ecd893287f359ed41aa) | ✅ |  |
| [fix: crash when mount listener fires after GestureDetector unmount](https://github.com/software-mansion/react-native-gesture-handler/pull/4268) | [991ccb5](https://github.com/software-mansion/react-native-gesture-handler/commit/991ccb539e5edc1278fe6b9b2e11494cd3a6f6ee) | [4c7865c](https://github.com/software-mansion/react-native-gesture-handler/commit/4c7865c8d4fdb348088e86856780e13517c8f924) | ✅ |  |
| [[macOS] Fix `Pan` activation criteria being ignored](https://github.com/software-mansion/react-native-gesture-handler/pull/4387) | [6819385](https://github.com/software-mansion/react-native-gesture-handler/commit/6819385fca53c3414feeef4024dc99f5c68d445a) | [4ed49fa](https://github.com/software-mansion/react-native-gesture-handler/commit/4ed49fa450676d878659577ad2525314cfa4e7e5) | ❌ | Kept 2.x `self.enabled = YES` in `reset` |
| [[macOS] Fix `manualActivation` never blocking gesture activation](https://github.com/software-mansion/react-native-gesture-handler/pull/4389) | [10235ad](https://github.com/software-mansion/react-native-gesture-handler/commit/10235ad6011b4c5ab2ceb8bdd1e2ef5723f21151) | [ad6e542](https://github.com/software-mansion/react-native-gesture-handler/commit/ad6e542468ce680b352af71bdc6cdbe3919d8a7f) | ✅ |  |
| [[macOS] Fix `Fling` not sending touch events and begin/end states consistently](https://github.com/software-mansion/react-native-gesture-handler/pull/4395) | [9c84c6d](https://github.com/software-mansion/react-native-gesture-handler/commit/9c84c6d8c9d4bd0912ab4a9ae8f2ece22ca8b5bd) | [f2ab06c](https://github.com/software-mansion/react-native-gesture-handler/commit/f2ab06c4fde43b8b10f7e26e96aeb8c588f33607) | ❌ | Kept 2.x `Vector` type and `handleGesture:fromReset:` signature |
| [[Android] Fix handlers cancelled while awaiting leaking in the orchestrator](https://github.com/software-mansion/react-native-gesture-handler/pull/4402) | [ce811da](https://github.com/software-mansion/react-native-gesture-handler/commit/ce811da53eca0f745c6002cae03ba04ba9ce8848) | [2dc6455](https://github.com/software-mansion/react-native-gesture-handler/commit/2dc645519947833e256163ce5e08a5a7a24b4535) | ❌ | Whitespace-only conflict |
| [[General] Align `pointerType` across native and JS](https://github.com/software-mansion/react-native-gesture-handler/pull/4403) | [2b37b3c](https://github.com/software-mansion/react-native-gesture-handler/commit/2b37b3cf478ca373049ed47f09c14262f82a7835) | [dcdb39e](https://github.com/software-mansion/react-native-gesture-handler/commit/dcdb39e7dcadf9ad92f1bfe985bc270780960c22) | ❌ | Native only; dropped v3 `EventTypes.ts`. Behavior change: native `OTHER` pointer type now reports 4 |
| [feat: Adopt AGP v9](https://github.com/software-mansion/react-native-gesture-handler/pull/4263) | [cb0f953](https://github.com/software-mansion/react-native-gesture-handler/commit/cb0f9534af8d04a8db0dbf0b4de11c5c5f0e984e) | [ea76dca](https://github.com/software-mansion/react-native-gesture-handler/commit/ea76dca416826ea05445f053090b04e37f895bef) | ❌ | Kept `fabric` / `paper` source dirs |
| [Clear pending timers on unmount in StatefulPressable](https://github.com/software-mansion/react-native-gesture-handler/pull/4413) | [3f1bf74](https://github.com/software-mansion/react-native-gesture-handler/commit/3f1bf74debe156a30972f8fb1224421e1a73716b) | [cca199e](https://github.com/software-mansion/react-native-gesture-handler/commit/cca199ed124b411f6f20a4f932a93dd16966f5d4) | ❌ | Applied to legacy `Pressable.tsx` (v3 `StatefulPressable` absent) |
| [Derive `Pressable` pressed state from `testOnly_pressed`](https://github.com/software-mansion/react-native-gesture-handler/pull/4414) | [2469c1d](https://github.com/software-mansion/react-native-gesture-handler/commit/2469c1df3f964fd0090ac890302c3598fc39511a) | [1494f54](https://github.com/software-mansion/react-native-gesture-handler/commit/1494f54e1a9d2efab60d75fac14ef27ab4d98234) | ❌ | Applied to legacy `Pressable.tsx`; dropped v3 engines |
| [Update `Pressable` props](https://github.com/software-mansion/react-native-gesture-handler/pull/4421) | [3e4497e](https://github.com/software-mansion/react-native-gesture-handler/commit/3e4497eb00301b744ea62a5d670beafbd3d2f553) | [d33e6f5](https://github.com/software-mansion/react-native-gesture-handler/commit/d33e6f58c7d73cf131fe591bd1d196251418afa0) | ❌ | Kept hover `testOnly_*` props only; dropped v3 engines, relation-prop widening and test |
| [Forward `borderless` and `foreground` from `android_ripple`](https://github.com/software-mansion/react-native-gesture-handler/pull/4442) | [b2bbb49](https://github.com/software-mansion/react-native-gesture-handler/commit/b2bbb4974d66f6a95c2447f5dceacf91d621604f) | [365b333](https://github.com/software-mansion/react-native-gesture-handler/commit/365b333006561c689f9ff2a09ce711fcafbdc806) | ❌ | Legacy `Pressable.tsx` only; dropped v3 engine and test |
| [Keep ReanimatedSwipeable native handlers stable when event callbacks change](https://github.com/software-mansion/react-native-gesture-handler/pull/4466) | [5de6d23](https://github.com/software-mansion/react-native-gesture-handler/commit/5de6d2358d22a9eda0ef3bd4fe54b14ea3d4ed9d) | [92d422b](https://github.com/software-mansion/react-native-gesture-handler/commit/92d422bbd58d0591325eddc9e31e32c8ec71de93) | ❌ | Ported `useEventCallback` wrappers only; kept 2.x `Gesture.Pan` / `Gesture.Tap` builders; dropped test |
| [Don't pass dependencies to Reanimated hooks on native](https://github.com/software-mansion/react-native-gesture-handler/pull/4472) | [7e1de71](https://github.com/software-mansion/react-native-gesture-handler/commit/7e1de71c2f9f53daabb226a8adccd4e0c9609b90) | [484f7c9](https://github.com/software-mansion/react-native-gesture-handler/commit/484f7c9aeaf42ddc21748312bf9d8e999363f9df) | ❌ | Kept 2.x `runOnJS`; added `Platform` import |
| [Fix ReanimatedDrawerLayout animation speed after rerender](https://github.com/software-mansion/react-native-gesture-handler/pull/4470) | [ed9410d](https://github.com/software-mansion/react-native-gesture-handler/commit/ed9410d3f1a1b017aa2f929a1c5b95cfbee4b80a) | [0d90a42](https://github.com/software-mansion/react-native-gesture-handler/commit/0d90a42079f4c7c3fc4d3e6969030344b3390d60) | ❌ | Indentation-only conflict |
| [Reset `numberOfPointers` in `LongPressGestureHandler`](https://github.com/software-mansion/react-native-gesture-handler/pull/4479) | [2efd514](https://github.com/software-mansion/react-native-gesture-handler/commit/2efd5144a2223101fe772a6b73f77ece54af85c0) | [81fb95f](https://github.com/software-mansion/react-native-gesture-handler/commit/81fb95f88efa11d6722aaf1ecbad065e95ddd565) | ✅ | Amended: dropped web test (2.x web `init` is protected) |
| [Reset `enableTrackpadTwoFingerGesture` in web `PanGestureHandler`](https://github.com/software-mansion/react-native-gesture-handler/pull/4480) | [5eaf877](https://github.com/software-mansion/react-native-gesture-handler/commit/5eaf8778d43c7eadde4d9a79265a3a7a63de1aa8) | [6494ef0](https://github.com/software-mansion/react-native-gesture-handler/commit/6494ef0dae61127520657e0ae1babd4303ef483b) | ❌ | One-line reset only; dropped test |
| [[Android] Don't let an awaiting parent handler cancel the child it is waiting for](https://github.com/software-mansion/react-native-gesture-handler/pull/4476) | [f232258](https://github.com/software-mansion/react-native-gesture-handler/commit/f2322586e2a17f7a92ae90a95d2443850cbd8a7a) | [533ca40](https://github.com/software-mansion/react-native-gesture-handler/commit/533ca408d3bd1e63955d476fd7dad8eaad37f3e4) | ✅ |  |
| [[Web] Reset NativeViewGestureHandler config on a full config replace](https://github.com/software-mansion/react-native-gesture-handler/pull/4486) | [f3e0706](https://github.com/software-mansion/react-native-gesture-handler/commit/f3e070666ee076319e906bad61829846a975af77) | [1a092b8](https://github.com/software-mansion/react-native-gesture-handler/commit/1a092b8249214c78724c9898d28293390ea2af52) | ❌ | `resetConfig` with 2.x fields only, called from `updateGestureConfig` (2.x has no `setGestureConfig`); dropped test (belongs to skipped #4420) |
| [Resolve `DrawerLayoutAndroid` lazily to avoid RN deprecation warning on import](https://github.com/software-mansion/react-native-gesture-handler/pull/4493) | [a95f00f](https://github.com/software-mansion/react-native-gesture-handler/commit/a95f00f9605cdf2503647dc60ffa380b8cc02e44) | [48f354b](https://github.com/software-mansion/react-native-gesture-handler/commit/48f354b4da8f8674d7c3c0cb1720f39056cea7ab) | ❌ | Kept 2.x `DrawerLayoutAndroid` name; type-only import |
| [Reset accumulated wheel delta in web `WheelEventManager`](https://github.com/software-mansion/react-native-gesture-handler/pull/4484) | [3ffb544](https://github.com/software-mansion/react-native-gesture-handler/commit/3ffb544c1263acbfc640b2c11fb4a14ca853a96e) | [25d36d9](https://github.com/software-mansion/react-native-gesture-handler/commit/25d36d96bbd74ab06938524a7a904ae1cba7124e) | ❌ | Source applied clean; dropped test file |
| [[Android] Stop nested scroll when a native handler's gesture ends](https://github.com/software-mansion/react-native-gesture-handler/pull/4492) | [4768ffe](https://github.com/software-mansion/react-native-gesture-handler/commit/4768ffe73edcc06fb65463ebe5df1c620fbe8091) | [ef9ade7](https://github.com/software-mansion/react-native-gesture-handler/commit/ef9ade7ac8da1e7c109ee55b6417afbbc248b43d) | ✅ |  |
| [Chore: ref forwarding to child in wrap v2](https://github.com/software-mansion/react-native-gesture-handler/pull/4385) | [0b82de0](https://github.com/software-mansion/react-native-gesture-handler/commit/0b82de01f0d7ce0c30494227c8f07b4b4c387ab3) | [3d6ca41](https://github.com/software-mansion/react-native-gesture-handler/commit/3d6ca416a27fa6788c1898b0dd2b5e9489bac866) | ❌ | Kept 2.x imports and flattening check; dropped v3 `VirtualDetector/Wrap.tsx`. Behavior change: `GestureDetector` child ref is now forwarded through `Wrap` |
| [[iOS] Keep button hit testing within its own subtree](https://github.com/software-mansion/react-native-gesture-handler/pull/4495) | [18b08dd](https://github.com/software-mansion/react-native-gesture-handler/commit/18b08dd2fb3d2fc248093deed130856d31db9a60) | [c68bf94](https://github.com/software-mansion/react-native-gesture-handler/commit/c68bf944e95a5a2e71185d8e506e57a5d6b7be83) | ❌ | `hitTest` loop only; dropped the four `_userEnabled` guards (v3 button tracking / mouse overrides absent on 2.x) |
| [[Web] Drop handlers that never began from the orchestrator](https://github.com/software-mansion/react-native-gesture-handler/pull/4505) | [bcd4b52](https://github.com/software-mansion/react-native-gesture-handler/commit/bcd4b522e4853ea1b8afee081dda15f24c44d864) | [493578c](https://github.com/software-mansion/react-native-gesture-handler/commit/493578c8f8239ce732e72faf6b2aeeeda9ea81fa) | ❌ | Kept 2.x `includes` check in `recordHandlerIfNotPresent`; dropped absent test file |
| [fix: stop circular GestureStateManagerType import on web](https://github.com/software-mansion/react-native-gesture-handler/pull/4508) | [1c8af36](https://github.com/software-mansion/react-native-gesture-handler/commit/1c8af36504011afe02c03fe7818fea9aa2e1486a) | [5e1d48d](https://github.com/software-mansion/react-native-gesture-handler/commit/5e1d48daa7558889e2251f9d585716919aebfb20) | ❌ | Legacy web file only: local interface without the v3 `@deprecated` note; dropped the three v3 files |
| [[iOS] Preserve disabled button targets under box-none parents](https://github.com/software-mansion/react-native-gesture-handler/pull/4506) | [9703a2a](https://github.com/software-mansion/react-native-gesture-handler/commit/9703a2aa8e74e9cb285170d4708096ebe25480ec) | [59b47bf](https://github.com/software-mansion/react-native-gesture-handler/commit/59b47bfa8286030601567246edf6804afb2db4da) | ❌ | box-none branch adapted to the 2.x one-arg `shouldHandleTouch:`; the `shouldHandleTouch:` pointerEvents follow-up applied clean |


## Test plan

Tested that example apps are built correctly
