### PR TITLE
[iOS] Cancel an in-progress press when the button gets disabled

### DIFF
--- a/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
+++ b/packages/react-native-gesture-handler/apple/RNGestureHandlerButton.mm
@@ -330,12 +330,41 @@
   }
 
   _userEnabled = userEnabled;
+
+#if !TARGET_OS_OSX
+  if (!userEnabled) {
+    [self cancelActivePress];
+  }
+#endif
+
   [self dispatchHoverEventIfNeeded];
 
   if (_isHovered && !_isPressed) {
     [self animateHoverState];
   }
 }
+
+#if !TARGET_OS_OSX
+// Ends a press that is in progress when the button gets disabled underneath
+// it, so JS receives the press-out
+- (void)cancelActivePress
+{
+  if (!self.tracking) {
+    return;
+  }
+
+  [self cancelTrackingWithEvent:nil];
+  [self rngh_sendActionsForControlEvents:UIControlEventTouchCancel withEvent:nil];
+
+  // No finger lifted, so skip the press-out fade: it would overlap the restyle
+  // that usually comes with disabling and show as a flash.
+  [self cancelPendingPressOutAnimation];
+  [self animateToOpacity:self.restingOpacity
+                   scale:self.restingScale
+         underlayOpacity:self.restingUnderlayOpacity
+                duration:0];
+}
+#endif
 
 - (void)setUnderlayColor:(RNGHColor *)underlayColor
 {
@@ -1197,7 +1226,6 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
     return;
   }
 
-  
   _isTouchInsideBounds = YES;
   [self handleAnimatePressIn];
   [super mouseDown:event];
@@ -1208,7 +1236,7 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   if (!_userEnabled) {
     return;
   }
-  
+
   NSPoint locationInView = [self convertPoint:[event locationInWindow] fromView:nil];
   _isHovered = NSPointInRect(locationInView, self.bounds);
   [self recordHoverSampleForMouseEvent:event];
@@ -1224,7 +1252,7 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   if (!_userEnabled) {
     return;
   }
-  
+
   NSPoint locationInWindow = [event locationInWindow];
   NSPoint locationInView = [self convertPoint:locationInWindow fromView:nil];
   BOOL currentlyInside = NSPointInRect(locationInView, self.bounds);
@@ -1260,7 +1288,7 @@ static CATransform3D RNGHCenterScaleTransform(NSRect bounds, CGFloat scale)
   if (!_userEnabled) {
     return NO;
   }
-  
+
   _isTouchInsideBounds = YES;
   // A pencil's hover-out arrives just before touch-down but only schedules the
   // clear, so `_isHovered` still reflects the open hover. Under Reduce Motion


### PR DESCRIPTION
## Description

When a `Touchable`/`Pressable` is disabled while a press is in progress, the button kept tracking the touch: `onPressOut` only arrived on release and `onPress` still fired even though the button was already disabled.

`setUserEnabled:` now ends the press when it flips to `NO`. It cancels `UIControl` tracking and sends `UIControlEventTouchCancel` to the targets, so the managed handler moves to `CANCELLED` and JS receives `onPressOut` without `onPress`. The press visuals are reset with a zero-duration animation instead of the regular press-out fade: no finger lifted, and a disable usually restyles the button in the same frame, so the fade showed as a brief flash.


## Test plan

Add a `Touchable` that disables itself shortly after `onPressIn`, e.g. a 700 ms timeout, and hold it past that point:

- `onPressOut` fires the moment the button gets disabled
- `onPress` does not fire on release
- the button snaps back to its resting look with no flash
- re-enabling and pressing again works as before

<details>
<summary>Tested on the following example:</summary>

```tsx
import React, { useCallback, useRef, useState } from 'react';
import { StyleSheet, Text, View } from 'react-native';
import { Touchable } from 'react-native-gesture-handler';

// A button that gets disabled while a press is in progress.
// Press and hold the blue box. After `DISABLE_AFTER_MS` it disables itself.
// Expected: onPressOut fires at that moment, onPress never fires on release,
// and the press animation resets instead of staying stuck (macOS especially).
const DISABLE_AFTER_MS = 700;

export default function EmptyExample() {
  const [disabled, setDisabled] = useState(false);
  const [log, setLog] = useState<string[]>([]);
  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);

  const push = useCallback((entry: string) => {
    console.log(`RNGH-mid-press: ${entry}`);
    setLog((l) => [...l.slice(-7), entry]);
  }, []);

  const onPressIn = useCallback(() => {
    push('onPressIn');
    timer.current = setTimeout(() => {
      push(`disabled after ${DISABLE_AFTER_MS}ms`);
      setDisabled(true);
    }, DISABLE_AFTER_MS);
  }, [push]);

  const onPressOut = useCallback(() => {
    push('onPressOut');
    if (timer.current) {
      clearTimeout(timer.current);
      timer.current = null;
    }
  }, [push]);

  const onPress = useCallback(() => push('onPress'), [push]);

  const reset = useCallback(() => {
    setDisabled(false);
    setLog([]);
  }, []);

  return (
    <View style={styles.container}>
      <Text>
        Hold the box for longer than {DISABLE_AFTER_MS}ms. It disables itself
        mid-press.
      </Text>
      <Touchable
        disabled={disabled}
        onPressIn={onPressIn}
        onPressOut={onPressOut}
        onPress={onPress}
        activeOpacity={0.4}
        style={[styles.box, disabled ? styles.boxDisabled : styles.boxEnabled]}>
        <Text style={styles.boxText}>{disabled ? 'disabled' : 'hold me'}</Text>
      </Touchable>
      <Touchable onPress={reset} style={styles.reset}>
        <Text style={styles.boxText}>re-enable and clear log</Text>
      </Touchable>
      {log.map((entry, i) => (
        <Text key={i} style={styles.log}>
          {entry}
        </Text>
      ))}
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    padding: 16,
    gap: 12,
  },
  box: {
    height: 100,
    borderRadius: 8,
    justifyContent: 'center',
    alignItems: 'center',
  },
  boxEnabled: {
    backgroundColor: '#5b7bd5',
  },
  boxDisabled: {
    backgroundColor: '#9a9a9a',
  },
  boxText: {
    color: 'white',
    fontWeight: '600',
  },
  reset: {
    height: 44,
    borderRadius: 8,
    backgroundColor: '#3a3a3a',
    justifyContent: 'center',
    alignItems: 'center',
  },
  log: {
    fontVariant: ['tabular-nums'],
  },
});
```

</details>
