### PR TITLE
[Web] Drop handlers that never began from the orchestrator

### DIFF
--- a/packages/react-native-gesture-handler/src/web/handlers/__tests__/GestureHandler.test.ts
+++ b/packages/react-native-gesture-handler/src/web/handlers/__tests__/GestureHandler.test.ts
@@ -1,6 +1,9 @@
-import type { Config } from '../../interfaces';
+import { PointerType } from '../../../PointerType';
+import type { AdaptedEvent, Config } from '../../interfaces';
+import { EventTypes } from '../../interfaces';
 import EventManager from '../../tools/EventManager';
 import type { GestureHandlerDelegate } from '../../tools/GestureHandlerDelegate';
+import GestureHandlerOrchestrator from '../../tools/GestureHandlerOrchestrator';
 import { GestureHandlerWebDelegate } from '../../tools/GestureHandlerWebDelegate';
 import GestureHandler from '../GestureHandler';
 import type IGestureHandler from '../IGestureHandler';
@@ -72,5 +75,61 @@ describe('GestureHandler web event manager attachment', () => {
     createHandler(false).attachEventManager(manager);
 
     expect(manager.registerListeners).not.toHaveBeenCalled();
+  });
+});
+
+describe('GestureHandlerOrchestrator idle handlers', () => {
+  const delegate = {
+    onEnabledChange: jest.fn(),
+  } as unknown as GestureHandlerDelegate<unknown, IGestureHandler>;
+  const pointerDown: AdaptedEvent = {
+    x: 10,
+    y: 10,
+    offsetX: 10,
+    offsetY: 10,
+    pointerId: 1,
+    eventType: EventTypes.DOWN,
+    pointerType: PointerType.MOUSE,
+    time: 0,
+  };
+
+  afterEach(() => {
+    (
+      GestureHandlerOrchestrator.instance as unknown as {
+        gestureHandlers: IGestureHandler[];
+      }
+    ).gestureHandlers = [];
+  });
+
+  test('a recorded handler that never began is dropped once its pointers are gone', () => {
+    const stale = new TestGestureHandler(delegate);
+    const next = new TestGestureHandler(delegate);
+    stale.setGestureConfig({ enabled: true });
+    next.setGestureConfig({ enabled: true });
+
+    GestureHandlerOrchestrator.instance.recordHandlerIfNotPresent(stale);
+    GestureHandlerOrchestrator.instance.recordHandlerIfNotPresent(next);
+
+    expect(GestureHandlerOrchestrator.instance.isHandlerRecorded(stale)).toBe(
+      false
+    );
+    expect(GestureHandlerOrchestrator.instance.isHandlerRecorded(next)).toBe(
+      true
+    );
+  });
+
+  test('a recorded handler that still tracks a pointer is kept', () => {
+    const pressed = new TestGestureHandler(delegate);
+    const next = new TestGestureHandler(delegate);
+    pressed.setGestureConfig({ enabled: true });
+    next.setGestureConfig({ enabled: true });
+
+    pressed.tracker.addToTracker(pointerDown);
+    GestureHandlerOrchestrator.instance.recordHandlerIfNotPresent(pressed);
+    GestureHandlerOrchestrator.instance.recordHandlerIfNotPresent(next);
+
+    expect(GestureHandlerOrchestrator.instance.isHandlerRecorded(pressed)).toBe(
+      true
+    );
   });
 });

--- a/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
+++ b/packages/react-native-gesture-handler/src/web/tools/GestureHandlerOrchestrator.ts
@@ -269,7 +269,26 @@ export default class GestureHandlerOrchestrator {
     handler.activationIndex = this.activationIndex++;
   }
 
