### PR TITLE
[Android] Release the press when the button gets disabled

### DIFF
--- a/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
+++ b/packages/react-native-gesture-handler/android/src/main/java/com/swmansion/gesturehandler/react/RNGestureHandlerButtonViewManager.kt
@@ -1494,6 +1494,16 @@ class RNGestureHandlerButtonViewManager :
         return
       }
 
+      if (!enabled && isPressed) {
+        setPressed(false)
+
+        // No finger lifted, so skip the press-out fade: it would overlap the
+        // restyle that usually comes with disabling and show as a flash.
+        pendingPressOut?.let { handler?.removeCallbacks(it) }
+        pendingPressOut = null
+        animateTo(restingOpacity, restingScale, restingUnderlayOpacity, 0)
+      }
+
       // The managed handler mirrors the button's enabled state.
       managedHandlerNeedsUpdate = true
 


### PR DESCRIPTION
## Description

Follow-up to #4495.

When a `Touchable`/`Pressable` is disabled while a press is in progress, the button stayed dimmed until the next tap. Disabling the managed handler posts a cancel that reaches the button as a synthetic `ACTION_CANCEL`, but a disabled `View` only clears its pressed flag on `ACTION_UP`, so the press-in animation was never released.

`setEnabled(false)` now releases the press itself. The press visuals are reset with a zero-duration animation instead of the regular press-out fade: no finger lifted, and a disable usually restyles the button in the same frame, so the fade showed as a brief flash.

## Test plan

Add a `Touchable` that disables itself shortly after `onPressIn`, e.g. a 700 ms timeout, and hold it past that point:

- the button snaps back to its resting look the moment it gets disabled, with no flash
- `onPressOut` fires at that moment and `onPress` does not fire on release
- re-enabling and pressing again works as before

<details>
<summary>Tested on the following code:</summary>

```tsx
import React, { useCallback, useRef, useState } from 'react';
import { StyleSheet, Text, View } from 'react-native';
import { Touchable } from 'react-native-gesture-handler';

// A button that gets disabled while a press is in progress.
// Press and hold the blue box. After `DISABLE_AFTER_MS` it disables itself.
// Expected: onPressOut fires at that moment, onPress never fires on release,
// and the press animation resets instead of staying stuck (macOS especially).
const DISABLE_AFTER_MS = 700;

export default function EmptyExample() {
  const [disabled, setDisabled] = useState(false);
  const [log, setLog] = useState<string[]>([]);
  const timer = useRef<ReturnType<typeof setTimeout> | null>(null);

  const push = useCallback((entry: string) => {
    console.log(`RNGH-mid-press: ${entry}`);
    setLog((l) => [...l.slice(-7), entry]);
  }, []);

  const onPressIn = useCallback(() => {
    push('onPressIn');
    timer.current = setTimeout(() => {
      push(`disabled after ${DISABLE_AFTER_MS}ms`);
      setDisabled(true);
    }, DISABLE_AFTER_MS);
  }, [push]);

  const onPressOut = useCallback(() => {
    push('onPressOut');
    if (timer.current) {
      clearTimeout(timer.current);
      timer.current = null;
    }
  }, [push]);

  const onPress = useCallback(() => push('onPress'), [push]);

  const reset = useCallback(() => {
    setDisabled(false);
    setLog([]);
  }, []);

  return (
    <View style={styles.container}>
      <Text>
        Hold the box for longer than {DISABLE_AFTER_MS}ms. It disables itself
        mid-press.
      </Text>
      <Touchable
        disabled={disabled}
        onPressIn={onPressIn}
        onPressOut={onPressOut}
        onPress={onPress}
        activeOpacity={0.4}
        style={[styles.box, disabled ? styles.boxDisabled : styles.boxEnabled]}>
        <Text style={styles.boxText}>{disabled ? 'disabled' : 'hold me'}</Text>
      </Touchable>
      <Touchable onPress={reset} style={styles.reset}>
        <Text style={styles.boxText}>re-enable and clear log</Text>
      </Touchable>
      {log.map((entry, i) => (
        <Text key={i} style={styles.log}>
          {entry}
        </Text>
      ))}
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    padding: 16,
    gap: 12,
  },
  box: {
    height: 100,
    borderRadius: 8,
    justifyContent: 'center',
    alignItems: 'center',
  },
  boxEnabled: {
    backgroundColor: '#5b7bd5',
  },
  boxDisabled: {
    backgroundColor: '#9a9a9a',
  },
  boxText: {
    color: 'white',
    fontWeight: '600',
  },
  reset: {
    height: 44,
    borderRadius: 8,
    backgroundColor: '#3a3a3a',
    justifyContent: 'center',
    alignItems: 'center',
  },
  log: {
    fontVariant: ['tabular-nums'],
  },
});
```

</details>