### PR TITLE
fix(fabric): prevent Yoga layout assertion crash in RNGestureHandlerDetectorShadowNode

### DIFF
--- a/packages/react-native-gesture-handler/shared/shadowNodes/react/renderer/components/rngesturehandler_codegen/RNGestureHandlerDetectorShadowNode.cpp
+++ b/packages/react-native-gesture-handler/shared/shadowNodes/react/renderer/components/rngesturehandler_codegen/RNGestureHandlerDetectorShadowNode.cpp
@@ -72,9 +72,8 @@ void RNGestureHandlerDetectorShadowNode::layout(LayoutContext layoutContext) {
   // Default layout will reset the flag on child nodes.
   YogaLayoutableShadowNode::layout(layoutContext);
 
-  // No child had its layout changed, we can reuse previous values
-  if (!anyChildHasNewLayout) {
-    react_native_assert(previousLayoutMetrics_.has_value());
+  // No child had its layout changed, we can reuse previous values if available
+  if (!anyChildHasNewLayout && previousLayoutMetrics_.has_value()) {
     setLayoutMetrics(previousLayoutMetrics_.value());
     return;
   }
@@ -101,6 +100,7 @@ void RNGestureHandlerDetectorShadowNode::layout(LayoutContext layoutContext) {
   metrics.frame.origin = Point{minX, minY};
   metrics.frame.size = Size{maxX - minX, maxY - minY};
   setLayoutMetrics(metrics);
+  previousLayoutMetrics_ = metrics;
 
   // Shift all children so their positions are relative to the detector's origin
   for (const auto &child : children) {


### PR DESCRIPTION
## Description
Fixes #4241

### Problem
When dynamically inserting \GestureDetector\ / \ReanimatedSwipeable\ rows into a layout on Fabric (such as inside a list or alongside BottomSheet), \nyChildHasNewLayout\ can evaluate to false on initial layout passes if child Yoga subtrees have cached layouts. This caused \eact_native_assert(previousLayoutMetrics_.has_value())\ to fail, resulting in a \SIGABRT\ crash.

### Solution
- Safely fall back to computing bounding box metrics when \previousLayoutMetrics_\ is \std::nullopt\ instead of asserting.
- Cache \previousLayoutMetrics_ = metrics;\ so subsequent unchanged layout passes can reuse the metrics.
- Preserves Fabric C++ ShadowNode layout semantics across Android and iOS.

Fixes #4241