+  // A handler whose pointer sequence ended before it began (e.g. a press
+  // outside a negative hit slop) never reaches a finished state, so
+  // `cleanupFinishedHandlers` never drops it and it would block or park every
+  // later gesture. Drop such idle entries before a new gesture consults them.
+  private dropIdleHandlers(): void {
+    for (let i = this.gestureHandlers.length - 1; i >= 0; --i) {
+      const handler = this.gestureHandlers[i];
+
+      if (
+        handler.state === State.UNDETERMINED &&
+        handler.tracker.trackedPointersCount === 0
+      ) {
+        this.removeHandlerFromOrchestrator(handler);
+      }
+    }
+  }
+
   public recordHandlerIfNotPresent(handler: IGestureHandler): void {
+    this.dropIdleHandlers();
+
     if (this.isHandlerRecorded(handler)) {
       return;
     }


### PR DESCRIPTION
## Description

A button pressed inside its element but outside a negative `hitSlop` killed every other button on the page: nothing pressed after that would begin, until the first button was pressed properly.

The orchestrator records a handler on pointer-down, before the handler calls `begin()`. When the hit slop check rejects the pointer, `begin()` bails and the handler stays `UNDETERMINED`. On release it goes through `fail()`, which only acts on `BEGAN` and `ACTIVE`, so it never reaches a finished state and the orchestrator's finished-handler cleanup never drops it. Every later button then finds the stale entry in `shouldBeginWithRecordedHandlers` and cancels itself. A handler waiting for such an entry through `waitFor` would stay parked the same way.

`recordHandlerIfNotPresent` now drops recorded handlers that are `UNDETERMINED` with no tracked pointers before a new gesture consults the list. That combination only describes a handler whose pointer sequence ended without a begin: every handler adds the pointer to its tracker before recording itself, so anything in flight has at least one.

## Test plan

Added tests in `GestureHandler.test.ts`, the first fails without the fix.

Manually, on web: a `Touchable` with `hitSlop={-40}` next to a second, plain `Touchable` with a press counter.

- tap the second button: counts
- tap the first button in its outer 40 px band: nothing, as expected
- tap the second button again: counts, previously it was dead

<details>
<summary>Tested on the following code:</summary>

```tsx
import React, { useState } from 'react';
import { StyleSheet, Text, View } from 'react-native';
import { Touchable } from 'react-native-gesture-handler';

// Web only: a button pressed inside its element but outside a negative hitSlop
// never begins, yet it was already recorded by the orchestrator on pointer-down.
// Nothing ever finishes it, so it stays recorded and every other button cancels
// itself against the stale entry. Pressing the trap inside its slop clears it.
const TRAP_SLOP = -40;

export default function EmptyExample() {
  const [trap, setTrap] = useState(0);
  const [victim, setVictim] = useState(0);

  return (
    <View style={styles.container}>
      <Text>
        1. tap "victim" (counts). 2. tap the outer {-TRAP_SLOP}px band of "trap"
        (nothing, expected). 3. tap "victim" again: should count.
      </Text>
      <Touchable
        hitSlop={TRAP_SLOP}
        onPress={() => setTrap((n) => n + 1)}
        style={styles.trap}>
        <View style={styles.trapInner}>
          <Text style={styles.text}>trap: {trap}</Text>
        </View>
      </Touchable>
      <Touchable onPress={() => setVictim((n) => n + 1)} style={styles.victim}>
        <Text style={styles.text}>victim: {victim}</Text>
      </Touchable>
    </View>
  );
}

const styles = StyleSheet.create({
  container: {
    flex: 1,
    padding: 16,
    gap: 12,
  },
  text: {
    color: 'white',
    fontWeight: '600',
  },
  trap: {
    height: 120,
    borderRadius: 8,
    backgroundColor: '#d5865b',
    padding: -TRAP_SLOP,
  },
  trapInner: {
    flex: 1,
    borderRadius: 4,
    backgroundColor: '#b4643a',
    justifyContent: 'center',
    alignItems: 'center',
  },
  victim: {
    height: 44,
    borderRadius: 8,
    backgroundColor: '#3a3a3a',
    justifyContent: 'center',
    alignItems: 'center',
  },
});
```

</details>